### PR TITLE
[v0.17 REL-CI H-5] Implement the release-driver receipt

### DIFF
--- a/.github/scripts/release-driver-receipt.mjs
+++ b/.github/scripts/release-driver-receipt.mjs
@@ -1,0 +1,711 @@
+#!/usr/bin/env node
+
+import { readFileSync, renameSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+export const RECEIPT_SCHEMA = "codestory.release-driver-receipt/v1";
+
+const CONSTANT_SET_PATH =
+  "crates/codestory-llama-sys/per-user-embedding-server-constant-set.json";
+const PHASES = ["pre-freeze", "frozen", "published", "closeout"];
+const RUN_GROUPS = new Set([
+  "calibration-source-acceptance",
+  "calibration",
+  "frozen-candidate-acceptance",
+  "source-proof",
+  "package",
+  "hardware",
+  "installed-candidate",
+  "qualification",
+]);
+const PRE_FREEZE_GROUPS = [
+  "calibration-source",
+  "pull-requests",
+  "calibration-source-acceptance",
+  "evidence",
+  "next-action",
+];
+const FROZEN_GROUPS = [
+  ...PRE_FREEZE_GROUPS,
+  "calibration",
+  "frozen-candidate",
+  "frozen-candidate-acceptance",
+  "source-proof",
+  "package",
+  "hardware",
+  "installed-candidate",
+  "qualification",
+  "pre-publish-ledger",
+];
+const PUBLISHED_GROUPS = [
+  ...FROZEN_GROUPS,
+  "promotion",
+  "publication",
+];
+const CLOSEOUT_GROUPS = [
+  ...PUBLISHED_GROUPS,
+  "post-publish-ledger",
+  "catalog-delivery",
+];
+const OPTIONAL_GROUPS = new Set(["native-release-manifest"]);
+const GROUPS_BY_PHASE = Object.freeze({
+  "pre-freeze": Object.freeze(PRE_FREEZE_GROUPS),
+  frozen: Object.freeze(FROZEN_GROUPS),
+  published: Object.freeze(PUBLISHED_GROUPS),
+  closeout: Object.freeze(CLOSEOUT_GROUPS),
+});
+const ALL_GROUPS = new Set([...CLOSEOUT_GROUPS, ...OPTIONAL_GROUPS]);
+const POST_CALIBRATION_CASCADE = [
+  "calibration-source",
+  "pull-requests",
+  "calibration-source-acceptance",
+  "evidence",
+  "calibration",
+  "frozen-candidate",
+  "frozen-candidate-acceptance",
+  "source-proof",
+  "package",
+  "hardware",
+  "installed-candidate",
+  "qualification",
+  "pre-publish-ledger",
+  "promotion",
+  "publication",
+  "native-release-manifest",
+  "post-publish-ledger",
+  "catalog-delivery",
+];
+const POST_FREEZE_CASCADE = [
+  "frozen-candidate",
+  "frozen-candidate-acceptance",
+  "source-proof",
+  "package",
+  "hardware",
+  "installed-candidate",
+  "qualification",
+  "pre-publish-ledger",
+  "promotion",
+  "publication",
+  "native-release-manifest",
+  "post-publish-ledger",
+  "catalog-delivery",
+];
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function present(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function object(value, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    fail(`${label} must be an object`);
+  }
+  return value;
+}
+
+function nonEmpty(value, label) {
+  if (!present(value)) {
+    fail(`${label} is required`);
+  }
+  return value;
+}
+
+function positiveInteger(value, label) {
+  const number = Number(value);
+  if (!Number.isSafeInteger(number) || number <= 0) {
+    fail(`${label} must be a positive integer`);
+  }
+  return number;
+}
+
+function sha(value, label) {
+  if (!/^[0-9a-f]{40}$/u.test(String(value ?? ""))) {
+    fail(`${label} must be a full lowercase commit or tree SHA`);
+  }
+  return value;
+}
+
+function digest(value, label) {
+  if (!/^(?:sha256:)?[0-9a-f]{64}$/u.test(String(value ?? ""))) {
+    fail(`${label} digest must be a SHA-256 digest`);
+  }
+  return value;
+}
+
+function artifact(value, label) {
+  nonEmpty(value, `${label} artifact`);
+  if (value.includes("\n") || value.includes("\r")) {
+    fail(`${label} artifact must be one immutable artifact name`);
+  }
+  return value;
+}
+
+function validateRunRow(value, label) {
+  const row = object(value, label);
+  nonEmpty(row.lane, `${label} lane`);
+  const runId = positiveInteger(row.run_id, `${label} run_id`);
+  const attempt = positiveInteger(row.attempt, `${label} attempt`);
+  artifact(row.artifact, label);
+  digest(row.digest, label);
+  nonEmpty(row.identity, `${label} identity`);
+  if (!new Set(["success", "failure"]).has(row.conclusion)) {
+    fail(`${label} conclusion must be success or failure`);
+  }
+  sha(row.commit, `${label} commit`);
+  sha(row.tree, `${label} tree`);
+  return {
+    ...row,
+    run_id: runId,
+    attempt,
+  };
+}
+
+function validateArtifactRow(value, label) {
+  const row = object(value, label);
+  artifact(row.artifact, label);
+  digest(row.digest, label);
+  return row;
+}
+
+function validateGroupValue(group, value) {
+  if (RUN_GROUPS.has(group)) {
+    const rows = Array.isArray(value) ? value : [value];
+    if (rows.length === 0) {
+      fail(`${group} must contain at least one evidence row`);
+    }
+    const normalized = rows.map((row, index) =>
+      validateRunRow(row, `${group}[${index}]`)
+    );
+    if (new Set(normalized.map(row => row.lane)).size !== normalized.length) {
+      fail(`${group} lanes must be unique`);
+    }
+    if (group === "calibration" && normalized.length !== 3) {
+      fail("calibration must contain exactly three run evidence rows");
+    }
+    return normalized;
+  }
+
+  const row = object(value, group);
+  if (group === "calibration-source" || group === "frozen-candidate") {
+    sha(row.commit, `${group} commit`);
+    sha(row.tree, `${group} tree`);
+  } else if (group === "pull-requests") {
+    positiveInteger(row.release_pr, "pull-requests release_pr");
+    if (
+      !Array.isArray(row.integrated_support_prs)
+      || !row.integrated_support_prs.every(number =>
+        Number.isSafeInteger(number) && number > 0
+      )
+      || new Set(row.integrated_support_prs).size !== row.integrated_support_prs.length
+    ) {
+      fail("pull-requests integrated_support_prs must contain unique positive integers");
+    }
+  } else if (group === "evidence") {
+    if (!Array.isArray(row.reusable) || !Array.isArray(row.invalidated)) {
+      fail("evidence must contain reusable and invalidated arrays");
+    }
+    for (const [index, entry] of row.reusable.entries()) {
+      object(entry, `evidence reusable[${index}]`);
+      nonEmpty(entry.identity, `evidence reusable[${index}] identity`);
+      sha(entry.commit, `evidence reusable[${index}] commit`);
+      sha(entry.tree, `evidence reusable[${index}] tree`);
+      artifact(entry.artifact, `evidence reusable[${index}]`);
+      digest(entry.digest, `evidence reusable[${index}]`);
+      nonEmpty(
+        entry.machine_policy,
+        `evidence reusable[${index}] machine_policy`,
+      );
+      nonEmpty(
+        entry.evidence_window,
+        `evidence reusable[${index}] evidence_window`,
+      );
+    }
+    for (const [index, entryValue] of row.invalidated.entries()) {
+      const entry = object(entryValue, `evidence invalidated[${index}]`);
+      nonEmpty(entry.identity, `evidence invalidated[${index}] identity`);
+      nonEmpty(entry.reason, `evidence invalidated[${index}] reason`);
+      sha(entry.replacing_sha, `evidence invalidated[${index}] replacing_sha`);
+    }
+  } else if (group === "pre-publish-ledger" || group === "post-publish-ledger") {
+    validateArtifactRow(row, group);
+  } else if (group === "promotion") {
+    positiveInteger(row.pull_request, "promotion pull_request");
+    nonEmpty(row.approver, "promotion approver");
+    if (!Number.isFinite(Date.parse(String(row.approved_at ?? "")))) {
+      fail("promotion approved_at must be an ISO-compatible timestamp");
+    }
+  } else if (group === "publication") {
+    sha(row.commit, "publication commit");
+    sha(row.tree, "publication tree");
+    nonEmpty(row.tag, "publication tag");
+    nonEmpty(row.release_url, "publication release_url");
+    row.release_run = validateRunRow(row.release_run, "publication release_run");
+  } else if (group === "native-release-manifest") {
+    validateArtifactRow(row, group);
+    nonEmpty(row.identity, "native-release-manifest identity");
+  } else if (group === "catalog-delivery") {
+    nonEmpty(row.state, "catalog-delivery state");
+    nonEmpty(row.installer_identity, "catalog-delivery installer_identity");
+  } else if (group === "next-action") {
+    nonEmpty(row.action, "next-action action");
+    nonEmpty(row.owner, "next-action owner");
+  } else {
+    fail(`unknown field group ${group}`);
+  }
+  return row;
+}
+
+function groupRunRows(group, value) {
+  if (RUN_GROUPS.has(group)) {
+    return value;
+  }
+  return group === "publication" ? [value.release_run] : [];
+}
+
+function validateReceiptShape(receipt) {
+  object(receipt, "receipt");
+  if (receipt.schema !== RECEIPT_SCHEMA) {
+    fail(`receipt schema must be ${RECEIPT_SCHEMA}`);
+  }
+  nonEmpty(receipt.version, "receipt version");
+  if (!Number.isSafeInteger(receipt.sequence) || receipt.sequence < 0) {
+    fail("receipt sequence is invalid");
+  }
+  object(receipt.groups, "receipt groups");
+  if (!Array.isArray(receipt.attempt_history)) {
+    fail("receipt attempt_history must be an array");
+  }
+  if (!Array.isArray(receipt.invalidations)) {
+    fail("receipt invalidations must be an array");
+  }
+  for (const group of Object.keys(receipt.groups)) {
+    if (!ALL_GROUPS.has(group)) {
+      fail(`receipt contains unknown field group ${group}`);
+    }
+  }
+  return receipt;
+}
+
+export function initReceipt(version) {
+  nonEmpty(version, "--version");
+  return {
+    schema: RECEIPT_SCHEMA,
+    version,
+    sequence: 0,
+    groups: {},
+    attempt_history: [],
+    invalidations: [],
+  };
+}
+
+function compareAttempts(left, right) {
+  const leftRun = BigInt(left.run_id);
+  const rightRun = BigInt(right.run_id);
+  if (leftRun !== rightRun) {
+    return leftRun < rightRun ? -1 : 1;
+  }
+  return left.attempt - right.attempt;
+}
+
+function rejectAttemptFallback(receipt, group, rows) {
+  for (const row of rows) {
+    const sameAttempt = receipt.attempt_history.find(candidate =>
+      candidate.group === group
+      && candidate.lane === row.lane
+      && candidate.run_id === row.run_id
+      && candidate.attempt === row.attempt
+      && candidate.conclusion !== row.conclusion
+    );
+    if (sameAttempt) {
+      fail(
+        `${group} lane ${row.lane} run ${row.run_id} attempt ${row.attempt} `
+        + `is already recorded as ${sameAttempt.conclusion}`,
+      );
+    }
+    if (row.conclusion !== "success") {
+      continue;
+    }
+    const newerFailure = receipt.attempt_history.find(candidate =>
+      candidate.group === group
+      && candidate.lane === row.lane
+      && candidate.conclusion === "failure"
+      && compareAttempts(candidate, row) > 0
+    );
+    if (newerFailure) {
+      fail(
+        `${group} lane ${row.lane} refuses successful run ${row.run_id} `
+        + `attempt ${row.attempt}: newer failed run ${newerFailure.run_id} `
+        + `attempt ${newerFailure.attempt} exists`,
+      );
+    }
+  }
+}
+
+export function recordGroup(receiptValue, group, value) {
+  const receipt = structuredClone(validateReceiptShape(receiptValue));
+  if (!ALL_GROUPS.has(group)) {
+    fail(`unknown field group ${group}`);
+  }
+  const normalized = validateGroupValue(group, structuredClone(value));
+  const rows = groupRunRows(group, normalized);
+  rejectAttemptFallback(receipt, group, rows);
+
+  const sequence = receipt.sequence + 1;
+  receipt.sequence = sequence;
+  if (rows.length > 0) {
+    for (const row of rows) {
+      receipt.attempt_history.push({
+        group,
+        lane: row.lane,
+        run_id: row.run_id,
+        attempt: row.attempt,
+        conclusion: row.conclusion,
+        sequence,
+      });
+    }
+  }
+  const successful = rows.length === 0
+    || rows.every(row => row.conclusion === "success");
+  receipt.groups[group] = {
+    sequence,
+    status: successful ? "active" : "blocked",
+    value: normalized,
+  };
+  return receipt;
+}
+
+function changedPathsRequireCalibration(changedPaths) {
+  return changedPaths.length === 0
+    || changedPaths.some(changedPath => changedPath !== CONSTANT_SET_PATH);
+}
+
+export function invalidateReceipt(receiptValue, {
+  event,
+  groups = [],
+  reason,
+  replacingSha,
+  changedPaths = [],
+}) {
+  const receipt = structuredClone(validateReceiptShape(receiptValue));
+  nonEmpty(reason, "--reason");
+  sha(replacingSha, "--replacing-sha");
+  if (!Array.isArray(changedPaths) || !changedPaths.every(present)) {
+    fail("--changed-path values must be non-empty paths");
+  }
+
+  let affected;
+  let recalibrationRequired = false;
+  let resumePhase;
+  if (event === "post-calibration-commit") {
+    if (
+      changedPaths.length > 0
+      && !changedPathsRequireCalibration(changedPaths)
+    ) {
+      fail("the generated constant-set child is planned and must not invalidate calibration-source acceptance");
+    }
+    affected = POST_CALIBRATION_CASCADE;
+    recalibrationRequired = true;
+    resumePhase = "calibration-source";
+  } else if (event === "post-freeze-commit") {
+    recalibrationRequired = changedPathsRequireCalibration(changedPaths);
+    affected = recalibrationRequired
+      ? POST_CALIBRATION_CASCADE
+      : POST_FREEZE_CASCADE;
+    resumePhase = recalibrationRequired ? "calibration-source" : "frozen-candidate";
+  } else if (event === "evidence") {
+    if (groups.length === 0) {
+      fail("evidence invalidation requires at least one --group");
+    }
+    for (const group of groups) {
+      if (!ALL_GROUPS.has(group)) {
+        fail(`unknown field group ${group}`);
+      }
+    }
+    affected = [...new Set(groups)];
+    resumePhase = "evidence-replacement";
+  } else {
+    fail("--event must be post-calibration-commit, post-freeze-commit, or evidence");
+  }
+
+  const sequence = receipt.sequence + 1;
+  receipt.sequence = sequence;
+  const invalidation = {
+    id: receipt.invalidations.length + 1,
+    sequence,
+    event,
+    reason,
+    replacing_sha: replacingSha,
+    changed_paths: [...changedPaths],
+    affected_groups: [...affected],
+    recalibration_required: recalibrationRequired,
+    resume_phase: resumePhase,
+  };
+  receipt.invalidations.push(invalidation);
+  for (const group of affected) {
+    if (receipt.groups[group]) {
+      receipt.groups[group] = {
+        ...receipt.groups[group],
+        status: "invalidated",
+        invalidation_id: invalidation.id,
+      };
+    }
+  }
+  return receipt;
+}
+
+function latestAttempt(receipt, group, lane) {
+  return receipt.attempt_history
+    .filter(entry => entry.group === group && entry.lane === lane)
+    .reduce((latest, entry) =>
+      !latest || compareAttempts(entry, latest) > 0 ? entry : latest
+    , undefined);
+}
+
+function requireRunIdentity(receipt, group, commit, tree) {
+  for (const row of groupRunRows(group, receipt.groups[group].value)) {
+    if (row.commit !== commit || row.tree !== tree) {
+      fail(`${group} must bind exact commit ${commit} and tree ${tree}`);
+    }
+  }
+}
+
+export function validatePhase(receiptValue, phase) {
+  const receipt = validateReceiptShape(receiptValue);
+  if (!PHASES.includes(phase)) {
+    fail("--phase must be pre-freeze, frozen, published, or closeout");
+  }
+  const requiredGroups = new Set(GROUPS_BY_PHASE[phase]);
+  const allowedGroups = new Set(requiredGroups);
+  if (phase === "published" || phase === "closeout") {
+    allowedGroups.add("native-release-manifest");
+  }
+
+  for (const group of requiredGroups) {
+    const entry = receipt.groups[group];
+    if (!entry) {
+      fail(`${phase} requires field group ${group}`);
+    }
+    if (entry.status !== "active") {
+      fail(`${phase} field group ${group} is ${entry.status} without replacement`);
+    }
+    const normalized = validateGroupValue(group, entry.value);
+    const runRows = groupRunRows(group, normalized);
+    if (runRows.length > 0) {
+      for (const row of runRows) {
+        const latest = latestAttempt(receipt, group, row.lane);
+        if (
+          !latest
+          || latest.conclusion !== "success"
+          || latest.run_id !== row.run_id
+          || latest.attempt !== row.attempt
+        ) {
+          fail(
+            `${phase} field group ${group} lane ${row.lane} does not carry `
+            + "the latest successful attempt",
+          );
+        }
+      }
+    }
+  }
+  for (const [group, entry] of Object.entries(receipt.groups)) {
+    if (!allowedGroups.has(group)) {
+      fail(`${phase} does not allow later field group ${group}`);
+    }
+    if (entry.status === "invalidated") {
+      fail(`${phase} field group ${group} is invalidated without replacement`);
+    }
+  }
+  const calibrationSource = receipt.groups["calibration-source"].value;
+  requireRunIdentity(
+    receipt,
+    "calibration-source-acceptance",
+    calibrationSource.commit,
+    calibrationSource.tree,
+  );
+  if (phase !== "pre-freeze") {
+    requireRunIdentity(
+      receipt,
+      "calibration",
+      calibrationSource.commit,
+      calibrationSource.tree,
+    );
+    const frozenCandidate = receipt.groups["frozen-candidate"].value;
+    for (const group of [
+      "frozen-candidate-acceptance",
+      "source-proof",
+      "package",
+      "hardware",
+      "installed-candidate",
+      "qualification",
+    ]) {
+      requireRunIdentity(
+        receipt,
+        group,
+        frozenCandidate.commit,
+        frozenCandidate.tree,
+      );
+    }
+    if (phase === "published" || phase === "closeout") {
+      const publication = receipt.groups.publication.value;
+      if (publication.tree !== frozenCandidate.tree) {
+        fail("publication tree must match the frozen-candidate tree");
+      }
+      requireRunIdentity(
+        receipt,
+        "publication",
+        publication.commit,
+        publication.tree,
+      );
+    }
+  }
+  return true;
+}
+
+export function summarizeReceipt(receiptValue) {
+  const receipt = validateReceiptShape(receiptValue);
+  const lines = [
+    `Release ${receipt.version}`,
+    `Schema: ${receipt.schema}`,
+    "Field groups:",
+  ];
+  const names = Object.keys(receipt.groups).sort();
+  if (names.length === 0) {
+    lines.push("  (none)");
+  } else {
+    for (const name of names) {
+      const entry = receipt.groups[name];
+      const suffix = entry.invalidation_id
+        ? ` (invalidation ${entry.invalidation_id})`
+        : "";
+      lines.push(`  ${name}: ${entry.status}${suffix}`);
+    }
+  }
+  lines.push("Phase readiness:");
+  for (const phase of PHASES) {
+    try {
+      validatePhase(receipt, phase);
+      lines.push(`  ${phase}: ready`);
+    } catch (error) {
+      lines.push(`  ${phase}: blocked - ${error.message}`);
+    }
+  }
+  if (receipt.invalidations.length > 0) {
+    lines.push("Invalidations:");
+    for (const entry of receipt.invalidations) {
+      lines.push(
+        `  ${entry.id}: ${entry.reason}; replacement ${entry.replacing_sha}; `
+        + `resume ${entry.resume_phase}`,
+      );
+    }
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function values(args, name) {
+  const result = [];
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] === name) {
+      const found = args[index + 1];
+      if (!found || found.startsWith("--")) {
+        fail(`${name} requires a value`);
+      }
+      result.push(found);
+      index += 1;
+    }
+  }
+  return result;
+}
+
+function value(args, name, fallback = undefined) {
+  const found = values(args, name);
+  if (found.length > 1) {
+    fail(`${name} may be specified only once`);
+  }
+  return found[0] ?? fallback;
+}
+
+function required(args, name) {
+  return nonEmpty(value(args, name), name);
+}
+
+function readReceipt(receiptPath) {
+  try {
+    return validateReceiptShape(JSON.parse(readFileSync(receiptPath, "utf8")));
+  } catch (error) {
+    fail(`receipt ${receiptPath} is not valid: ${error.message}`);
+  }
+}
+
+function writeReceipt(receiptPath, receipt) {
+  const temporary = path.join(
+    path.dirname(receiptPath),
+    `.${path.basename(receiptPath)}.${process.pid}.tmp`,
+  );
+  writeFileSync(temporary, `${JSON.stringify(receipt, null, 2)}\n`, { flag: "wx" });
+  renameSync(temporary, receiptPath);
+}
+
+function parseData(args) {
+  const json = value(args, "--data-json");
+  const file = value(args, "--data-file");
+  if (Boolean(json) === Boolean(file)) {
+    fail("exactly one of --data-json or --data-file is required");
+  }
+  try {
+    return JSON.parse(file ? readFileSync(file, "utf8") : json);
+  } catch (error) {
+    fail(`field group data is not valid JSON: ${error.message}`);
+  }
+}
+
+function main() {
+  const [command, ...args] = process.argv.slice(2);
+  if (command === "init") {
+    const receiptPath = required(args, "--receipt");
+    writeReceipt(receiptPath, initReceipt(required(args, "--version")));
+    process.stdout.write(`${receiptPath}\n`);
+  } else if (command === "record") {
+    const [group, ...options] = args;
+    nonEmpty(group, "record field-group");
+    const receiptPath = required(options, "--receipt");
+    const receipt = recordGroup(readReceipt(receiptPath), group, parseData(options));
+    writeReceipt(receiptPath, receipt);
+    process.stdout.write(`${group}\n`);
+  } else if (command === "invalidate") {
+    const receiptPath = required(args, "--receipt");
+    const receipt = invalidateReceipt(readReceipt(receiptPath), {
+      event: required(args, "--event"),
+      groups: values(args, "--group"),
+      reason: required(args, "--reason"),
+      replacingSha: required(args, "--replacing-sha"),
+      changedPaths: values(args, "--changed-path"),
+    });
+    writeReceipt(receiptPath, receipt);
+    process.stdout.write(`${receipt.invalidations.at(-1).id}\n`);
+  } else if (command === "validate") {
+    const receipt = readReceipt(required(args, "--receipt"));
+    const phase = required(args, "--phase");
+    validatePhase(receipt, phase);
+    process.stdout.write(`${phase}: valid\n`);
+  } else if (command === "show") {
+    process.stdout.write(summarizeReceipt(readReceipt(required(args, "--receipt"))));
+  } else {
+    fail(
+      "usage: release-driver-receipt.mjs "
+      + "<init|record|invalidate|validate|show> ...",
+    );
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`release driver receipt rejected: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/.github/scripts/release-driver-receipt.test.mjs
+++ b/.github/scripts/release-driver-receipt.test.mjs
@@ -1,0 +1,349 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  RECEIPT_SCHEMA,
+  initReceipt,
+  invalidateReceipt,
+  recordGroup,
+  summarizeReceipt,
+  validatePhase,
+} from "./release-driver-receipt.mjs";
+
+const SCRIPT = new URL("./release-driver-receipt.mjs", import.meta.url).pathname;
+const C = "1".repeat(40);
+const C_TREE = "2".repeat(40);
+const F = "3".repeat(40);
+const F_TREE = "4".repeat(40);
+const P = "5".repeat(40);
+const DIGEST = "a".repeat(64);
+const CONSTANT_SET_PATH =
+  "crates/codestory-llama-sys/per-user-embedding-server-constant-set.json";
+
+function runEvidence(
+  lane,
+  runId,
+  attempt = 1,
+  conclusion = "success",
+  commit = F,
+  tree = F_TREE,
+) {
+  return {
+    lane,
+    run_id: runId,
+    attempt,
+    artifact: `${lane}-run-${runId}-attempt-${attempt}`,
+    digest: DIGEST,
+    identity: `${lane}-identity`,
+    conclusion,
+    commit,
+    tree,
+  };
+}
+
+function record(receipt, group, value) {
+  return recordGroup(receipt, group, value);
+}
+
+function preFreezeReceipt() {
+  let receipt = initReceipt("0.17.0");
+  receipt = record(receipt, "calibration-source", { commit: C, tree: C_TREE });
+  receipt = record(receipt, "pull-requests", {
+    release_pr: 1873,
+    integrated_support_prs: [1869, 1871],
+  });
+  receipt = record(
+    receipt,
+    "calibration-source-acceptance",
+    runEvidence("calibration-source-acceptance", 100, 1, "success", C, C_TREE),
+  );
+  receipt = record(receipt, "evidence", {
+    reusable: [{
+      identity: "focused-checks@C",
+      commit: C,
+      tree: C_TREE,
+      artifact: "focused-checks-at-C",
+      digest: DIGEST,
+      machine_policy: "release-claims.json/workflow_policy",
+      evidence_window: "v0.17.0-candidate",
+    }],
+    invalidated: [{
+      identity: "obsolete-package-run",
+      reason: "candidate advanced",
+      replacing_sha: C,
+    }],
+  });
+  return record(receipt, "next-action", {
+    action: "run calibration",
+    owner: "release-driver",
+  });
+}
+
+function frozenReceipt() {
+  let receipt = preFreezeReceipt();
+  receipt = record(receipt, "calibration", [
+    runEvidence("metal-1", 101, 1, "success", C, C_TREE),
+    runEvidence("metal-2", 102, 1, "success", C, C_TREE),
+    runEvidence("metal-3", 103, 1, "success", C, C_TREE),
+  ]);
+  receipt = record(receipt, "frozen-candidate", { commit: F, tree: F_TREE });
+  receipt = record(
+    receipt,
+    "frozen-candidate-acceptance",
+    runEvidence("frozen-candidate-acceptance", 104),
+  );
+  receipt = record(receipt, "source-proof", runEvidence("source-proof", 105));
+  receipt = record(receipt, "package", runEvidence("package", 106));
+  receipt = record(receipt, "hardware", runEvidence("hardware", 107));
+  receipt = record(
+    receipt,
+    "installed-candidate",
+    runEvidence("installed-candidate", 108),
+  );
+  receipt = record(receipt, "qualification", runEvidence("qualification", 109));
+  receipt = record(receipt, "pre-publish-ledger", {
+    artifact: "pre-publish-ledger-attempt-1",
+    digest: DIGEST,
+  });
+  return record(receipt, "next-action", {
+    action: "obtain promotion approval",
+    owner: "release-driver",
+  });
+}
+
+function publishedReceipt() {
+  let receipt = frozenReceipt();
+  receipt = record(receipt, "promotion", {
+    pull_request: 1900,
+    approver: "TheGreenCedar",
+    approved_at: "2026-08-08T15:00:00Z",
+  });
+  receipt = record(receipt, "publication", {
+    commit: P,
+    tree: F_TREE,
+    tag: "v0.17.0",
+    release_url: "https://github.com/TheGreenCedar/CodeStory/releases/tag/v0.17.0",
+    release_run: runEvidence("release", 110, 1, "success", P, F_TREE),
+  });
+  return record(receipt, "next-action", {
+    action: "run post-publish closeout",
+    owner: "release-driver",
+  });
+}
+
+test("init creates a versioned structured receipt", () => {
+  assert.deepEqual(initReceipt("0.17.0"), {
+    schema: RECEIPT_SCHEMA,
+    version: "0.17.0",
+    sequence: 0,
+    groups: {},
+    attempt_history: [],
+    invalidations: [],
+  });
+});
+
+test("record refuses a run evidence row without its digest by name", () => {
+  const incomplete = runEvidence("source-proof", 200);
+  delete incomplete.digest;
+  assert.throws(
+    () => record(initReceipt("0.17.0"), "source-proof", incomplete),
+    /source-proof\[0\] digest/u,
+  );
+});
+
+test("record refuses an older success after a newer failed attempt in the same lane", () => {
+  let receipt = record(
+    initReceipt("0.17.0"),
+    "source-proof",
+    runEvidence("source-proof", 202, 2, "failure"),
+  );
+  assert.throws(
+    () => record(
+      receipt,
+      "source-proof",
+      runEvidence("source-proof", 202, 1, "success"),
+    ),
+    /newer failed run 202 attempt 2 exists/u,
+  );
+  receipt = record(
+    receipt,
+    "source-proof",
+    runEvidence("source-proof", 203, 1, "success"),
+  );
+  assert.equal(receipt.groups["source-proof"].status, "active");
+});
+
+test("frozen and later phases require the qualification run identity", () => {
+  const receipt = frozenReceipt();
+  delete receipt.groups.qualification;
+  assert.throws(() => validatePhase(receipt, "frozen"), /requires field group qualification/u);
+  assert.throws(() => validatePhase(receipt, "published"), /requires field group qualification/u);
+  assert.throws(() => validatePhase(receipt, "closeout"), /requires field group qualification/u);
+});
+
+test("post-calibration and post-freeze commits cascade invalidation", () => {
+  const frozen = frozenReceipt();
+  const afterCalibrationChange = invalidateReceipt(frozen, {
+    event: "post-calibration-commit",
+    reason: "unplanned workflow fix",
+    replacingSha: "6".repeat(40),
+    changedPaths: [".github/workflows/release.yml"],
+  });
+  assert.equal(
+    afterCalibrationChange.groups["calibration-source-acceptance"].status,
+    "invalidated",
+  );
+  assert.equal(afterCalibrationChange.groups.qualification.status, "invalidated");
+  assert.equal(afterCalibrationChange.groups["calibration-source"].status, "invalidated");
+  assert.equal(afterCalibrationChange.invalidations[0].recalibration_required, true);
+  assert.equal(afterCalibrationChange.invalidations[0].resume_phase, "calibration-source");
+  assert.throws(
+    () => validatePhase(afterCalibrationChange, "frozen"),
+    /invalidated without replacement/u,
+  );
+
+  const constantOnly = invalidateReceipt(frozen, {
+    event: "post-freeze-commit",
+    reason: "replace frozen candidate",
+    replacingSha: "7".repeat(40),
+    changedPaths: [CONSTANT_SET_PATH],
+  });
+  assert.equal(constantOnly.groups.calibration.status, "active");
+  assert.equal(constantOnly.groups["frozen-candidate"].status, "invalidated");
+  assert.equal(
+    constantOnly.groups["frozen-candidate-acceptance"].status,
+    "invalidated",
+  );
+  assert.equal(constantOnly.invalidations[0].recalibration_required, false);
+  assert.equal(constantOnly.invalidations[0].resume_phase, "frozen-candidate");
+
+  const sourceChange = invalidateReceipt(frozen, {
+    event: "post-freeze-commit",
+    reason: "documentation changed after freeze",
+    replacingSha: "8".repeat(40),
+    changedPaths: ["docs/contributors/release-runbook.md"],
+  });
+  assert.equal(sourceChange.groups.calibration.status, "invalidated");
+  assert.equal(
+    sourceChange.groups["calibration-source-acceptance"].status,
+    "invalidated",
+  );
+  assert.equal(sourceChange.invalidations[0].recalibration_required, true);
+});
+
+test("the planned constant-set child is not accepted as an invalidation event", () => {
+  assert.throws(
+    () => invalidateReceipt(preFreezeReceipt(), {
+      event: "post-calibration-commit",
+      reason: "generated child",
+      replacingSha: F,
+      changedPaths: [CONSTANT_SET_PATH],
+    }),
+    /planned and must not invalidate/u,
+  );
+});
+
+test("phase validation gates missing future evidence and rejects later evidence backwards", () => {
+  const preFreeze = preFreezeReceipt();
+  assert.equal(validatePhase(preFreeze, "pre-freeze"), true);
+  assert.throws(
+    () => validatePhase(preFreeze, "frozen"),
+    /frozen requires field group calibration/u,
+  );
+
+  const frozen = frozenReceipt();
+  assert.equal(validatePhase(frozen, "frozen"), true);
+  assert.throws(
+    () => validatePhase(frozen, "pre-freeze"),
+    /pre-freeze does not allow later field group calibration/u,
+  );
+});
+
+test("a receipt advances through the complete happy-path lifecycle", () => {
+  const preFreeze = preFreezeReceipt();
+  assert.equal(validatePhase(preFreeze, "pre-freeze"), true);
+
+  const frozen = frozenReceipt();
+  assert.equal(validatePhase(frozen, "frozen"), true);
+
+  const published = publishedReceipt();
+  assert.equal(validatePhase(published, "published"), true);
+
+  let closeout = record(published, "post-publish-ledger", {
+    artifact: "post-publish-ledger-attempt-1",
+    digest: DIGEST,
+  });
+  closeout = record(closeout, "catalog-delivery", {
+    state: "published",
+    installer_identity: "codex_marketplace_live",
+  });
+  closeout = record(closeout, "next-action", {
+    action: "retain evidence and close release children",
+    owner: "release-driver",
+  });
+  assert.equal(validatePhase(closeout, "closeout"), true);
+  assert.match(summarizeReceipt(closeout), /closeout: ready/u);
+});
+
+test("the CLI initializes, records, shows, and validates a receipt", () => {
+  const directory = mkdtempSync(path.join(tmpdir(), "release-driver-receipt-"));
+  const receiptPath = path.join(directory, "receipt.json");
+  execFileSync(process.execPath, [
+    SCRIPT,
+    "init",
+    "--version",
+    "0.17.0",
+    "--receipt",
+    receiptPath,
+  ]);
+  for (const [group, data] of Object.entries(preFreezeReceipt().groups)) {
+    execFileSync(process.execPath, [
+      SCRIPT,
+      "record",
+      group,
+      "--receipt",
+      receiptPath,
+      "--data-json",
+      JSON.stringify(data.value),
+    ]);
+  }
+  assert.equal(
+    execFileSync(process.execPath, [
+      SCRIPT,
+      "validate",
+      "--phase",
+      "pre-freeze",
+      "--receipt",
+      receiptPath,
+    ], { encoding: "utf8" }),
+    "pre-freeze: valid\n",
+  );
+  assert.match(
+    execFileSync(process.execPath, [SCRIPT, "show", "--receipt", receiptPath], {
+      encoding: "utf8",
+    }),
+    /Release 0\.17\.0/u,
+  );
+  assert.equal(JSON.parse(readFileSync(receiptPath, "utf8")).schema, RECEIPT_SCHEMA);
+
+  const failed = spawnSync(process.execPath, [
+    SCRIPT,
+    "record",
+    "source-proof",
+    "--receipt",
+    receiptPath,
+    "--data-json",
+    JSON.stringify({
+      lane: "source-proof",
+      run_id: 300,
+      attempt: 1,
+      artifact: "source-proof-attempt-1",
+      conclusion: "success",
+    }),
+  ], { encoding: "utf8" });
+  assert.equal(failed.status, 1);
+  assert.match(failed.stderr, /source-proof\[0\] digest/u);
+});

--- a/docs/contributors/release-runbook.md
+++ b/docs/contributors/release-runbook.md
@@ -117,8 +117,13 @@ full workspace source proof exactly once on this unchanged frozen candidate.
 Run package, protected hardware, installed-candidate, and qualification lanes
 from artifacts built from that same head. Qualification is a program gate; the
 live release workflow does not yet authenticate an earlier qualification run,
-so the planned release-driver receipt must carry it rather than implying the
-workflow already does.
+so record its complete run identity in the release-driver receipt rather than
+implying the workflow already carries it:
+
+```sh
+node .github/scripts/release-driver-receipt.mjs record qualification \
+  --receipt release-driver-receipt.json --data-file qualification.json
+```
 
 Use the testing matrix and workflow inputs as the command authority. Do not copy
 a target checklist from this page; `release-claims.json` declares the current
@@ -126,8 +131,28 @@ inventory.
 
 ## Evidence handoff
 
-Keep one release record. For v0.17.0, #1179 owns the operator handoff until the
-release driver emits its receipt.
+Keep one release record. Initialize it once, record each field group from a JSON
+file or inline JSON, and inspect it without reconstructing state from workflow
+pages:
+
+```sh
+node .github/scripts/release-driver-receipt.mjs init \
+  --version 0.17.0 --receipt release-driver-receipt.json
+node .github/scripts/release-driver-receipt.mjs record <field-group> \
+  --receipt release-driver-receipt.json --data-file <field-group>.json
+node .github/scripts/release-driver-receipt.mjs show \
+  --receipt release-driver-receipt.json
+```
+
+The field-group names are `calibration-source`, `pull-requests`,
+`calibration-source-acceptance`, `calibration`, `frozen-candidate`,
+`frozen-candidate-acceptance`, `source-proof`, `package`, `hardware`,
+`installed-candidate`, `qualification`, `pre-publish-ledger`, `evidence`,
+`promotion`, `publication`, `native-release-manifest`,
+`post-publish-ledger`, `catalog-delivery`, and `next-action`. Run evidence uses
+`lane`, `run_id`, `attempt`, immutable `artifact`, `digest`, `identity`,
+`commit`, `tree`, and `conclusion`. Calibration records exactly three such
+rows. For v0.17.0, #1179 owns this operator handoff.
 
 The record must carry:
 
@@ -155,6 +180,16 @@ evidence handoff. A failed newer attempt cannot fall back to an older successful
 attempt. Reuse is valid only when the machine policy accepts the exact commit,
 tree, artifact, identity, and evidence window.
 
+Validate the record before each transition. Validation is cumulative, requires
+exactly the groups available at that phase, and rejects later-phase groups when
+checking an earlier phase:
+
+```sh
+node .github/scripts/release-driver-receipt.mjs validate \
+  --phase <pre-freeze|frozen|published|closeout> \
+  --receipt release-driver-receipt.json
+```
+
 ## Invalidation
 
 Any unplanned commit after calibration-source acceptance invalidates that
@@ -174,6 +209,21 @@ When invalidated:
 3. Return to the earliest state whose entry condition remains true.
 4. Recalibrate when any path other than the generated constant-set file differs
    from the accepted calibration source.
+
+Record the invalidation before replacing evidence. Repeat `--changed-path` for
+every changed path; if the changed-path list is omitted, the tool conservatively
+requires recalibration. Use `--event evidence --group <field-group>` for an
+identity, expiry, attempt, host, or promotion invalidation that is not a source
+commit:
+
+```sh
+node .github/scripts/release-driver-receipt.mjs invalidate \
+  --event <post-calibration-commit|post-freeze-commit|evidence> \
+  --receipt release-driver-receipt.json \
+  --reason <reason> --replacing-sha <sha> --changed-path <path>
+```
+
+Invalidated groups remain unusable until `record` replaces each affected group.
 
 Do not reorder history or widen the allowed calibration path to preserve old
 proof.


### PR DESCRIPTION
## Context

H-5 sub-contract of #1670. The runbook's Evidence-handoff section fully specified the release record but called the receipt 'planned'; #1179 has carried the operator handoff by hand.

Closes #1873
Refs #1670
Refs #1233
Refs #1179

## What changed

- `.github/scripts/release-driver-receipt.mjs`: `init` / `record` / `invalidate` / `validate --phase` / `show` over a versioned structured receipt, enforcing the runbook's rules by construction: a run without attempt + immutable artifact + digest is refused; an older successful attempt cannot replace a newer failed one; `frozen` and later phases require the qualification-run identity the live workflow does not yet authenticate; invalidation cascades with reason + replacing SHA per the Invalidation section.
- 9-test suite covering completeness rejection, attempt-fallback rejection, qualification carriage, invalidation cascade, phase gating both directions, and the happy-path lifecycle.
- Runbook rewritten from 'planned' to the actual command surface, after the tests existed.

Deliberately no claims-graph declaration: unlike the workflow-executed freeze barrier, this operator-side receipt has no workflow-policy consumer, and declaring it would ripple the versioned graph digest through out-of-scope fixtures.

## Verification

Passed on `d16879a2` (implementer + supervisor decisive re-runs): receipt tests 9/0, policy checker + tests 1361/0, claims 43/0, doc links, generalization lint, `git diff --check`. Hostile checks demonstrated and reverted: missing digest refused by name, frozen-phase validation fails without qualification identity, older-attempt fallback refused.

Draft until independent review accepts the exact head and CI is green.