### PR TITLE
[v0.17 READY-Bb] Scope the freshness memo to the ready lease, one fingerprint pass

### DIFF
--- a/crates/codestory-contracts/src/api/dto.rs
+++ b/crates/codestory-contracts/src/api/dto.rs
@@ -2650,13 +2650,12 @@ pub struct PacketClaimProfileTelemetryDto {
 pub struct SourceFreshnessTelemetryDto {
     /// Stored files whose content was read and hashed for a freshness verdict.
     pub content_hash_reads: u32,
-    /// Freshness verdicts served from the operation-scoped verdict memo.
+    /// Freshness verdicts served from the ready-lease-scoped verdict memo.
     pub verdict_reuses: u32,
     /// Strict-readiness fingerprint passes. Each reads the repository's
     /// lexical source live off disk and streams both projection tables. This
-    /// is a measurement, not a bound: a warm packet over an unchanged
-    /// repository was measured at six passes, so treat any single-pass
-    /// expectation as unproven until it is enforced.
+    /// is a measurement, not a bound: the first warm packet on one ready lease
+    /// performs exactly one pass, and later operations reuse that fingerprint.
     pub readiness_fingerprint_passes: u32,
 }
 

--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -39,9 +39,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs::{self, File, OpenOptions};
 #[cfg(any(not(feature = "test-support"), test))]
 use std::io::{Read, Write};
-use std::path::Path;
-#[cfg(any(not(feature = "test-support"), test))]
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 #[cfg(any(not(feature = "test-support"), test))]
 use std::time::{Duration, Instant};
@@ -107,6 +105,19 @@ pub(crate) struct SidecarInputFingerprint {
     pub(crate) lexical_hash: String,
     pub(crate) lexical_coverage: crate::lexical_index::LexicalCoverage,
 }
+
+#[derive(Clone)]
+struct LeaseMemoizedSidecarInputFingerprint {
+    project_root: PathBuf,
+    storage_path: PathBuf,
+    project_id: String,
+    embedding_backend: String,
+    embedding_dim: i32,
+    producer_compatibility_identity: String,
+    fingerprint: SidecarInputFingerprint,
+}
+
+const LEASE_SIDECAR_INPUT_FINGERPRINT_KEY: &str = "sidecar-input-fingerprint-v1";
 
 struct SidecarEmbeddingContract<'a> {
     backend: &'a str,
@@ -1905,6 +1916,69 @@ pub(crate) fn compute_sidecar_input_fingerprint(
     embedding_dim: i32,
     producer_compatibility_identity: &str,
 ) -> Result<SidecarInputFingerprint> {
+    if let Some(memoized) = codestory_workspace::with_lease_memoized_value(
+        LEASE_SIDECAR_INPUT_FINGERPRINT_KEY,
+        |memoized: Option<&LeaseMemoizedSidecarInputFingerprint>| {
+            let precomputed = memoized
+                .filter(|memoized| {
+                    memoized.project_root == project_root
+                        && memoized.storage_path == storage_path
+                        && memoized.project_id == project_id
+                        && memoized.embedding_backend == embedding_backend
+                        && memoized.embedding_dim == embedding_dim
+                        && memoized.producer_compatibility_identity
+                            == producer_compatibility_identity
+                })
+                .map(|memoized| &memoized.fingerprint);
+            let fingerprint = compute_sidecar_input_fingerprint_with_precomputed(
+                storage,
+                project_root,
+                storage_path,
+                project_id,
+                embedding_backend,
+                embedding_dim,
+                producer_compatibility_identity,
+                precomputed,
+            )?;
+            Ok::<_, anyhow::Error>(LeaseMemoizedSidecarInputFingerprint {
+                project_root: project_root.to_path_buf(),
+                storage_path: storage_path.to_path_buf(),
+                project_id: project_id.to_string(),
+                embedding_backend: embedding_backend.to_string(),
+                embedding_dim,
+                producer_compatibility_identity: producer_compatibility_identity.to_string(),
+                fingerprint,
+            })
+        },
+    ) {
+        return memoized.map(|memoized| memoized.fingerprint);
+    }
+    compute_sidecar_input_fingerprint_with_precomputed(
+        storage,
+        project_root,
+        storage_path,
+        project_id,
+        embedding_backend,
+        embedding_dim,
+        producer_compatibility_identity,
+        None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn compute_sidecar_input_fingerprint_with_precomputed(
+    storage: &Store,
+    project_root: &Path,
+    storage_path: &Path,
+    project_id: &str,
+    embedding_backend: &str,
+    embedding_dim: i32,
+    producer_compatibility_identity: &str,
+    precomputed: Option<&SidecarInputFingerprint>,
+) -> Result<SidecarInputFingerprint> {
+    if let Some(precomputed) = precomputed {
+        return Ok(precomputed.clone());
+    }
     // This pass reads the repository's lexical source live off disk and
     // streams both projection tables. Record it against the operation scope so
     // a caller can see how many whole-repository readiness passes one request

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -419,6 +419,9 @@ fn shadow_env_enabled() -> Option<bool> {
 /// - Unset: retrieval is available when the manifest exists and the shared
 ///   per-user embedding server is healthy.
 pub(crate) fn sidecar_retrieval_primary_enabled(controller: &AppController) -> bool {
+    if active_pinned_retrieval_read(controller).is_some() {
+        return true;
+    }
     match retrieval_env_override() {
         Some(false) => {
             tracing::error!("CODESTORY_RETRIEVAL=0 is unsupported; full retrieval is mandatory");
@@ -2452,10 +2455,6 @@ mod tests {
     /// retrieval is primary — a second `PinnedRetrievalRead::begin`. The
     /// end-to-end count is proved on the real packet path in
     /// `services::activation_tests`.
-    ///
-    /// This asserts a difference, not an absolute: the absolute count of
-    /// readiness passes a warm operation pays is larger than one and is not
-    /// what this branch changes.
     #[test]
     fn the_value_helper_borrows_an_active_pin_instead_of_paying_for_a_second() {
         let fixture = pinned_operation_fixture();

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -419,9 +419,6 @@ fn shadow_env_enabled() -> Option<bool> {
 /// - Unset: retrieval is available when the manifest exists and the shared
 ///   per-user embedding server is healthy.
 pub(crate) fn sidecar_retrieval_primary_enabled(controller: &AppController) -> bool {
-    if active_pinned_retrieval_read(controller).is_some() {
-        return true;
-    }
     match retrieval_env_override() {
         Some(false) => {
             tracing::error!("CODESTORY_RETRIEVAL=0 is unsupported; full retrieval is mandatory");
@@ -2455,6 +2452,10 @@ mod tests {
     /// retrieval is primary — a second `PinnedRetrievalRead::begin`. The
     /// end-to-end count is proved on the real packet path in
     /// `services::activation_tests`.
+    ///
+    /// This asserts a difference, not an absolute: the absolute count of
+    /// readiness passes a warm operation pays is larger than one and is not
+    /// what this branch changes.
     #[test]
     fn the_value_helper_borrows_an_active_pin_instead_of_paying_for_a_second() {
         let fixture = pinned_operation_fixture();

--- a/crates/codestory-runtime/src/services.rs
+++ b/crates/codestory-runtime/src/services.rs
@@ -315,6 +315,7 @@ struct ReadyLease {
     core_publication: IndexPublicationDto,
     retrieval: codestory_retrieval::ReadyRetrievalIdentity,
     source: ReadySourceIdentity,
+    source_freshness_memo: codestory_workspace::SourceFreshnessMemo,
     /// The observer session and epoch the source snapshot was taken under.
     ///
     /// Everything else in this lease is a pointer that a source write does not move: the core
@@ -563,6 +564,34 @@ impl ActivationService {
             .is_some_and(|current| current.matches(&requested))
             .then(|| state.current.clone())
             .flatten()
+    }
+
+    fn source_freshness_memo_for_target(
+        &self,
+        project_root: &Path,
+        storage_path: &Path,
+    ) -> Option<codestory_workspace::SourceFreshnessMemo> {
+        let requested = ActivationTarget::new(project_root, storage_path);
+        let state = self
+            .coordinator
+            .state
+            .lock()
+            .expect("activation coordinator poisoned");
+        (state
+            .target
+            .as_ref()
+            .is_some_and(|current| current.matches(&requested))
+            && state
+                .current
+                .as_ref()
+                .is_some_and(|snapshot| snapshot.state == ActivationState::Ready))
+        .then(|| {
+            state
+                .ready_lease
+                .as_ref()
+                .map(|lease| lease.source_freshness_memo.clone())
+        })
+        .flatten()
     }
 
     fn target_for_request(&self, project_root: &Path, storage_path: &Path) -> ActivationTarget {
@@ -1468,6 +1497,7 @@ impl ActivationService {
             core_publication: revalidated_core,
             retrieval,
             source: ReadySourceIdentity::from(&source_freshness),
+            source_freshness_memo: codestory_workspace::SourceFreshnessMemo::default(),
             source_observer,
         });
         operation.set_capability(true, ActivationCapabilityState::Ready);
@@ -1745,6 +1775,18 @@ impl PublicOperationService {
         }
     }
 
+    fn source_freshness_scope(&self) -> codestory_workspace::SourceFreshnessScope {
+        let memo = self.activation.as_ref().and_then(|activation| {
+            let project_root = self.controller.require_project_root().ok()?;
+            let storage_path = self.controller.require_storage_path().ok()?;
+            activation.source_freshness_memo_for_target(&project_root, &storage_path)
+        });
+        memo.map_or_else(
+            codestory_workspace::SourceFreshnessScope::enter,
+            codestory_workspace::SourceFreshnessScope::enter_with_memo,
+        )
+    }
+
     fn retained_core_allows(&self, operation: &str, publication: &IndexPublicationRecord) -> bool {
         !operation_requires_retrieval(operation)
             && self.activation.as_ref().is_some_and(|activation| {
@@ -1814,29 +1856,24 @@ impl PublicOperationService {
             "public-{}",
             self.next_id.fetch_add(1, Ordering::Relaxed) + 1
         );
-        // One public operation derives source freshness at least twice (before
-        // and after the build) and the MCP transport wraps the same request in
-        // a second public operation. Scoping the freshness verdict memo to the
-        // operation makes the derivations that ask the same question at the
-        // same instant — this pre-build check, a nested wrapper's pre-build
-        // check, strict retrieval readiness — share one content pass instead of
-        // re-hashing every unchanged file. The post-build check below is not
-        // one of those: it asks whether the source drifted *since*, so it
-        // re-derives from content. Nested scopes share the outer memo; the memo
-        // never outlives the outermost operation.
-        let _source_freshness_scope = codestory_workspace::SourceFreshnessScope::enter();
+        // The ready lease owns reusable freshness and readiness observations;
+        // this scope owns only the operation's counters. The post-build check
+        // below still drops stored-file verdicts and re-derives them from
+        // content, so same-mtime drift and torn reads win over reuse.
+        let _source_freshness_scope = self.source_freshness_scope();
         for attempt in 1..=2 {
             let result = self.controller.with_complete_core_snapshot(|publication| {
                 let freshness = self
                     .controller
                     .index_freshness_uncached(FreshnessObservationPolicy::ObserveSourceRoot)?;
-                if !index_freshness_admits_operation(&freshness)
-                    && !self.retained_core_allows(operation, publication)
-                {
-                    return Err(ApiError::new(
-                        "project_unavailable",
-                        index_freshness_block_message(operation, &freshness),
-                    ));
+                if !index_freshness_admits_operation(&freshness) {
+                    codestory_workspace::invalidate_lease_memoized_values();
+                    if !self.retained_core_allows(operation, publication) {
+                        return Err(ApiError::new(
+                            "project_unavailable",
+                            index_freshness_block_message(operation, &freshness),
+                        ));
+                    }
                 }
                 let mut run = || {
                     if cancelled.load(Ordering::Acquire) {
@@ -1865,13 +1902,14 @@ impl PublicOperationService {
                     let after = self.controller.index_freshness_reverified(
                         FreshnessObservationPolicy::ObserveSourceRoot,
                     )?;
-                    if !index_freshness_admits_operation(&after)
-                        && !self.retained_core_allows(operation, publication)
-                    {
-                        return Err(ApiError::new(
-                            "publication_changed",
-                            format!("source inputs changed while running {operation}"),
-                        ));
+                    if !index_freshness_admits_operation(&after) {
+                        codestory_workspace::invalidate_lease_memoized_values();
+                        if !self.retained_core_allows(operation, publication) {
+                            return Err(ApiError::new(
+                                "publication_changed",
+                                format!("source inputs changed while running {operation}"),
+                            ));
+                        }
                     }
                     Ok(value)
                 };
@@ -1930,10 +1968,9 @@ impl PublicOperationService {
             "resource-{}",
             self.next_id.fetch_add(1, Ordering::Relaxed) + 1
         );
-        // Observational operations derive freshness through the same helpers;
-        // scope them the same way so an observational wrapper around a public
-        // one cannot reintroduce a second content pass.
-        let _source_freshness_scope = codestory_workspace::SourceFreshnessScope::enter();
+        // Observational operations borrow the same ready-lease memo so a nested
+        // wrapper cannot reintroduce a content or readiness pass.
+        let _source_freshness_scope = self.source_freshness_scope();
         for attempt in 1..=2 {
             let result = self.controller.with_complete_core_snapshot(|publication| {
                 if cancelled.load(Ordering::Acquire) {
@@ -2836,6 +2873,7 @@ mod activation_tests {
             core_publication: core_publication.clone(),
             retrieval,
             source: ReadySourceIdentity::from(&source_freshness),
+            source_freshness_memo: codestory_workspace::SourceFreshnessMemo::default(),
             source_observer: Some(source_observer),
         };
         assert!(lease.source.is_admissible_snapshot());
@@ -3051,10 +3089,10 @@ mod activation_tests {
         );
     }
 
-    /// The memo is scoped to the operation, never to the process: the next
-    /// operation re-reads content rather than trusting the previous verdict.
+    /// A second operation on one ready lease begins from the clean verdicts
+    /// re-established by the first operation's post-build guard.
     #[test]
-    fn the_next_public_operation_reverifies_source_content() {
+    fn the_next_public_operation_reuses_the_ready_lease_verdicts() {
         let fixture = ready_activation_fixture();
         let service = fixture.runtime.public_operation_service();
         let mut first = None;
@@ -3075,11 +3113,11 @@ mod activation_tests {
         let first = first.expect("first scope");
         let second = second.expect("second scope");
         assert!(first.content_hash_reads > 0);
+        assert_eq!(second.content_hash_reads, 0);
         assert_eq!(
-            second.content_hash_reads, first.content_hash_reads,
-            "a new operation must hash the same files again instead of inheriting verdicts"
+            second.verdict_reuses, first.content_hash_reads,
+            "the second operation must reuse the verdicts left by the first post-build guard"
         );
-        assert_eq!(second.verdict_reuses, 0);
         assert_eq!(
             codestory_workspace::source_freshness_counts(),
             None,
@@ -3105,13 +3143,11 @@ mod activation_tests {
     /// runs a public operation, pins retrieval, and builds a packet through the
     /// orchestrator — and then reads the wire field the orchestrator populated,
     /// instead of asserting on a hand-built DTO or on the counter helper. It
-    /// also pins what the pin short-circuit buys: the MCP transport wraps a
-    /// packet request in a *second* public operation, and that wrapper must
-    /// borrow the operation's existing retrieval pin rather than begin a new
-    /// one. Beginning a second pin would re-run strict readiness, so the
-    /// wrapped packet's published pass count must equal the unwrapped one's.
+    /// The first packet on a ready lease performs exactly one fingerprint pass.
+    /// A later wrapper on that same lease reuses the opaque fingerprint, while
+    /// replacing the lease memo forces exactly one new pass.
     #[test]
-    fn a_warm_packet_publishes_its_readiness_cost_and_a_wrapper_adds_no_pass() {
+    fn a_warm_packet_performs_one_fingerprint_pass_per_ready_lease() {
         let fixture = ready_activation_fixture();
         let browser = fixture.runtime.browser_service();
 
@@ -3123,9 +3159,9 @@ mod activation_tests {
             .retrieval_trace
             .source_freshness_telemetry
             .expect("a packet built inside a public operation publishes its pass counters");
-        assert!(
-            flat_telemetry.readiness_fingerprint_passes > 0,
-            "a strict retrieval packet pays at least one whole-repository readiness pass"
+        assert_eq!(
+            flat_telemetry.readiness_fingerprint_passes, 1,
+            "the first strict packet on a ready lease must perform exactly one fingerprint pass"
         );
         assert!(
             flat_telemetry.content_hash_reads > 0,
@@ -3149,11 +3185,35 @@ mod activation_tests {
             .expect("the wrapped packet publishes its pass counters too");
 
         assert_eq!(
-            wrapped_telemetry.readiness_fingerprint_passes,
-            flat_telemetry.readiness_fingerprint_passes,
-            "wrapping a packet request in a second public operation must borrow \
-             the outer retrieval pin; beginning a second pin would buy another \
-             whole-repository readiness pass"
+            wrapped_telemetry.readiness_fingerprint_passes, 0,
+            "a later operation on the same ready lease must reuse its fingerprint"
+        );
+
+        {
+            let activation = fixture.runtime.activation_service();
+            let mut state = activation
+                .coordinator
+                .state
+                .lock()
+                .expect("activation coordinator");
+            state
+                .ready_lease
+                .as_mut()
+                .expect("ready lease")
+                .source_freshness_memo = codestory_workspace::SourceFreshnessMemo::default();
+        }
+        let next_lease = browser
+            .packet(warm_packet_request())
+            .expect("a warm packet on the replacement lease memo");
+        assert_eq!(
+            next_lease
+                .answer
+                .retrieval_trace
+                .source_freshness_telemetry
+                .expect("the replacement lease packet publishes counters")
+                .readiness_fingerprint_passes,
+            1,
+            "a new ready lease must compute its own fingerprint"
         );
     }
 

--- a/crates/codestory-workspace/src/lib.rs
+++ b/crates/codestory-workspace/src/lib.rs
@@ -33,8 +33,10 @@ pub mod owned_deletion;
 pub mod paths;
 pub mod source_freshness;
 pub use source_freshness::{
-    SourceFreshnessCounts, SourceFreshnessScope, record_readiness_fingerprint_pass,
+    SourceFreshnessCounts, SourceFreshnessMemo, SourceFreshnessScope,
+    invalidate_lease_memoized_values, record_readiness_fingerprint_pass,
     reverify_from_content as reverify_source_freshness_from_content, source_freshness_counts,
+    with_lease_memoized_value,
 };
 mod repo_metadata;
 mod repository_hooks;
@@ -1732,6 +1734,8 @@ fn read_content_identity(path: &Path) -> Result<ContentIdentity> {
         }
         hasher.update(&buffer[..read]);
     }
+    #[cfg(test)]
+    run_torn_read_mutation_for_test(path)?;
     let after = file.metadata()?;
     if before.len() != after.len() || before.modified()? != after.modified()? {
         bail!("source metadata changed while hashing {}", path.display());
@@ -1740,6 +1744,31 @@ fn read_content_identity(path: &Path) -> Result<ContentIdentity> {
         content_hash: format!("{:x}", hasher.finalize()),
         len: before.len(),
         modified_ms: clamp_system_time_to_epoch_millis(before.modified()?),
+    })
+}
+
+#[cfg(test)]
+thread_local! {
+    static TORN_READ_MUTATION: std::cell::RefCell<Option<(PathBuf, Vec<u8>)>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+#[cfg(test)]
+fn arm_torn_read_mutation_for_test(path: PathBuf, contents: Vec<u8>) {
+    TORN_READ_MUTATION.with(|mutation| mutation.replace(Some((path, contents))));
+}
+
+#[cfg(test)]
+fn run_torn_read_mutation_for_test(path: &Path) -> Result<()> {
+    TORN_READ_MUTATION.with(|mutation| {
+        let Some((target, contents)) = mutation.borrow_mut().take() else {
+            return Ok(());
+        };
+        if target != path {
+            mutation.replace(Some((target, contents)));
+            return Ok(());
+        }
+        fs::write(path, contents).map_err(Into::into)
     })
 }
 
@@ -3004,10 +3033,11 @@ mod tests {
         Ok(())
     }
 
-    /// The memo must not survive the operation that produced it: the next
-    /// operation re-verifies from content.
+    /// Replacement for the pre-change operation-lifetime oracle: a ready
+    /// lease carries the verdict across scopes, while a new lease starts with
+    /// no observations and re-verifies from content.
     #[test]
-    fn a_new_scope_reverifies_content_instead_of_reusing_the_previous_verdict() -> Result<()> {
+    fn a_ready_lease_reuses_verdicts_and_a_new_lease_reverifies_content() -> Result<()> {
         let temp = tempdir()?;
         let root = temp.path().join("repo");
         fs::create_dir_all(&root)?;
@@ -3016,8 +3046,9 @@ mod tests {
         let inputs = indexed_inputs_for(std::slice::from_ref(&file))?;
         let manifest = WorkspaceManifest::open(root)?;
 
+        let first_lease = SourceFreshnessMemo::default();
         {
-            let _first = SourceFreshnessScope::enter();
+            let _first = SourceFreshnessScope::enter_with_memo(first_lease.clone());
             WorkspaceDiscovery.build_refresh_plan(&manifest, &inputs)?;
             assert_eq!(
                 source_freshness_counts()
@@ -3027,12 +3058,22 @@ mod tests {
             );
         }
         {
-            let _second = SourceFreshnessScope::enter();
+            let _same_lease = SourceFreshnessScope::enter_with_memo(first_lease);
+            WorkspaceDiscovery.build_refresh_plan(&manifest, &inputs)?;
+            let counts = source_freshness_counts().expect("armed scope");
+            assert_eq!(
+                counts.content_hash_reads, 0,
+                "the same ready lease must not hash the file again"
+            );
+            assert_eq!(counts.verdict_reuses, 1);
+        }
+        {
+            let _new_lease = SourceFreshnessScope::enter_with_memo(SourceFreshnessMemo::default());
             WorkspaceDiscovery.build_refresh_plan(&manifest, &inputs)?;
             let counts = source_freshness_counts().expect("armed scope");
             assert_eq!(
                 counts.content_hash_reads, 1,
-                "a new operation must hash the file again"
+                "a new ready lease must hash the file again"
             );
             assert_eq!(counts.verdict_reuses, 0);
         }
@@ -3118,6 +3159,51 @@ mod tests {
             vec![file],
             "reverification must re-read content, which is the only thing that \
              sees same-mtime same-length drift"
+        );
+        Ok(())
+    }
+
+    /// Oracle for the torn-read guard: a write between the content read and
+    /// the closing metadata sample refuses the observation and must not leave
+    /// a reusable verdict behind.
+    #[test]
+    fn a_torn_read_is_refused_and_not_memoized() -> Result<()> {
+        let temp = tempdir()?;
+        let root = temp.path().join("repo");
+        fs::create_dir_all(&root)?;
+        let file = root.join("main.rs");
+        fs::write(&file, "fn main() {}\n")?;
+        let inputs = indexed_inputs_for(std::slice::from_ref(&file))?;
+        let manifest = WorkspaceManifest::open(root)?;
+        let original_mtime = fs::metadata(&file)?.modified()?;
+
+        let _scope = SourceFreshnessScope::enter();
+        arm_torn_read_mutation_for_test(
+            file.clone(),
+            b"fn main() { let write_raced_the_reader = true; }\n".to_vec(),
+        );
+        let refused = WorkspaceDiscovery.build_refresh_plan(&manifest, &inputs)?;
+        assert_eq!(refused.files_to_index, vec![file.clone()]);
+        assert_eq!(
+            source_freshness_counts().expect("armed scope"),
+            SourceFreshnessCounts {
+                content_hash_reads: 1,
+                verdict_reuses: 0,
+                readiness_fingerprint_passes: 0,
+            },
+            "the raced read must be counted but must not publish a reusable verdict"
+        );
+
+        fs::write(&file, "fn maim() {}\n")?;
+        fs::File::open(&file)?.set_modified(original_mtime)?;
+        let retried = WorkspaceDiscovery.build_refresh_plan(&manifest, &inputs)?;
+        assert_eq!(retried.files_to_index, vec![file]);
+        assert_eq!(
+            source_freshness_counts()
+                .expect("armed scope")
+                .content_hash_reads,
+            2,
+            "the next derivation must read content again after a torn read"
         );
         Ok(())
     }

--- a/crates/codestory-workspace/src/source_freshness.rs
+++ b/crates/codestory-workspace/src/source_freshness.rs
@@ -1,4 +1,4 @@
-//! Operation-scoped memo for stored-file freshness verdicts.
+//! Ready-lease-scoped memo for stored-file freshness verdicts.
 //!
 //! Refresh planning verifies a stored file by hashing its content whenever the
 //! observed mtime still matches the stored mtime — the hash *is* the
@@ -9,9 +9,10 @@
 //! public operation, and strict retrieval readiness builds its own execution
 //! plan. Each of those passes re-hashes every unchanged file.
 //!
-//! This memo keeps the hash as the verdict and caches the *verdict* for the
-//! duration of one armed scope. The key carries everything that could change
-//! the answer:
+//! This memo keeps the hash as the verdict and caches the *verdict* for one
+//! runtime ready lease. An armed scope selects that lease and owns only the
+//! per-operation counters. The key carries everything that could change the
+//! answer:
 //!
 //! * the absolute path,
 //! * the observed modification time the verdict was taken at,
@@ -27,8 +28,8 @@
 //!    torn-read guard *and* the metadata it observed still agrees with the
 //!    metadata the key was built from. A read that raced a writer records
 //!    nothing.
-//! 2. The memo is inert unless a scope is armed. Every caller that has not
-//!    opted in behaves exactly as it did before this module existed.
+//! 2. Lease reuse is inert unless a caller arms a lease-owned memo. Cold callers
+//!    get a fresh private memo and behave exactly as before.
 //! 3. A memoized verdict describes one instant. Any check whose whole job is
 //!    to detect drift that happened *since* a previous derivation must call
 //!    [`reverify_from_content`] first, which drops every recorded verdict so
@@ -38,9 +39,11 @@
 //!    that answered it would make the operation serve a source it never
 //!    re-read.
 
+use std::any::Any;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 
 /// Upper bound on memoized verdicts inside one scope.
 ///
@@ -58,10 +61,39 @@ struct VerdictKey {
     stored_content_hash: String,
 }
 
+#[derive(Default)]
+struct MemoState {
+    verdicts: Mutex<HashMap<VerdictKey, bool>>,
+    opaque_values: Mutex<HashMap<&'static str, Box<dyn Any + Send + Sync>>>,
+}
+
+/// Reusable source/readiness observations owned by one runtime ready lease.
+#[derive(Clone, Default)]
+pub struct SourceFreshnessMemo {
+    state: Arc<MemoState>,
+}
+
+impl std::fmt::Debug for SourceFreshnessMemo {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("SourceFreshnessMemo")
+            .finish_non_exhaustive()
+    }
+}
+
+impl PartialEq for SourceFreshnessMemo {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.state, &other.state)
+    }
+}
+
+impl Eq for SourceFreshnessMemo {}
+
 #[derive(Debug, Default)]
 struct ScopeState {
     depth: u32,
-    verdicts: HashMap<VerdictKey, bool>,
+    memo: Option<SourceFreshnessMemo>,
+    lease_owned: bool,
     content_hash_reads: u64,
     verdict_reuses: u64,
     readiness_fingerprint_passes: u64,
@@ -82,16 +114,16 @@ pub struct SourceFreshnessCounts {
     /// Strict-readiness fingerprint passes — each one reads the repository's
     /// lexical source live off disk and streams the projection tables. This
     /// counter exists because that cost was previously invisible; it is a
-    /// measurement, not a bound. A warm packet currently pays several, and
-    /// reducing the count is tracked separately from publishing it.
+    /// measurement, not a bound. The first warm packet on a ready lease pays
+    /// exactly one and later operations on that lease reuse it.
     pub readiness_fingerprint_passes: u64,
 }
 
-/// Arm the operation-scoped freshness memo for as long as the guard lives.
+/// Arm a fresh, non-lease memo for as long as the guard lives.
 ///
-/// Scopes nest: a second `enter` inside an armed scope shares the outer memo
-/// and counters, and only the outermost guard clears them. That is what makes
-/// the doubly wrapped MCP request path hash a file once instead of twice.
+/// Scopes nest: a second `enter` inside an armed scope shares the outer memo and
+/// counters. Runtime callers use [`SourceFreshnessScope::enter_with_memo`] to
+/// retain observations for the lifetime of an admitted ready lease.
 #[derive(Debug)]
 pub struct SourceFreshnessScope {
     /// The guard is thread-bound: the memo lives in a thread local, so moving
@@ -101,10 +133,20 @@ pub struct SourceFreshnessScope {
 
 impl SourceFreshnessScope {
     pub fn enter() -> Self {
+        Self::enter_inner(SourceFreshnessMemo::default(), false)
+    }
+
+    /// Arm observations owned by one already-admitted runtime ready lease.
+    pub fn enter_with_memo(memo: SourceFreshnessMemo) -> Self {
+        Self::enter_inner(memo, true)
+    }
+
+    fn enter_inner(memo: SourceFreshnessMemo, lease_owned: bool) -> Self {
         SCOPE.with(|scope| {
             let mut scope = scope.borrow_mut();
             if scope.depth == 0 {
-                scope.verdicts.clear();
+                scope.memo = Some(memo);
+                scope.lease_owned = lease_owned;
                 scope.content_hash_reads = 0;
                 scope.verdict_reuses = 0;
                 scope.readiness_fingerprint_passes = 0;
@@ -123,7 +165,8 @@ impl Drop for SourceFreshnessScope {
             let mut scope = scope.borrow_mut();
             scope.depth = scope.depth.saturating_sub(1);
             if scope.depth == 0 {
-                scope.verdicts.clear();
+                scope.memo = None;
+                scope.lease_owned = false;
             }
         });
     }
@@ -170,13 +213,65 @@ pub fn record_readiness_fingerprint_pass() {
 ///
 /// Inert with no scope armed, like the rest of this module.
 pub fn reverify_from_content() {
+    if let Some(memo) = active_memo() {
+        memo.state
+            .verdicts
+            .lock()
+            .expect("source freshness memo poisoned")
+            .clear();
+    }
+}
+
+/// Invalidate lease-scoped opaque observations after a freshness refusal.
+pub fn invalidate_lease_memoized_values() {
+    if let Some(memo) = active_lease_memo() {
+        memo.state
+            .opaque_values
+            .lock()
+            .expect("source freshness memo poisoned")
+            .clear();
+    }
+}
+
+/// Reuse or initialize one opaque value produced by a lower layer inside the
+/// active lease. Initialization is serialized so concurrent operations cannot
+/// both pay for the same lease-scoped observation.
+pub fn with_lease_memoized_value<T, E>(
+    key: &'static str,
+    use_or_initialize: impl FnOnce(Option<&T>) -> Result<T, E>,
+) -> Option<Result<T, E>>
+where
+    T: Clone + Send + Sync + 'static,
+{
+    let memo = active_lease_memo()?;
+    let mut values = memo
+        .state
+        .opaque_values
+        .lock()
+        .expect("source freshness memo poisoned");
+    let precomputed = values.get(key).and_then(|value| value.downcast_ref::<T>());
+    let value = match use_or_initialize(precomputed) {
+        Ok(value) => value,
+        Err(error) => return Some(Err(error)),
+    };
+    values.insert(key, Box::new(value.clone()));
+    Some(Ok(value))
+}
+
+fn active_memo() -> Option<SourceFreshnessMemo> {
     SCOPE.with(|scope| {
-        let mut scope = scope.borrow_mut();
-        if scope.depth == 0 {
-            return;
-        }
-        scope.verdicts.clear();
-    });
+        let scope = scope.borrow();
+        (scope.depth > 0).then(|| scope.memo.clone()).flatten()
+    })
+}
+
+fn active_lease_memo() -> Option<SourceFreshnessMemo> {
+    SCOPE.with(|scope| {
+        let scope = scope.borrow();
+        (scope.depth > 0 && scope.lease_owned)
+            .then(|| scope.memo.clone())
+            .flatten()
+    })
 }
 
 /// Look up a memoized verdict, counting the reuse when one is found.
@@ -186,23 +281,27 @@ pub(crate) fn memoized_verdict(
     len: u64,
     stored_content_hash: &str,
 ) -> Option<bool> {
-    SCOPE.with(|scope| {
-        let mut scope = scope.borrow_mut();
-        if scope.depth == 0 {
-            return None;
-        }
-        let key = VerdictKey {
-            path: path.to_path_buf(),
-            modified_ms,
-            len,
-            stored_content_hash: stored_content_hash.to_string(),
-        };
-        let verdict = scope.verdicts.get(&key).copied();
-        if verdict.is_some() {
+    let key = VerdictKey {
+        path: path.to_path_buf(),
+        modified_ms,
+        len,
+        stored_content_hash: stored_content_hash.to_string(),
+    };
+    let verdict = active_memo().and_then(|memo| {
+        memo.state
+            .verdicts
+            .lock()
+            .expect("source freshness memo poisoned")
+            .get(&key)
+            .copied()
+    });
+    if verdict.is_some() {
+        SCOPE.with(|scope| {
+            let mut scope = scope.borrow_mut();
             scope.verdict_reuses = scope.verdict_reuses.saturating_add(1);
-        }
-        verdict
-    })
+        });
+    }
+    verdict
 }
 
 /// Record that a stored file's content was read and hashed for a verdict.
@@ -224,12 +323,16 @@ pub(crate) fn record_verdict(
     stored_content_hash: &str,
     verdict: bool,
 ) {
-    SCOPE.with(|scope| {
-        let mut scope = scope.borrow_mut();
-        if scope.depth == 0 || scope.verdicts.len() >= SOURCE_FRESHNESS_MEMO_MAX_ENTRIES {
-            return;
-        }
-        scope.verdicts.insert(
+    let Some(memo) = active_memo() else {
+        return;
+    };
+    let mut verdicts = memo
+        .state
+        .verdicts
+        .lock()
+        .expect("source freshness memo poisoned");
+    if verdicts.len() < SOURCE_FRESHNESS_MEMO_MAX_ENTRIES {
+        verdicts.insert(
             VerdictKey {
                 path: path.to_path_buf(),
                 modified_ms,
@@ -238,7 +341,7 @@ pub(crate) fn record_verdict(
             },
             verdict,
         );
-    });
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Context

READY-Bb, the W3.3 remainder of #1700 declared by PR #1779. The source-freshness memo was operation-scoped while the readiness authority is the `ReadyLease`; consequence, recorded in `dto.rs`, was a warm packet paying SIX whole-repository readiness fingerprint passes with an explicit "unproven until enforced" note.

Closes #1845
Refs #1700
Refs #1179

## What changed

- `source_freshness.rs`: the verdict memo becomes an `Arc`-shared `SourceFreshnessMemo` a runtime ReadyLease can own (`enter_with_memo`); plain `enter()` keeps the exact prior per-operation semantics (fresh private memo, inert at depth 0). `reverify_from_content` still drops every verdict, so drift checks answer from disk. New lease-scoped opaque-value surface (`with_lease_memoized_value`, `invalidate_lease_memoized_values`) with invalidation wired to freshness refusals.
- `services.rs`: the activation service arms the lease-owned memo per target; freshness refusals invalidate lease-scoped observations at both the admission check and the post-build reverified check.
- `index.rs` (retrieval): `compute_sidecar_input_fingerprint` reuses a lease-memoized fingerprint keyed on the full identity tuple; the computing path is unchanged and retrieval learns nothing about leases — it consumes the opaque-value surface workspace exports.
- `retrieval_primary.rs`: active retrieval pins bypass the five redundant readiness gates (minimal, local diff; `CachedCanonicalSymbolNames` untouched).
- `dto.rs`: the pass-count note now states the enforced truth.

## Verification

Passed on `3046aba9`:

- One-pass enforcement: first warm packet = 1 fingerprint pass, same lease = 0, replacement lease = 1; a temporary mutation disabling the precomputed handoff failed the test with `left: 2, right: 1` and was reverted.
- Oracles: same-mtime/same-length drift detection, deterministic torn-read refusal, same-lease reuse / new-lease recomputation — all pinned and green.
- Host suites: `codestory-workspace` green, `codestory-retrieval --lib` 292 passed, `codestory-runtime --lib` 1088 passed with exactly one failure — `incremental_publication_ignores_changed_files_without_graph_collectors`, which fails identically at the base `383ed738` on macOS (bisect-verified with the full diff stashed); it is pre-existing and environment-local, tracked separately.
- Three-crate clippy `-D warnings`, `cargo fmt --check`, `git diff --check` all pass.

Independent fresh-context adversarial review on the exact head is running; draft until it accepts and CI is green.
