### PR TITLE
[v0.17 S4-10a] Dissolve the planning SCC with three seam breaks

### DIFF
--- a/crates/codestory-agent/src/lib.rs
+++ b/crates/codestory-agent/src/lib.rs
@@ -16,8 +16,10 @@
 #[cfg(any(test, feature = "test-support"))]
 pub mod eval_probes;
 pub mod packet_citations;
+pub mod packet_command;
 pub mod packet_evidence_carriers;
 pub mod packet_evidence_roles;
+pub mod packet_execution_graphs;
 pub mod packet_flow_requirements;
 pub mod packet_probes;
 pub mod packet_scoring;

--- a/crates/codestory-agent/src/packet_command.rs
+++ b/crates/codestory-agent/src/packet_command.rs
@@ -1,0 +1,90 @@
+use codestory_contracts::api::{PacketBudgetModeDto, PacketFollowUpInvocationDto};
+use std::path::Path;
+
+pub fn packet_argv(arguments: &[&str]) -> Vec<String> {
+    std::iter::once("codestory-cli".to_string())
+        .chain(arguments.iter().map(|argument| (*argument).to_string()))
+        .collect()
+}
+
+/// Split argv into the published `{program, args}` invocation.
+pub fn packet_follow_up_invocation(argv: &[String]) -> PacketFollowUpInvocationDto {
+    let (program, args) = argv.split_first().expect("packet argv carries a program");
+    PacketFollowUpInvocationDto {
+        program: program.clone(),
+        args: args.to_vec(),
+    }
+}
+
+/// Render argv as one copy-pasteable POSIX shell command.
+///
+/// Arguments made only of characters a shell passes through untouched stay
+/// bare so the suggestion reads like something a person would type; everything
+/// else is single-quoted.
+pub fn render_packet_command(argv: &[String]) -> String {
+    argv.iter()
+        .map(|argument| {
+            if packet_command_argument_is_shell_safe(argument) {
+                argument.clone()
+            } else {
+                quote_packet_command_value(argument)
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn packet_command_argument_is_shell_safe(argument: &str) -> bool {
+    !argument.is_empty()
+        && argument
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || "_@%+=:,./-".contains(character))
+}
+
+/// The project argument as the caller would type it, before any quoting.
+pub fn packet_display_project_arg(project_root: &Path) -> String {
+    project_root.to_string_lossy().into_owned()
+}
+
+/// Quote one argv element for a POSIX shell.
+///
+/// Doubling the apostrophe is the PowerShell/SQL convention; `sh` concatenates
+/// the adjacent quoted runs and drops the character, so an argument has to end
+/// the quoted run, escape the apostrophe, and reopen it.
+pub fn quote_packet_command_value(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+pub fn next_deeper_packet_command(
+    project_root: &Path,
+    question: &str,
+    requested: PacketBudgetModeDto,
+) -> Option<String> {
+    next_deeper_packet_argv(project_root, question, requested)
+        .map(|argv| render_packet_command(&argv))
+}
+
+/// The deeper-budget retry as executable argv; the displayed command renders
+/// from this, never the other way round.
+pub fn next_deeper_packet_argv(
+    project_root: &Path,
+    question: &str,
+    requested: PacketBudgetModeDto,
+) -> Option<Vec<String>> {
+    let next = match requested {
+        PacketBudgetModeDto::Tiny => "compact",
+        PacketBudgetModeDto::Compact => "standard",
+        PacketBudgetModeDto::Standard => "deep",
+        PacketBudgetModeDto::Deep => return None,
+    };
+    let project = packet_display_project_arg(project_root);
+    Some(packet_argv(&[
+        "packet",
+        "--project",
+        project.as_str(),
+        "--question",
+        question,
+        "--budget",
+        next,
+    ]))
+}

--- a/crates/codestory-agent/src/packet_execution_graphs.rs
+++ b/crates/codestory-agent/src/packet_execution_graphs.rs
@@ -1,0 +1,20 @@
+use crate::trail::is_speculative_trail_edge;
+use codestory_contracts::api::{AgentAnswerDto, EdgeKind, GraphArtifactDto, GraphResponse};
+
+pub fn packet_execution_graphs(answer: &AgentAnswerDto) -> Vec<&GraphResponse> {
+    answer
+        .graphs
+        .iter()
+        .filter_map(|artifact| match artifact {
+            GraphArtifactDto::Uml { graph, .. } => Some(graph),
+            GraphArtifactDto::Mermaid { .. } => None,
+        })
+        .filter(|graph| {
+            graph.edges.iter().any(|edge| {
+                edge.kind == EdgeKind::CALL
+                    && edge.source != edge.target
+                    && !is_speculative_trail_edge(edge)
+            })
+        })
+        .collect()
+}

--- a/crates/codestory-runtime/src/agent/orchestrator.rs
+++ b/crates/codestory-runtime/src/agent/orchestrator.rs
@@ -922,7 +922,12 @@ fn append_packet_evidence_sections(
     );
 
     let (mut claims, claim_telemetry) = if let Some(obligations) = obligations {
-        packet_claims_with_obligation_receipts_and_telemetry(answer, obligations)
+        let supported_claims_with_telemetry = packet_supported_claims_with_telemetry(answer);
+        packet_claims_with_obligation_receipts_and_telemetry(
+            answer,
+            obligations,
+            supported_claims_with_telemetry,
+        )
     } else {
         packet_supported_claims_with_telemetry(answer)
     };

--- a/crates/codestory-runtime/src/agent/packet_budget.rs
+++ b/crates/codestory-runtime/src/agent/packet_budget.rs
@@ -1,5 +1,7 @@
 use crate::agent::packet_capping::cap_packet_citations;
-use crate::agent::packet_claims::packet_flow_claims_markdown;
+use crate::agent::packet_claims::{
+    packet_flow_claims_markdown, packet_supported_claims_with_telemetry,
+};
 use crate::agent::packet_command_profiles::packet_command_exact_probe_queries;
 use crate::agent::packet_obligations::{
     bind_claims_to_packet_obligations, finalize_packet_obligation_plan,
@@ -10,7 +12,6 @@ use crate::agent::packet_probe::exact_packet_probe_paths;
 use crate::agent::packet_required_probes::packet_sufficiency_required_probe_queries_with_extra;
 use crate::agent::packet_sufficiency::{
     PACKET_MARKDOWN_TRUNCATION_SUFFIX, build_packet_sufficiency_with_obligation_context,
-    packet_argv, packet_display_project_arg, render_packet_command,
 };
 use crate::agent::trace_export::packet_retrieval_trace_summary;
 use codestory_contracts::api::{
@@ -20,6 +21,10 @@ use codestory_contracts::api::{
 };
 use std::collections::HashSet;
 use std::path::Path;
+
+#[allow(unused_imports)]
+pub(crate) use codestory_agent::packet_command::next_deeper_packet_argv;
+pub(crate) use codestory_agent::packet_command::next_deeper_packet_command;
 
 const MARKDOWN_TRUNCATION_FLOOR_BYTES: usize = 256;
 const AVOID_OPENING_OMISSION: &str = "avoid_opening";
@@ -293,8 +298,12 @@ fn rebuild_packet_budget_dependents(
 }
 
 fn refresh_packet_claim_markdown(packet: &mut AgentPacketDto) {
-    let mut claims =
-        packet_claims_with_obligation_receipts(&packet.answer, &packet.plan.obligations);
+    let supported_claims_with_telemetry = packet_supported_claims_with_telemetry(&packet.answer);
+    let mut claims = packet_claims_with_obligation_receipts(
+        &packet.answer,
+        &packet.plan.obligations,
+        supported_claims_with_telemetry,
+    );
     bind_claims_to_packet_obligations(&packet.plan.obligations, &mut claims);
     let Some(markdown) = packet
         .answer
@@ -562,40 +571,6 @@ pub(crate) fn packet_budget_usage(answer: &AgentAnswerDto) -> PacketBudgetUsageD
     }
 }
 
-pub(crate) fn next_deeper_packet_command(
-    project_root: &Path,
-    question: &str,
-    requested: PacketBudgetModeDto,
-) -> Option<String> {
-    next_deeper_packet_argv(project_root, question, requested)
-        .map(|argv| render_packet_command(&argv))
-}
-
-/// The deeper-budget retry as executable argv; the displayed command renders
-/// from this, never the other way round.
-pub(crate) fn next_deeper_packet_argv(
-    project_root: &Path,
-    question: &str,
-    requested: PacketBudgetModeDto,
-) -> Option<Vec<String>> {
-    let next = match requested {
-        PacketBudgetModeDto::Tiny => "compact",
-        PacketBudgetModeDto::Compact => "standard",
-        PacketBudgetModeDto::Standard => "deep",
-        PacketBudgetModeDto::Deep => return None,
-    };
-    let project = packet_display_project_arg(project_root);
-    Some(packet_argv(&[
-        "packet",
-        "--project",
-        project.as_str(),
-        "--question",
-        question,
-        "--budget",
-        next,
-    ]))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -802,8 +777,13 @@ mod tests {
             &packet.answer,
             &packet.budget,
         );
-        let mut initial_claims =
-            packet_claims_with_obligation_receipts(&packet.answer, &packet.plan.obligations);
+        let supported_claims_with_telemetry =
+            packet_supported_claims_with_telemetry(&packet.answer);
+        let mut initial_claims = packet_claims_with_obligation_receipts(
+            &packet.answer,
+            &packet.plan.obligations,
+            supported_claims_with_telemetry,
+        );
         bind_claims_to_packet_obligations(&packet.plan.obligations, &mut initial_claims);
         let full_initial_markdown = packet_flow_claims_markdown(&initial_claims);
         let proven_marker_end = full_initial_markdown

--- a/crates/codestory-runtime/src/agent/packet_obligations.rs
+++ b/crates/codestory-runtime/src/agent/packet_obligations.rs
@@ -1,6 +1,5 @@
 //! Versioned packet obligations planned before retrieval and finalized from carried evidence.
 
-use super::packet_claims::packet_supported_claims_with_telemetry;
 use super::packet_evidence::citation_sufficiency_eligible;
 use super::packet_flow_requirements::{
     CoverageMode, EvidencePredicate, FlowRequirement, FlowRole, packet_flow_requirements_for_terms,
@@ -13,8 +12,8 @@ use super::packet_scoring::{
     normalize_identifier, packet_adjacent_query_stop_term, packet_display_path,
     packet_query_stop_term,
 };
-use super::packet_sufficiency::packet_execution_graphs;
 use super::packet_terms::packet_probe_terms;
+use codestory_agent::packet_execution_graphs::packet_execution_graphs;
 use codestory_contracts::api::{
     AgentAnswerDto, AgentCitationDto, AgentRetrievalStepKindDto, AgentRetrievalStepStatusDto,
     EdgeKind, NodeKind, PACKET_OBLIGATION_PLAN_VERSION, PacketBudgetDto, PacketClaimDto,
@@ -1265,15 +1264,21 @@ fn packet_unproven_claim_status(
 pub(crate) fn packet_claims_with_obligation_receipts(
     answer: &AgentAnswerDto,
     plan: &PacketObligationPlanDto,
+    supported_claims_with_telemetry: (Vec<PacketClaimDto>, PacketClaimTelemetry),
 ) -> Vec<PacketClaimDto> {
-    packet_claims_with_obligation_receipts_and_telemetry(answer, plan).0
+    packet_claims_with_obligation_receipts_and_telemetry(
+        answer,
+        plan,
+        supported_claims_with_telemetry,
+    )
+    .0
 }
 
 pub(crate) fn packet_claims_with_obligation_receipts_and_telemetry(
     answer: &AgentAnswerDto,
     plan: &PacketObligationPlanDto,
+    (mut claims, telemetry): (Vec<PacketClaimDto>, PacketClaimTelemetry),
 ) -> (Vec<PacketClaimDto>, PacketClaimTelemetry) {
-    let (mut claims, telemetry) = packet_supported_claims_with_telemetry(answer);
     append_packet_obligation_receipt_claims(answer, plan, &mut claims);
     (claims, telemetry)
 }
@@ -1549,6 +1554,7 @@ fn packet_discovery_subject_has_negator(tokens: &[String], subject_index: usize)
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agent::packet_claims::packet_supported_claims_with_telemetry;
     use crate::agent::packet_sufficiency::build_packet_sufficiency_with_obligation_context;
     use codestory_contracts::api::{
         AgentRetrievalPolicyModeDto, AgentRetrievalPresetDto, AgentRetrievalTraceDto, EdgeId,
@@ -2461,7 +2467,9 @@ mod tests {
             Some("required_carrier_missing")
         );
 
-        let mut claims = packet_claims_with_obligation_receipts(&answer, &plan);
+        let supported_claims_with_telemetry = packet_supported_claims_with_telemetry(&answer);
+        let mut claims =
+            packet_claims_with_obligation_receipts(&answer, &plan, supported_claims_with_telemetry);
         bind_claims_to_packet_obligations(&plan, &mut claims);
         let storage_claim = claims
             .iter()
@@ -2512,7 +2520,9 @@ mod tests {
             query_obligations: Vec::new(),
         };
 
-        let mut claims = packet_claims_with_obligation_receipts(&answer, &plan);
+        let supported_claims_with_telemetry = packet_supported_claims_with_telemetry(&answer);
+        let mut claims =
+            packet_claims_with_obligation_receipts(&answer, &plan, supported_claims_with_telemetry);
         bind_claims_to_packet_obligations(&plan, &mut claims);
         let receipts = claims
             .iter()
@@ -2584,7 +2594,9 @@ mod tests {
             query_obligations: Vec::new(),
         };
         let answer = answer(vec![reported_carrier]);
-        let mut claims = packet_claims_with_obligation_receipts(&answer, &plan);
+        let supported_claims_with_telemetry = packet_supported_claims_with_telemetry(&answer);
+        let mut claims =
+            packet_claims_with_obligation_receipts(&answer, &plan, supported_claims_with_telemetry);
         bind_claims_to_packet_obligations(&plan, &mut claims);
         let receipts = claims
             .iter()

--- a/crates/codestory-runtime/src/agent/packet_sufficiency.rs
+++ b/crates/codestory-runtime/src/agent/packet_sufficiency.rs
@@ -1,5 +1,7 @@
-use crate::agent::packet_budget::next_deeper_packet_argv;
-use crate::agent::packet_claims::{decorate_packet_claims_proof_metadata, packet_supported_claims};
+use crate::agent::packet_claims::{
+    decorate_packet_claims_proof_metadata, packet_supported_claims,
+    packet_supported_claims_with_telemetry,
+};
 use crate::agent::packet_coverage::PacketCoverageInput;
 use crate::agent::packet_degradation::packet_primary_retrieval_truncated;
 use crate::agent::packet_evidence::citation_sufficiency_eligible;
@@ -22,13 +24,20 @@ use crate::agent::packet_scoring::{
     packet_display_path,
 };
 use crate::agent::packet_terms::packet_probe_terms;
+use codestory_agent::packet_command::next_deeper_packet_argv;
+#[allow(unused_imports)]
+pub(crate) use codestory_agent::packet_command::quote_packet_command_value;
+pub(crate) use codestory_agent::packet_command::{
+    packet_argv, packet_display_project_arg, packet_follow_up_invocation, render_packet_command,
+};
+pub(crate) use codestory_agent::packet_execution_graphs::packet_execution_graphs;
 use codestory_contracts::api::{
-    AgentAnswerDto, AgentCitationDto, AgentRetrievalStepStatusDto, EdgeKind, GraphArtifactDto,
-    GraphResponse, NodeKind, PacketBudgetDto, PacketBudgetModeDto, PacketClaimDto,
-    PacketClaimObligationDto, PacketCoverageReportDto, PacketEvidenceTierDto,
-    PacketFollowUpInvocationDto, PacketObligationPlanDto, PacketObligationProofStatusDto,
-    PacketProbeDto, PacketQueryCompletionDto, PacketSidecarQueryDiagnosticDto,
-    PacketSufficiencyDto, PacketSufficiencyStatusDto, PacketTaskClassDto,
+    AgentAnswerDto, AgentCitationDto, AgentRetrievalStepStatusDto, EdgeKind, GraphResponse,
+    NodeKind, PacketBudgetDto, PacketBudgetModeDto, PacketClaimDto, PacketClaimObligationDto,
+    PacketCoverageReportDto, PacketEvidenceTierDto, PacketObligationPlanDto,
+    PacketObligationProofStatusDto, PacketProbeDto, PacketQueryCompletionDto,
+    PacketSidecarQueryDiagnosticDto, PacketSufficiencyDto, PacketSufficiencyStatusDto,
+    PacketTaskClassDto,
 };
 use std::collections::{BTreeMap, BTreeSet, HashSet, VecDeque};
 use std::path::Path;
@@ -134,9 +143,12 @@ fn build_packet_sufficiency_with_optional_obligation_context(
     exact_probe_paths: &[String],
     obligations: Option<&PacketObligationPlanDto>,
 ) -> PacketSufficiencyDto {
-    let supported_claims = obligations
-        .map(|plan| packet_claims_with_obligation_receipts(answer, plan))
-        .unwrap_or_else(|| packet_supported_claims(answer));
+    let supported_claims = if let Some(plan) = obligations {
+        let supported_claims_with_telemetry = packet_supported_claims_with_telemetry(answer);
+        packet_claims_with_obligation_receipts(answer, plan, supported_claims_with_telemetry)
+    } else {
+        packet_supported_claims(answer)
+    };
     let missing_required_probe_queries = packet_missing_sufficiency_probe_queries_with_extra(
         question,
         task_class,
@@ -1210,24 +1222,6 @@ fn packet_route_citation_is_endpoint(citation: &AgentCitationDto) -> bool {
             terminal.as_str(),
             "helper" | "helpers" | "util" | "utils" | "utility" | "generichelper"
         )
-}
-
-pub(crate) fn packet_execution_graphs(answer: &AgentAnswerDto) -> Vec<&GraphResponse> {
-    answer
-        .graphs
-        .iter()
-        .filter_map(|artifact| match artifact {
-            GraphArtifactDto::Uml { graph, .. } => Some(graph),
-            GraphArtifactDto::Mermaid { .. } => None,
-        })
-        .filter(|graph| {
-            graph.edges.iter().any(|edge| {
-                edge.kind == EdgeKind::CALL
-                    && edge.source != edge.target
-                    && !crate::graph_builders::is_speculative_trail_edge(edge)
-            })
-        })
-        .collect()
 }
 
 fn packet_graph_contains_route(graph: &GraphResponse, stages: &[RouteStageEvidence]) -> bool {
@@ -2587,8 +2581,8 @@ fn packet_blocking_follow_up_probe_queries(
 #[allow(clippy::items_after_test_module)]
 #[cfg(test)]
 mod tests {
+    use super::super::packet_budget::{apply_packet_budget, packet_budget_limits};
     use super::*;
-    use crate::agent::packet_budget::{apply_packet_budget, packet_budget_limits};
     use crate::agent::packet_obligations::{
         build_packet_obligation_plan, finalize_packet_obligation_plan,
     };
@@ -3068,7 +3062,12 @@ mod tests {
             &answer,
             &budget,
         );
-        let claims = packet_claims_with_obligation_receipts(&answer, &obligations);
+        let supported_claims_with_telemetry = packet_supported_claims_with_telemetry(&answer);
+        let claims = packet_claims_with_obligation_receipts(
+            &answer,
+            &obligations,
+            supported_claims_with_telemetry,
+        );
         let sufficiency = build_packet_sufficiency_with_obligation_context(
             Path::new("C:/workspace/project"),
             question,
@@ -8487,48 +8486,8 @@ fn packet_follow_up_argv(
     }
 }
 
-pub(crate) fn packet_argv(arguments: &[&str]) -> Vec<String> {
-    std::iter::once("codestory-cli".to_string())
-        .chain(arguments.iter().map(|argument| (*argument).to_string()))
-        .collect()
-}
-
 fn packet_search_argv(project: &str, query: &str) -> Vec<String> {
     packet_argv(&["search", "--project", project, "--query", query, "--why"])
-}
-
-/// Split argv into the published `{program, args}` invocation.
-pub(crate) fn packet_follow_up_invocation(argv: &[String]) -> PacketFollowUpInvocationDto {
-    let (program, args) = argv.split_first().expect("packet argv carries a program");
-    PacketFollowUpInvocationDto {
-        program: program.clone(),
-        args: args.to_vec(),
-    }
-}
-
-/// Render argv as one copy-pasteable POSIX shell command.
-///
-/// Arguments made only of characters a shell passes through untouched stay
-/// bare so the suggestion reads like something a person would type; everything
-/// else is single-quoted.
-pub(crate) fn render_packet_command(argv: &[String]) -> String {
-    argv.iter()
-        .map(|argument| {
-            if packet_command_argument_is_shell_safe(argument) {
-                argument.clone()
-            } else {
-                quote_packet_command_value(argument)
-            }
-        })
-        .collect::<Vec<_>>()
-        .join(" ")
-}
-
-fn packet_command_argument_is_shell_safe(argument: &str) -> bool {
-    !argument.is_empty()
-        && argument
-            .chars()
-            .all(|character| character.is_ascii_alphanumeric() || "_@%+=:,./-".contains(character))
 }
 
 fn packet_full_retrieval_available(answer: &AgentAnswerDto) -> bool {
@@ -8603,20 +8562,6 @@ fn packet_follow_up_search_argv(project: &str, queries: &[String]) -> Vec<Vec<St
         push_unique_argv(&mut commands, packet_search_argv(project, query));
     }
     commands
-}
-
-/// The project argument as the caller would type it, before any quoting.
-pub(crate) fn packet_display_project_arg(project_root: &Path) -> String {
-    project_root.to_string_lossy().into_owned()
-}
-
-/// Quote one argv element for a POSIX shell.
-///
-/// Doubling the apostrophe is the PowerShell/SQL convention; `sh` concatenates
-/// the adjacent quoted runs and drops the character, so an argument has to end
-/// the quoted run, escape the apostrophe, and reopen it.
-pub(crate) fn quote_packet_command_value(value: &str) -> String {
-    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 fn contains_any(haystack: &str, needles: &[&str]) -> bool {


### PR DESCRIPTION
## Context

S4-10a executes the seam surgery the S4-10 feasibility spike designed (recorded on #1673): the planning strongly-connected component — five modules, not the three the plan originally counted — dissolves through three mechanical breaks, clearing v0.17's single stated schedule risk before any module moves.

Closes #1865
Refs #1673
Refs #1179

## What changed

- **A1**: sufficiency's command-rendering tail and budget's `next_deeper_packet_argv`/`next_deeper_packet_command` moved to the new contracts-only `codestory_agent::packet_command`, re-exported at old paths — sufficiency↔budget cycle gone.
- **A2**: `packet_execution_graphs` moved to the new contracts-only `codestory_agent::packet_execution_graphs` (consuming the S4-1-hoisted `trail::is_speculative_trail_edge`) — obligations↔sufficiency cycle gone.
- **B3**: `packet_claims_with_obligation_receipts_and_telemetry` parameter-hoisted to accept the `(claims, telemetry)` pair, computed by each caller via the same `packet_supported_claims_with_telemetry` immediately before the call — claims→plan→obligations→claims cycle gone at the correct seam.

Edge proof: the three broken imports grep empty in release code; the final edge list is acyclic with topological order obligations → plan → claims → sufficiency → budget (budget stays runtime-pinned, as the spike requires). Zero public-API change to codestory-runtime; `codestory-agent` remains contracts + serde; `architecture_contracts.rs` untouched.

## Verification

Passed on `122d0571` (implementer, supervisor re-ran agent/contracts/packet groups): runtime lib 1092 passed with only the #1853 macOS flake; agent 64/0; architecture contracts 41/0 unchanged; all-target clippy `-D warnings` both crates; fmt; `git diff --check`.

Independent fresh-context adversarial review on the exact head is running; draft until it accepts and CI is green. The S4 move slices (S4-10b/c and siblings) can now be scheduled against a settled DAG.
