### PR TITLE
[v0.17 EV-4b] Version the 0.60 Ripgrep release-evidence contract

### DIFF
--- a/benchmarks/release-evidence/corpus-contracts/v0.17-ripgrep-rust-v2.json
+++ b/benchmarks/release-evidence/corpus-contracts/v0.17-ripgrep-rust-v2.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 1,
+  "corpus_id": "codestory-release-corpus-v0.17-ripgrep-rust-v2",
+  "task_ids": [
+    "ripgrep-search-pipeline-v2"
+  ],
+  "runtime_modes": [
+    "cold_cli_packet"
+  ],
+  "repeats": 3,
+  "task_manifests": {
+    "ripgrep-search-pipeline-v2": {
+      "path": "benchmarks/tasks/release-evidence/ripgrep-search-pipeline-v2.task.json",
+      "sha256": "91005e5380edcbf18fc93aa78a79bcba9bd470ad8edfbcbffe9579e3b490bc4e"
+    }
+  },
+  "project_manifests": {
+    "ripgrep-search-pipeline-v2": {
+      "path": "benchmarks/tasks/release-evidence/ripgrep-rust-codestory-project-v2.json",
+      "sha256": "58ddc0a740af06f99e00c51beb1b7331445a1c63f432251a7b0fb7d753db8962"
+    }
+  }
+}

--- a/benchmarks/tasks/release-evidence/ripgrep-rust-codestory-project-v2.json
+++ b/benchmarks/tasks/release-evidence/ripgrep-rust-codestory-project-v2.json
@@ -1,0 +1,21 @@
+{
+  "name": "ripgrep-release-evidence-rust-v2",
+  "version": 1,
+  "source_groups": [
+    {
+      "id": "9bf47d5a-7838-5f8d-b7ae-4a2cf12d14e6",
+      "language": "Rust",
+      "standard": "Default",
+      "source_paths": [
+        "."
+      ],
+      "exclude_patterns": [
+        "**/.git/**",
+        "**/target/**"
+      ],
+      "include_paths": [],
+      "defines": {},
+      "language_specific": "Other"
+    }
+  ]
+}

--- a/benchmarks/tasks/release-evidence/ripgrep-search-pipeline-v2.task.json
+++ b/benchmarks/tasks/release-evidence/ripgrep-search-pipeline-v2.task.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "../manifest.schema.json",
+  "id": "ripgrep-search-pipeline-v2",
+  "version": 2,
+  "suite": "release-evidence",
+  "task_class": "architecture_explanation",
+  "repo": {
+    "name": "ripgrep",
+    "url": "https://github.com/BurntSushi/ripgrep.git",
+    "ref": "e50df40a1967708b9781486b1c017e48040bceb0",
+    "workspace_root": ".",
+    "languages": [
+      "Rust"
+    ],
+    "setup": [
+      "No dependency setup is required for read-only benchmark inspection."
+    ],
+    "codestory_project_manifest": {
+      "path": "ripgrep-rust-codestory-project-v2.json",
+      "sha256": "58ddc0a740af06f99e00c51beb1b7331445a1c63f432251a7b0fb7d753db8962"
+    }
+  },
+  "prompt": "Explain how ripgrep parses CLI flags, walks candidate files, and executes a search over each haystack through matcher, searcher, and printer components. Cite the source files that support the path.",
+  "expected_files": [
+    "crates/core/main.rs",
+    "crates/core/flags/mod.rs",
+    "crates/core/flags/hiargs.rs",
+    "crates/core/haystack.rs",
+    "crates/core/search.rs"
+  ],
+  "expected_symbols": [
+    {
+      "name": "main",
+      "path": "crates/core/main.rs",
+      "kind": "function",
+      "why": "CLI entry point that delegates into the search driver."
+    },
+    {
+      "name": "run",
+      "path": "crates/core/main.rs",
+      "kind": "function",
+      "why": "Selects search, files, types, or generate modes after flag parsing."
+    },
+    {
+      "name": "search",
+      "path": "crates/core/main.rs",
+      "kind": "function",
+      "why": "Single-threaded directory walk and per-file search loop."
+    },
+    {
+      "name": "SearchWorker",
+      "path": "crates/core/search.rs",
+      "kind": "struct",
+      "why": "Coordinates matcher, searcher, and printer for each haystack."
+    },
+    {
+      "name": "SearchWorker::search",
+      "path": "crates/core/search.rs",
+      "kind": "method",
+      "why": "Executes one haystack search including preprocessors and decompression."
+    }
+  ],
+  "expected_claims": [
+    {
+      "text": "main calls run after flags::parse and routes into search or parallel search modes."
+    },
+    {
+      "text": "HiArgs builds walkers, matchers, searchers, and printers used by the search driver."
+    },
+    {
+      "text": "search walks haystacks from the ignore crate and invokes SearchWorker per file."
+    },
+    {
+      "text": "SearchWorker connects a PatternMatcher, grep searcher, and Printer for each haystack."
+    },
+    {
+      "text": "search_parallel uses walk_builder().build_parallel() to search files concurrently."
+    }
+  ],
+  "forbidden_claims": [
+    {
+      "text": "ripgrep searches files without building haystacks from the directory walker.",
+      "severity": "critical"
+    },
+    {
+      "text": "Flag parsing happens inside SearchWorker instead of before run selects a mode.",
+      "severity": "major"
+    }
+  ],
+  "quality_thresholds": {
+    "min_expected_anchor_recall": 0.7,
+    "min_expected_file_recall": 0.6,
+    "min_expected_symbol_recall": 0.65,
+    "min_expected_claim_recall": 0.75,
+    "min_citation_coverage": 0.6,
+    "max_forbidden_claims": 0
+  },
+  "tags": [
+    "release-evidence",
+    "rust",
+    "search",
+    "generalization"
+  ],
+  "notes": [
+    "Versioned v0.17 release-only evidence task. Do not add it to the general holdout suite or tune product behavior against it."
+  ]
+}

--- a/docs/contributors/release-evidence-runner.md
+++ b/docs/contributors/release-evidence-runner.md
@@ -1,241 +1,50 @@
-# Release-evidence runner
+# Release-evidence quality contract
 
-CodeStory release-candidate measurements run on one repository-scoped Linux
-runner so baseline identity, cache state, model bytes, and toolchain remain
-stable between candidates. Ordinary pull requests must not target this runner.
+The v0.17 release-evidence packet-quality contract targets the protected macOS
+Metal and Windows quality lanes. The current workflow still selects the v0.16
+Axios contract; EV-4c owns moving that producer to this contract. The Linux
+ARM64 Colima guest host was retired from live lanes in H-1 (PR #1849), so it is
+no longer a measurement authority. Its in-tree harness remains until EV-4c.
 
-## v0.16 corpus boundary
+## v0.17 Ripgrep corpus boundary
 
-The v0.16 measurement workflow uses
-`codestory-release-corpus-v0.16-axios-js-ts-v2`: one release-only Axios
-JavaScript/TypeScript task with three cold CLI packet repeats. Its deterministic
-CodeStory project manifest schedules `index.js` and `lib/` as JavaScript plus
-`index.d.ts` and `index.d.cts` as TypeScript. That source boundary excludes
-Axios's JSON-with-comments compiler fixtures structurally; production parsing
-and malformed-source policy are unchanged. The checked corpus contract binds
-the exact task and project-manifest bytes and rejects missing, changed, escaped,
-substituted, extra, or task-inconsistent declarations. Ripgrep's pinned Rust
-task and project template remain available for follow-up diagnostics, but a
-retained three-repeat run
-did not meet its preregistered file and citation recall thresholds, so v0.16
-makes no Ripgrep or general Rust packet-quality claim. Redis/C, shell dialects,
-and general parser completeness are also outside this release-evidence claim.
-The retained v1 task, corpus contract, raw evidence, and approved baseline stay
-unchanged. The first protected v2 run may establish the three raw Axios rows,
-but it cannot become release evidence until those exact bytes receive a separate
-approved, release-eligible baseline. The evaluator therefore fails closed while
-the approved profile still names v1; it cannot silently widen, narrow, or
-replace that scope.
+`codestory-release-corpus-v0.17-ripgrep-rust-v2` defines one release-only
+Ripgrep Rust task, `ripgrep-search-pipeline-v2`, with three deterministic cold
+CLI packet repeats. Its task and CodeStory project manifests are bound by
+SHA-256 in
+`benchmarks/release-evidence/corpus-contracts/v0.17-ripgrep-rust-v2.json`.
+The gate rejects a missing, changed, substituted, escaped, extra, or
+task-inconsistent declaration.
 
-Cold CLI packet provenance is taken from the packet process that actually ran.
-It binds the packet's executed semantic stage, full sidecar diagnostics, and
-zero semantic fallback to the exact semantic generation prepared by the
-harness. A later status process cannot supply the earlier process-local
-embedding-engine instance identity; warm-process evidence still requires that
-live identity directly.
+The retained run `29624645979` measured every Ripgrep repeat at file recall
+and citation coverage of `0.60`, symbol recall `0.80`, claim recall `1.0`,
+anchor recall `0.80`, and zero forbidden claims. The v0.17 contract therefore
+pins the D2-corrected `0.60` file-recall and citation-coverage floors; it keeps
+the existing `0.65` symbol, `0.75` claim, `0.70` anchor, and zero-forbidden
+claim floors. The protected macOS Metal and Windows quality lanes will supply
+the current-host proof when EV-4c wires this contract. It makes a scoped
+Ripgrep packet-quality claim only; it does not establish a general Rust,
+parser-completeness, or answer-accuracy claim.
 
-## Machine contract
+The v0.16 Axios contracts and their approved baselines remain frozen. The
+holdout `ripgrep-search-pipeline.task.json` is separate and must remain
+byte-identical; release-only work uses the v2 manifest.
 
-The approved host shape for the 0.16 per-user embedding-server retrieval
-baseline is:
+## Retired Linux ARM64 host and retained harness
 
-| Field | Value |
-| --- | --- |
-| GitHub runner | `codestory-release-evidence-m5-colima-arm64` |
-| Required labels | `self-hosted`, `Linux`, `ARM64`, `codestory-release-evidence` |
-| Physical host | `Mac17,4`, Apple M5, 24 GiB, macOS 26.5.2 |
-| VM | Colima VZ profile `codestory-release-evidence`, Ubuntu 24.04 ARM64 |
-| Colima | 0.10.3 |
-| Capacity | 4 vCPU, 8 GiB maximum memory, 80 GiB data disk |
-| Host mounts | none; the runner cannot see or write `/Users` or the macOS home directory |
-| Guest container runtime | containerd from the checksum-pinned Colima image; foreign-architecture emulation is disabled and the host context is never activated |
-| Stable profile ID | `codestory-release-evidence-linux-arm64-v2` |
-| Machine contract | `scripts/release-evidence/machine-contract.json` |
-| Runner volume | `/srv/codestory-release-evidence` |
-| Drill manifest | `/srv/codestory-release-evidence/drills/real-repo-drill-cases.json` |
-| Drill project manifest | `scripts/release-evidence/serde-json-codestory-project.json` |
+The `codestory-release-evidence-linux-arm64-v2` machine contract, guest
+provisioning scripts, and Colima runner lifecycle remain in tree so the workflow
+policy checker and its mutation tests continue to exercise their contract. The
+host itself was retired from live lanes in H-1 (PR #1849); do not use it as
+measurement authority or recreate it for new evidence. EV-4c retires the
+harness and policy layer together, alongside the claims-graph and producer
+re-pointing. Until then, the retained profile is historical contract coverage,
+not a runnable release-evidence lane.
 
-The profile ID is a stable comparison key, not evidence about the current
-machine. Provisioning records the observed host, generated Colima VM shape,
-guest boot, native package manifest, and toolchain in one attestation. The
-workflow reruns the guest verifier and derives its fingerprint from the profile
-ID plus the checked-in contract hash. A stale host attestation from another VM
-boot is rejected.
+## Evidence boundary
 
-## Provision and verify
-
-The host needs macOS, Colima, and an authenticated `gh` with repository
-administration access. The proof VM is capped at 8 GiB and should run only for
-an accepted release head. Stop it immediately after collecting the final
-evidence; it is not a development service.
-
-From a clean trusted CodeStory checkout:
-
-```sh
-scripts/codestory-release-evidence-runner.sh provision
-scripts/codestory-release-evidence-runner.sh verify
-```
-
-Provisioning is idempotent. It:
-
-- creates the dedicated VM and service account;
-- disables Colima's default writable host-home mount;
-- leaves the caller's active container context unchanged;
-- verifies the checksum-pinned Colima base image before VM creation;
-- installs native packages from a fixed Ubuntu archive snapshot at exact
-  versions, then records the complete native package manifest;
-- uses the containerd runtime already owned by the checksum-pinned VM image;
-- binds the runner workspace from the dedicated 80 GiB data disk only after
-  Colima reports that disk ready, and verifies the single mount before accepting
-  evidence;
-- verifies checksums before installing Node, Rust, GitHub CLI, and the Actions runner;
-- disables automatic runner updates so baseline changes are deliberate;
-- verifies that the exact candidate contains its checksum-pinned CodeRankEmbed model and
-  linked embedding engine without provisioning either one;
-- prepares a source-backed `serde_json` drill at an exact commit and installs
-  the checksum-bound project manifest that excludes its intentionally malformed
-  compiler UI fixtures from the valid-source corpus;
-- registers the runner only with `TheGreenCedar/CodeStory`; and
-- keeps Cargo, Rust, temp, XDG, CodeStory, drill, work, and artifact state
-  under the proof-owned volume. The Actions service receives a dedicated
-  runner-owned `XDG_RUNTIME_DIR` with mode `0700`; verification rejects a
-  missing, linked, broadly accessible, or differently owned runtime authority.
-
-The runner workspace is mounted by the owned host lifecycle instead of guest
-`fstab`; this avoids boot-order races between the root disk and Colima's data
-disk. The tracked CodeStory source used by provisioning checks is streamed into the
-guest over SSH. It replaces the previous validation tree atomically enough for
-the stopped runner, so untracked or modified validation files cannot survive a
-provisioning pass. No source or tool is executed through a host mount. `verify`
-prints the guest mount table and fails if it finds a host-backed VirtioFS, 9p,
-SSHFS, Lima, osxfs, or gRPC FUSE mount; any `/Users` visibility is also a hard
-failure. The exact candidate under test owns model materialization, digest
-verification, and accelerator selection. Provisioning supplies no model or
-backend asset.
-
-Provisioning first proves that an existing owned runner is idle. It requests a
-GitHub registration token only when the runner is unconfigured, checks the
-exact runner binary version and `.runner` repository/name identity, and leaves
-the systemd service disabled across VM boots. The host `start` command verifies
-and attests the current host and VM before starting the service. Starting the
-Colima profile directly therefore leaves the runner offline. Provision, verify,
-start, and stop all quiesce the exact runner first and confirm that GitHub sees
-it offline and idle before changing validation or proof state.
-
-The GitHub registration and removal tokens are short-lived and passed directly
-to the guest. They are never written to the repository or provisioning
-artifacts. Long-lived runner credentials remain inside the dedicated VM.
-
-## Operate and recover
-
-```sh
-scripts/codestory-release-evidence-runner.sh stop
-scripts/codestory-release-evidence-runner.sh start
-scripts/codestory-release-evidence-runner.sh verify
-```
-
-After a host restart, use the script's `start` command rather than `colima
-start`. Require `verify` to show the runner online, the exact model checksum,
-the clean drill commit, a current-boot
-host attestation, the contract-derived fingerprint, and sufficient guest
-capacity.
-
-When intentionally changing the toolchain, runner, model, VM
-shape, or drill commit, update the pinned constants in the provisioning script
-and create a new approved baseline. Do not compare results across the identity
-change as though they came from the same machine profile.
-
-`stop`, `unregister`, and `destroy` deliberately do not require the pinned host
-OS, Colima version, or a clean checkout. They validate the durable ownership
-marker and exact local and remote runner identity first. `stop` requires GitHub
-access so it cannot stop a runner whose busy state is unknown. If GitHub access
-is unavailable during unregister, the script leaves the runner, credentials,
-ownership marker, and proof-owned VM unchanged. `destroy` removes the VM only
-after GitHub confirms that the runner was deleted or already absent. API
-failures never count as absence, and a busy runner is never reprovisioned,
-stopped, unregistered, or destroyed.
-
-To unregister while preserving the VM and proof artifacts:
-
-```sh
-scripts/codestory-release-evidence-runner.sh unregister
-```
-
-To unregister and delete all proof-owned VM state:
-
-```sh
-scripts/codestory-release-evidence-runner.sh destroy
-```
-
-## Evaluation workflow handoff
-
-`release-candidate-evidence.yml` is an optional performance and answer-quality
-evaluation lane. `packaged-platform-pr.yml` may call it for a selected exact
-head with:
-
-| Input | Value |
-| --- | --- |
-| `profile` | `codestory-release-evidence-linux-arm64-v2` |
-| `drill_manifest` | `/srv/codestory-release-evidence/drills/real-repo-drill-cases.json` |
-| `source_run_id` | empty for measurement; a rejected run ID only for exact-artifact re-evaluation |
-
-An evaluation failure does not block the standard desktop release. The release
-coordinator does not call this workflow, wait for this runner, or consume its
-artifact.
-
-The approval document uses schema v3, but none of the current full-product gate
-metrics is waivable. A model exception is admissible only through separately
-trusted model-microbenchmark evidence: more than 5% regression over at least
-three repeats, exact candidate and baseline hashes, the selected release key,
-passing same-run full-product answer-quality evidence, owner, rationale,
-rollback, and an expiry no more than 14 days after approval. The next release
-key invalidates it sooner. An accepted model exception remains
-`pass_with_exception`; approval never turns a regression into a plain pass.
-
-The reusable workflow remains behind the protected `release-evidence`
-environment gate. PR packaging passes no approval secret. Any separately
-authorized re-evaluation must authenticate the exact retained artifact; it
-does not alter standard release closeout.
-
-The workflow uploads `release-evidence-<full SHA>` from
-`target/release-evidence`, including provisioning, raw stats, packet summary,
-candidate, approval when supplied, and report files that exist. Runner
-provisioning alone does not establish a baseline, execute the real-repo drill,
-or prove a candidate acceptable.
-
-## Closeout handoff
-
-Release-evidence output is not an input to the standard release closeout. Each
-standard producer supplies one
-`codestory.release-cell-manifest/v1` document for its graph-owned cell. The
-manifest carries the claim evidence row plus its workflow, run, attempt and
-artifact identity. Production cells are emitted only on producer success, and
-each immutable Actions artifact name includes its run attempt. The closeout
-coordinator queries artifact and per-attempt job metadata for the current run,
-selects each graph-owned job's latest execution, and requires that execution to
-be successful before binding the container id, digest, creation window and
-unflattened directory to its manifests. A failed newer execution cannot fall
-back to older evidence; jobs absent from a failed-job rerun may retain their
-last successful attempt. Manifests cannot authenticate themselves. Native
-cells also carry the applicable target, concrete
-host, runtime/native engine and calibration identities. The coordinator
-derives the required inventory from `release-claims.json`, so operators must
-not maintain a separate target checklist or combine multiple hosts into one
-manifest.
-
-First evaluate and retain the `pre_publish` ledger. Package rows preserve the
-archive name, byte count and SHA-256 used by publication. After the GitHub
-release exists, run the `post_publish` phase with that accepted ledger; every
-current package row and published download must match its retained manifest and
-archive digests exactly. Producer and runtime versions bind to the closeout
-version, and platform hosts bind to the package matrix target. Keep the per-cell
-manifests and evaluations with both ledgers. A missing, duplicate, expired, failed,
-cross-commit, cross-tree, identity-incomplete or reused row is a rejection, not
-an operator override.
-
-The production pre-publish inventory is ten cells: source, three package
-identities, three accelerator receipts, and three candidate-installed receipts.
-The post-publish inventory is twenty-two after adding platform, installed
-runtime, downloaded-byte proof, and protected-package retrieval readiness for
-all three targets. Performance,
-answer-quality, and their exception documents are outside this closeout.
+Raw packet output must identify the selected corpus contract, exact task and
+project-manifest hashes, cold CLI runtime mode, and exactly three repeats. The
+release-evidence gate checks that binding before evaluating rows. A green local
+contract test or a retained measurement is not a fresh-host qualification;
+packaged, installed, and live behavior proof retain their own evidence tiers.

--- a/docs/testing/performance-review-playbook.md
+++ b/docs/testing/performance-review-playbook.md
@@ -198,10 +198,12 @@ Protected run `29623187686` stopped before measurement after detecting a stale
 retrieval namespace in the harness. Run `29624645979` at
 `dd14e2d0e29b9e09438a0aa4f9a6ea6250e69738` then completed the source and Serde
 gates plus all six cold packet rows. Axios passed all three repeats. Ripgrep
-failed all three at 0.60 file recall and 0.60 citation coverage against the
-fixed 0.70 thresholds, and a later status process could not report the packet
-process's local engine identity. Those failures are retained; they do not
-define a baseline.
+measured 0.60 file recall and 0.60 citation coverage on all three repeats,
+with 0.80 symbol and anchor recall, 1.0 claim recall, and zero forbidden
+claims. Those retained rows define the v0.17 release-only Ripgrep contract's
+D2-corrected 0.60 floors; v0.16 remains Axios-only. A later status process
+could not report the packet process's local engine identity, so the retained
+run does not replace current-host quality-lane proof.
 
 Before another protected measurement, v0.16 is narrowed to the new hash-bound
 `codestory-release-corpus-v0.16-axios-js-ts-v1` contract: exactly the Axios task

--- a/scripts/codestory-release-evidence-gate.mjs
+++ b/scripts/codestory-release-evidence-gate.mjs
@@ -49,6 +49,10 @@ const RELEASE_CORPUS_CONTRACTS = new Map([
     "codestory-release-corpus-v0.16-axios-js-ts-v2",
     "benchmarks/release-evidence/corpus-contracts/v0.16-axios-js-ts-v2.json",
   ],
+  [
+    "codestory-release-corpus-v0.17-ripgrep-rust-v2",
+    "benchmarks/release-evidence/corpus-contracts/v0.17-ripgrep-rust-v2.json",
+  ],
 ]);
 
 function fail(message) { throw new Error(message); }

--- a/scripts/tests/codestory-release-closeout.test.mjs
+++ b/scripts/tests/codestory-release-closeout.test.mjs
@@ -86,7 +86,7 @@ function identityFor(cell, producerRunAttempt = "1") {
           ? "codex_marketplace_install"
           : "managed_plugin";
         break;
-      case "profile": identity[key] = "codestory-release-evidence-linux-arm64-v2"; break;
+      case "profile": identity[key] = "release-evidence-fixture-profile-v1"; break;
       case "corpus_id": identity[key] = "v0.16-axios-js-ts-v1"; break;
       case "cache_id": identity[key] = "cold-full-retrieval-v1"; break;
       case "machine_fingerprint": identity[key] = "fixture/machine"; break;

--- a/scripts/tests/codestory-release-evidence-gate.test.mjs
+++ b/scripts/tests/codestory-release-evidence-gate.test.mjs
@@ -99,6 +99,24 @@ function axiosV2CorpusFixture(mutate) {
   return { dir, paths, contractRelative };
 }
 
+function ripgrepV2CorpusFixture(mutate) {
+  const dir = mkdtempSync(path.join(tmpdir(), "codestory-ripgrep-v2-corpus-"));
+  const taskRelative = "benchmarks/tasks/release-evidence/ripgrep-search-pipeline-v2.task.json";
+  const projectRelative = "benchmarks/tasks/release-evidence/ripgrep-rust-codestory-project-v2.json";
+  const contractRelative = "benchmarks/release-evidence/corpus-contracts/v0.17-ripgrep-rust-v2.json";
+  for (const relative of [taskRelative, projectRelative, contractRelative]) {
+    mkdirSync(path.dirname(path.join(dir, relative)), { recursive: true });
+    copyFileSync(path.join(root, relative), path.join(dir, relative));
+  }
+  const paths = {
+    task: path.join(dir, taskRelative),
+    project: path.join(dir, projectRelative),
+    contract: path.join(dir, contractRelative),
+  };
+  mutate?.(paths);
+  return { dir, paths, contractRelative };
+}
+
 function rewriteJson(filePath, mutate) {
   const document = JSON.parse(readFileSync(filePath));
   mutate(document);
@@ -116,6 +134,8 @@ function rebindTaskHash(paths) {
 function validateAxiosV2Fixture(dir, paths, contractRelative) {
   const contractBytes = readFileSync(paths.contract);
   const contract = JSON.parse(contractBytes);
+  const taskId = contract.task_ids[0];
+  const task = JSON.parse(readFileSync(path.join(dir, contract.task_manifests[taskId].path)));
   const identity = {
     corpus_id: contract.corpus_id,
     cache_id: "cold-inprocess-v1",
@@ -129,12 +149,12 @@ function validateAxiosV2Fixture(dir, paths, contractRelative) {
     runtime_modes: contract.runtime_modes,
     repeats: contract.repeats,
     task_manifests: contract.task_manifests,
-    task_repositories: { "axios-request-dispatch-v2": "axios" },
+    task_repositories: { [taskId]: task.repo.name },
     project_manifests: contract.project_manifests,
   };
   const rows = Array.from({ length: contract.repeats }, (_, index) => ({
-    repo: "axios",
-    task_id: "axios-request-dispatch-v2",
+    repo: task.repo.name,
+    task_id: taskId,
     mode: "cold_cli_packet",
     repeat: index + 1,
   }));
@@ -190,9 +210,36 @@ test("Axios v2 project manifest binding fails closed", async (t) => {
   }
 });
 
+test("Ripgrep v2 corpus binds retained 0.60 floors and fails closed on changed task bytes", async (t) => {
+  const fixture = ripgrepV2CorpusFixture();
+  const task = JSON.parse(readFileSync(fixture.paths.task));
+  assert.deepEqual(task.quality_thresholds, {
+    min_expected_anchor_recall: 0.7,
+    min_expected_file_recall: 0.6,
+    min_expected_symbol_recall: 0.65,
+    min_expected_claim_recall: 0.75,
+    min_citation_coverage: 0.6,
+    max_forbidden_claims: 0,
+  });
+
+  assert.doesNotThrow(validateAxiosV2Fixture(fixture.dir, fixture.paths, fixture.contractRelative));
+
+  await t.test("corrupt task-manifest binding is rejected", () => {
+    const changed = ripgrepV2CorpusFixture(paths => {
+      rewriteJson(paths.contract, contract => {
+        contract.task_manifests["ripgrep-search-pipeline-v2"].sha256 = "0".repeat(64);
+      });
+    });
+    assert.throws(
+      validateAxiosV2Fixture(changed.dir, changed.paths, changed.contractRelative),
+      /release corpus task manifest hash does not match for ripgrep-search-pipeline-v2/,
+    );
+  });
+});
+
 test("fingerprint prefers a validated provisioned machine identity", () => {
   const dir = mkdtempSync(path.join(tmpdir(), "codestory-provisioning-"));
-  const profile = "codestory-release-evidence-linux-arm64-v1";
+  const profile = "release-evidence-fixture-profile-v1";
   const contractSha = "1".repeat(64);
   const observed = { guest: { arch: "aarch64" }, host: { model: "Mac17,4" } };
   const observedSha = createHash("sha256").update(`${JSON.stringify(observed)}\n`).digest("hex");


### PR DESCRIPTION
## Context

EV-4b, the contract half of #1245 after PR #1753. The D2 decision corrected the Ripgrep Rust recall claim to the measured 0.60 floor; until now no release-evidence manifest carried it, the corpus contract pinned only the 0.70 holdout, and the runner docs said v0.16 makes no Ripgrep claim.

Closes #1846
Refs #1245
Refs #1179

## What changed

- New versioned release-evidence manifests: `ripgrep-search-pipeline-v2.task.json` + `ripgrep-rust-codestory-project-v2.json` under `benchmarks/tasks/release-evidence/`, floors `min_expected_file_recall 0.60`, `min_citation_coverage 0.60` (D2, at measured value) and `symbol 0.65 / claim 0.75 / anchor 0.70` carried unchanged from the holdout manifest — all under the retained measurement (`quality-debug` artifact `8d68c23e…`, run 29624645979: 0.60/0.60/0.80/1.0/0.80, deterministic across three repeats). The 0.70 holdout manifest is untouched.
- New corpus contract `v0.17-ripgrep-rust-v2.json` binding task + project manifest hashes; frozen v0.16 contracts untouched; digests computed, never typed.
- Gate registration in `codestory-release-evidence-gate.mjs` with new floor-pin and binding-mismatch coverage (22 tests).
- Dead ARM64 profile fixture strings in the closeout/gate tests replaced with neutral ids.
- `release-evidence-runner.md` rewritten: the ARM64 host is retired from live lanes (H-1); the in-tree guest harness remains until EV-4c retires it together with the policy layer, claims graph, and producer re-pointing. Playbook updated with the retained-measurement record.

Deliberately NOT here: workflow YAML, `release-claims.json`, `check-workflow-policy.mjs` — EV-4c owns the quality-lane and claims-graph re-pointing (a first-revision attempt to retire the harness here crashed the policy checker, which reads the guest scripts; restored and deferred).

## Verification

Passed on `47700376` (implementer where sandbox allowed, all re-run by supervisor with full deps): evidence-gate 22/0, closeout 39/0, restored harness contract 1/1, policy checker pass, policy tests 1364/0, plugin-static 130/0, generalization lint, `git diff --check`. Hostile checks demonstrated and reverted: corrupted bound hash → `release corpus task manifest hash does not match for ripgrep-search-pipeline-v2`; floor lowered to 0.5 → deep-equality failure showing expected 0.6.

The frozen-SHA 3-repeat protected measurement and `approved-baselines.json` entry remain frozen-candidate proof work. Independent fresh-context adversarial review on the exact head is running; draft until it accepts and CI is green.
