### PR TITLE
[v0.17 EV-7c] Lift freshness inventory caps under proven observer coverage

### DIFF
--- a/crates/codestory-runtime/src/index_freshness.rs
+++ b/crates/codestory-runtime/src/index_freshness.rs
@@ -217,7 +217,7 @@ struct IndexFreshnessInventory {
 struct IndexFreshnessPlan {
     plan: codestory_contracts::workspace::RefreshPlan,
     current_policy_exclusions: Vec<codestory_workspace::OversizedSourceExclusionCandidate>,
-    current_file_count: usize,
+    admitted_file_count: usize,
 }
 
 #[derive(Clone, Copy)]
@@ -383,25 +383,10 @@ fn plan_index_freshness(
         });
     }
 
-    let new_file_count = refresh
-        .refresh
-        .plan
-        .files_to_index
-        .iter()
-        .filter(|path| !refresh.refresh.plan.existing_file_ids.contains_key(*path))
-        .count();
-    let current_file_count = refresh
-        .refresh
-        .plan
-        .existing_file_ids
-        .len()
-        .saturating_add(new_file_count)
-        .saturating_add(refresh.policy_exclusions.len());
-
     Ok(IndexFreshnessPlan {
         plan: refresh.refresh.plan,
         current_policy_exclusions: refresh.policy_exclusions,
-        current_file_count,
+        admitted_file_count: refresh.admitted_file_count,
     })
 }
 
@@ -416,7 +401,7 @@ fn complete_scan_within_bounded_caps(
             "indexed file inventory exceeds bounded freshness cap ({indexed_file_count} > {indexed_file_cap})"
         )));
     }
-    if planned.current_file_count > current_file_cap {
+    if planned.admitted_file_count > current_file_cap {
         return Err(NotCheckedReason::bounded(format!(
             "current workspace inventory is {:?} (>{})",
             WorkspaceInventoryOutcome::Bounded,

--- a/crates/codestory-runtime/src/index_freshness.rs
+++ b/crates/codestory-runtime/src/index_freshness.rs
@@ -26,6 +26,8 @@ pub(super) const EXACT_SYMBOL_HYBRID_MAX_RESULTS_CAP: usize = 80;
 thread_local! {
     static AFTER_INDEX_FRESHNESS_FENCE_TEST_HOOK: RefCell<Option<Box<dyn FnOnce()>>> =
         const { RefCell::new(None) };
+    static INDEX_FRESHNESS_CAPS_TEST_OVERRIDE: RefCell<Option<(usize, usize)>> =
+        const { RefCell::new(None) };
 }
 
 #[cfg(test)]
@@ -39,6 +41,37 @@ fn run_after_index_freshness_fence_test_hook() {
     if let Some(hook) = hook {
         hook();
     }
+}
+
+fn index_freshness_caps() -> (usize, usize) {
+    #[cfg(test)]
+    if let Some(caps) = INDEX_FRESHNESS_CAPS_TEST_OVERRIDE.with(|slot| *slot.borrow()) {
+        return caps;
+    }
+    (
+        INDEX_FRESHNESS_INDEXED_FILE_CAP,
+        INDEX_FRESHNESS_CURRENT_FILE_CAP,
+    )
+}
+
+#[cfg(test)]
+pub(super) fn with_index_freshness_caps_for_test<T>(
+    indexed_file_cap: usize,
+    current_file_cap: usize,
+    run: impl FnOnce() -> T,
+) -> T {
+    struct ResetCaps(Option<(usize, usize)>);
+
+    impl Drop for ResetCaps {
+        fn drop(&mut self) {
+            INDEX_FRESHNESS_CAPS_TEST_OVERRIDE.with(|slot| *slot.borrow_mut() = self.0);
+        }
+    }
+
+    let previous = INDEX_FRESHNESS_CAPS_TEST_OVERRIDE
+        .with(|slot| slot.replace(Some((indexed_file_cap, current_file_cap))));
+    let _reset = ResetCaps(previous);
+    run()
 }
 
 /// Whether a freshness read may arm a filesystem observer around its discovery scan.
@@ -184,6 +217,13 @@ struct IndexFreshnessInventory {
 struct IndexFreshnessPlan {
     plan: codestory_contracts::workspace::RefreshPlan,
     current_policy_exclusions: Vec<codestory_workspace::OversizedSourceExclusionCandidate>,
+    current_file_count: usize,
+}
+
+#[derive(Clone, Copy)]
+enum IndexFreshnessInventoryBound {
+    Bounded,
+    Complete,
 }
 
 struct IndexFreshnessChanges {
@@ -239,6 +279,7 @@ fn validate_index_freshness_publication(
 
 fn load_index_freshness_inventory(
     storage: &Storage,
+    bound: IndexFreshnessInventoryBound,
 ) -> Result<IndexFreshnessInventory, (NotCheckedReason, u32)> {
     let files = storage.get_files().map_err(|error| {
         (
@@ -255,12 +296,13 @@ fn load_index_freshness_inventory(
             indexed_file_count,
         ));
     }
-    if files.len() > INDEX_FRESHNESS_INDEXED_FILE_CAP {
+    let (indexed_file_cap, _) = index_freshness_caps();
+    if matches!(bound, IndexFreshnessInventoryBound::Bounded) && files.len() > indexed_file_cap {
         return Err((
             NotCheckedReason::bounded(format!(
                 "indexed file inventory exceeds bounded freshness cap ({} > {})",
                 files.len(),
-                INDEX_FRESHNESS_INDEXED_FILE_CAP,
+                indexed_file_cap,
             )),
             indexed_file_count,
         ));
@@ -305,16 +347,23 @@ fn plan_index_freshness(
     workspace: &WorkspaceManifest,
     inventory: &IndexFreshnessInventory,
     policy: &SourceIndexPolicy,
+    bound: IndexFreshnessInventoryBound,
 ) -> Result<IndexFreshnessPlan, NotCheckedReason> {
-    let refresh = workspace
-        .build_execution_outcome_bounded_with_policy(
-            &inventory.refresh_inputs,
-            INDEX_FRESHNESS_CURRENT_FILE_CAP,
-            policy,
-        )
-        .map_err(|error| {
-            NotCheckedReason::unavailable(format!("failed to check workspace inventory: {error}"))
-        })?;
+    let (_, current_file_cap) = index_freshness_caps();
+    let refresh = match bound {
+        IndexFreshnessInventoryBound::Bounded => workspace
+            .build_execution_outcome_bounded_with_policy(
+                &inventory.refresh_inputs,
+                current_file_cap,
+                policy,
+            ),
+        IndexFreshnessInventoryBound::Complete => {
+            workspace.build_execution_outcome_with_policy(&inventory.refresh_inputs, policy)
+        }
+    }
+    .map_err(|error| {
+        NotCheckedReason::unavailable(format!("failed to check workspace inventory: {error}"))
+    })?;
     if refresh.refresh.inventory_outcome != WorkspaceInventoryOutcome::Complete {
         let detail = refresh
             .refresh
@@ -329,15 +378,52 @@ fn plan_index_freshness(
             )),
             None => NotCheckedReason::bounded(format!(
                 "current workspace inventory is {:?} (>{})",
-                refresh.refresh.inventory_outcome, INDEX_FRESHNESS_CURRENT_FILE_CAP
+                refresh.refresh.inventory_outcome, current_file_cap
             )),
         });
     }
 
+    let new_file_count = refresh
+        .refresh
+        .plan
+        .files_to_index
+        .iter()
+        .filter(|path| !refresh.refresh.plan.existing_file_ids.contains_key(*path))
+        .count();
+    let current_file_count = refresh
+        .refresh
+        .plan
+        .existing_file_ids
+        .len()
+        .saturating_add(new_file_count)
+        .saturating_add(refresh.policy_exclusions.len());
+
     Ok(IndexFreshnessPlan {
         plan: refresh.refresh.plan,
         current_policy_exclusions: refresh.policy_exclusions,
+        current_file_count,
     })
+}
+
+fn complete_scan_within_bounded_caps(
+    inventory: &IndexFreshnessInventory,
+    planned: &IndexFreshnessPlan,
+) -> Result<(), NotCheckedReason> {
+    let (indexed_file_cap, current_file_cap) = index_freshness_caps();
+    let indexed_file_count = inventory.removed_paths.len();
+    if indexed_file_count > indexed_file_cap {
+        return Err(NotCheckedReason::bounded(format!(
+            "indexed file inventory exceeds bounded freshness cap ({indexed_file_count} > {indexed_file_cap})"
+        )));
+    }
+    if planned.current_file_count > current_file_cap {
+        return Err(NotCheckedReason::bounded(format!(
+            "current workspace inventory is {:?} (>{})",
+            WorkspaceInventoryOutcome::Bounded,
+            current_file_cap
+        )));
+    }
+    Ok(())
 }
 
 fn classify_index_freshness_changes(
@@ -532,34 +618,56 @@ where
     #[cfg(test)]
     run_after_index_freshness_fence_test_hook();
 
-    let inventory = match load_index_freshness_inventory(storage) {
-        Ok(inventory) => inventory,
+    // The observer is armed before the scan and sealed after it, so its window is exactly the
+    // stretch during which the scan's answer could go out of date underneath it.
+    let (scan, coverage) = match observation {
+        FreshnessObservation::Unobserved => (
+            load_index_freshness_inventory(storage, IndexFreshnessInventoryBound::Bounded)
+                .and_then(|inventory| {
+                    let indexed_file_count = inventory.indexed_file_count;
+                    match plan_index_freshness(
+                        workspace,
+                        &inventory,
+                        policy,
+                        IndexFreshnessInventoryBound::Bounded,
+                    ) {
+                        Ok(planned) => Ok((inventory, planned)),
+                        Err(reason) => Err((reason, indexed_file_count)),
+                    }
+                }),
+            None,
+        ),
+        FreshnessObservation::Observed(session) => {
+            let (mut scan, coverage) = session.observe_window(|| {
+                load_index_freshness_inventory(storage, IndexFreshnessInventoryBound::Complete)
+                    .and_then(|inventory| {
+                        let indexed_file_count = inventory.indexed_file_count;
+                        match plan_index_freshness(
+                            workspace,
+                            &inventory,
+                            policy,
+                            IndexFreshnessInventoryBound::Complete,
+                        ) {
+                            Ok(planned) => Ok((inventory, planned)),
+                            Err(reason) => Err((reason, indexed_file_count)),
+                        }
+                    })
+            });
+            if coverage.proven().is_none()
+                && let Ok((inventory, planned)) = &scan
+                && let Err(reason) = complete_scan_within_bounded_caps(inventory, planned)
+            {
+                scan = Err((reason, inventory.indexed_file_count));
+            }
+            (scan, Some(coverage))
+        }
+    };
+    let (inventory, planned) = match scan {
+        Ok(scan) => scan,
         Err((reason, indexed_file_count)) => {
             return IndexFreshnessObservation::incomplete(not_checked_index_freshness(
                 reason,
                 indexed_file_count,
-                started_at,
-            ));
-        }
-    };
-    // The observer is armed before the scan and sealed after it, so its window is exactly the
-    // stretch during which the scan's answer could go out of date underneath it.
-    let (planned, coverage) = match observation {
-        FreshnessObservation::Unobserved => {
-            (plan_index_freshness(workspace, &inventory, policy), None)
-        }
-        FreshnessObservation::Observed(session) => {
-            let (planned, coverage) =
-                session.observe_window(|| plan_index_freshness(workspace, &inventory, policy));
-            (planned, Some(coverage))
-        }
-    };
-    let planned = match planned {
-        Ok(planned) => planned,
-        Err(reason) => {
-            return IndexFreshnessObservation::incomplete(not_checked_index_freshness(
-                reason,
-                inventory.indexed_file_count,
                 started_at,
             ));
         }

--- a/crates/codestory-runtime/src/tests/freshness_observer.rs
+++ b/crates/codestory-runtime/src/tests/freshness_observer.rs
@@ -8,10 +8,12 @@
 use super::{hybrid_test_env, test_sidecar_runtime_from_env};
 use crate::index_freshness::{
     FreshnessObservation, FreshnessObservationPolicy, index_freshness_from_storage_with_policy,
+    with_index_freshness_caps_for_test,
 };
 use crate::{AppController, SourceIndexPolicy, Storage, WorkspaceManifest};
 use codestory_contracts::api::{
-    IndexFreshnessChangeKindDto, IndexFreshnessDto, IndexFreshnessStatusDto, IndexMode,
+    IndexFreshnessChangeKindDto, IndexFreshnessDto, IndexFreshnessNotCheckedCauseDto,
+    IndexFreshnessStatusDto, IndexMode,
 };
 use codestory_workspace::filesystem_observer::{
     FilesystemObserverSession, MutationScope, ObservedFilesystemEvent, ObserverEventSource,
@@ -63,11 +65,23 @@ struct ObservedProject {
 
 impl ObservedProject {
     fn publish() -> Self {
+        Self::publish_with_source_count(1)
+    }
+
+    fn publish_with_source_count(source_count: usize) -> Self {
+        assert!(source_count > 0);
         let workspace = tempdir().expect("workspace");
         let source_directory = workspace.path().join("src");
         std::fs::create_dir(&source_directory).expect("source directory");
         let source = source_directory.join("lib.rs");
         std::fs::write(&source, "pub fn published() {}\n").expect("published source");
+        for index in 1..source_count {
+            std::fs::write(
+                source_directory.join(format!("published_{index}.rs")),
+                format!("pub fn published_{index}() {{}}\n"),
+            )
+            .expect("additional published source");
+        }
         let storage_path = workspace.path().join(".cache/codestory.db");
         let controller = AppController::new_with_config(test_sidecar_runtime_from_env());
         controller
@@ -122,6 +136,108 @@ fn an_unobserved_scan_reports_the_published_tree_as_fresh() {
     let freshness = project.freshness(FreshnessObservation::Unobserved);
     assert_eq!(freshness.status, IndexFreshnessStatusDto::Fresh);
     assert_eq!(freshness.reason, None);
+}
+
+#[test]
+fn proven_observer_coverage_lifts_both_freshness_inventory_caps() {
+    let _env = hybrid_test_env();
+    let project = ObservedProject::publish_with_source_count(2);
+    std::fs::write(
+        project.root().join("src/new_beyond_cap.rs"),
+        "pub fn discovered_only_by_a_complete_scan() {}\n",
+    )
+    .expect("source beyond the synthetic current-file cap");
+    std::fs::write(
+        project.root().join("src/new_furthest_beyond_cap.rs"),
+        "pub fn also_requires_a_complete_scan() {}\n",
+    )
+    .expect("second source beyond the synthetic current-file cap");
+    let session = scripted_session(project.root(), |_| Vec::new());
+
+    let freshness = with_index_freshness_caps_for_test(1, 1, || {
+        project.freshness(FreshnessObservation::Observed(&session))
+    });
+
+    assert_eq!(
+        freshness.status,
+        IndexFreshnessStatusDto::Stale,
+        "a complete scan sealed by proven coverage must retain its complete verdict"
+    );
+    assert_eq!(freshness.not_checked_cause, None);
+    assert_eq!(freshness.indexed_file_count, 2);
+    assert_eq!(freshness.new_file_count, 2);
+    assert_eq!(
+        freshness.checked_file_count, 4,
+        "a complete claim must include the source beyond the synthetic cap"
+    );
+}
+
+#[test]
+fn an_unobserved_inventory_over_the_cap_keeps_the_bounded_verdict() {
+    let _env = hybrid_test_env();
+    let project = ObservedProject::publish_with_source_count(2);
+    std::fs::write(
+        project.root().join("src/new_beyond_cap.rs"),
+        "pub fn discovered_only_by_a_complete_scan() {}\n",
+    )
+    .expect("source beyond the synthetic current-file cap");
+    std::fs::write(
+        project.root().join("src/new_furthest_beyond_cap.rs"),
+        "pub fn also_requires_a_complete_scan() {}\n",
+    )
+    .expect("second source beyond the synthetic current-file cap");
+
+    let freshness = with_index_freshness_caps_for_test(1, 1, || {
+        project.freshness(FreshnessObservation::Unobserved)
+    });
+
+    assert_eq!(freshness.status, IndexFreshnessStatusDto::NotChecked);
+    assert_eq!(
+        freshness.not_checked_cause,
+        Some(IndexFreshnessNotCheckedCauseDto::BoundedInventory)
+    );
+    assert_eq!(
+        freshness.reason.as_deref(),
+        Some("indexed file inventory exceeds bounded freshness cap (2 > 1)")
+    );
+}
+
+#[test]
+fn an_observer_coverage_error_falls_back_to_the_bounded_verdict() {
+    let _env = hybrid_test_env();
+    let project = ObservedProject::publish_with_source_count(2);
+    std::fs::write(
+        project.root().join("src/new_beyond_cap.rs"),
+        "pub fn discovered_only_by_a_complete_scan() {}\n",
+    )
+    .expect("source beyond the synthetic current-file cap");
+    std::fs::write(
+        project.root().join("src/new_furthest_beyond_cap.rs"),
+        "pub fn also_requires_a_complete_scan() {}\n",
+    )
+    .expect("second source beyond the synthetic current-file cap");
+    let session = scripted_session(project.root(), |drain| {
+        (drain > 0)
+            .then(|| ObservedFilesystemEvent::CoverageLost {
+                detail: "injected coverage failure".to_string(),
+            })
+            .into_iter()
+            .collect()
+    });
+
+    let freshness = with_index_freshness_caps_for_test(1, 1, || {
+        project.freshness(FreshnessObservation::Observed(&session))
+    });
+
+    assert_eq!(freshness.status, IndexFreshnessStatusDto::NotChecked);
+    assert_eq!(
+        freshness.not_checked_cause,
+        Some(IndexFreshnessNotCheckedCauseDto::BoundedInventory)
+    );
+    assert_eq!(
+        freshness.reason.as_deref(),
+        Some("indexed file inventory exceeds bounded freshness cap (2 > 1)")
+    );
 }
 
 #[test]

--- a/crates/codestory-runtime/src/tests/freshness_observer.rs
+++ b/crates/codestory-runtime/src/tests/freshness_observer.rs
@@ -241,6 +241,45 @@ fn an_observer_coverage_error_falls_back_to_the_bounded_verdict() {
 }
 
 #[test]
+fn lost_observer_coverage_counts_route_unsupported_files_like_the_bounded_walk() {
+    let _env = hybrid_test_env();
+    let project = ObservedProject::publish_with_source_count(2);
+    std::fs::write(project.root().join("src/NOTICE"), "post-publish notice\n")
+        .expect("route-unsupported file beyond the synthetic current-file cap");
+    let session = scripted_session(project.root(), |drain| {
+        (drain > 0)
+            .then(|| ObservedFilesystemEvent::CoverageLost {
+                detail: "injected coverage failure".to_string(),
+            })
+            .into_iter()
+            .collect()
+    });
+
+    let (unobserved, observed) = with_index_freshness_caps_for_test(10, 2, || {
+        (
+            project.freshness(FreshnessObservation::Unobserved),
+            project.freshness(FreshnessObservation::Observed(&session)),
+        )
+    });
+
+    for freshness in [&unobserved, &observed] {
+        assert_eq!(freshness.status, IndexFreshnessStatusDto::NotChecked);
+        assert_eq!(
+            freshness.not_checked_cause,
+            Some(IndexFreshnessNotCheckedCauseDto::BoundedInventory)
+        );
+        assert_eq!(
+            freshness.reason.as_deref(),
+            Some("current workspace inventory is Bounded (>2)")
+        );
+    }
+    assert_eq!(observed.status, unobserved.status);
+    assert_eq!(observed.not_checked_cause, unobserved.not_checked_cause);
+    assert_eq!(observed.reason, unobserved.reason);
+    assert_eq!(observed.checked_file_count, unobserved.checked_file_count);
+}
+
+#[test]
 fn a_write_that_races_the_scan_is_reported_stale_instead_of_fresh() {
     let _env = hybrid_test_env();
     let project = ObservedProject::publish();

--- a/crates/codestory-workspace/src/lib.rs
+++ b/crates/codestory-workspace/src/lib.rs
@@ -337,6 +337,8 @@ pub struct WorkspaceRefreshOutcome {
 pub struct WorkspacePolicyRefreshOutcome {
     pub refresh: WorkspaceRefreshOutcome,
     pub policy_exclusions: Vec<OversizedSourceExclusionCandidate>,
+    /// Files admitted by discovery before source-route and policy classification.
+    pub admitted_file_count: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -608,7 +610,9 @@ impl WorkspaceManifest {
         &self,
         policy: &SourceIndexPolicy,
     ) -> Result<WorkspacePolicyFileInventory> {
-        WorkspaceDiscovery.source_inventory_with_policy_inner(self, policy, None)
+        WorkspaceDiscovery
+            .source_inventory_with_policy_inner(self, policy, None)
+            .map(|(inventory, _)| inventory)
     }
 
     /// Re-read every classified exclusion at the publication fence.
@@ -791,6 +795,7 @@ impl WorkspaceDiscovery {
             &legacy_positional_policy(byte_cap, policy_version),
             None,
         )
+        .map(|(inventory, _)| inventory)
     }
 
     /// Verify that classified exclusions still name the same stable bytes at publication time.
@@ -856,7 +861,7 @@ impl WorkspaceDiscovery {
         manifest: &WorkspaceManifest,
         policy: &SourceIndexPolicy,
         max_files: Option<usize>,
-    ) -> Result<WorkspacePolicyFileInventory> {
+    ) -> Result<(WorkspacePolicyFileInventory, usize)> {
         if policy.byte_cap == 0
             || policy.structural_byte_cap == 0
             || policy.structural_unit_cap == 0
@@ -865,14 +870,18 @@ impl WorkspaceDiscovery {
             bail!("bounded source policy requires non-zero caps and a non-empty version");
         }
         let inventory = self.source_inventory_inner(manifest, max_files)?;
+        let admitted_file_count = inventory.files.len();
         if !inventory.outcome.is_complete() {
-            return Ok(WorkspacePolicyFileInventory {
-                files: inventory.files,
-                policy_exclusions: Vec::new(),
-                outcome: inventory.outcome,
-                issues: inventory.issues,
-                warnings: inventory.warnings,
-            });
+            return Ok((
+                WorkspacePolicyFileInventory {
+                    files: inventory.files,
+                    policy_exclusions: Vec::new(),
+                    outcome: inventory.outcome,
+                    issues: inventory.issues,
+                    warnings: inventory.warnings,
+                },
+                admitted_file_count,
+            ));
         }
 
         let root = workspace_root(manifest);
@@ -955,13 +964,16 @@ impl WorkspaceDiscovery {
         } else {
             WorkspaceInventoryOutcome::Partial
         };
-        Ok(WorkspacePolicyFileInventory {
-            files,
-            policy_exclusions,
-            outcome,
-            issues,
-            warnings,
-        })
+        Ok((
+            WorkspacePolicyFileInventory {
+                files,
+                policy_exclusions,
+                outcome,
+                issues,
+                warnings,
+            },
+            admitted_file_count,
+        ))
     }
 
     fn source_inventory_inner(
@@ -1244,7 +1256,11 @@ impl WorkspaceDiscovery {
         byte_cap: u64,
         policy_version: &str,
     ) -> Result<WorkspacePolicyRefreshOutcome> {
-        let inventory = self.source_inventory_with_policy(manifest, byte_cap, policy_version)?;
+        let (inventory, admitted_file_count) = self.source_inventory_with_policy_inner(
+            manifest,
+            &legacy_positional_policy(byte_cap, policy_version),
+            None,
+        )?;
         let refresh = build_refresh_outcome_from_inventory(
             manifest,
             inputs,
@@ -1256,6 +1272,7 @@ impl WorkspaceDiscovery {
         Ok(WorkspacePolicyRefreshOutcome {
             refresh,
             policy_exclusions: inventory.policy_exclusions,
+            admitted_file_count,
         })
     }
 
@@ -1266,7 +1283,8 @@ impl WorkspaceDiscovery {
         inputs: &RefreshInputs,
         policy: &SourceIndexPolicy,
     ) -> Result<WorkspacePolicyRefreshOutcome> {
-        let mut inventory = self.source_inventory_with_policy_inner(manifest, policy, None)?;
+        let (mut inventory, admitted_file_count) =
+            self.source_inventory_with_policy_inner(manifest, policy, None)?;
         self.carry_forward_verified_policy_exclusions(manifest, inputs, policy, &mut inventory);
         let refresh = build_refresh_outcome_from_inventory(
             manifest,
@@ -1279,6 +1297,7 @@ impl WorkspaceDiscovery {
         Ok(WorkspacePolicyRefreshOutcome {
             refresh,
             policy_exclusions: inventory.policy_exclusions,
+            admitted_file_count,
         })
     }
 
@@ -1291,7 +1310,7 @@ impl WorkspaceDiscovery {
         byte_cap: u64,
         policy_version: &str,
     ) -> Result<WorkspacePolicyRefreshOutcome> {
-        let inventory = self.source_inventory_with_policy_inner(
+        let (inventory, admitted_file_count) = self.source_inventory_with_policy_inner(
             manifest,
             &legacy_positional_policy(byte_cap, policy_version),
             Some(max_current_files),
@@ -1307,6 +1326,7 @@ impl WorkspaceDiscovery {
         Ok(WorkspacePolicyRefreshOutcome {
             refresh,
             policy_exclusions: inventory.policy_exclusions,
+            admitted_file_count,
         })
     }
 
@@ -1318,7 +1338,7 @@ impl WorkspaceDiscovery {
         max_current_files: usize,
         policy: &SourceIndexPolicy,
     ) -> Result<WorkspacePolicyRefreshOutcome> {
-        let mut inventory =
+        let (mut inventory, admitted_file_count) =
             self.source_inventory_with_policy_inner(manifest, policy, Some(max_current_files))?;
         self.carry_forward_verified_policy_exclusions(manifest, inputs, policy, &mut inventory);
         let refresh = build_refresh_outcome_from_inventory(
@@ -1332,6 +1352,7 @@ impl WorkspaceDiscovery {
         Ok(WorkspacePolicyRefreshOutcome {
             refresh,
             policy_exclusions: inventory.policy_exclusions,
+            admitted_file_count,
         })
     }
 


### PR DESCRIPTION
## Context

EV-7c, the closing implementation slice of #1651 after the recorded clause-4 substitution. At the base, the 25k inventory caps sealed large repositories into `NotChecked`/`BoundedInventory` before the observer window opened — an armed observer with proven coverage never received a scan to keep honest.

Closes #1859
Refs #1651
Refs #1200
Refs #1179

## What changed

- Observed freshness sessions now run the complete streamed inventory and refresh plan; if the observer's coverage proof does NOT hold after the window closes, the result is retroactively re-checked against the bounded caps and downgraded to the original typed bounded verdict — a complete-scan claim can never outlive its proof.
- Unobserved paths keep the 25k caps and existing messages byte-for-byte.
- A test-only cap override (thread-local, drop-reset) enables synthetic small-cap fixtures; new tests cover proven-coverage lift, no-coverage bound, and coverage-failure downgrade, without creating 25k real files.

## Verification

Passed on `0794ff46` (implementer + supervisor re-runs):

- `cargo test --locked -p codestory-runtime --lib` — 1091 passed; sole failure is the known macOS-local #1853 flake with its exact signature, unrelated to this diff
- `freshness_observer` 17 passed, `affected` 38 passed, ready-lease one-pass enforcement passed
- Hostile self-check: forcing bounded discovery while claiming Complete fails the lifted-path test (`left: 1, right: 2`); reverted
- clippy `-D warnings`, `cargo fmt --check`, `git diff --check`

The Mac/Windows/Linux real-notifier parity matrices remain #1651's final closure proof. Independent fresh-context adversarial review on the exact head is running; draft until it accepts and CI is green.
