### PR TITLE
[v0.17 S4-4a] Agent crate CI lane and home-crate leaf coverage

### DIFF
--- a/.github/workflows/crate-durability.yml
+++ b/.github/workflows/crate-durability.yml
@@ -10,6 +10,7 @@ on:
       - crates/codestory-indexer/**
       - crates/codestory-workspace/**
       - crates/codestory-contracts/**
+      - crates/codestory-agent/**
       - .github/workflows/crate-durability.yml
       - .github/scripts/check-workflow-policy.mjs
       - .github/scripts/check-workflow-policy.test.mjs
@@ -29,6 +30,7 @@ on:
       - crates/codestory-indexer/**
       - crates/codestory-workspace/**
       - crates/codestory-contracts/**
+      - crates/codestory-agent/**
       - .github/workflows/crate-durability.yml
       - .github/scripts/check-workflow-policy.mjs
       - .github/scripts/check-workflow-policy.test.mjs
@@ -80,6 +82,7 @@ jobs:
           cargo test --locked -p codestory-store
           cargo test --locked -p codestory-indexer --test fidelity_regression
           cargo test --locked -p codestory-indexer --test tictactoe_language_coverage
+          cargo test --locked -p codestory-agent
 
       - name: Save durability Cargo cache
         if: success() && steps.cargo-cache-restore.outputs.cache-hit != 'true' && steps.cargo-cache-restore.outputs.cache-primary-key != ''

--- a/.github/workflows/retrieval-engine-smoke.yml
+++ b/.github/workflows/retrieval-engine-smoke.yml
@@ -172,6 +172,7 @@ jobs:
           cargo test --locked -p codestory-runtime --lib services::
           cargo test --locked -p codestory-cli --lib
           cargo test --locked -p codestory-workspace
+          cargo test --locked -p codestory-agent
 
       - name: Stdio protocol contract tests
         run: cargo test --locked -p codestory-cli --test stdio_protocol_contracts

--- a/benchmarks/release-evidence/fixtures/candidate.json
+++ b/benchmarks/release-evidence/fixtures/candidate.json
@@ -62,7 +62,7 @@
   },
   "release_claims": {
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "6891c64e81972f2c061121811bb0043a037a9a6a14e96a38654734947087661a",
+    "graph_sha256": "9dc31326a801a1e6333200e0543bd95daad078322a3d31760199813cd262efb8",
     "observed_at": "2026-08-08T19:19:24.395Z",
     "expires_at": "2026-08-09T19:19:24.395Z",
     "requested_claims": [
@@ -85,7 +85,7 @@
         "type": "performance",
         "tier": "live_behavior",
         "status": "measured",
-        "graph_sha256": "6891c64e81972f2c061121811bb0043a037a9a6a14e96a38654734947087661a",
+        "graph_sha256": "9dc31326a801a1e6333200e0543bd95daad078322a3d31760199813cd262efb8",
         "observed_at": "2026-08-08T19:19:24.395Z",
         "expires_at": "2026-08-09T19:19:24.395Z",
         "identity": {
@@ -106,7 +106,7 @@
         "type": "answer_quality",
         "tier": "answer_quality",
         "status": "pass",
-        "graph_sha256": "6891c64e81972f2c061121811bb0043a037a9a6a14e96a38654734947087661a",
+        "graph_sha256": "9dc31326a801a1e6333200e0543bd95daad078322a3d31760199813cd262efb8",
         "observed_at": "2026-08-08T19:19:24.395Z",
         "expires_at": "2026-08-09T19:19:24.395Z",
         "identity": {

--- a/benchmarks/release-evidence/fixtures/report.json
+++ b/benchmarks/release-evidence/fixtures/report.json
@@ -7,7 +7,7 @@
   "baseline_id": "ci-contract-v1@1111111111111111111111111111111111111111",
   "baseline_sha256": "0bbbe6dd8b4000151edf7b1270959d08e94e08db876e7f2372b25613e0f237c1",
   "candidate_path": "benchmarks/release-evidence/fixtures/candidate.json",
-  "candidate_sha256": "7fdf3696087641e72f6a7f3e44227bf33412f13192b6f631aebe4f3e16914169",
+  "candidate_sha256": "ba4757e837fece35e7da9ce06bed0f15ef5b924d9425fc2fb03ebf3287ca90b9",
   "artifact_paths": [
     {
       "path": "candidate-stats.json",
@@ -26,7 +26,7 @@
       "type": "performance",
       "tier": "live_behavior",
       "status": "pass",
-      "graph_sha256": "6891c64e81972f2c061121811bb0043a037a9a6a14e96a38654734947087661a",
+      "graph_sha256": "9dc31326a801a1e6333200e0543bd95daad078322a3d31760199813cd262efb8",
       "observed_at": "2026-08-08T19:19:24.395Z",
       "expires_at": "2026-08-09T19:19:24.395Z",
       "identity": {
@@ -47,7 +47,7 @@
       "type": "answer_quality",
       "tier": "answer_quality",
       "status": "pass",
-      "graph_sha256": "6891c64e81972f2c061121811bb0043a037a9a6a14e96a38654734947087661a",
+      "graph_sha256": "9dc31326a801a1e6333200e0543bd95daad078322a3d31760199813cd262efb8",
       "observed_at": "2026-08-08T19:19:24.395Z",
       "expires_at": "2026-08-09T19:19:24.395Z",
       "identity": {
@@ -69,7 +69,7 @@
     "schema": "codestory.release-claim-evaluation/v1",
     "status": "pass",
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "6891c64e81972f2c061121811bb0043a037a9a6a14e96a38654734947087661a",
+    "graph_sha256": "9dc31326a801a1e6333200e0543bd95daad078322a3d31760199813cd262efb8",
     "evidence_selection": "all_matching_rows_must_pass",
     "expected_commit": "2222222222222222222222222222222222222222",
     "evaluated_at": "2026-08-08T19:19:24.395Z",

--- a/crates/codestory-agent/src/packet_command.rs
+++ b/crates/codestory-agent/src/packet_command.rs
@@ -88,3 +88,62 @@ pub fn next_deeper_packet_argv(
         next,
     ]))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codestory_contracts::api::PacketBudgetModeDto;
+    use std::path::Path;
+
+    #[test]
+    fn packet_argv_and_rendering_preserve_argv_and_quote_shell_values() {
+        let argv = packet_argv(&[
+            "packet",
+            "--project",
+            "/tmp/project with space",
+            "--question",
+            "it's ready",
+        ]);
+
+        assert_eq!(
+            argv,
+            vec![
+                "codestory-cli".to_string(),
+                "packet".to_string(),
+                "--project".to_string(),
+                "/tmp/project with space".to_string(),
+                "--question".to_string(),
+                "it's ready".to_string(),
+            ],
+        );
+        assert_eq!(
+            render_packet_command(&argv),
+            "codestory-cli packet --project '/tmp/project with space' --question 'it'\\''s ready'",
+        );
+    }
+
+    #[test]
+    fn deeper_packet_argv_advances_budget_and_stops_at_deep() {
+        let project = Path::new("/tmp/project with space");
+        let argv = next_deeper_packet_argv(project, "show $HOME", PacketBudgetModeDto::Tiny)
+            .expect("tiny has a deeper retry");
+
+        assert_eq!(
+            argv,
+            vec![
+                "codestory-cli".to_string(),
+                "packet".to_string(),
+                "--project".to_string(),
+                "/tmp/project with space".to_string(),
+                "--question".to_string(),
+                "show $HOME".to_string(),
+                "--budget".to_string(),
+                "compact".to_string(),
+            ],
+        );
+        assert_eq!(
+            next_deeper_packet_argv(project, "question", PacketBudgetModeDto::Deep),
+            None,
+        );
+    }
+}

--- a/crates/codestory-agent/src/packet_execution_graphs.rs
+++ b/crates/codestory-agent/src/packet_execution_graphs.rs
@@ -18,3 +18,119 @@ pub fn packet_execution_graphs(answer: &AgentAnswerDto) -> Vec<&GraphResponse> {
         })
         .collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codestory_contracts::api::{
+        AgentRetrievalPolicyModeDto, AgentRetrievalPresetDto, AgentRetrievalTraceDto, EdgeId,
+        GraphEdgeDto, NodeId,
+    };
+
+    fn edge(
+        id: &str,
+        kind: EdgeKind,
+        certainty: Option<&str>,
+        confidence: Option<f32>,
+    ) -> GraphEdgeDto {
+        GraphEdgeDto {
+            id: EdgeId(id.to_string()),
+            source: NodeId("source".to_string()),
+            target: NodeId("target".to_string()),
+            kind,
+            confidence,
+            certainty: certainty.map(str::to_string),
+            callsite_identity: None,
+            candidate_targets: Vec::new(),
+        }
+    }
+
+    fn graph(id: &str, edges: Vec<GraphEdgeDto>) -> GraphArtifactDto {
+        GraphArtifactDto::Uml {
+            id: id.to_string(),
+            title: id.to_string(),
+            graph: GraphResponse {
+                center_id: NodeId("source".to_string()),
+                nodes: Vec::new(),
+                edges,
+                truncated: false,
+                omitted_edge_count: 0,
+                canonical_layout: None,
+            },
+        }
+    }
+
+    fn answer(graphs: Vec<GraphArtifactDto>) -> AgentAnswerDto {
+        AgentAnswerDto {
+            answer_id: "answer".to_string(),
+            prompt: "question".to_string(),
+            summary: "summary".to_string(),
+            freshness: None,
+            source_coverage: Vec::new(),
+            sections: Vec::new(),
+            citations: Vec::new(),
+            subgraph_ids: Vec::new(),
+            retrieval_version: "test".to_string(),
+            graphs,
+            retrieval_trace: AgentRetrievalTraceDto {
+                request_id: "answer".to_string(),
+                retrieval_publication: None,
+                resolved_profile: AgentRetrievalPresetDto::Architecture,
+                policy_mode: AgentRetrievalPolicyModeDto::LatencyFirst,
+                total_latency_ms: 1,
+                sla_target_ms: None,
+                sla_missed: false,
+                semantic_fallback_count: 0,
+                semantic_fallbacks: Vec::new(),
+                semantic_stage_timeout_zero_hits: 0,
+                semantic_abstained_count: 0,
+                annotations: Vec::new(),
+                packet_claim_profile_telemetry: None,
+                source_freshness_telemetry: None,
+                steps: Vec::new(),
+                packet_sidecar_diagnostics: Vec::new(),
+                retrieval_shadow: None,
+            },
+        }
+    }
+
+    #[test]
+    fn execution_graphs_require_a_non_speculative_non_self_call_edge() {
+        let answer = answer(vec![
+            graph(
+                "qualified",
+                vec![edge("certain", EdgeKind::CALL, Some("certain"), Some(0.85))],
+            ),
+            graph(
+                "probable",
+                vec![edge(
+                    "probable",
+                    EdgeKind::CALL,
+                    Some("probable"),
+                    Some(0.70),
+                )],
+            ),
+            graph(
+                "low-confidence",
+                vec![edge("low", EdgeKind::CALL, Some("certain"), Some(0.54))],
+            ),
+            graph(
+                "macro",
+                vec![edge(
+                    "macro",
+                    EdgeKind::MACRO_USAGE,
+                    Some("certain"),
+                    Some(0.85),
+                )],
+            ),
+        ]);
+
+        let execution_graphs = packet_execution_graphs(&answer);
+
+        assert_eq!(execution_graphs.len(), 1);
+        assert_eq!(
+            execution_graphs[0].edges[0].id,
+            EdgeId("certain".to_string())
+        );
+    }
+}

--- a/crates/codestory-agent/src/trail.rs
+++ b/crates/codestory-agent/src/trail.rs
@@ -27,3 +27,67 @@ fn is_probable_certainty_label(certainty: Option<&str>) -> bool {
 fn is_runtime_bridge_edge(kind: EdgeKind) -> bool {
     matches!(kind, EdgeKind::CALL | EdgeKind::MACRO_USAGE)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codestory_contracts::api::{EdgeId, NodeId};
+
+    fn edge(
+        id: &str,
+        kind: EdgeKind,
+        certainty: Option<&str>,
+        confidence: Option<f32>,
+    ) -> GraphEdgeDto {
+        GraphEdgeDto {
+            id: EdgeId(id.to_string()),
+            source: NodeId("source".to_string()),
+            target: NodeId("target".to_string()),
+            kind,
+            confidence,
+            certainty: certainty.map(str::to_string),
+            callsite_identity: None,
+            candidate_targets: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn speculative_trail_edge_filters_uncertain_speculative_and_bridge_only_evidence() {
+        assert!(is_speculative_trail_edge(&edge(
+            "uncertain",
+            EdgeKind::USAGE,
+            Some("uncertain"),
+            Some(1.0),
+        )));
+        assert!(is_speculative_trail_edge(&edge(
+            "speculative",
+            EdgeKind::USAGE,
+            Some("SpEcUlAtIvE"),
+            Some(1.0),
+        )));
+        assert!(is_speculative_trail_edge(&edge(
+            "probable-call",
+            EdgeKind::CALL,
+            Some("probable"),
+            Some(0.70),
+        )));
+        assert!(is_speculative_trail_edge(&edge(
+            "low-confidence-macro",
+            EdgeKind::MACRO_USAGE,
+            Some("certain"),
+            Some(0.54),
+        )));
+        assert!(!is_speculative_trail_edge(&edge(
+            "certain-call",
+            EdgeKind::CALL,
+            Some("certain"),
+            Some(0.85),
+        )));
+        assert!(!is_speculative_trail_edge(&edge(
+            "probable-usage",
+            EdgeKind::USAGE,
+            Some("probable"),
+            Some(0.70),
+        )));
+    }
+}

--- a/release-claims.json
+++ b/release-claims.json
@@ -1058,6 +1058,7 @@
           "crates/codestory-indexer/**",
           "crates/codestory-workspace/**",
           "crates/codestory-contracts/**",
+          "crates/codestory-agent/**",
           ".github/workflows/crate-durability.yml",
           ".github/scripts/check-workflow-policy.mjs",
           ".github/scripts/check-workflow-policy.test.mjs",
@@ -1070,7 +1071,8 @@
         "commands": [
           "cargo test --locked -p codestory-store",
           "cargo test --locked -p codestory-indexer --test fidelity_regression",
-          "cargo test --locked -p codestory-indexer --test tictactoe_language_coverage"
+          "cargo test --locked -p codestory-indexer --test tictactoe_language_coverage",
+          "cargo test --locked -p codestory-agent"
         ]
       },
       "merged_suite_lanes": {
@@ -1084,7 +1086,8 @@
           "cargo test --locked -p codestory-runtime --lib tests::search_scoring_tests::",
           "cargo test --locked -p codestory-runtime --lib services::",
           "cargo test --locked -p codestory-cli --lib",
-          "cargo test --locked -p codestory-workspace"
+          "cargo test --locked -p codestory-workspace",
+          "cargo test --locked -p codestory-agent"
         ]
       }
     },

--- a/scripts/codestory-release-claims.mjs
+++ b/scripts/codestory-release-claims.mjs
@@ -940,6 +940,7 @@ function validateProofFloor(value) {
       "crates/codestory-indexer/**",
       "crates/codestory-workspace/**",
       "crates/codestory-contracts/**",
+      "crates/codestory-agent/**",
       ".github/workflows/crate-durability.yml",
       ".github/scripts/check-workflow-policy.mjs",
       ".github/scripts/check-workflow-policy.test.mjs",
@@ -956,6 +957,7 @@ function validateProofFloor(value) {
       "cargo test --locked -p codestory-store",
       "cargo test --locked -p codestory-indexer --test fidelity_regression",
       "cargo test --locked -p codestory-indexer --test tictactoe_language_coverage",
+      "cargo test --locked -p codestory-agent",
     ],
     "workflow_policy.proof_floor.crate_durability.commands",
   );
@@ -986,6 +988,7 @@ function validateProofFloor(value) {
       "cargo test --locked -p codestory-runtime --lib services::",
       "cargo test --locked -p codestory-cli --lib",
       "cargo test --locked -p codestory-workspace",
+      "cargo test --locked -p codestory-agent",
     ],
     "workflow_policy.proof_floor.merged_suite_lanes.commands",
   );

--- a/scripts/tests/codestory-release-claims.test.mjs
+++ b/scripts/tests/codestory-release-claims.test.mjs
@@ -397,6 +397,7 @@ test("claim graph owns the universal architecture and path-scoped durability flo
     "cargo test --locked -p codestory-store",
     "cargo test --locked -p codestory-indexer --test fidelity_regression",
     "cargo test --locked -p codestory-indexer --test tictactoe_language_coverage",
+    "cargo test --locked -p codestory-agent",
   ]);
   assert.deepEqual(floor.crate_durability.paths.slice(0, 3), [
     "Cargo.toml",

--- a/scripts/tests/fixtures/release-claims/positive.json
+++ b/scripts/tests/fixtures/release-claims/positive.json
@@ -17,7 +17,7 @@
       "type": "source_behavior",
       "tier": "source",
       "status": "pass",
-      "graph_sha256": "6891c64e81972f2c061121811bb0043a037a9a6a14e96a38654734947087661a",
+      "graph_sha256": "9dc31326a801a1e6333200e0543bd95daad078322a3d31760199813cd262efb8",
       "observed_at": "2026-07-16T11:00:00.000Z",
       "expires_at": "2026-07-17T11:00:00.000Z",
       "identity": {


### PR DESCRIPTION
## Context

S4-4a of the #1673 plan. The agent crate had no CI lane in the merged-suite triple and the hoisted leaf modules carried no home-crate coverage — the S4-1 verifier recorded that `is_speculative_trail_edge`'s behavioral oracle lived only in runtime tests.

Closes #1869
Refs #1673
Refs #1179

## What changed

- `cargo test --locked -p codestory-agent` joins the merged-suite lanes coherently across all four surfaces: `release-claims.json` `merged_suite_lanes`, `crate-durability.yml`, `retrieval-engine-smoke.yml`, and the hard-coded validator list in `codestory-release-claims.mjs` (the lane triple the policy checker enforces); digests and fixture pins regenerated through the normal flow including the attested `candidate_sha256`.
- Home-crate unit tests for the hoisted leaves: trail classification (uncertain/speculative/probable × bridge kinds × confidence floor), packet argv/render goldens, execution-graph speculative filtering — agent suite now 68 tests.
- Mutation proof: "treat probable as speculative unconditionally" fails the agent-crate trail test on the probable USAGE case — the coverage gap the S4-1 verifier recorded is closed in the crate that owns the code.

## Verification

Passed on `3a9b2bfb` (implementer; supervisor re-ran the decisive slice): agent 68/0, policy checker, policy tests, claims 43/0, evidence-gate 23/0, clippy `-D warnings`, fmt, `git diff --check`. Two earlier dispatch attempts stopped honestly on scope contradictions (modules not yet merged; the lane-triple topology) — both were supervisor envelope errors, corrected before this run.

Independent fresh-context adversarial review on the exact head is running; draft until it accepts and CI is green.
