### PR TITLE
[v0.17 REL-MANb] Executable catalog rollback with a recorded restored state

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -2902,6 +2902,14 @@ function validatePluginAndDraftWorkflows(workflows, violations, graph) {
 // lets a run that never touched the catalog report that it did.
 function catalogDeliveryOutcomeViolations(file, job, delivery) {
   const violations = [];
+  const checkout = list(job.steps).find(
+    (step) => String(object(step).uses ?? "").startsWith("actions/checkout@"),
+  );
+  add(
+    violations,
+    object(object(checkout).with)["fetch-depth"] === 0,
+    `${file} marketplace publication must retain history needed to restore the recorded prior SHA`,
+  );
   const tokenStep = namedStep(job, "Mint a scoped marketplace token");
   add(
     violations,
@@ -2924,6 +2932,48 @@ function catalogDeliveryOutcomeViolations(file, job, delivery) {
     '--commit "$GITHUB_SHA"',
     '--github-output "$GITHUB_OUTPUT"',
   ]);
+  const liveSmoke = namedStep(job, "Smoke the published live catalog");
+  add(
+    violations,
+    liveSmoke?.["continue-on-error"] === true
+      && liveSmoke?.if === "steps.publish.outcome == 'success'",
+    `${file} live-catalog smoke must be a recorded post-push outcome, not a release gate`,
+  );
+  requireStepRun(violations, file, job, "Smoke the published live catalog", [
+    "install-codestory-marketplace-proof.mjs",
+    "--marketplace-source TheGreenCedar/AgentPluginMarketplace",
+    '--marketplace-revision "$MARKETPLACE_REVISION"',
+    "--local-fixture false",
+  ]);
+  const restore = namedStep(job, "Restore the previous catalog pin");
+  add(
+    violations,
+    delivery.recovery.automatic_restore === true
+      && restore?.["continue-on-error"] === true
+      && restore?.if
+        === "steps.publish.outcome == 'success' && steps.publish.outputs.catalog_changed == 'true' && steps.live-catalog-smoke.outcome == 'failure'",
+    `${file} must automatically restore after a failed smoke without failing the irreversible release`,
+  );
+  requireStepRun(violations, file, job, "Restore the previous catalog pin", [
+    "publish-marketplace-catalog.mjs",
+    '--commit "$PREVIOUS_PLUGIN_SHA"',
+    '--version "$PREVIOUS_PLUGIN_VERSION"',
+    '--expected-current-revision "$PUBLISHED_REVISION"',
+    "--expected-current-plugin-sha",
+    "--expected-current-plugin-version",
+    '--github-output "$GITHUB_OUTPUT"',
+  ]);
+  add(
+    violations,
+    object(restore?.env).GH_TOKEN === "${{ steps.token.outputs.token }}"
+      && object(restore?.env).PREVIOUS_PLUGIN_SHA
+        === "${{ steps.publish.outputs.previous_plugin_sha }}"
+      && object(restore?.env).PREVIOUS_PLUGIN_VERSION
+        === "${{ steps.publish.outputs.previous_plugin_version }}"
+      && object(restore?.env).PUBLISHED_REVISION
+        === "${{ steps.publish.outputs.marketplace_revision }}",
+    `${file} automatic restore must use the scoped token and the exact pin the push replaced`,
+  );
   const deliveryOutcome = namedStep(job, "Record catalog delivery outcome");
   add(
     violations,
@@ -2934,6 +2984,11 @@ function catalogDeliveryOutcomeViolations(file, job, delivery) {
     violations,
     object(deliveryOutcome?.env).TOKEN_OUTCOME === "${{ steps.token.outcome }}"
       && object(deliveryOutcome?.env).PUBLISH_OUTCOME === "${{ steps.publish.outcome }}"
+      && object(deliveryOutcome?.env).LIVE_SMOKE_OUTCOME
+        === "${{ steps.live-catalog-smoke.outcome }}"
+      && object(deliveryOutcome?.env).RESTORE_OUTCOME === "${{ steps.restore.outcome }}"
+      && object(deliveryOutcome?.env).RESTORED_REVISION
+        === "${{ steps.restore.outputs.marketplace_revision }}"
       && object(deliveryOutcome?.env).PUBLISHED_REVISION
         === "${{ steps.publish.outputs.marketplace_revision }}",
     `${file} catalog delivery outcome must read the real token, push, and revision results`,
@@ -2945,10 +3000,12 @@ function catalogDeliveryOutcomeViolations(file, job, delivery) {
   );
   requireStepRun(violations, file, job, "Record catalog delivery outcome", [
     "catalog_published=false",
+    "catalog_delivery_state=deferred",
     '[ "$TOKEN_OUTCOME" = "success" ]',
     '[ "$PUBLISH_OUTCOME" = "success" ]',
     `printf '%s' "$PUBLISHED_REVISION" | grep -Eq '^[0-9a-f]{40}$'`,
     'echo "catalog_published=$catalog_published"',
+    'echo "catalog_delivery_state=$catalog_delivery_state"',
     'echo "marketplace_revision=$marketplace_revision"',
     // The delivery state and the rollback target leave this step through one grouped redirect,
     // so the redirect itself is pinned: the echoes alone would be satisfied by a step that
@@ -2961,10 +3018,19 @@ function catalogDeliveryOutcomeViolations(file, job, delivery) {
     // absent must say that, or the ledger records an instruction nobody can follow.
     'if [ "$TOKEN_OUTCOME" != "success" ]; then',
     "provision the marketplace-publish credential",
+    '[ "$LIVE_SMOKE_OUTCOME" = "success" ]',
+    '[ "$LIVE_SMOKE_OUTCOME" = "failure" ]',
+    '[ "$RESTORE_OUTCOME" = "success" ]',
+    "catalog_delivery_state=published",
+    `catalog_delivery_state=${delivery.recovery.restored_state}`,
+    "catalog_delivery_state=unresolved",
+    "automatic restore did not complete",
   ]);
   add(
     violations,
     object(job.outputs).catalog_published === "${{ steps.delivery.outputs.catalog_published }}"
+      && object(job.outputs).catalog_delivery_state
+        === "${{ steps.delivery.outputs.catalog_delivery_state }}"
       && object(job.outputs).marketplace_revision === "${{ steps.delivery.outputs.marketplace_revision }}",
     `${file} marketplace publication must publish the recorded delivery state, not the raw push result`,
   );
@@ -3627,7 +3693,9 @@ function validateReleaseCoordinator(workflows, violations, graph) {
   add(
     violations,
     object(post.with).catalog_published
-      === `\${{ needs.${catalogDelivery.publish_job}.outputs.catalog_published == 'true' }}`,
+      === `\${{ needs.${catalogDelivery.publish_job}.outputs.catalog_published == 'true' }}`
+      && object(post.with).catalog_delivery_state
+        === `\${{ needs.${catalogDelivery.publish_job}.outputs.catalog_delivery_state }}`,
     `${releaseFile} post-publish smoke must derive catalog_published from the recorded ${catalogDelivery.publish_job} outcome`,
   );
   add(
@@ -4820,6 +4888,7 @@ function catalogDeliveryStateViolations(file, job, delivery, handoff, installSte
   const violations = [];
   const published = delivery.states.find(({ id }) => id === "published");
   const deferred = delivery.states.find(({ id }) => id === "deferred");
+  const restored = delivery.states.find(({ id }) => id === "restored");
   // Whatever else the deferred branch does, it builds a catalog out of a tree and then verifies
   // the install back against a tree. If those may be the same tree by default, the comparison is
   // a tautology and the smoke cannot fail for any release-related reason. Both lanes therefore
@@ -4855,21 +4924,24 @@ function catalogDeliveryStateViolations(file, job, delivery, handoff, installSte
   add(
     violations,
     object(step?.env).CATALOG_PUBLISHED === handoff.published
+      && object(step?.env).CATALOG_DELIVERY_STATE === handoff.state
       && object(step?.env).INPUT_MARKETPLACE_REVISION === handoff.revision,
     `${file} catalog delivery state must read the recorded publication handoff`,
   );
   requireStepRun(violations, file, job, "Record catalog delivery state", [
     // The published branch: the live catalog, its live revision, no fixture.
-    'if [ "$CATALOG_PUBLISHED" = "true" ]; then',
+    'if [ "$CATALOG_DELIVERY_STATE" = "published" ] && [ "$CATALOG_PUBLISHED" = "true" ]; then',
     "marketplace_source=TheGreenCedar/AgentPluginMarketplace",
     'marketplace_revision="$INPUT_MARKETPLACE_REVISION"',
     "local_fixture=false",
     `installer=${published.installer}`,
     // The deferred branch: a catalog pinned to this published commit, and a revision that cannot
     // be a live one because the caller is required to have supplied none.
-    'elif [ "$CATALOG_PUBLISHED" = "false" ]; then',
+    '[ "$CATALOG_DELIVERY_STATE" = "deferred" ]',
+    '[ "$CATALOG_DELIVERY_STATE" = "restored" ]',
+    '[ "$CATALOG_PUBLISHED" = "false" ]',
     'if [ -n "$INPUT_MARKETPLACE_REVISION" ]; then',
-    "Deferred catalog publication must not carry a live catalog revision",
+    "catalog delivery must not carry the failed live catalog revision",
     "build-marketplace-fixture.mjs",
     // The fixture pins the PUBLISHED commit, never the workspace's own head. Building a catalog
     // out of the tree that then verifies the install makes the source-tree comparison a
@@ -4878,9 +4950,10 @@ function catalogDeliveryStateViolations(file, job, delivery, handoff, installSte
     'marketplace_revision="$(git -C "$fixture_root" rev-parse HEAD)"',
     "local_fixture=true",
     `installer=${deferred.installer}`,
+    `installer=${restored.installer}`,
     // Neither branch may fall through: an unset or unexpected handoff is a hard failure, never a
     // silent default into the published identity.
-    "catalog_published must be true or false",
+    "catalog delivery handoff is inconsistent",
     // Immutability, not length. A 40-character string is not a commit: the published branch
     // takes its revision from a `workflow_dispatch`-able input, and a length-only test admits
     // any 40 characters of anything.
@@ -4890,8 +4963,8 @@ function catalogDeliveryStateViolations(file, job, delivery, handoff, installSte
   const deliveryRun = executableRunText(String(step?.run ?? ""));
   const publishedIndex = deliveryRun.indexOf(`installer=${published.installer}`);
   const deferredIndex = deliveryRun.indexOf(`installer=${deferred.installer}`);
-  const publishedBranch = deliveryRun.indexOf('if [ "$CATALOG_PUBLISHED" = "true" ]; then');
-  const deferredBranch = deliveryRun.indexOf('elif [ "$CATALOG_PUBLISHED" = "false" ]; then');
+  const publishedBranch = deliveryRun.indexOf('if [ "$CATALOG_DELIVERY_STATE" = "published" ]');
+  const deferredBranch = deliveryRun.indexOf('[ "$CATALOG_DELIVERY_STATE" = "deferred" ]');
   add(
     violations,
     published.installer !== deferred.installer
@@ -4899,7 +4972,8 @@ function catalogDeliveryStateViolations(file, job, delivery, handoff, installSte
       && deferredBranch > publishedBranch
       && publishedIndex > publishedBranch
       && publishedIndex < deferredBranch
-      && deferredIndex > deferredBranch,
+      && deferredIndex > deferredBranch
+      && deliveryRun.indexOf(`installer=${restored.installer}`) > deferredBranch,
     `${file} the published installer identity must be reachable only from the published branch`,
   );
   // Neither state may be fabricated in a later step: the install must come from what this step
@@ -4914,12 +4988,14 @@ function catalogDeliveryStateViolations(file, job, delivery, handoff, installSte
   requireStepRun(violations, file, job, installStepName, [
     '--marketplace-source "$MARKETPLACE_SOURCE"',
     '--local-fixture "$LOCAL_FIXTURE"',
+    '--installation-source "$INSTALLATION_SOURCE"',
   ]);
   // The install arguments arrive as variables now, so the command text no longer says which
   // delivery state they came from. This binds each variable back to that step's own output.
   requireStepEnv(violations, file, job, installStepName, {
     MARKETPLACE_SOURCE: "${{ steps.delivery.outputs.marketplace_source }}",
     LOCAL_FIXTURE: "${{ steps.delivery.outputs.local_fixture }}",
+    INSTALLATION_SOURCE: "${{ steps.delivery.outputs.installer }}",
   });
   return violations;
 }
@@ -4942,6 +5018,13 @@ function validatePostPublish(workflows, violations, graph) {
       violations,
       publishedInput.required === true && publishedInput.type === "boolean",
       `${file} ${event} catalog_published must be a required boolean`,
+    );
+    const stateInput = object(at(workflow, "on", event, "inputs", "catalog_delivery_state"));
+    add(
+      violations,
+      stateInput.required === true
+        && (stateInput.type === "string" || stateInput.type === "choice"),
+      `${file} ${event} catalog_delivery_state must be required`,
     );
     const marketplaceInput = object(
       at(workflow, "on", event, "inputs", "marketplace_revision"),
@@ -5248,6 +5331,7 @@ function validatePostPublish(workflows, violations, graph) {
     catalogDelivery,
     {
       published: "${{ inputs.catalog_published }}",
+      state: "${{ inputs.catalog_delivery_state }}",
       revision: "${{ inputs.marketplace_revision }}",
     },
     resolveStepName,
@@ -10651,6 +10735,30 @@ export function validatePluginRelease(workflows, violations, graph) {
     object(preflight.outputs).marketplace_revision === undefined,
     `${file} preflight must not capture a marketplace revision that predates publication`,
   );
+  const candidateCatalogProof = namedStep(
+    preflight,
+    "Prove the candidate-pinned marketplace install path",
+  );
+  add(
+    violations,
+    candidateCatalogProof?.["continue-on-error"] === undefined,
+    `${file} W8.4 candidate-pinned marketplace proof must fail closed before publication`,
+  );
+  requireStepRun(
+    violations,
+    file,
+    preflight,
+    "Prove the candidate-pinned marketplace install path",
+    [
+      "build-marketplace-fixture.mjs",
+      '--commit "$GITHUB_SHA"',
+      'fixture_revision="$(git -C "$fixture_root" rev-parse HEAD)"',
+      "install-codestory-marketplace-proof.mjs",
+      '--marketplace-source "$fixture_root"',
+      '--marketplace-revision "$fixture_revision"',
+      "--local-fixture true",
+    ],
+  );
   const installStepName = "Prove the public marketplace install path";
   add(
     violations,
@@ -10664,6 +10772,7 @@ export function validatePluginRelease(workflows, violations, graph) {
     catalogDelivery,
     {
       published: "${{ needs.marketplace-publish.outputs.catalog_published == 'true' }}",
+      state: "${{ needs.marketplace-publish.outputs.catalog_delivery_state }}",
       revision: "${{ needs.marketplace-publish.outputs.marketplace_revision }}",
     },
     installStepName,

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -8123,6 +8123,9 @@ function runCatalogDeliveryOutcome(environment, [file, jobName] = catalogOutcome
     PREVIOUS_REVISION: "",
     PREVIOUS_PLUGIN_SHA: "",
     PREVIOUS_PLUGIN_VERSION: "",
+    LIVE_SMOKE_OUTCOME: "skipped",
+    RESTORE_OUTCOME: "skipped",
+    RESTORED_REVISION: "",
     ...environment,
   });
 }
@@ -8167,12 +8170,14 @@ test("a release records catalog publication only when the catalog push actually 
     const published = runCatalogDeliveryOutcome({
       TOKEN_OUTCOME: "success",
       PUBLISH_OUTCOME: "success",
+      LIVE_SMOKE_OUTCOME: "success",
       PUBLISHED_REVISION: revision,
       ...previousPin,
     }, lane);
     assert.equal(published.status, 0, published.stderr);
     assert.deepEqual(published.outputs, {
       catalog_published: "true",
+      catalog_delivery_state: "published",
       marketplace_revision: revision,
       ...recordedPin,
     }, lane.join("/"));
@@ -8186,21 +8191,6 @@ test("a release records catalog publication only when the catalog push actually 
     ["missing credential", { TOKEN_OUTCOME: "failure", PUBLISH_OUTCOME: "", PUBLISHED_REVISION: "" }],
     ["push rejected", { TOKEN_OUTCOME: "success", PUBLISH_OUTCOME: "failure", PUBLISHED_REVISION: "" }],
     ["push skipped", { TOKEN_OUTCOME: "failure", PUBLISH_OUTCOME: "skipped", PUBLISHED_REVISION: "" }],
-    ["push reported success without a revision", {
-      TOKEN_OUTCOME: "success",
-      PUBLISH_OUTCOME: "success",
-      PUBLISHED_REVISION: "",
-    }],
-    ["push reported a mutable ref", {
-      TOKEN_OUTCOME: "success",
-      PUBLISH_OUTCOME: "success",
-      PUBLISHED_REVISION: "main",
-    }],
-    ["push reported a truncated revision", {
-      TOKEN_OUTCOME: "success",
-      PUBLISH_OUTCOME: "success",
-      PUBLISHED_REVISION: "a".repeat(39),
-    }],
   ];
   for (const lane of catalogOutcomeLanes) {
     for (const [label, environment] of deferrals) {
@@ -8209,6 +8199,7 @@ test("a release records catalog publication only when the catalog push actually 
       assert.equal(deferred.status, 0, `${where}: ${deferred.stderr}`);
       assert.deepEqual(deferred.outputs, {
         catalog_published: "false",
+        catalog_delivery_state: "deferred",
         marketplace_revision: "",
         ...recordedPin,
       }, where);
@@ -8218,6 +8209,42 @@ test("a release records catalog publication only when the catalog push actually 
       // A deferred run never announces a rollback target: the catalog did not move, so there is
       // nothing to restore and nothing may read as if there were.
       assert.doesNotMatch(deferred.summary, /Rollback target/u, where);
+    }
+
+    const restored = runCatalogDeliveryOutcome({
+      TOKEN_OUTCOME: "success",
+      PUBLISH_OUTCOME: "success",
+      LIVE_SMOKE_OUTCOME: "failure",
+      RESTORE_OUTCOME: "success",
+      PUBLISHED_REVISION: revision,
+      RESTORED_REVISION: "d".repeat(40),
+      ...previousPin,
+    }, lane);
+    assert.equal(restored.status, 0, restored.stderr);
+    assert.deepEqual(restored.outputs, {
+      catalog_published: "false",
+      catalog_delivery_state: "restored",
+      marketplace_revision: "",
+      ...recordedPin,
+    });
+    assert.match(restored.summary, /RESTORED/u);
+    assert.doesNotMatch(restored.summary, /Catalog delivery: published/u);
+
+    for (const [label, publishedRevision] of [
+      ["missing", ""],
+      ["mutable", "main"],
+      ["truncated", "a".repeat(39)],
+    ]) {
+      const unresolved = runCatalogDeliveryOutcome({
+        TOKEN_OUTCOME: "success",
+        PUBLISH_OUTCOME: "success",
+        PUBLISHED_REVISION: publishedRevision,
+        ...previousPin,
+      }, lane);
+      assert.equal(unresolved.status, 0, `${label}: ${unresolved.stderr}`);
+      assert.equal(unresolved.outputs.catalog_delivery_state, "unresolved", label);
+      assert.equal(unresolved.outputs.catalog_published, "false", label);
+      assert.match(unresolved.summary, /UNRESOLVED/u, label);
     }
 
     // The credential never minted, so the push step was skipped and recorded no pin at all. The
@@ -8230,6 +8257,7 @@ test("a release records catalog publication only when the catalog push actually 
     assert.equal(unrecorded.status, 0, unrecorded.stderr);
     assert.deepEqual(unrecorded.outputs, {
       catalog_published: "false",
+      catalog_delivery_state: "deferred",
       marketplace_revision: "",
       previous_marketplace_revision: "",
       previous_plugin_sha: "",
@@ -8243,6 +8271,7 @@ test("the post-publish smoke cannot record a public catalog install it did not p
   const { states } = graph.workflow_policy.catalog_delivery;
   const publishedInstaller = states.find(({ id }) => id === "published").installer;
   const deferredInstaller = states.find(({ id }) => id === "deferred").installer;
+  const restoredInstaller = states.find(({ id }) => id === "restored").installer;
   const liveRevision = "b".repeat(40);
   const head = repositoryHead();
 
@@ -8250,6 +8279,7 @@ test("the post-publish smoke cannot record a public catalog install it did not p
     const where = lane.join("/");
     const published = runCatalogDeliveryStateBound({
       CATALOG_PUBLISHED: "true",
+      CATALOG_DELIVERY_STATE: "published",
       INPUT_MARKETPLACE_REVISION: liveRevision,
     }, lane);
     assert.equal(published.status, 0, published.stderr);
@@ -8264,6 +8294,7 @@ test("the post-publish smoke cannot record a public catalog install it did not p
     // for the public one.
     const deferred = runCatalogDeliveryStateBound({
       CATALOG_PUBLISHED: "false",
+      CATALOG_DELIVERY_STATE: "deferred",
       INPUT_MARKETPLACE_REVISION: "",
     }, lane);
     assert.equal(deferred.status, 0, deferred.stderr);
@@ -8280,32 +8311,47 @@ test("the post-publish smoke cannot record a public catalog install it did not p
     ));
     assert.equal(catalog.plugins[0].source.sha, head, `${where}: fixture must pin the released commit`);
 
+    const restored = runCatalogDeliveryStateBound({
+      CATALOG_PUBLISHED: "false",
+      CATALOG_DELIVERY_STATE: "restored",
+      INPUT_MARKETPLACE_REVISION: "",
+    }, lane);
+    assert.equal(restored.status, 0, restored.stderr);
+    assert.equal(restored.outputs.state, "restored", where);
+    assert.equal(restored.outputs.installer, restoredInstaller, where);
+    assert.notEqual(restored.outputs.installer, publishedInstaller, where);
+    assert.equal(restored.outputs.local_fixture, "true", where);
+
     // Refusals. A handoff that is inconsistent, absent, or merely truthy-looking must stop the
     // smoke rather than fall through into the published identity.
     for (const [label, environment] of [
-      ["deferred with a live revision", { CATALOG_PUBLISHED: "false", INPUT_MARKETPLACE_REVISION: liveRevision }],
-      ["absent handoff", { CATALOG_PUBLISHED: "", INPUT_MARKETPLACE_REVISION: "" }],
-      ["truthy handoff", { CATALOG_PUBLISHED: "TRUE", INPUT_MARKETPLACE_REVISION: liveRevision }],
-      ["handoff spelled yes", { CATALOG_PUBLISHED: "yes", INPUT_MARKETPLACE_REVISION: liveRevision }],
+      ["deferred with a live revision", { CATALOG_PUBLISHED: "false", CATALOG_DELIVERY_STATE: "deferred", INPUT_MARKETPLACE_REVISION: liveRevision }],
+      ["absent handoff", { CATALOG_PUBLISHED: "", CATALOG_DELIVERY_STATE: "", INPUT_MARKETPLACE_REVISION: "" }],
+      ["truthy handoff", { CATALOG_PUBLISHED: "TRUE", CATALOG_DELIVERY_STATE: "published", INPUT_MARKETPLACE_REVISION: liveRevision }],
+      ["handoff spelled yes", { CATALOG_PUBLISHED: "yes", CATALOG_DELIVERY_STATE: "published", INPUT_MARKETPLACE_REVISION: liveRevision }],
       // Published demands an IMMUTABLE revision. "main" is refused by any length test at all, so
       // it never exercised immutability; the 40-character non-hex cases below do, and they are
       // reachable in practice because this workflow is dispatchable with an arbitrary string.
-      ["published without a revision", { CATALOG_PUBLISHED: "true", INPUT_MARKETPLACE_REVISION: "" }],
-      ["published with a mutable ref", { CATALOG_PUBLISHED: "true", INPUT_MARKETPLACE_REVISION: "main" }],
+      ["published without a revision", { CATALOG_PUBLISHED: "true", CATALOG_DELIVERY_STATE: "published", INPUT_MARKETPLACE_REVISION: "" }],
+      ["published with a mutable ref", { CATALOG_PUBLISHED: "true", CATALOG_DELIVERY_STATE: "published", INPUT_MARKETPLACE_REVISION: "main" }],
       ["published with a truncated revision", {
         CATALOG_PUBLISHED: "true",
+        CATALOG_DELIVERY_STATE: "published",
         INPUT_MARKETPLACE_REVISION: "b".repeat(39),
       }],
       ["published with forty non-hex characters", {
         CATALOG_PUBLISHED: "true",
+        CATALOG_DELIVERY_STATE: "published",
         INPUT_MARKETPLACE_REVISION: "z".repeat(40),
       }],
       ["published with a forty-character branch name", {
         CATALOG_PUBLISHED: "true",
+        CATALOG_DELIVERY_STATE: "published",
         INPUT_MARKETPLACE_REVISION: "refs/heads/some-quite-long-branch-name-xy",
       }],
       ["published with an uppercase revision", {
         CATALOG_PUBLISHED: "true",
+        CATALOG_DELIVERY_STATE: "published",
         INPUT_MARKETPLACE_REVISION: "B".repeat(40),
       }],
     ]) {
@@ -8323,6 +8369,7 @@ test("the post-publish smoke cannot record a public catalog install it did not p
     ]) {
       const refused = runCatalogDeliveryState({
         CATALOG_PUBLISHED: "false",
+        CATALOG_DELIVERY_STATE: "deferred",
         INPUT_MARKETPLACE_REVISION: "",
         PUBLISHED_COMMIT: publishedCommit,
       }, lane);
@@ -8364,8 +8411,8 @@ test("catalog publication cannot be reinstated as a gate or claimed without happ
     }, /must derive catalog_published from the recorded marketplace-publish outcome/u],
     ["delivery outcome ignores whether the push ran", workflows => {
       const step = draftStep(publishJob(workflows), "Record catalog delivery outcome");
-      step.run = step.run.replace('&& [ "$PUBLISH_OUTCOME" = "success" ] \\\n', "");
-    }, /must run \[ "\$PUBLISH_OUTCOME" = "success" \]/u],
+      step.env.PUBLISH_OUTCOME = "${{ steps.token.outcome }}";
+    }, /catalog delivery outcome must read the real token, push, and revision results/u],
     ["delivery outcome accepts any revision the push printed", workflows => {
       const step = draftStep(publishJob(workflows), "Record catalog delivery outcome");
       step.run = step.run.replace(
@@ -8408,8 +8455,8 @@ test("catalog publication cannot be reinstated as a gate or claimed without happ
     }, /must run if \[ -n "\$INPUT_MARKETPLACE_REVISION" \]/u],
     ["unknown delivery states fall through instead of failing", workflows => {
       const step = draftStep(smokeJob(workflows), "Record catalog delivery state");
-      step.run = step.run.replace("catalog_published must be true or false", "unreachable");
-    }, /must run catalog_published must be true or false/u],
+      step.run = step.run.replace("catalog delivery handoff is inconsistent", "unreachable");
+    }, /must run catalog delivery handoff is inconsistent/u],
     ["delivery state becomes conditional", workflows => {
       draftStep(smokeJob(workflows), "Record catalog delivery state").if = "inputs.catalog_published";
     }, /catalog delivery state must be unconditional and fail closed/u],
@@ -8447,6 +8494,21 @@ test("catalog publication cannot be reinstated as a gate or claimed without happ
     ["catalog push runs without a minted token", workflows => {
       delete draftStep(publishJob(workflows), "Point the catalog at the published release").if;
     }, /catalog push must run only with a minted token and must not fail the release/u],
+    ["failed live-catalog smoke no longer restores the prior pin", workflows => {
+      const job = publishJob(workflows);
+      job.steps = job.steps.filter(({ name }) => name !== "Restore the previous catalog pin");
+    }, /must contain named step Restore the previous catalog pin/u],
+    ["automatic restore targets something other than the replaced pin", workflows => {
+      const step = draftStep(publishJob(workflows), "Restore the previous catalog pin");
+      step.run = step.run.replace('--commit "$PREVIOUS_PLUGIN_SHA"', '--commit "$GITHUB_SHA"');
+    }, /must run --commit "\$PREVIOUS_PLUGIN_SHA"/u],
+    ["automatic restore drops the expected-current fence", workflows => {
+      const step = draftStep(publishJob(workflows), "Restore the previous catalog pin");
+      step.run = step.run.replace('--expected-current-revision "$PUBLISHED_REVISION"', "");
+    }, /must run --expected-current-revision "\$PUBLISHED_REVISION"/u],
+    ["restore failure gates the irreversible release", workflows => {
+      delete draftStep(publishJob(workflows), "Restore the previous catalog pin")["continue-on-error"];
+    }, /must automatically restore after a failed smoke without failing the irreversible release/u],
     ["smoke waits for the catalog job to succeed", workflows => {
       smokeCall(workflows).if
         = "inputs.publish_release && needs.marketplace-publish.result == 'success'";
@@ -8473,6 +8535,10 @@ test("catalog publication cannot be reinstated as a gate or claimed without happ
     ["plugin lane catalog push failure fails its tagged release again", workflows => {
       delete draftStep(pluginPublishJob(workflows), "Point the catalog at the published release")["continue-on-error"];
     }, /plugin-release\.yml catalog push must run only with a minted token/u],
+    ["plugin W8.4 candidate-pinned proof is removed", workflows => {
+      const job = workflows.get(pluginFile).jobs.preflight;
+      job.steps = job.steps.filter(({ name }) => name !== "Prove the candidate-pinned marketplace install path");
+    }, /must contain named step Prove the candidate-pinned marketplace install path/u],
     ["plugin lane stops recording its delivery outcome", workflows => {
       const job = pluginPublishJob(workflows);
       job.steps = job.steps.filter(({ name }) => name !== "Record catalog delivery outcome");

--- a/.github/scripts/install-codestory-marketplace-proof.mjs
+++ b/.github/scripts/install-codestory-marketplace-proof.mjs
@@ -20,6 +20,8 @@ import {
   DEFERRED_MARKETPLACE_REPOSITORY,
   LIVE_INSTALLATION_SOURCE,
   LIVE_MARKETPLACE_REPOSITORY,
+  RESTORED_INSTALLATION_SOURCE,
+  RESTORED_MARKETPLACE_REPOSITORY,
 } from "./marketplace-delivery-identity.mjs";
 
 function fail(message) {
@@ -148,18 +150,27 @@ function prepareInstallation(rawArgs) {
     fail(`--local-fixture must be true or false, not ${JSON.stringify(localFixtureRaw ?? null)}`);
   }
   const localFixture = localFixtureRaw === "true";
-  const installationSource = localFixture
-    ? DEFERRED_INSTALLATION_SOURCE
-    : LIVE_INSTALLATION_SOURCE;
+  const requestedInstallationSource = args.installation_source;
+  const allowedInstallationSources = localFixture
+    ? new Map([
+      [DEFERRED_INSTALLATION_SOURCE, DEFERRED_MARKETPLACE_REPOSITORY],
+      [RESTORED_INSTALLATION_SOURCE, RESTORED_MARKETPLACE_REPOSITORY],
+    ])
+    : new Map([[LIVE_INSTALLATION_SOURCE, LIVE_MARKETPLACE_REPOSITORY]]);
+  const installationSource = requestedInstallationSource
+    ?? (localFixture ? DEFERRED_INSTALLATION_SOURCE : LIVE_INSTALLATION_SOURCE);
+  if (!allowedInstallationSources.has(installationSource)) {
+    fail(
+      `--installation-source ${JSON.stringify(installationSource)} is incompatible with local-fixture=${localFixtureRaw}`,
+    );
+  }
   const marketplaceSource = required(args, "marketplace_source");
   if (!localFixture && marketplaceSource !== LIVE_MARKETPLACE_REPOSITORY) {
     fail(
       `a live marketplace install must resolve ${LIVE_MARKETPLACE_REPOSITORY}, not ${marketplaceSource}`,
     );
   }
-  const marketplaceRepository = localFixture
-    ? DEFERRED_MARKETPLACE_REPOSITORY
-    : marketplaceSource;
+  const marketplaceRepository = allowedInstallationSources.get(installationSource);
 
   const codexPackageRoot = path.resolve(required(args, "codex_package_root"));
   const codexExecutable = path.join(

--- a/.github/scripts/install-codestory-marketplace-proof.test.mjs
+++ b/.github/scripts/install-codestory-marketplace-proof.test.mjs
@@ -238,6 +238,34 @@ test("pinned Codex installs a local marketplace fixture into the attested cache"
     assert.match(config, /\[plugins\."codestory@Fixture"\]/u);
     assert.match(config, /enabled = true/u);
 
+    const restoredRoot = path.join(root, "restored-proof");
+    const restoredArgs = proofArgs({
+      packageRoot,
+      proofRoot: restoredRoot,
+      marketplaceRoot,
+      marketplaceRevision,
+      expectedVersion: pluginManifest.version,
+      sourceRepository: pluginSourceRoot,
+    });
+    restoredArgs.push(
+      "--installation-source",
+      "codex_marketplace_restored_fixture",
+    );
+    run(process.execPath, restoredArgs, {
+      env: { ...process.env, HOME: personalHome },
+    });
+    const restoredAttestation = JSON.parse(
+      readFileSync(path.join(restoredRoot, "attestation.json")),
+    );
+    assert.equal(
+      restoredAttestation.installation_source,
+      "codex_marketplace_restored_fixture",
+    );
+    assert.equal(
+      restoredAttestation.marketplace.repository,
+      "local:candidate-pinned-marketplace-restored-fixture",
+    );
+
     writeFileSync(
       path.join(pluginSourceRoot, "plugins", "codestory", "mismatched.txt"),
       "different package bytes\n",

--- a/.github/scripts/marketplace-delivery-identity.mjs
+++ b/.github/scripts/marketplace-delivery-identity.mjs
@@ -1,9 +1,9 @@
-// The two catalog delivery states, named once.
+// The catalog delivery states, named once.
 //
 // Catalog publication is delivery, not a release gate, so a release can be proved against
-// either the live public catalog or a catalog pinned to the exact published commit. Those are
-// DISTINCT states, and the whole risk in allowing the second one is that it quietly reads as
-// the first. So neither state is an absence: each has its own installer identity, its own
+// either the live public catalog or a catalog pinned to the exact published commit. Deferred and
+// automatically restored delivery are DISTINCT local-fixture states, and neither may quietly read
+// as live publication. So no state is an absence: each has its own installer identity, its own
 // attestation repository name, and its own accepted shape in the Python predicate, and the
 // three names live here so the producer and the verifier cannot drift apart.
 //
@@ -14,6 +14,8 @@
 export const LIVE_INSTALLATION_SOURCE = "codex_marketplace_install";
 /** Installer identity for a resolve through a catalog pinned to the published commit. */
 export const DEFERRED_INSTALLATION_SOURCE = "codex_marketplace_deferred_fixture";
+/** Installer identity after a failed live-catalog smoke restored the previous public pin. */
+export const RESTORED_INSTALLATION_SOURCE = "codex_marketplace_restored_fixture";
 
 /** `marketplace.repository` for the live state: the real catalog repository. */
 export const LIVE_MARKETPLACE_REPOSITORY = "TheGreenCedar/AgentPluginMarketplace";
@@ -24,6 +26,8 @@ export const LIVE_MARKETPLACE_REPOSITORY = "TheGreenCedar/AgentPluginMarketplace
  * be mistaken for one.
  */
 export const DEFERRED_MARKETPLACE_REPOSITORY = "local:candidate-pinned-marketplace-fixture";
+/** `marketplace.repository` for proof after the public catalog was automatically restored. */
+export const RESTORED_MARKETPLACE_REPOSITORY = "local:candidate-pinned-marketplace-restored-fixture";
 
 /** Marker file the fixture builder writes so a fixture can identify itself to the verifier. */
 export const FIXTURE_MARKER_FILENAME = ".codestory-marketplace-fixture.json";

--- a/.github/scripts/packaged_agent_proof/marketplace_installation.py
+++ b/.github/scripts/packaged_agent_proof/marketplace_installation.py
@@ -1,7 +1,8 @@
 """Marketplace checkout and installed-plugin provenance.
 
-Two delivery states resolve a released plugin through a Codex marketplace, and this module
-accepts exactly two correspondingly distinct shapes:
+Three delivery states resolve a released plugin through a Codex marketplace. Published uses the
+live checkout; deferred and restored use distinct identities over the same candidate-pinned local
+fixture shape:
 
 * ``codex_marketplace_install`` -- the live public catalog. The resolver clones
   ``TheGreenCedar/AgentPluginMarketplace`` over Git into the isolated Codex home at a pinned
@@ -43,10 +44,12 @@ _PLUGIN_ID = f"codestory@{_MARKETPLACE_NAME}"
 
 LIVE_INSTALLATION_SOURCE = "codex_marketplace_install"
 DEFERRED_INSTALLATION_SOURCE = "codex_marketplace_deferred_fixture"
+RESTORED_INSTALLATION_SOURCE = "codex_marketplace_restored_fixture"
 # Mirrors DEFERRED_MARKETPLACE_REPOSITORY in
 # .github/scripts/marketplace-delivery-identity.mjs. Deliberately not a filesystem path and
 # deliberately not shaped like "owner/repo": it can never be confused with the live catalog.
 _DEFERRED_MARKETPLACE_REPOSITORY = "local:candidate-pinned-marketplace-fixture"
+_RESTORED_MARKETPLACE_REPOSITORY = "local:candidate-pinned-marketplace-restored-fixture"
 _FIXTURE_MARKER_FILENAME = ".codestory-marketplace-fixture.json"
 _FIXTURE_MARKER_PURPOSE = "codestory-candidate-pinned-marketplace-fixture"
 
@@ -74,8 +77,16 @@ _DEFERRED = _DeliveryState(
     source_type="local",
     checkout_inside_codex_home=False,
 )
+_RESTORED = _DeliveryState(
+    installation_source=RESTORED_INSTALLATION_SOURCE,
+    repository=_RESTORED_MARKETPLACE_REPOSITORY,
+    source_type="local",
+    checkout_inside_codex_home=False,
+)
 
-_DELIVERY_STATES = {state.installation_source: state for state in (_LIVE, _DEFERRED)}
+_DELIVERY_STATES = {
+    state.installation_source: state for state in (_LIVE, _DEFERRED, _RESTORED)
+}
 
 
 def delivery_state(installation_source: object) -> _DeliveryState | None:
@@ -352,7 +363,7 @@ def _validate_fixture_identity(
     marker_path = marketplace_root / _FIXTURE_MARKER_FILENAME
     require(
         marker_path.is_file(),
-        "deferred catalog resolve did not use a candidate-pinned marketplace fixture",
+        "local catalog resolve did not use a candidate-pinned marketplace fixture",
     )
     marker = json.loads(marker_path.read_text(encoding="utf-8"))
     require_exact_keys(
@@ -404,7 +415,7 @@ def _validate_marketplace_checkout(
     # Checked before the Git probes, not after: the marker is committed into the fixture, so a
     # missing or altered one also dirties the tree. Ordering it first means the failure names
     # the actual defect instead of passing for an unrelated reason.
-    if state is _DEFERRED:
+    if state is not _LIVE:
         _validate_fixture_identity(marketplace_root, plugin_source_sha, manifest)
     marketplace_commit = _git_output(marketplace_root, "rev-parse", "HEAD")
     origin = _git_origin_url(marketplace_root)

--- a/.github/scripts/packaged_agent_proof/self_test_marketplace_delivery.py
+++ b/.github/scripts/packaged_agent_proof/self_test_marketplace_delivery.py
@@ -30,12 +30,14 @@ from .installed_identity import installed_plugin_identity
 from .marketplace_installation import (
     DEFERRED_INSTALLATION_SOURCE,
     LIVE_INSTALLATION_SOURCE,
+    RESTORED_INSTALLATION_SOURCE,
 )
 
 _MARKETPLACE_NAME = "TheGreenCedar"
 _LIVE_REPOSITORY = "TheGreenCedar/AgentPluginMarketplace"
 _LIVE_URL = f"https://github.com/{_LIVE_REPOSITORY}.git"
 _DEFERRED_REPOSITORY = "local:candidate-pinned-marketplace-fixture"
+_RESTORED_REPOSITORY = "local:candidate-pinned-marketplace-restored-fixture"
 _MARKER_FILENAME = ".codestory-marketplace-fixture.json"
 _MARKER_PURPOSE = "codestory-candidate-pinned-marketplace-fixture"
 _PLUGIN_ID = f"codestory@{_MARKETPLACE_NAME}"
@@ -477,6 +479,28 @@ def _run_live_self_tests(root: Path, manifest: dict) -> None:
     )
 
 
+def _run_restored_self_tests(root: Path, manifest: dict) -> None:
+    world = _build_world(root / "restored", deferred=True, manifest=manifest)
+    attestation = world["attestation"]
+    attestation["installation_source"] = RESTORED_INSTALLATION_SOURCE
+    attestation["marketplace"]["repository"] = _RESTORED_REPOSITORY
+    identity = _verify(world, attestation, root, manifest)
+    require(
+        identity["installation_source"] == RESTORED_INSTALLATION_SOURCE
+        and identity["marketplace_repository"] == _RESTORED_REPOSITORY,
+        "an automatically restored catalog did not record its own installer identity",
+    )
+    _reject(
+        world,
+        root,
+        manifest,
+        "a restored resolve relabelled as a deferred publication",
+        lambda candidate: candidate.update(
+            installation_source=DEFERRED_INSTALLATION_SOURCE
+        ),
+    )
+
+
 def _run_retained_provenance_self_tests() -> None:
     """The retained evidence verifier must bind each installer identity to its own repository.
 
@@ -507,6 +531,7 @@ def _run_retained_provenance_self_tests() -> None:
     for source, repository in (
         (LIVE_INSTALLATION_SOURCE, _LIVE_REPOSITORY),
         (DEFERRED_INSTALLATION_SOURCE, _DEFERRED_REPOSITORY),
+        (RESTORED_INSTALLATION_SOURCE, _RESTORED_REPOSITORY),
     ):
         retained._verify_marketplace_provenance(contract, plugin(source, repository), runtime)
 
@@ -517,6 +542,8 @@ def _run_retained_provenance_self_tests() -> None:
          DEFERRED_INSTALLATION_SOURCE, _LIVE_REPOSITORY),
         ("a live install claiming the fixture repository",
          LIVE_INSTALLATION_SOURCE, _DEFERRED_REPOSITORY),
+        ("a restored install claiming the deferred fixture repository",
+         RESTORED_INSTALLATION_SOURCE, _DEFERRED_REPOSITORY),
         ("an installer identity no delivery state declares",
          "codex_marketplace_install_v3", _LIVE_REPOSITORY),
     ):
@@ -544,8 +571,10 @@ def _run_shared_identity_self_tests() -> None:
     for name, value in (
         ("LIVE_INSTALLATION_SOURCE", LIVE_INSTALLATION_SOURCE),
         ("DEFERRED_INSTALLATION_SOURCE", DEFERRED_INSTALLATION_SOURCE),
+        ("RESTORED_INSTALLATION_SOURCE", RESTORED_INSTALLATION_SOURCE),
         ("LIVE_MARKETPLACE_REPOSITORY", _LIVE_REPOSITORY),
         ("DEFERRED_MARKETPLACE_REPOSITORY", _DEFERRED_REPOSITORY),
+        ("RESTORED_MARKETPLACE_REPOSITORY", _RESTORED_REPOSITORY),
         ("FIXTURE_MARKER_FILENAME", _MARKER_FILENAME),
         ("FIXTURE_MARKER_PURPOSE", _MARKER_PURPOSE),
     ):
@@ -560,6 +589,7 @@ def run_marketplace_delivery_self_tests() -> None:
     with tempfile.TemporaryDirectory(prefix="codestory-marketplace-delivery-") as raw:
         root = Path(raw).resolve()
         _run_deferred_self_tests(root, manifest)
+        _run_restored_self_tests(root, manifest)
         _run_live_self_tests(root, manifest)
     _run_retained_provenance_self_tests()
     _run_shared_identity_self_tests()

--- a/.github/scripts/publish-marketplace-catalog.mjs
+++ b/.github/scripts/publish-marketplace-catalog.mjs
@@ -11,6 +11,11 @@
 //
 //   node .github/scripts/publish-marketplace-catalog.mjs \
 //     --source-repository DIR --commit SHA --version X.Y.Z [--github-output FILE]
+//
+// Automatic restore supplies the just-pushed catalog revision, plugin SHA, and version through
+// the three --expected-current-* arguments. The target --commit/--version is the recorded prior
+// pin. All three fences are required together so restore cannot overwrite an independently moved
+// catalog.
 
 import { execFileSync } from "node:child_process";
 import { appendFileSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
@@ -41,6 +46,16 @@ const args = parseArgs(process.argv.slice(2));
 for (const key of ["source_repository", "commit", "version"]) {
   if (!args[key]) fail(`--${key.replaceAll("_", "-")} is required`);
 }
+const restoreCoordinates = [
+  "expected_current_revision",
+  "expected_current_plugin_sha",
+  "expected_current_plugin_version",
+];
+const restoreCoordinateCount = restoreCoordinates.filter((key) => args[key]).length;
+if (restoreCoordinateCount !== 0 && restoreCoordinateCount !== restoreCoordinates.length) {
+  fail("automatic restore requires the expected current catalog revision, plugin SHA, and plugin version together");
+}
+const restoring = restoreCoordinateCount === restoreCoordinates.length;
 const token = process.env.GH_TOKEN;
 if (!token) fail("GH_TOKEN must carry a marketplace-scoped installation token");
 
@@ -99,10 +114,10 @@ if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.]+)?$/u.test(previousVersion)) {
 }
 const previousRevision = git("rev-parse", "HEAD");
 
-const output = (revision, published) => {
+const output = (revision, changed) => {
   console.log(
-    published
-      ? `Catalog now pins codestory ${args.version} at ${commit} (${revision}).`
+    changed
+      ? `Catalog ${restoring ? "restored" : "now pins"} codestory ${args.version} at ${commit} (${revision}).`
       : `Catalog already pins codestory ${args.version} at ${commit} (${revision}); nothing to push.`,
   );
   console.log(
@@ -114,7 +129,9 @@ const output = (revision, published) => {
       `marketplace_revision=${revision}\n`
         + `previous_marketplace_revision=${previousRevision}\n`
         + `previous_plugin_sha=${previousSha}\n`
-        + `previous_plugin_version=${previousVersion}\n`,
+        + `previous_plugin_version=${previousVersion}\n`
+        + `catalog_changed=${changed}\n`
+        + `catalog_operation=${restoring ? "restore" : "publish"}\n`,
     );
   }
 };
@@ -124,6 +141,21 @@ if (entry.source.sha === commit && entry.version === args.version) {
   process.exit(0);
 }
 
+if (restoring) {
+  const expectedRevision = String(args.expected_current_revision);
+  const expectedSha = String(args.expected_current_plugin_sha);
+  const expectedVersion = String(args.expected_current_plugin_version);
+  if (
+    previousRevision !== expectedRevision
+    || previousSha !== expectedSha
+    || previousVersion !== expectedVersion
+  ) {
+    fail(
+      `catalog no longer names the just-published rollback source ${expectedVersion} at ${expectedSha} (${expectedRevision}); refusing automatic restore`,
+    );
+  }
+}
+
 entry.version = args.version;
 entry.source.sha = commit;
 writeFileSync(catalogPath, `${JSON.stringify(catalog, null, 2)}\n`);
@@ -131,6 +163,6 @@ writeFileSync(catalogPath, `${JSON.stringify(catalog, null, 2)}\n`);
 git("config", "user.email", "release@codestory.invalid");
 git("config", "user.name", "CodeStory release");
 git("add", CATALOG);
-git("commit", "--message", `codestory ${args.version}`);
+git("commit", "--message", `${restoring ? "restore" : "codestory"} ${args.version}`);
 git("push", "origin", "HEAD:main");
 output(git("rev-parse", "HEAD"), true);

--- a/.github/scripts/publish-marketplace-catalog.test.mjs
+++ b/.github/scripts/publish-marketplace-catalog.test.mjs
@@ -83,7 +83,7 @@ function scratch() {
   return { root, configPath };
 }
 
-function runPublisher({ root, configPath }, repo, { commit, version }) {
+function runPublisher({ root, configPath }, repo, { commit, version, ...extra }) {
   const outputPath = path.join(root, `output-${Math.random().toString(36).slice(2)}.txt`);
   fs.writeFileSync(outputPath, "");
   const result = spawnSync(
@@ -96,6 +96,10 @@ function runPublisher({ root, configPath }, repo, { commit, version }) {
       commit,
       "--version",
       version,
+      ...Object.entries(extra).flatMap(([key, value]) => [
+        `--${key.replaceAll("_", "-")}`,
+        value,
+      ]),
       "--github-output",
       outputPath,
     ],
@@ -149,11 +153,27 @@ test("the catalog move records the pin it replaced, and that pin is a working ro
     const back = runPublisher(env, repo, {
       commit: forward.outputs.previous_plugin_sha,
       version: forward.outputs.previous_plugin_version,
+      expected_current_revision: forward.outputs.marketplace_revision,
+      expected_current_plugin_sha: commits["0.2.0"],
+      expected_current_plugin_version: "0.2.0",
     });
     assert.equal(back.status, 0, `${back.stdout}${back.stderr}`);
     assert.equal(readCatalog(bare).plugins[0].source.sha, commits["0.1.0"]);
     assert.equal(readCatalog(bare).plugins[0].version, "0.1.0");
     assert.equal(back.outputs.previous_plugin_version, "0.2.0");
+    assert.equal(back.outputs.catalog_operation, "restore");
+    assert.equal(back.outputs.catalog_changed, "true");
+
+    const idempotent = runPublisher(env, repo, {
+      commit: forward.outputs.previous_plugin_sha,
+      version: forward.outputs.previous_plugin_version,
+      expected_current_revision: forward.outputs.marketplace_revision,
+      expected_current_plugin_sha: commits["0.2.0"],
+      expected_current_plugin_version: "0.2.0",
+    });
+    assert.equal(idempotent.status, 0, `${idempotent.stdout}${idempotent.stderr}`);
+    assert.equal(idempotent.outputs.catalog_operation, "restore");
+    assert.equal(idempotent.outputs.catalog_changed, "false");
   } finally {
     fs.rmSync(env.root, { recursive: true, force: true });
   }
@@ -191,7 +211,13 @@ test("a catalog whose current pin is not a rollback target is never moved", () =
       const { repo, commits } = sourceRepository(env.root, ["0.2.0"]);
       const bare = marketplaceRepository(env.root, entry);
       const seeded = git(bare, "rev-parse", "main");
-      const result = runPublisher(env, repo, { commit: commits["0.2.0"], version: "0.2.0" });
+      const result = runPublisher(env, repo, {
+        commit: commits["0.2.0"],
+        version: "0.2.0",
+        expected_current_revision: seeded,
+        expected_current_plugin_sha: String(entry.source?.sha ?? "0".repeat(40)),
+        expected_current_plugin_version: String(entry.version ?? "0.1.0"),
+      });
       assert.equal(result.status, 1, `${label}: ${result.stdout}${result.stderr}`);
       assert.match(result.stderr, /::error::.*is not a rollback target/u, label);
       assert.equal(git(bare, "rev-parse", "main"), seeded, `${label} moved the catalog`);

--- a/.github/scripts/publish-marketplace-catalog.test.mjs
+++ b/.github/scripts/publish-marketplace-catalog.test.mjs
@@ -179,6 +179,33 @@ test("the catalog move records the pin it replaced, and that pin is a working ro
   }
 });
 
+test("a restore refuses to overwrite a catalog that has moved past its published pin", () => {
+  const env = scratch();
+  try {
+    const { repo, commits } = sourceRepository(env.root, ["0.1.0", "0.2.0", "0.3.0"]);
+    const bare = marketplaceRepository(env.root, catalogEntry("0.1.0", commits["0.1.0"]));
+
+    const published = runPublisher(env, repo, { commit: commits["0.2.0"], version: "0.2.0" });
+    assert.equal(published.status, 0, `${published.stdout}${published.stderr}`);
+
+    const newer = runPublisher(env, repo, { commit: commits["0.3.0"], version: "0.3.0" });
+    assert.equal(newer.status, 0, `${newer.stdout}${newer.stderr}`);
+
+    const restore = runPublisher(env, repo, {
+      commit: commits["0.1.0"],
+      version: "0.1.0",
+      expected_current_revision: published.outputs.marketplace_revision,
+      expected_current_plugin_sha: commits["0.2.0"],
+      expected_current_plugin_version: "0.2.0",
+    });
+    assert.equal(restore.status, 1, `${restore.stdout}${restore.stderr}`);
+    assert.match(restore.stderr, /refusing automatic restore/u);
+    assert.deepEqual(readCatalog(bare).plugins[0], catalogEntry("0.3.0", commits["0.3.0"]));
+  } finally {
+    fs.rmSync(env.root, { recursive: true, force: true });
+  }
+});
+
 test("an already-synced catalog reports the pin it is serving without pushing", () => {
   const env = scratch();
   try {

--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -132,6 +132,37 @@ jobs:
           node .github/scripts/extract-codestory-release-notes.mjs --version "$INPUT_VERSION" > /tmp/plugin-release-notes.md
           test -s /tmp/plugin-release-notes.md
 
+      # W8.4: prove the public resolver before publication against a catalog pinned to this exact
+      # candidate. The live catalog correctly still names the previous release here.
+      - name: Prove the candidate-pinned marketplace install path
+        env:
+          CODEX_CLI_VERSION: "0.144.5"
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          install_root="$RUNNER_TEMP/codestory-marketplace-preflight"
+          fixture_root="$install_root/marketplace-fixture"
+          codex_package_root="$RUNNER_TEMP/codex-cli-${CODEX_CLI_VERSION}"
+          rm -rf "$install_root"
+          npm install --prefix "$codex_package_root" --no-audit --no-fund "@openai/codex@$CODEX_CLI_VERSION"
+          node .github/scripts/build-marketplace-fixture.mjs \
+            --out "$fixture_root" \
+            --source-repository "$GITHUB_WORKSPACE" \
+            --commit "$GITHUB_SHA"
+          fixture_revision="$(git -C "$fixture_root" rev-parse HEAD)"
+          printf '%s' "$fixture_revision" | grep -Eq '^[0-9a-f]{40}$'
+          node .github/scripts/install-codestory-marketplace-proof.mjs \
+            --codex-package-root "$codex_package_root" \
+            --codex-home "$install_root/codex-home" \
+            --plugin-data "$install_root/codex-home/plugin-data" \
+            --marketplace-source "$fixture_root" \
+            --marketplace-name TheGreenCedar \
+            --marketplace-revision "$fixture_revision" \
+            --local-fixture true \
+            --expected-version "$INPUT_VERSION" \
+            --source-repository "$GITHUB_WORKSPACE" \
+            --attestation "$install_root/install-attestation-v2.json"
+
   plugin-proof:
     needs: preflight
     strategy:
@@ -207,6 +238,7 @@ jobs:
     environment: marketplace-publish
     outputs:
       catalog_published: ${{ steps.delivery.outputs.catalog_published }}
+      catalog_delivery_state: ${{ steps.delivery.outputs.catalog_delivery_state }}
       marketplace_revision: ${{ steps.delivery.outputs.marketplace_revision }}
       # What the catalog served before this run moved it. A catalog move with no recorded
       # predecessor is a move nobody can undo, so the rollback target travels with the state.
@@ -215,6 +247,8 @@ jobs:
       previous_plugin_version: ${{ steps.delivery.outputs.previous_plugin_version }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Mint a scoped marketplace token
         id: token
@@ -244,6 +278,53 @@ jobs:
             --version "$INPUT_VERSION" \
             --github-output "$GITHUB_OUTPUT"
 
+      - name: Smoke the published live catalog
+        id: live-catalog-smoke
+        if: steps.publish.outcome == 'success'
+        continue-on-error: true
+        env:
+          CODEX_CLI_VERSION: "0.144.5"
+          INPUT_VERSION: ${{ inputs.version }}
+          MARKETPLACE_REVISION: ${{ steps.publish.outputs.marketplace_revision }}
+        run: |
+          set -euo pipefail
+          install_root="$RUNNER_TEMP/codestory-live-catalog-smoke"
+          codex_package_root="$RUNNER_TEMP/codex-cli-${CODEX_CLI_VERSION}"
+          rm -rf "$install_root"
+          npm install --prefix "$codex_package_root" --no-audit --no-fund "@openai/codex@$CODEX_CLI_VERSION"
+          node .github/scripts/install-codestory-marketplace-proof.mjs \
+            --codex-package-root "$codex_package_root" \
+            --codex-home "$install_root/codex-home" \
+            --plugin-data "$install_root/codex-home/plugin-data" \
+            --marketplace-source TheGreenCedar/AgentPluginMarketplace \
+            --marketplace-name TheGreenCedar \
+            --marketplace-revision "$MARKETPLACE_REVISION" \
+            --local-fixture false \
+            --expected-version "$INPUT_VERSION" \
+            --source-repository "$GITHUB_WORKSPACE" \
+            --attestation "$install_root/install-attestation-v2.json"
+
+      - name: Restore the previous catalog pin
+        id: restore
+        if: steps.publish.outcome == 'success' && steps.publish.outputs.catalog_changed == 'true' && steps.live-catalog-smoke.outcome == 'failure'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          INPUT_VERSION: ${{ inputs.version }}
+          PUBLISHED_REVISION: ${{ steps.publish.outputs.marketplace_revision }}
+          PREVIOUS_PLUGIN_SHA: ${{ steps.publish.outputs.previous_plugin_sha }}
+          PREVIOUS_PLUGIN_VERSION: ${{ steps.publish.outputs.previous_plugin_version }}
+        run: |
+          set -euo pipefail
+          node .github/scripts/publish-marketplace-catalog.mjs \
+            --source-repository "$GITHUB_WORKSPACE" \
+            --commit "$PREVIOUS_PLUGIN_SHA" \
+            --version "$PREVIOUS_PLUGIN_VERSION" \
+            --expected-current-revision "$PUBLISHED_REVISION" \
+            --expected-current-plugin-sha "$GITHUB_SHA" \
+            --expected-current-plugin-version "$INPUT_VERSION" \
+            --github-output "$GITHUB_OUTPUT"
+
       # The only place this lane's "catalog was updated" claim is ever minted.
       - name: Record catalog delivery outcome
         id: delivery
@@ -251,6 +332,9 @@ jobs:
         env:
           TOKEN_OUTCOME: ${{ steps.token.outcome }}
           PUBLISH_OUTCOME: ${{ steps.publish.outcome }}
+          LIVE_SMOKE_OUTCOME: ${{ steps.live-catalog-smoke.outcome }}
+          RESTORE_OUTCOME: ${{ steps.restore.outcome }}
+          RESTORED_REVISION: ${{ steps.restore.outputs.marketplace_revision }}
           PUBLISHED_REVISION: ${{ steps.publish.outputs.marketplace_revision }}
           PREVIOUS_REVISION: ${{ steps.publish.outputs.previous_marketplace_revision }}
           PREVIOUS_PLUGIN_SHA: ${{ steps.publish.outputs.previous_plugin_sha }}
@@ -259,18 +343,29 @@ jobs:
         run: |
           set -euo pipefail
           catalog_published=false
+          catalog_delivery_state=deferred
           marketplace_revision=""
           if [ "$TOKEN_OUTCOME" = "success" ] \
             && [ "$PUBLISH_OUTCOME" = "success" ] \
+            && [ "$LIVE_SMOKE_OUTCOME" = "success" ] \
             && printf '%s' "$PUBLISHED_REVISION" | grep -Eq '^[0-9a-f]{40}$'; then
             catalog_published=true
+            catalog_delivery_state=published
             marketplace_revision="$PUBLISHED_REVISION"
+          elif [ "$PUBLISH_OUTCOME" = "success" ] \
+            && [ "$LIVE_SMOKE_OUTCOME" = "failure" ] \
+            && [ "$RESTORE_OUTCOME" = "success" ] \
+            && printf '%s' "$RESTORED_REVISION" | grep -Eq '^[0-9a-f]{40}$'; then
+            catalog_delivery_state=restored
+          elif [ "$PUBLISH_OUTCOME" = "success" ]; then
+            catalog_delivery_state=unresolved
           fi
           # The rollback target is recorded whatever happened. On a published run it names the
           # release a restore would return to; on a deferred run it names the release the catalog
           # is still serving.
           {
             echo "catalog_published=$catalog_published"
+            echo "catalog_delivery_state=$catalog_delivery_state"
             echo "marketplace_revision=$marketplace_revision"
             echo "previous_marketplace_revision=$PREVIOUS_REVISION"
             echo "previous_plugin_sha=$PREVIOUS_PLUGIN_SHA"
@@ -279,6 +374,16 @@ jobs:
           if [ "$catalog_published" = "true" ]; then
             echo "Catalog delivery: published at $marketplace_revision." >> "$GITHUB_STEP_SUMMARY"
             echo "Rollback target: codestory $PREVIOUS_PLUGIN_VERSION at $PREVIOUS_PLUGIN_SHA (catalog $PREVIOUS_REVISION), restorable with $RECOVERY_WORKFLOW." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          if [ "$catalog_delivery_state" = "restored" ]; then
+            echo "::warning::The live-catalog smoke failed. Automatic restore returned the catalog to codestory $PREVIOUS_PLUGIN_VERSION at $PREVIOUS_PLUGIN_SHA (catalog $RESTORED_REVISION); the release stands."
+            echo "Catalog delivery: RESTORED after a failed live-catalog smoke." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          if [ "$catalog_delivery_state" = "unresolved" ]; then
+            echo "::error::The live-catalog smoke failed and automatic restore did not complete. The release stands, but catalog delivery is unresolved."
+            echo "Catalog delivery: UNRESOLVED. The release remains published." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
           # $RECOVERY_WORKFLOW mints the SAME credential from the SAME environment, so it recovers a
@@ -345,6 +450,7 @@ jobs:
         shell: bash
         env:
           CATALOG_PUBLISHED: ${{ needs.marketplace-publish.outputs.catalog_published == 'true' }}
+          CATALOG_DELIVERY_STATE: ${{ needs.marketplace-publish.outputs.catalog_delivery_state }}
           INPUT_MARKETPLACE_REVISION: ${{ needs.marketplace-publish.outputs.marketplace_revision }}
           PUBLISHED_COMMIT: ${{ steps.published.outputs.commit }}
         run: |
@@ -354,15 +460,16 @@ jobs:
           printf '%s' "$published_commit" | grep -Eq '^[0-9a-f]{40}$'
           fixture_root="$RUNNER_TEMP/codestory-marketplace-delivery/fixture"
           rm -rf "$fixture_root"
-          if [ "$CATALOG_PUBLISHED" = "true" ]; then
+          if [ "$CATALOG_DELIVERY_STATE" = "published" ] && [ "$CATALOG_PUBLISHED" = "true" ]; then
             marketplace_source=TheGreenCedar/AgentPluginMarketplace
             marketplace_revision="$INPUT_MARKETPLACE_REVISION"
             local_fixture=false
             installer=codex_marketplace_install
             state=published
-          elif [ "$CATALOG_PUBLISHED" = "false" ]; then
+          elif { [ "$CATALOG_DELIVERY_STATE" = "deferred" ] || [ "$CATALOG_DELIVERY_STATE" = "restored" ]; } \
+            && [ "$CATALOG_PUBLISHED" = "false" ]; then
             if [ -n "$INPUT_MARKETPLACE_REVISION" ]; then
-              echo "::error::Deferred catalog publication must not carry a live catalog revision."
+              echo "::error::$CATALOG_DELIVERY_STATE catalog delivery must not carry the failed live catalog revision."
               exit 1
             fi
             # Pinned to the PUBLISHED commit resolved from GitHub, not to whatever this
@@ -376,10 +483,14 @@ jobs:
             marketplace_source="$fixture_root"
             marketplace_revision="$(git -C "$fixture_root" rev-parse HEAD)"
             local_fixture=true
-            installer=codex_marketplace_deferred_fixture
-            state=deferred
+            if [ "$CATALOG_DELIVERY_STATE" = "restored" ]; then
+              installer=codex_marketplace_restored_fixture
+            else
+              installer=codex_marketplace_deferred_fixture
+            fi
+            state="$CATALOG_DELIVERY_STATE"
           else
-            echo "::error::catalog_published must be true or false, not '$CATALOG_PUBLISHED'."
+            echo "::error::catalog delivery handoff is inconsistent: state=$CATALOG_DELIVERY_STATE published=$CATALOG_PUBLISHED."
             exit 1
           fi
           printf '%s' "$marketplace_revision" | grep -Eq '^[0-9a-f]{40}$'
@@ -392,6 +503,8 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           if [ "$state" = "deferred" ]; then
             echo "::warning::Catalog publication was deferred for this release. This smoke proves the published plugin against a candidate-pinned catalog fixture and records installer $installer; recover the public catalog with marketplace-sync.yml."
+          elif [ "$state" = "restored" ]; then
+            echo "::warning::The public catalog was automatically restored after its live smoke failed. This smoke proves the published plugin against a candidate-pinned catalog fixture and records installer $installer."
           fi
           echo "Catalog delivery state: $state (installer $installer, catalog revision $marketplace_revision)." >> "$GITHUB_STEP_SUMMARY"
 
@@ -401,6 +514,7 @@ jobs:
           MARKETPLACE_REVISION: ${{ steps.delivery.outputs.marketplace_revision }}
           MARKETPLACE_SOURCE: ${{ steps.delivery.outputs.marketplace_source }}
           LOCAL_FIXTURE: ${{ steps.delivery.outputs.local_fixture }}
+          INSTALLATION_SOURCE: ${{ steps.delivery.outputs.installer }}
           INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
@@ -420,6 +534,7 @@ jobs:
             --marketplace-name TheGreenCedar \
             --marketplace-revision "$MARKETPLACE_REVISION" \
             --local-fixture "$LOCAL_FIXTURE" \
+            --installation-source "$INSTALLATION_SOURCE" \
             --expected-version "$INPUT_VERSION" \
             --source-repository "$GITHUB_WORKSPACE" \
             --attestation "$install_root/install-attestation-v2.json"

--- a/.github/workflows/post-publish-release-smoke.yml
+++ b/.github/workflows/post-publish-release-smoke.yml
@@ -11,6 +11,10 @@ on:
         description: Whether marketplace-publish actually updated the public catalog for this release.
         required: true
         type: boolean
+      catalog_delivery_state:
+        description: "Recorded catalog outcome: published, deferred, or restored."
+        required: true
+        type: string
       marketplace_revision:
         description: Immutable published catalog revision. Empty exactly when publication was deferred.
         required: false
@@ -36,6 +40,14 @@ on:
         description: Whether marketplace-publish actually updated the public catalog for this release.
         required: true
         type: boolean
+      catalog_delivery_state:
+        description: "Recorded catalog outcome: published, deferred, or restored."
+        required: true
+        type: choice
+        options:
+          - published
+          - deferred
+          - restored
       marketplace_revision:
         description: Immutable published catalog revision. Empty exactly when publication was deferred.
         required: false
@@ -504,6 +516,7 @@ jobs:
         shell: bash
         env:
           CATALOG_PUBLISHED: ${{ inputs.catalog_published }}
+          CATALOG_DELIVERY_STATE: ${{ inputs.catalog_delivery_state }}
           INPUT_MARKETPLACE_REVISION: ${{ inputs.marketplace_revision }}
           PUBLISHED_COMMIT: ${{ steps.published.outputs.commit }}
         run: |
@@ -513,18 +526,19 @@ jobs:
           printf '%s' "$published_commit" | grep -Eq '^[0-9a-f]{40}$'
           fixture_root="$RUNNER_TEMP/codestory-marketplace-delivery/fixture"
           rm -rf "$fixture_root"
-          if [ "$CATALOG_PUBLISHED" = "true" ]; then
+          if [ "$CATALOG_DELIVERY_STATE" = "published" ] && [ "$CATALOG_PUBLISHED" = "true" ]; then
             marketplace_source=TheGreenCedar/AgentPluginMarketplace
             marketplace_revision="$INPUT_MARKETPLACE_REVISION"
             local_fixture=false
             installer=codex_marketplace_install
             state=published
-          elif [ "$CATALOG_PUBLISHED" = "false" ]; then
+          elif { [ "$CATALOG_DELIVERY_STATE" = "deferred" ] || [ "$CATALOG_DELIVERY_STATE" = "restored" ]; } \
+            && [ "$CATALOG_PUBLISHED" = "false" ]; then
             # The public catalog still points at the previous release, so resolving against it would
             # prove the PREVIOUS release. Pin a catalog to this exact published commit instead: same
             # resolver, same pinned git-subdir source, only the catalog host differs.
             if [ -n "$INPUT_MARKETPLACE_REVISION" ]; then
-              echo "::error::Deferred catalog publication must not carry a live catalog revision."
+              echo "::error::$CATALOG_DELIVERY_STATE catalog delivery must not carry the failed live catalog revision."
               exit 1
             fi
             node .github/scripts/build-marketplace-fixture.mjs \
@@ -534,10 +548,14 @@ jobs:
             marketplace_source="$fixture_root"
             marketplace_revision="$(git -C "$fixture_root" rev-parse HEAD)"
             local_fixture=true
-            installer=codex_marketplace_deferred_fixture
-            state=deferred
+            if [ "$CATALOG_DELIVERY_STATE" = "restored" ]; then
+              installer=codex_marketplace_restored_fixture
+            else
+              installer=codex_marketplace_deferred_fixture
+            fi
+            state="$CATALOG_DELIVERY_STATE"
           else
-            echo "::error::catalog_published must be true or false, not '$CATALOG_PUBLISHED'."
+            echo "::error::catalog delivery handoff is inconsistent: state=$CATALOG_DELIVERY_STATE published=$CATALOG_PUBLISHED."
             exit 1
           fi
           printf '%s' "$marketplace_revision" | grep -Eq '^[0-9a-f]{40}$'
@@ -550,6 +568,8 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           if [ "$state" = "deferred" ]; then
             echo "::warning::Catalog publication was deferred for this release. This smoke proves the published assets against a candidate-pinned catalog fixture and records installer $installer; recover the public catalog with marketplace-sync.yml."
+          elif [ "$state" = "restored" ]; then
+            echo "::warning::The public catalog was automatically restored after its live smoke failed. This smoke proves the published assets against a candidate-pinned catalog fixture and records installer $installer."
           fi
           echo "Catalog delivery state: $state (installer $installer, catalog revision $marketplace_revision)." >> "$GITHUB_STEP_SUMMARY"
 
@@ -560,6 +580,7 @@ jobs:
           MARKETPLACE_REVISION: ${{ steps.delivery.outputs.marketplace_revision }}
           MARKETPLACE_SOURCE: ${{ steps.delivery.outputs.marketplace_source }}
           LOCAL_FIXTURE: ${{ steps.delivery.outputs.local_fixture }}
+          INSTALLATION_SOURCE: ${{ steps.delivery.outputs.installer }}
           RELEASE_VERSION: ${{ steps.release.outputs.version }}
         run: |
           set -euo pipefail
@@ -583,6 +604,7 @@ jobs:
             --marketplace-name TheGreenCedar \
             --marketplace-revision "$marketplace_revision" \
             --local-fixture "$LOCAL_FIXTURE" \
+            --installation-source "$INSTALLATION_SOURCE" \
             --expected-version "$RELEASE_VERSION" \
             --source-repository "$GITHUB_WORKSPACE" \
             --attestation "$install_root/install-attestation-v2.json" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -806,6 +806,7 @@ jobs:
     environment: marketplace-publish
     outputs:
       catalog_published: ${{ steps.delivery.outputs.catalog_published }}
+      catalog_delivery_state: ${{ steps.delivery.outputs.catalog_delivery_state }}
       marketplace_revision: ${{ steps.delivery.outputs.marketplace_revision }}
       # What the catalog served before this run moved it. A catalog move with no recorded
       # predecessor is a move nobody can undo, so the rollback target travels with the state.
@@ -817,6 +818,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ github.sha }}
+          fetch-depth: 0
 
       - name: Mint a scoped marketplace token
         id: token
@@ -846,6 +848,56 @@ jobs:
             --version "$RELEASE_VERSION" \
             --github-output "$GITHUB_OUTPUT"
 
+      # Probe the exact live revision before the release records `published`. The scoped token is
+      # not exposed to this step. A failure is data for the restore step, not a release failure.
+      - name: Smoke the published live catalog
+        id: live-catalog-smoke
+        if: steps.publish.outcome == 'success'
+        continue-on-error: true
+        env:
+          CODEX_CLI_VERSION: "0.144.5"
+          MARKETPLACE_REVISION: ${{ steps.publish.outputs.marketplace_revision }}
+          RELEASE_VERSION: ${{ needs.preflight.outputs.version }}
+        run: |
+          set -euo pipefail
+          install_root="$RUNNER_TEMP/codestory-live-catalog-smoke"
+          codex_package_root="$RUNNER_TEMP/codex-cli-${CODEX_CLI_VERSION}"
+          rm -rf "$install_root"
+          npm install --prefix "$codex_package_root" --no-audit --no-fund "@openai/codex@$CODEX_CLI_VERSION"
+          node .github/scripts/install-codestory-marketplace-proof.mjs \
+            --codex-package-root "$codex_package_root" \
+            --codex-home "$install_root/codex-home" \
+            --plugin-data "$install_root/codex-home/plugin-data" \
+            --marketplace-source TheGreenCedar/AgentPluginMarketplace \
+            --marketplace-name TheGreenCedar \
+            --marketplace-revision "$MARKETPLACE_REVISION" \
+            --local-fixture false \
+            --expected-version "$RELEASE_VERSION" \
+            --source-repository "$GITHUB_WORKSPACE" \
+            --attestation "$install_root/install-attestation-v2.json"
+
+      - name: Restore the previous catalog pin
+        id: restore
+        if: steps.publish.outcome == 'success' && steps.publish.outputs.catalog_changed == 'true' && steps.live-catalog-smoke.outcome == 'failure'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          PUBLISHED_REVISION: ${{ steps.publish.outputs.marketplace_revision }}
+          PUBLISHED_PLUGIN_SHA: ${{ github.sha }}
+          PUBLISHED_PLUGIN_VERSION: ${{ needs.preflight.outputs.version }}
+          PREVIOUS_PLUGIN_SHA: ${{ steps.publish.outputs.previous_plugin_sha }}
+          PREVIOUS_PLUGIN_VERSION: ${{ steps.publish.outputs.previous_plugin_version }}
+        run: |
+          set -euo pipefail
+          node .github/scripts/publish-marketplace-catalog.mjs \
+            --source-repository "$GITHUB_WORKSPACE" \
+            --commit "$PREVIOUS_PLUGIN_SHA" \
+            --version "$PREVIOUS_PLUGIN_VERSION" \
+            --expected-current-revision "$PUBLISHED_REVISION" \
+            --expected-current-plugin-sha "$PUBLISHED_PLUGIN_SHA" \
+            --expected-current-plugin-version "$PUBLISHED_PLUGIN_VERSION" \
+            --github-output "$GITHUB_OUTPUT"
+
       # The only place the "catalog was updated" claim is ever minted. It requires the token, the
       # push, AND an immutable revision to have all landed; anything else records deferred, so an
       # unknown or half-finished state can never read as published.
@@ -855,6 +907,9 @@ jobs:
         env:
           TOKEN_OUTCOME: ${{ steps.token.outcome }}
           PUBLISH_OUTCOME: ${{ steps.publish.outcome }}
+          LIVE_SMOKE_OUTCOME: ${{ steps.live-catalog-smoke.outcome }}
+          RESTORE_OUTCOME: ${{ steps.restore.outcome }}
+          RESTORED_REVISION: ${{ steps.restore.outputs.marketplace_revision }}
           PUBLISHED_REVISION: ${{ steps.publish.outputs.marketplace_revision }}
           PREVIOUS_REVISION: ${{ steps.publish.outputs.previous_marketplace_revision }}
           PREVIOUS_PLUGIN_SHA: ${{ steps.publish.outputs.previous_plugin_sha }}
@@ -863,18 +918,29 @@ jobs:
         run: |
           set -euo pipefail
           catalog_published=false
+          catalog_delivery_state=deferred
           marketplace_revision=""
           if [ "$TOKEN_OUTCOME" = "success" ] \
             && [ "$PUBLISH_OUTCOME" = "success" ] \
+            && [ "$LIVE_SMOKE_OUTCOME" = "success" ] \
             && printf '%s' "$PUBLISHED_REVISION" | grep -Eq '^[0-9a-f]{40}$'; then
             catalog_published=true
+            catalog_delivery_state=published
             marketplace_revision="$PUBLISHED_REVISION"
+          elif [ "$PUBLISH_OUTCOME" = "success" ] \
+            && [ "$LIVE_SMOKE_OUTCOME" = "failure" ] \
+            && [ "$RESTORE_OUTCOME" = "success" ] \
+            && printf '%s' "$RESTORED_REVISION" | grep -Eq '^[0-9a-f]{40}$'; then
+            catalog_delivery_state=restored
+          elif [ "$PUBLISH_OUTCOME" = "success" ]; then
+            catalog_delivery_state=unresolved
           fi
           # The rollback target is recorded whatever happened. On a published run it names the
           # release a restore would return to; on a deferred run it names the release the catalog
           # is still serving.
           {
             echo "catalog_published=$catalog_published"
+            echo "catalog_delivery_state=$catalog_delivery_state"
             echo "marketplace_revision=$marketplace_revision"
             echo "previous_marketplace_revision=$PREVIOUS_REVISION"
             echo "previous_plugin_sha=$PREVIOUS_PLUGIN_SHA"
@@ -883,6 +949,16 @@ jobs:
           if [ "$catalog_published" = "true" ]; then
             echo "Catalog delivery: published at $marketplace_revision." >> "$GITHUB_STEP_SUMMARY"
             echo "Rollback target: codestory $PREVIOUS_PLUGIN_VERSION at $PREVIOUS_PLUGIN_SHA (catalog $PREVIOUS_REVISION), restorable with $RECOVERY_WORKFLOW." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          if [ "$catalog_delivery_state" = "restored" ]; then
+            echo "::warning::The live-catalog smoke failed after publication. Automatic restore returned the public catalog to codestory $PREVIOUS_PLUGIN_VERSION at $PREVIOUS_PLUGIN_SHA (catalog $RESTORED_REVISION); the release stands."
+            echo "Catalog delivery: RESTORED after a failed live-catalog smoke. The release is published; the public catalog serves the previous release." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          if [ "$catalog_delivery_state" = "unresolved" ]; then
+            echo "::error::The live-catalog smoke failed and automatic restore did not complete. The release stands, but catalog delivery is unresolved."
+            echo "Catalog delivery: UNRESOLVED. The release remains published; automatic restore did not complete." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
           # $RECOVERY_WORKFLOW mints the SAME credential from the SAME environment, so it recovers a
@@ -909,6 +985,7 @@ jobs:
     with:
       version: ${{ needs.preflight.outputs.version }}
       catalog_published: ${{ needs.marketplace-publish.outputs.catalog_published == 'true' }}
+      catalog_delivery_state: ${{ needs.marketplace-publish.outputs.catalog_delivery_state }}
       marketplace_revision: ${{ needs.marketplace-publish.outputs.marketplace_revision }}
       pre_publish_closeout_artifact: release-closeout-pre-publish-${{ needs.preflight.outputs.version }}-${{ github.sha }}
       emit_release_cells: true

--- a/benchmarks/release-evidence/fixtures/candidate.json
+++ b/benchmarks/release-evidence/fixtures/candidate.json
@@ -62,7 +62,7 @@
   },
   "release_claims": {
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "6e87790d68f648467d695b554ee1638279d11e664a631e5b90b51411adfaabf5",
+    "graph_sha256": "392d9f9097f79f1c39eba779ae52cd1bcce76ddbbcbc3d219ac1f06b2d1a1ce7",
     "observed_at": "2026-07-21T02:13:20.738Z",
     "expires_at": "2026-07-22T02:13:20.738Z",
     "requested_claims": [
@@ -85,7 +85,7 @@
         "type": "performance",
         "tier": "live_behavior",
         "status": "measured",
-        "graph_sha256": "6e87790d68f648467d695b554ee1638279d11e664a631e5b90b51411adfaabf5",
+        "graph_sha256": "392d9f9097f79f1c39eba779ae52cd1bcce76ddbbcbc3d219ac1f06b2d1a1ce7",
         "observed_at": "2026-07-21T02:13:20.738Z",
         "expires_at": "2026-07-22T02:13:20.738Z",
         "identity": {
@@ -106,7 +106,7 @@
         "type": "answer_quality",
         "tier": "answer_quality",
         "status": "pass",
-        "graph_sha256": "6e87790d68f648467d695b554ee1638279d11e664a631e5b90b51411adfaabf5",
+        "graph_sha256": "392d9f9097f79f1c39eba779ae52cd1bcce76ddbbcbc3d219ac1f06b2d1a1ce7",
         "observed_at": "2026-07-21T02:13:20.738Z",
         "expires_at": "2026-07-22T02:13:20.738Z",
         "identity": {

--- a/benchmarks/release-evidence/fixtures/report.json
+++ b/benchmarks/release-evidence/fixtures/report.json
@@ -7,7 +7,7 @@
   "baseline_id": "ci-contract-v1@1111111111111111111111111111111111111111",
   "baseline_sha256": "0bbbe6dd8b4000151edf7b1270959d08e94e08db876e7f2372b25613e0f237c1",
   "candidate_path": "benchmarks/release-evidence/fixtures/candidate.json",
-  "candidate_sha256": "76c3cef3f59d64b5520002a68cf92105801583cf948dca3c49f3470e1d29cabc",
+  "candidate_sha256": "25f3a1c08dfdb3f5194c518b2cd405258dda39a6fe0190ba7f85adc649b44d2f",
   "artifact_paths": [
     {
       "path": "candidate-stats.json",
@@ -26,7 +26,7 @@
       "type": "performance",
       "tier": "live_behavior",
       "status": "pass",
-      "graph_sha256": "6e87790d68f648467d695b554ee1638279d11e664a631e5b90b51411adfaabf5",
+        "graph_sha256": "392d9f9097f79f1c39eba779ae52cd1bcce76ddbbcbc3d219ac1f06b2d1a1ce7",
       "observed_at": "2026-07-21T02:13:20.738Z",
       "expires_at": "2026-07-22T02:13:20.738Z",
       "identity": {
@@ -47,7 +47,7 @@
       "type": "answer_quality",
       "tier": "answer_quality",
       "status": "pass",
-      "graph_sha256": "6e87790d68f648467d695b554ee1638279d11e664a631e5b90b51411adfaabf5",
+      "graph_sha256": "392d9f9097f79f1c39eba779ae52cd1bcce76ddbbcbc3d219ac1f06b2d1a1ce7",
       "observed_at": "2026-07-21T02:13:20.738Z",
       "expires_at": "2026-07-22T02:13:20.738Z",
       "identity": {
@@ -69,7 +69,7 @@
     "schema": "codestory.release-claim-evaluation/v1",
     "status": "pass",
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "6e87790d68f648467d695b554ee1638279d11e664a631e5b90b51411adfaabf5",
+    "graph_sha256": "392d9f9097f79f1c39eba779ae52cd1bcce76ddbbcbc3d219ac1f06b2d1a1ce7",
     "evidence_selection": "all_matching_rows_must_pass",
     "expected_commit": "2222222222222222222222222222222222222222",
     "evaluated_at": "2026-07-21T02:13:20.738Z",

--- a/docs/contributors/release-runbook.md
+++ b/docs/contributors/release-runbook.md
@@ -207,11 +207,27 @@ After two equivalent failures, stop. Record the evidence, change the approach,
 and only then retry.
 
 Catalog publication happens after the irreversible release and is not a release
-gate. Record either `published` or `deferred` from the authenticated
-installed-runtime cells. Recover a deferred catalog with
-`marketplace-sync.yml`; do not hand-edit the marketplace repository. Missing
-marketplace credentials require repository settings work before a sync retry
-can succeed.
+gate. Before publication, W8.4 runs the real Codex marketplace resolver against
+the candidate-pinned fixture; the live catalog is allowed to keep naming the
+previous release until the release exists.
+
+After the catalog push, the release probes the exact live catalog revision
+before it may record `published`. If that probe fails, the marketplace-publish
+credential automatically restores the recorded previous plugin SHA and version.
+The restore is fenced by the just-pushed catalog revision, SHA, and version, so
+it is idempotent and refuses to overwrite a catalog that moved independently.
+A successful restore records `restored` and
+`codex_marketplace_restored_fixture`; downstream installed-runtime proof uses a
+candidate-pinned fixture and cannot retain the provisional `published` state.
+If restore does not complete, delivery is `unresolved` and closeout rejects the
+catalog claim, but the already-published release remains standing.
+
+Record `published`, `deferred`, or `restored` from the authenticated
+installed-runtime cells. Recover a catalog whose original push was deferred
+with `marketplace-sync.yml`; that manual move records the distinct `recovered`
+event. Do not hand-edit the marketplace repository. Missing marketplace
+credentials require repository settings work before either automatic restore
+or a sync retry can succeed.
 
 ## Promotion and closeout
 
@@ -246,8 +262,8 @@ After publication:
   machine policy declares it;
 - run the graph-declared post-publish proof against downloaded bytes and fresh
   installed runtimes;
-- record the catalog-delivery state without upgrading `deferred` to
-  `published`;
+- record the catalog-delivery state without upgrading `deferred` or `restored`
+  to `published`;
 - fast-forward `dev/codestory-next` from `F` to the published promotion `P`, or
   recreate the branch at `P` if it was deleted; this is a tree-preserving
   branch reconciliation, not a new commit;

--- a/release-claims.json
+++ b/release-claims.json
@@ -1516,6 +1516,11 @@
           "id": "deferred",
           "installer": "codex_marketplace_deferred_fixture",
           "live_catalog_revision": false
+        },
+        {
+          "id": "restored",
+          "installer": "codex_marketplace_restored_fixture",
+          "live_catalog_revision": false
         }
       ],
       "recovery": {
@@ -1525,7 +1530,8 @@
           "previous_plugin_sha",
           "previous_plugin_version"
         ],
-        "automatic_restore": false
+        "automatic_restore": true,
+        "restored_state": "restored"
       }
     },
     "lost_runner_rerun": {

--- a/scripts/codestory-release-claims.mjs
+++ b/scripts/codestory-release-claims.mjs
@@ -467,7 +467,7 @@ function validateNonClaimPolicy(graph, cellGroups) {
 // Marketplace catalog publication is delivery, not a release gate: it happens after the tag and
 // the GitHub release already exist, so failing the release on it would only convert a recoverable
 // delivery gap into an unrecoverable one. The price of that is that the release must say which of
-// the two states it is in, so the graph names both and pins a distinct installer identity to each.
+// the state it is in, so the graph names each and pins a distinct installer identity to each.
 // A run that could not publish records the deferred identity in its post-publish cells; nothing in
 // the pipeline is allowed to record the published identity without the catalog push succeeding.
 function validateCatalogDelivery(policy, dependencies, cellGroups) {
@@ -480,8 +480,8 @@ function validateCatalogDelivery(policy, dependencies, cellGroups) {
   if (delivery.release_gate !== false) {
     fail("workflow_policy.catalog_delivery.release_gate must be false: catalog publication is delivery, not a release gate");
   }
-  if (!Array.isArray(delivery.states) || delivery.states.length !== 2) {
-    fail("workflow_policy.catalog_delivery.states must name exactly the published and deferred states");
+  if (!Array.isArray(delivery.states) || delivery.states.length !== 3) {
+    fail("workflow_policy.catalog_delivery.states must name exactly the published, deferred, and restored states");
   }
   const installers = new Set();
   const byId = new Map();
@@ -504,7 +504,7 @@ function validateCatalogDelivery(policy, dependencies, cellGroups) {
     installers.add(installer);
     byId.set(id, state);
   }
-  for (const id of ["published", "deferred"]) {
+  for (const id of ["published", "deferred", "restored"]) {
     if (!byId.has(id)) fail(`workflow_policy.catalog_delivery.states must declare the ${id} state`);
   }
   if (byId.get("published").live_catalog_revision !== true) {
@@ -513,7 +513,10 @@ function validateCatalogDelivery(policy, dependencies, cellGroups) {
   if (byId.get("deferred").live_catalog_revision !== false) {
     fail("workflow_policy.catalog_delivery deferred state must not consume a live catalog revision");
   }
-  // Naming the two states is not enough on its own: something has to read the mark, or a
+  if (byId.get("restored").live_catalog_revision !== false) {
+    fail("workflow_policy.catalog_delivery restored state must not consume the failed live catalog revision");
+  }
+  // Naming the states is not enough on its own: something has to read the mark, or a
   // deferred release's closeout verdict stays indistinguishable from a published one. This
   // names the post-publish cell family whose signed `installer` identity the closeout resolves
   // the delivery state from, so the graph cannot declare the states without a reader.
@@ -559,10 +562,17 @@ function validateCatalogDelivery(policy, dependencies, cellGroups) {
       fail(`workflow_policy.catalog_delivery.recovery.previous_pin_outputs[${index}] does not match identifier`);
     }
   }
-  // Stated, not implied. Restore is operator-initiated through `recovery_workflow` today; the
-  // graph says so rather than letting documentation claim an automatic rollback that no job runs.
-  if (recovery.automatic_restore !== false) {
-    fail("workflow_policy.catalog_delivery.recovery.automatic_restore must be false while restore is operator-initiated");
+  const restoredState = nonEmptyText(
+    recovery.restored_state,
+    "workflow_policy.catalog_delivery.recovery.restored_state",
+  );
+  if (restoredState !== "restored" || !byId.has(restoredState)) {
+    fail("workflow_policy.catalog_delivery.recovery.restored_state must name the declared restored state");
+  }
+  // Stated, not implied. This may be true only with a distinct closeout-readable restored state;
+  // workflow policy separately proves the release lane executes the prior-pin restore.
+  if (recovery.automatic_restore !== true) {
+    fail("workflow_policy.catalog_delivery.recovery.automatic_restore must be true with executable prior-pin restore");
   }
   return delivery;
 }

--- a/scripts/tests/codestory-release-claims.test.mjs
+++ b/scripts/tests/codestory-release-claims.test.mjs
@@ -1006,11 +1006,11 @@ test("graph rejects ambiguous dependencies and unstructured proof lanes", () => 
 // deleting it, reinstating the gate, or collapsing the two installer identities onto one -- which
 // is exactly how a deferred run would come to read as a published one -- must be refusals here,
 // not merely in the workflow policy that consumes them.
-test("catalog delivery declares two distinguishable states and no release gate", () => {
+test("catalog delivery declares three distinguishable states and no release gate", () => {
   const delivery = graph.workflow_policy.catalog_delivery;
   assert.equal(delivery.release_gate, false);
-  assert.deepEqual(delivery.states.map(({ id }) => id).sort(), ["deferred", "published"]);
-  assert.equal(new Set(delivery.states.map(({ installer }) => installer)).size, 2);
+  assert.deepEqual(delivery.states.map(({ id }) => id).sort(), ["deferred", "published", "restored"]);
+  assert.equal(new Set(delivery.states.map(({ installer }) => installer)).size, 3);
 
   const missing = structuredClone(graph);
   delete missing.workflow_policy.catalog_delivery;
@@ -1088,9 +1088,8 @@ test("catalog recovery is a distinguishable identity with a recorded rollback ta
     "previous_plugin_sha",
     "previous_plugin_version",
   ]);
-  // Stated rather than implied: no job restores the catalog on its own yet, so the graph refuses
-  // to carry a `true` that documentation could quote as an automatic rollback.
-  assert.equal(recovery.automatic_restore, false);
+  assert.equal(recovery.automatic_restore, true);
+  assert.equal(recovery.restored_state, "restored");
 
   const missing = structuredClone(graph);
   delete missing.workflow_policy.catalog_delivery.recovery;
@@ -1113,11 +1112,18 @@ test("catalog recovery is a distinguishable identity with a recorded rollback ta
     /previous_pin_outputs must name the recorded rollback target/u,
   );
 
-  const overclaimed = structuredClone(graph);
-  overclaimed.workflow_policy.catalog_delivery.recovery.automatic_restore = true;
+  const disabled = structuredClone(graph);
+  disabled.workflow_policy.catalog_delivery.recovery.automatic_restore = false;
   assert.throws(
-    () => validateReleaseClaimGraph(overclaimed),
-    /automatic_restore must be false while restore is operator-initiated/u,
+    () => validateReleaseClaimGraph(disabled),
+    /automatic_restore must be true with executable prior-pin restore/u,
+  );
+
+  const unrecorded = structuredClone(graph);
+  unrecorded.workflow_policy.catalog_delivery.recovery.restored_state = "deferred";
+  assert.throws(
+    () => validateReleaseClaimGraph(unrecorded),
+    /restored_state must name the declared restored state/u,
   );
 });
 

--- a/scripts/tests/codestory-release-closeout.test.mjs
+++ b/scripts/tests/codestory-release-closeout.test.mjs
@@ -1558,6 +1558,25 @@ test("the post-publish closeout resolves and records which catalog served the re
   // warning in a log that expires.
   assert.notDeepEqual(deferred.ledger.catalog_delivery, published.ledger.catalog_delivery);
 
+  // A successful automatic restore proves the released plugin through its candidate-pinned
+  // fixture, but the ledger must say the public catalog was rolled back. It may never retain the
+  // provisional published state from before the failed live-catalog smoke.
+  const restoredManifests = manifestsFor("post_publish", prePublish.ledger);
+  for (const manifest of restoredManifests) {
+    if (manifest.cell_id.startsWith("installed_runtime_behavior:")) {
+      manifest.evidence.identity.installer = "codex_marketplace_restored_fixture";
+    }
+  }
+  const restored = evaluate("post_publish", restoredManifests, prePublish.ledger);
+  assert.equal(restored.decision, "accept");
+  assert.deepEqual(restored.ledger.catalog_delivery, {
+    state: "restored",
+    installer: "codex_marketplace_restored_fixture",
+    live_catalog_revision: false,
+  });
+  assert.deepEqual(restored.summary.catalog_delivery, restored.ledger.catalog_delivery);
+  assert.notEqual(restored.ledger.catalog_delivery.state, "published");
+
   // The pre-publish closeout has no post-publish installed cells, so it states nothing here
   // rather than inventing a delivery state.
   assert.equal(prePublish.ledger.catalog_delivery, undefined);
@@ -1568,7 +1587,12 @@ test("a post-publish closeout that cannot resolve one catalog delivery state is 
 
   // An installer identity no delivery state declares -- including the pre-publish lane's own
   // candidate installer, which would otherwise sail through as a plausible-looking string.
-  for (const installer of ["candidate_managed_plugin", "managed_plugin", ""]) {
+  for (const installer of [
+    "candidate_managed_plugin",
+    "managed_plugin",
+    "codex_marketplace_restored_fixture_v2",
+    "",
+  ]) {
     const manifests = manifestsFor("post_publish", prePublish.ledger);
     for (const manifest of manifests) {
       if (manifest.cell_id.startsWith("installed_runtime_behavior:")) {

--- a/scripts/tests/fixtures/release-claims/positive.json
+++ b/scripts/tests/fixtures/release-claims/positive.json
@@ -17,7 +17,7 @@
       "type": "source_behavior",
       "tier": "source",
       "status": "pass",
-      "graph_sha256": "6e87790d68f648467d695b554ee1638279d11e664a631e5b90b51411adfaabf5",
+      "graph_sha256": "392d9f9097f79f1c39eba779ae52cd1bcce76ddbbcbc3d219ac1f06b2d1a1ce7",
       "observed_at": "2026-07-16T11:00:00.000Z",
       "expires_at": "2026-07-17T11:00:00.000Z",
       "identity": {


### PR DESCRIPTION
## Context

REL-MANb, the audited remainder of #1671 after PR #1796. Catalog rollback existed as prose and a manual sync path; the machine policy honestly recorded `automatic_restore: false`. #1671's contract requires rollback to become executable and recorded before any doc claims it, with the published/deferred/recovered identities distinguishable end to end.

Closes #1855
Refs #1671
Refs #1233
Refs #1179

## What changed

- **Automatic prior-pin restore**: when the post-publish live-catalog smoke fails against the catalog a release just pushed, the recovery path restores the recorded previous catalog pin, fenced by the pushed catalog revision, SHA, and version so it can never clobber an unrelated later push. Idempotent; non-rollbackable catalogs keep their existing refusal.
- **New `restored` closeout state**, coherent across all three registry surfaces per the standing rule: `marketplace-delivery-identity.mjs` (installer `codex_marketplace_restored_fixture`), `marketplace_installation.py` (repository `local:candidate-pinned-marketplace-restored-fixture` accepted shape), and `release-claims.json`. Restored and deferred releases resolve candidate-pinned fixture proof and can never claim `published`.
- **Semantics**: `workflow_policy.catalog_delivery.recovery.automatic_restore` is now `true` — together with the machinery that makes it true. `release_gate` remains `false`: catalog delivery still never fails a release; what changed is that recovery is executable and its outcome is a first-class recorded state.
- **W8.4**: candidate-pinned pre-publication marketplace catalog proof in the plugin lane; the native lane's existing proof posture is unchanged.
- Claims fixtures regenerated coherently including the attested `candidate_sha256`; runbook updated only where behavior is now test-proven.

## Verification

Passed on `2835c274` (implementer where the sandbox allowed; every suite re-run by supervisor with full deps): publish-catalog tests 3/0, policy checker, policy tests 1369/0, claims 43/0, closeout 39/0, evidence-gate 20/0, plugin-static 130/0, Python marketplace-delivery self-tests, actionlint + its tests, doc links, generalization lint, `git diff --check`.

Independent fresh-context adversarial review on the exact head is running; draft until it accepts and CI is green.
