### PR TITLE
[v0.17 S4-2] Move retrieval stage labels to contracts ownership

### DIFF
--- a/crates/codestory-contracts/src/wire.rs
+++ b/crates/codestory-contracts/src/wire.rs
@@ -54,6 +54,17 @@ pub const SUPPORTED_MCP_PROTOCOL_VERSIONS: &[&str] = &["2024-11-05"];
 /// Revision the server answers with when the client offers nothing usable.
 pub const PREFERRED_MCP_PROTOCOL_VERSION: &str = "2024-11-05";
 
+/// Stable labels emitted for the retrieval planner's stage timing records.
+///
+/// These values cross the retrieval/runtime boundary in diagnostics and packet
+/// traces. Consumers compare the labels directly, so their spelling is a wire
+/// compatibility surface.
+pub const RETRIEVAL_STAGE0_SCIP_ANCHOR_LABEL: &str = "stage0_scip_anchor";
+pub const RETRIEVAL_STAGE1_LEXICAL_LABEL: &str = "stage1_lexical";
+pub const RETRIEVAL_STAGE1B_SEMANTIC_LABEL: &str = "stage1b_semantic";
+pub const RETRIEVAL_STAGE2_SCIP_EXPAND_LABEL: &str = "stage2_scip_expand";
+pub const RETRIEVAL_STAGE3_REPO_TEXT_FALLBACK_LABEL: &str = "stage3_repo_text_fallback";
+
 /// Outcome of one `initialize` protocol-revision negotiation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -285,5 +296,17 @@ mod tests {
         assert_eq!(LEGACY_PUBLICATION_STAMP_SCHEMA_VERSION, 0);
         assert_eq!(SUPPORTED_MCP_PROTOCOL_VERSIONS, &["2024-11-05"]);
         assert_eq!(PREFERRED_MCP_PROTOCOL_VERSION, "2024-11-05");
+    }
+
+    #[test]
+    fn retrieval_stage_labels_are_the_published_wire_values() {
+        assert_eq!(RETRIEVAL_STAGE0_SCIP_ANCHOR_LABEL, "stage0_scip_anchor");
+        assert_eq!(RETRIEVAL_STAGE1_LEXICAL_LABEL, "stage1_lexical");
+        assert_eq!(RETRIEVAL_STAGE1B_SEMANTIC_LABEL, "stage1b_semantic");
+        assert_eq!(RETRIEVAL_STAGE2_SCIP_EXPAND_LABEL, "stage2_scip_expand");
+        assert_eq!(
+            RETRIEVAL_STAGE3_REPO_TEXT_FALLBACK_LABEL,
+            "stage3_repo_text_fallback"
+        );
     }
 }

--- a/crates/codestory-retrieval/src/planner.rs
+++ b/crates/codestory-retrieval/src/planner.rs
@@ -1,5 +1,10 @@
 use crate::mode::RetrievalDegradedMode;
 use crate::query_features::{QueryFeatures, QueryShape};
+use codestory_contracts::wire::{
+    RETRIEVAL_STAGE0_SCIP_ANCHOR_LABEL, RETRIEVAL_STAGE1_LEXICAL_LABEL,
+    RETRIEVAL_STAGE1B_SEMANTIC_LABEL, RETRIEVAL_STAGE2_SCIP_EXPAND_LABEL,
+    RETRIEVAL_STAGE3_REPO_TEXT_FALLBACK_LABEL,
+};
 use serde::{Deserialize, Serialize};
 
 /// Staged retrieval lane.
@@ -21,11 +26,11 @@ pub enum RetrievalStageKind {
 impl RetrievalStageKind {
     pub fn label(self) -> &'static str {
         match self {
-            RetrievalStageKind::Stage0ScipAnchor => "stage0_scip_anchor",
-            RetrievalStageKind::Stage1Lexical => "stage1_lexical",
-            RetrievalStageKind::Stage1bSemantic => "stage1b_semantic",
-            RetrievalStageKind::Stage2ScipExpand => "stage2_scip_expand",
-            RetrievalStageKind::Stage3RepoTextFallback => "stage3_repo_text_fallback",
+            RetrievalStageKind::Stage0ScipAnchor => RETRIEVAL_STAGE0_SCIP_ANCHOR_LABEL,
+            RetrievalStageKind::Stage1Lexical => RETRIEVAL_STAGE1_LEXICAL_LABEL,
+            RetrievalStageKind::Stage1bSemantic => RETRIEVAL_STAGE1B_SEMANTIC_LABEL,
+            RetrievalStageKind::Stage2ScipExpand => RETRIEVAL_STAGE2_SCIP_EXPAND_LABEL,
+            RetrievalStageKind::Stage3RepoTextFallback => RETRIEVAL_STAGE3_REPO_TEXT_FALLBACK_LABEL,
         }
     }
 
@@ -268,6 +273,29 @@ mod tests {
                 has_sidecar_latency.then_some(u32::MAX)
             );
             assert_eq!(kind.sidecar_latency_ms(u64::from(u32::MAX) + 1), None);
+        }
+    }
+
+    #[test]
+    fn every_stage_kind_label_matches_the_wire_contract() {
+        for kind in [
+            RetrievalStageKind::Stage0ScipAnchor,
+            RetrievalStageKind::Stage1Lexical,
+            RetrievalStageKind::Stage1bSemantic,
+            RetrievalStageKind::Stage2ScipExpand,
+            RetrievalStageKind::Stage3RepoTextFallback,
+        ] {
+            let expected = match kind {
+                RetrievalStageKind::Stage0ScipAnchor => RETRIEVAL_STAGE0_SCIP_ANCHOR_LABEL,
+                RetrievalStageKind::Stage1Lexical => RETRIEVAL_STAGE1_LEXICAL_LABEL,
+                RetrievalStageKind::Stage1bSemantic => RETRIEVAL_STAGE1B_SEMANTIC_LABEL,
+                RetrievalStageKind::Stage2ScipExpand => RETRIEVAL_STAGE2_SCIP_EXPAND_LABEL,
+                RetrievalStageKind::Stage3RepoTextFallback => {
+                    RETRIEVAL_STAGE3_REPO_TEXT_FALLBACK_LABEL
+                }
+            };
+
+            assert_eq!(kind.label(), expected);
         }
     }
 

--- a/crates/codestory-runtime/src/agent/packet_degradation.rs
+++ b/crates/codestory-runtime/src/agent/packet_degradation.rs
@@ -18,8 +18,14 @@
 //! repository with no dense anchors is correct behavior, and its rate is the reconsideration
 //! trigger recorded against the retrieval backend non-claim.
 
-use codestory_contracts::api::{AgentAnswerDto, RetrievalShadowDto, RetrievalStageTimingDto};
-use codestory_retrieval::RetrievalStageKind;
+#[cfg(test)]
+use codestory_contracts::wire::{
+    RETRIEVAL_STAGE1_LEXICAL_LABEL, RETRIEVAL_STAGE2_SCIP_EXPAND_LABEL,
+};
+use codestory_contracts::{
+    api::{AgentAnswerDto, RetrievalShadowDto, RetrievalStageTimingDto},
+    wire::RETRIEVAL_STAGE1B_SEMANTIC_LABEL,
+};
 
 /// Query-level stop reason the planner takes deliberately once marginal gain flattens.
 ///
@@ -54,7 +60,7 @@ fn stage_lost_to_deadline(stage: &RetrievalStageTimingDto) -> bool {
 }
 
 fn is_semantic_stage(stage: &RetrievalStageTimingDto) -> bool {
-    stage.stage == RetrievalStageKind::Stage1bSemantic.label()
+    stage.stage == RETRIEVAL_STAGE1B_SEMANTIC_LABEL
 }
 
 /// Read one query's stage record for semantic degradation.
@@ -177,7 +183,7 @@ mod tests {
     #[test]
     fn semantic_deadline_loss_with_no_candidates_is_a_timeout() {
         let degradation = semantic_stage_degradation(&[stage(
-            RetrievalStageKind::Stage1bSemantic.label(),
+            RETRIEVAL_STAGE1B_SEMANTIC_LABEL,
             "pending_after_deadline",
             0,
         )]);
@@ -189,7 +195,7 @@ mod tests {
     #[test]
     fn semantic_deadline_loss_that_still_merged_candidates_is_not_a_zero_hit_timeout() {
         let degradation = semantic_stage_degradation(&[stage(
-            RetrievalStageKind::Stage1bSemantic.label(),
+            RETRIEVAL_STAGE1B_SEMANTIC_LABEL,
             "completed_late",
             3,
         )]);
@@ -200,7 +206,7 @@ mod tests {
     #[test]
     fn a_lexical_stage_timeout_is_not_a_semantic_timeout() {
         let degradation = semantic_stage_degradation(&[stage(
-            RetrievalStageKind::Stage1Lexical.label(),
+            RETRIEVAL_STAGE1_LEXICAL_LABEL,
             "pending_after_deadline",
             0,
         )]);
@@ -210,11 +216,8 @@ mod tests {
 
     #[test]
     fn a_skipped_semantic_stage_abstains_without_timing_out() {
-        let degradation = semantic_stage_degradation(&[stage(
-            RetrievalStageKind::Stage1bSemantic.label(),
-            "skipped",
-            0,
-        )]);
+        let degradation =
+            semantic_stage_degradation(&[stage(RETRIEVAL_STAGE1B_SEMANTIC_LABEL, "skipped", 0)]);
 
         assert!(degradation.abstained);
         assert!(!degradation.timed_out_zero_hits);
@@ -222,7 +225,7 @@ mod tests {
 
     #[test]
     fn a_stub_only_semantic_stage_abstains() {
-        let mut degraded = stage(RetrievalStageKind::Stage1bSemantic.label(), "completed", 2);
+        let mut degraded = stage(RETRIEVAL_STAGE1B_SEMANTIC_LABEL, "completed", 2);
         degraded.degraded = true;
         degraded.stub_reason = Some("phantom_stub_hits".to_string());
 
@@ -231,22 +234,14 @@ mod tests {
 
     #[test]
     fn a_complete_primary_run_is_not_truncated() {
-        let shadow = shadow(vec![stage(
-            RetrievalStageKind::Stage1Lexical.label(),
-            "completed",
-            5,
-        )]);
+        let shadow = shadow(vec![stage(RETRIEVAL_STAGE1_LEXICAL_LABEL, "completed", 5)]);
 
         assert!(!primary_retrieval_truncated(&shadow));
     }
 
     #[test]
     fn the_planned_marginal_gain_stop_is_not_truncation() {
-        let mut shadow = shadow(vec![stage(
-            RetrievalStageKind::Stage1Lexical.label(),
-            "completed",
-            5,
-        )]);
+        let mut shadow = shadow(vec![stage(RETRIEVAL_STAGE1_LEXICAL_LABEL, "completed", 5)]);
         shadow.cancel_reason = Some("marginal_gain".to_string());
 
         assert!(!primary_retrieval_truncated(&shadow));
@@ -254,11 +249,7 @@ mod tests {
 
     #[test]
     fn a_deadline_cancel_truncates_the_primary_run() {
-        let mut shadow = shadow(vec![stage(
-            RetrievalStageKind::Stage1Lexical.label(),
-            "completed",
-            5,
-        )]);
+        let mut shadow = shadow(vec![stage(RETRIEVAL_STAGE1_LEXICAL_LABEL, "completed", 5)]);
         shadow.cancel_reason = Some("deadline".to_string());
 
         assert!(primary_retrieval_truncated(&shadow));
@@ -266,11 +257,7 @@ mod tests {
 
     #[test]
     fn a_skipped_stage_alone_does_not_truncate_the_primary_run() {
-        let shadow = shadow(vec![stage(
-            RetrievalStageKind::Stage1bSemantic.label(),
-            "skipped",
-            0,
-        )]);
+        let shadow = shadow(vec![stage(RETRIEVAL_STAGE1B_SEMANTIC_LABEL, "skipped", 0)]);
 
         assert!(!primary_retrieval_truncated(&shadow));
     }
@@ -278,7 +265,7 @@ mod tests {
     #[test]
     fn a_stage_lost_to_its_deadline_truncates_the_primary_run() {
         let shadow = shadow(vec![stage(
-            RetrievalStageKind::Stage2ScipExpand.label(),
+            RETRIEVAL_STAGE2_SCIP_EXPAND_LABEL,
             "pending_after_deadline",
             0,
         )]);
@@ -298,7 +285,7 @@ mod tests {
             "completed_late",
         ] {
             let shadow = shadow(vec![stage(
-                RetrievalStageKind::Stage2ScipExpand.label(),
+                RETRIEVAL_STAGE2_SCIP_EXPAND_LABEL,
                 completion_status,
                 0,
             )]);
@@ -320,7 +307,7 @@ mod tests {
             "completed_late",
         ] {
             let degradation = semantic_stage_degradation(&[stage(
-                RetrievalStageKind::Stage1bSemantic.label(),
+                RETRIEVAL_STAGE1B_SEMANTIC_LABEL,
                 completion_status,
                 0,
             )]);
@@ -337,18 +324,16 @@ mod tests {
     #[test]
     fn a_completed_stage_is_not_a_deadline_loss() {
         let shadow = shadow(vec![stage(
-            RetrievalStageKind::Stage2ScipExpand.label(),
+            RETRIEVAL_STAGE2_SCIP_EXPAND_LABEL,
             "completed",
             0,
         )]);
 
         assert!(!primary_retrieval_truncated(&shadow));
         assert!(
-            !semantic_stage_degradation(&[stage(
-                RetrievalStageKind::Stage1bSemantic.label(),
-                "completed",
-                0,
-            )])
+            !semantic_stage_degradation(&[
+                stage(RETRIEVAL_STAGE1B_SEMANTIC_LABEL, "completed", 0,)
+            ])
             .timed_out_zero_hits
         );
     }
@@ -416,7 +401,7 @@ mod tests {
     fn counters_sum_the_primary_run_and_every_sidecar_query() {
         let mut answer = counter_answer();
         answer.retrieval_trace.retrieval_shadow = Some(shadow(vec![stage(
-            RetrievalStageKind::Stage1bSemantic.label(),
+            RETRIEVAL_STAGE1B_SEMANTIC_LABEL,
             "pending_after_deadline",
             0,
         )]));
@@ -439,7 +424,7 @@ mod tests {
     fn counters_stay_zero_for_a_run_with_no_semantic_degradation() {
         let mut answer = counter_answer();
         answer.retrieval_trace.retrieval_shadow = Some(shadow(vec![stage(
-            RetrievalStageKind::Stage1bSemantic.label(),
+            RETRIEVAL_STAGE1B_SEMANTIC_LABEL,
             "completed",
             6,
         )]));


### PR DESCRIPTION
## Context

S4-2 of the #1673 plan. `packet_degradation.rs` — a planning module destined for the contracts-only agent crate — still imported `codestory-retrieval`'s planner to compare stage labels, blocking its eventual move.

Closes #1868
Refs #1673
Refs #1179

## What changed

- Stage label strings now live in `codestory_contracts::wire` with exact-literal pins.
- `planner.rs`'s `RetrievalStageKind::label()` delegates to the contracts constants, with an exhaustive variant-to-contract differential test (no wildcard — a new variant forces the test).
- `packet_degradation.rs` compares contracts constants directly; zero `codestory_retrieval` references remain (grep-proven).

Every label byte-identical; wire shapes untouched.

## Verification

Passed on `87163abe` (implementer where the sandbox allowed; supervisor re-ran on host): contracts 103/0, retrieval lib 293/0, packet_degradation 15/0, architecture contracts 41/0 untouched, clippy `-D warnings` three crates, fmt, `git diff --check`. Hostile mutation (changed label literal) fails both the contracts pin and the planner differential, demonstrated and reverted.

Independent fresh-context adversarial review on the exact head is running; draft until it accepts and CI is green.
