### PR TITLE
[v0.17 S4-10b] Move obligations, plan, and probes into codestory-agent

### DIFF
--- a/crates/codestory-agent/Cargo.toml
+++ b/crates/codestory-agent/Cargo.toml
@@ -4,10 +4,8 @@ version = "0.16.3"
 edition = "2024"
 
 [features]
-# Compiles the eval/holdout probe hooks that used to ride `#[cfg(test)]` inside
-# `codestory-runtime`. `codestory-runtime` turns it on as a dev-dependency so its
-# own unit tests keep seeing the same hooks they saw before the extraction; no
-# product build enables it.
+# Compiles the eval/holdout probe hooks for downstream unit tests. No product
+# build enables it.
 test-support = []
 
 [dependencies]

--- a/crates/codestory-agent/src/eval_probes.rs
+++ b/crates/codestory-agent/src/eval_probes.rs
@@ -152,6 +152,22 @@ pub fn push_eval_required_probe_queries(terms: &[String], queries: &mut Vec<Stri
     }
 }
 
+/// Eval-only exact symbol probes for a backtick command prompt. The holdout
+/// CLI spelling (`Subcommand::<Title>`, `<module>::Cli`, `<module>::run_main`)
+/// stays in this eval-only module so production planning never carries it.
+pub fn push_eval_command_exact_probe_queries(
+    queries: &mut Vec<String>,
+    subcommand_title: &str,
+    module: &str,
+) {
+    if !eval_probes_enabled() {
+        return;
+    }
+    push_unique_term(queries, &format!("Subcommand::{subcommand_title}"));
+    push_unique_term(queries, &format!("{module}::Cli"));
+    push_unique_term(queries, &format!("{module}::run_main"));
+}
+
 pub fn push_prompt_concept_derived_symbol_probes(terms: &[String], queries: &mut Vec<String>) {
     if !eval_probes_enabled() {
         return;

--- a/crates/codestory-agent/src/lib.rs
+++ b/crates/codestory-agent/src/lib.rs
@@ -1,4 +1,4 @@
-//! Packet planning, extracted from `codestory-runtime`.
+//! Packet planning contracts and policy.
 //!
 //! This crate decides *what to ask for*: the terms a prompt carries, the flow
 //! requirements a task class implies, the evidence roles and carriers a
@@ -17,11 +17,16 @@
 pub mod eval_probes;
 pub mod packet_citations;
 pub mod packet_command;
+pub mod packet_command_profiles;
+pub mod packet_evidence;
 pub mod packet_evidence_carriers;
 pub mod packet_evidence_roles;
 pub mod packet_execution_graphs;
 pub mod packet_flow_requirements;
+pub mod packet_obligations;
+pub mod packet_plan;
 pub mod packet_probes;
+pub mod packet_required_probes;
 pub mod packet_scoring;
 pub mod packet_terms;
 pub mod pinned_reader;

--- a/crates/codestory-agent/src/packet_command_profiles.rs
+++ b/crates/codestory-agent/src/packet_command_profiles.rs
@@ -65,12 +65,11 @@ pub fn packet_command_exact_probe_queries(
 
         let mut queries = Vec::new();
         for descriptor in packet_command_descriptors(question) {
-            push_unique_term(
+            crate::eval_probes::push_eval_command_exact_probe_queries(
                 &mut queries,
-                &format!("Subcommand::{}", descriptor.subcommand_title),
+                &descriptor.subcommand_title,
+                &descriptor.module,
             );
-            push_unique_term(&mut queries, &format!("{}::Cli", descriptor.module));
-            push_unique_term(&mut queries, &format!("{}::run_main", descriptor.module));
         }
         queries
     }

--- a/crates/codestory-agent/src/packet_command_profiles.rs
+++ b/crates/codestory-agent/src/packet_command_profiles.rs
@@ -1,10 +1,10 @@
-#[cfg(test)]
-use crate::agent::eval_probes::eval_probes_enabled;
-use crate::agent::packet_citations::{
+#[cfg(any(test, feature = "test-support"))]
+use crate::eval_probes::eval_probes_enabled;
+use crate::packet_citations::{
     packet_citation_matching_display, packet_citation_matching_path_and_display,
     packet_command_crate_sources_contain_all,
 };
-use crate::agent::packet_scoring::normalize_identifier;
+use crate::packet_scoring::normalize_identifier;
 use codestory_contracts::api::{AgentCitationDto, PacketClaimDto, PacketTaskClassDto};
 use std::collections::HashSet;
 
@@ -47,17 +47,17 @@ fn packet_command_descriptors(question: &str) -> Vec<PacketCommandDescriptor> {
     descriptors
 }
 
-pub(crate) fn packet_command_exact_probe_queries(
+pub fn packet_command_exact_probe_queries(
     question: &str,
     task_class: PacketTaskClassDto,
 ) -> Vec<String> {
-    #[cfg(not(test))]
+    #[cfg(not(any(test, feature = "test-support")))]
     {
         let _ = (question, task_class);
         Vec::new()
     }
 
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-support"))]
     {
         if !eval_probes_enabled() || !packet_allows_command_probe_queries(question, task_class) {
             return Vec::new();
@@ -76,7 +76,7 @@ pub(crate) fn packet_command_exact_probe_queries(
     }
 }
 
-pub(crate) fn packet_command_role_probe_queries(
+pub fn packet_command_role_probe_queries(
     question: &str,
     task_class: PacketTaskClassDto,
 ) -> Vec<String> {
@@ -123,7 +123,7 @@ fn packet_allows_command_probe_queries(question: &str, task_class: PacketTaskCla
     )
 }
 
-pub(crate) fn packet_append_command_flow_template_claims(
+pub fn packet_append_command_flow_template_claims(
     prompt: &str,
     citations: &[AgentCitationDto],
     claims: &mut Vec<PacketClaimDto>,

--- a/crates/codestory-agent/src/packet_evidence.rs
+++ b/crates/codestory-agent/src/packet_evidence.rs
@@ -6,17 +6,17 @@ use codestory_contracts::api::{
 };
 const OPENAPI_ENDPOINT_SCHEMA_PRODUCER: &str = "openapi_endpoint_schema";
 
-pub(crate) type PacketEvidenceTier = PacketEvidenceTierDto;
-pub(crate) type PacketEvidenceResolution = PacketEvidenceResolutionDto;
+pub type PacketEvidenceTier = PacketEvidenceTierDto;
+pub type PacketEvidenceResolution = PacketEvidenceResolutionDto;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct DiagnosticSourceEvidence {
-    pub(crate) tier: PacketEvidenceTier,
-    pub(crate) producer: &'static str,
-    pub(crate) resolution: PacketEvidenceResolution,
+pub struct DiagnosticSourceEvidence {
+    pub tier: PacketEvidenceTier,
+    pub producer: &'static str,
+    pub resolution: PacketEvidenceResolution,
 }
 
-pub(crate) fn diagnostic_source_evidence(
+pub fn diagnostic_source_evidence(
     _path: Option<&str>,
     canonical_id: Option<&str>,
 ) -> Option<DiagnosticSourceEvidence> {
@@ -30,7 +30,7 @@ pub(crate) fn diagnostic_source_evidence(
     None
 }
 
-pub(crate) fn decorate_search_hit_evidence(hit: &mut SearchHit) {
+pub fn decorate_search_hit_evidence(hit: &mut SearchHit) {
     let diagnostic_source_proof = hit_is_diagnostic_source_proof(hit);
     let tier = evidence_tier_for_hit(hit);
     let resolution = evidence_resolution_for_hit(hit);
@@ -42,7 +42,7 @@ pub(crate) fn decorate_search_hit_evidence(hit: &mut SearchHit) {
         Some(!diagnostic_source_proof && evidence_is_sufficiency_eligible(tier, resolution));
 }
 
-pub(crate) fn decorate_lexical_search_hit_evidence(hit: &mut SearchHit) {
+pub fn decorate_lexical_search_hit_evidence(hit: &mut SearchHit) {
     hit.score_breakdown = Some(RetrievalScoreBreakdownDto {
         lexical: hit.score,
         semantic: 0.0,
@@ -57,7 +57,7 @@ pub(crate) fn decorate_lexical_search_hit_evidence(hit: &mut SearchHit) {
     decorate_search_hit_evidence(hit);
 }
 
-pub(crate) fn decorate_citation_from_hit(citation: &mut AgentCitationDto, hit: &SearchHit) {
+pub fn decorate_citation_from_hit(citation: &mut AgentCitationDto, hit: &SearchHit) {
     citation.target = hit.target.clone();
     citation.evidence_tier = hit
         .evidence_tier
@@ -94,7 +94,7 @@ pub(crate) fn decorate_citation_from_hit(citation: &mut AgentCitationDto, hit: &
     });
 }
 
-pub(crate) fn evidence_is_sufficiency_eligible(
+pub fn evidence_is_sufficiency_eligible(
     tier: PacketEvidenceTier,
     resolution: PacketEvidenceResolution,
 ) -> bool {
@@ -110,7 +110,7 @@ pub(crate) fn evidence_is_sufficiency_eligible(
     )
 }
 
-pub(crate) fn citation_sufficiency_eligible(citation: &AgentCitationDto) -> bool {
+pub fn citation_sufficiency_eligible(citation: &AgentCitationDto) -> bool {
     if citation_is_diagnostic_source_proof(citation) {
         return false;
     }
@@ -126,7 +126,7 @@ pub(crate) fn citation_sufficiency_eligible(citation: &AgentCitationDto) -> bool
     citation.eligible_for_sufficiency.unwrap_or(true)
 }
 
-pub(crate) fn evidence_tier_for_hit(hit: &SearchHit) -> PacketEvidenceTier {
+pub fn evidence_tier_for_hit(hit: &SearchHit) -> PacketEvidenceTier {
     if hit_is_diagnostic_source_proof(hit) {
         return if hit_is_structural_source_proof(hit) {
             PacketEvidenceTier::StructuralText
@@ -158,7 +158,7 @@ pub(crate) fn evidence_tier_for_hit(hit: &SearchHit) -> PacketEvidenceTier {
     PacketEvidenceTier::GeneratedSummary
 }
 
-pub(crate) fn evidence_resolution_for_hit(hit: &SearchHit) -> PacketEvidenceResolution {
+pub fn evidence_resolution_for_hit(hit: &SearchHit) -> PacketEvidenceResolution {
     if hit_is_diagnostic_source_proof(hit) {
         return if hit.file_path.is_some() && hit.line.is_some() {
             PacketEvidenceResolution::SourceRangeOnly
@@ -181,7 +181,7 @@ pub(crate) fn evidence_resolution_for_hit(hit: &SearchHit) -> PacketEvidenceReso
     }
 }
 
-pub(crate) fn evidence_producer_for_hit(hit: &SearchHit) -> String {
+pub fn evidence_producer_for_hit(hit: &SearchHit) -> String {
     if hit_is_openapi_endpoint_schema(hit) {
         return OPENAPI_ENDPOINT_SCHEMA_PRODUCER.to_string();
     }
@@ -202,7 +202,7 @@ pub(crate) fn evidence_producer_for_hit(hit: &SearchHit) -> String {
     }
 }
 
-pub(crate) fn evidence_tier_for_citation(citation: &AgentCitationDto) -> PacketEvidenceTier {
+pub fn evidence_tier_for_citation(citation: &AgentCitationDto) -> PacketEvidenceTier {
     if citation_is_diagnostic_source_proof(citation) {
         return if citation_is_structural_source_proof(citation) {
             PacketEvidenceTier::StructuralText
@@ -234,9 +234,7 @@ pub(crate) fn evidence_tier_for_citation(citation: &AgentCitationDto) -> PacketE
     PacketEvidenceTier::GeneratedSummary
 }
 
-pub(crate) fn evidence_resolution_for_citation(
-    citation: &AgentCitationDto,
-) -> PacketEvidenceResolution {
+pub fn evidence_resolution_for_citation(citation: &AgentCitationDto) -> PacketEvidenceResolution {
     if citation_is_diagnostic_source_proof(citation) {
         return if citation.file_path.is_some() && citation.line.is_some() {
             PacketEvidenceResolution::SourceRangeOnly

--- a/crates/codestory-agent/src/packet_obligations.rs
+++ b/crates/codestory-agent/src/packet_obligations.rs
@@ -4,7 +4,6 @@ use super::packet_evidence::citation_sufficiency_eligible;
 use super::packet_flow_requirements::{
     CoverageMode, EvidencePredicate, FlowRequirement, FlowRole, packet_flow_requirements_for_terms,
 };
-use super::packet_profile_telemetry::PacketClaimTelemetry;
 use super::packet_required_probes::{
     packet_prompt_exact_symbol_probe_queries, packet_sufficiency_required_probe_queries_from_terms,
 };
@@ -13,7 +12,11 @@ use super::packet_scoring::{
     packet_query_stop_term,
 };
 use super::packet_terms::packet_probe_terms;
-use codestory_agent::packet_execution_graphs::packet_execution_graphs;
+use crate::packet_execution_graphs::packet_execution_graphs;
+#[cfg(test)]
+use crate::text::exact_symbol_query_terms;
+use crate::text::symbol_query_tokens;
+use crate::trail::is_speculative_trail_edge;
 use codestory_contracts::api::{
     AgentAnswerDto, AgentCitationDto, AgentRetrievalStepKindDto, AgentRetrievalStepStatusDto,
     EdgeKind, NodeKind, PACKET_OBLIGATION_PLAN_VERSION, PacketBudgetDto, PacketClaimDto,
@@ -30,9 +33,9 @@ const PACKET_OBLIGATION_BINDING_TERM_CHAR_LIMIT: usize = 160;
 const PACKET_SUPPLEMENTAL_QUERY_OBLIGATION_LIMIT: usize = 16;
 const PACKET_SUPPLEMENTAL_QUERY_CHAR_LIMIT: usize = 240;
 const REQUESTED_CLAIM_OVERFLOW_ID: &str = "requested_claim_overflow";
-pub(crate) const PACKET_OBLIGATION_RECEIPT_COVERAGE_ROLE: &str = "obligation receipt";
+pub const PACKET_OBLIGATION_RECEIPT_COVERAGE_ROLE: &str = "obligation receipt";
 
-pub(crate) fn build_packet_obligation_plan(
+pub fn build_packet_obligation_plan(
     question: &str,
     task_class: PacketTaskClassDto,
     planned_queries: &[PacketPlanQueryDto],
@@ -142,7 +145,7 @@ pub(crate) fn build_packet_obligation_plan(
     }
 }
 
-pub(crate) fn append_packet_probe_obligations(
+pub fn append_packet_probe_obligations(
     plan: &mut PacketObligationPlanDto,
     resolutions: &[PacketProbeResolutionDto],
 ) {
@@ -364,7 +367,7 @@ fn requested_claim_binding_terms(
         for segment in symbol_identity_segments(term) {
             exact_symbol_components.insert(segment);
         }
-        for component in crate::symbol_query_tokens(term) {
+        for component in symbol_query_tokens(term) {
             exact_symbol_components.insert(normalize_identifier(&component));
         }
         push_exact_requested_claim_binding_candidate(&mut candidates, term);
@@ -565,7 +568,7 @@ fn push_query_obligation(
     });
 }
 
-pub(crate) fn finalize_packet_obligation_plan(
+pub fn finalize_packet_obligation_plan(
     question: &str,
     task_class: PacketTaskClassDto,
     plan: &mut PacketObligationPlanDto,
@@ -980,7 +983,7 @@ fn citation_matches_default_profile_binding(
 
 #[cfg(test)]
 fn citation_display_matches_requested_identity(display_name: &str, requested: &str) -> bool {
-    let exact_case = crate::exact_symbol_query_terms(requested)
+    let exact_case = exact_symbol_query_terms(requested)
         .iter()
         .any(|candidate| candidate == requested.trim());
     citation_display_matches_requested_identity_with_case(display_name, requested, exact_case)
@@ -1108,7 +1111,7 @@ fn citation_satisfies_edge_requirement(
                 edge.kind == required_edge_kind
                     && cited_edge_ids.contains(&edge.id)
                     && (edge.source == citation.node_id || edge.target == citation.node_id)
-                    && !crate::graph_builders::is_speculative_trail_edge(edge)
+                    && !is_speculative_trail_edge(edge)
             })
         })
 }
@@ -1161,7 +1164,7 @@ fn finalize_query_obligations(
     }
 }
 
-pub(crate) fn bind_claims_to_packet_obligations(
+pub fn bind_claims_to_packet_obligations(
     plan: &PacketObligationPlanDto,
     claims: &mut [PacketClaimDto],
 ) {
@@ -1261,10 +1264,10 @@ fn packet_unproven_claim_status(
     }
 }
 
-pub(crate) fn packet_claims_with_obligation_receipts(
+pub fn packet_claims_with_obligation_receipts<T>(
     answer: &AgentAnswerDto,
     plan: &PacketObligationPlanDto,
-    supported_claims_with_telemetry: (Vec<PacketClaimDto>, PacketClaimTelemetry),
+    supported_claims_with_telemetry: (Vec<PacketClaimDto>, T),
 ) -> Vec<PacketClaimDto> {
     packet_claims_with_obligation_receipts_and_telemetry(
         answer,
@@ -1274,11 +1277,11 @@ pub(crate) fn packet_claims_with_obligation_receipts(
     .0
 }
 
-pub(crate) fn packet_claims_with_obligation_receipts_and_telemetry(
+pub fn packet_claims_with_obligation_receipts_and_telemetry<T>(
     answer: &AgentAnswerDto,
     plan: &PacketObligationPlanDto,
-    (mut claims, telemetry): (Vec<PacketClaimDto>, PacketClaimTelemetry),
-) -> (Vec<PacketClaimDto>, PacketClaimTelemetry) {
+    (mut claims, telemetry): (Vec<PacketClaimDto>, T),
+) -> (Vec<PacketClaimDto>, T) {
     append_packet_obligation_receipt_claims(answer, plan, &mut claims);
     (claims, telemetry)
 }
@@ -1373,7 +1376,7 @@ fn packet_obligation_receipt_text(
     )
 }
 
-pub(crate) fn material_packet_obligations_are_proven(plan: &PacketObligationPlanDto) -> bool {
+pub fn material_packet_obligations_are_proven(plan: &PacketObligationPlanDto) -> bool {
     plan.claim_obligations
         .iter()
         .filter(|obligation| obligation.material)
@@ -1390,9 +1393,7 @@ pub(crate) fn material_packet_obligations_are_proven(plan: &PacketObligationPlan
             })
 }
 
-pub(crate) fn packet_obligation_open_next_candidates(
-    plan: &PacketObligationPlanDto,
-) -> Vec<String> {
+pub fn packet_obligation_open_next_candidates(plan: &PacketObligationPlanDto) -> Vec<String> {
     let has_missing_material_claim = plan.claim_obligations.iter().any(|obligation| {
         obligation.material && obligation.proof_status != PacketObligationProofStatusDto::Proven
     });
@@ -1433,9 +1434,7 @@ fn packet_obligation_requested_paths(plan: &PacketObligationPlanDto) -> Vec<Stri
         .collect()
 }
 
-pub(crate) fn packet_proven_obligation_carrier_paths(
-    plan: &PacketObligationPlanDto,
-) -> Vec<String> {
+pub fn packet_proven_obligation_carrier_paths(plan: &PacketObligationPlanDto) -> Vec<String> {
     plan.claim_obligations
         .iter()
         .filter(|obligation| obligation.proof_status == PacketObligationProofStatusDto::Proven)
@@ -1554,19 +1553,31 @@ fn packet_discovery_subject_has_negator(tokens: &[String], subject_index: usize)
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::agent::packet_claims::packet_supported_claims_with_telemetry;
-    use crate::agent::packet_sufficiency::build_packet_sufficiency_with_obligation_context;
     use codestory_contracts::api::{
         AgentRetrievalPolicyModeDto, AgentRetrievalPresetDto, AgentRetrievalTraceDto, EdgeId,
-        GraphArtifactDto, GraphEdgeDto, GraphResponse, NodeId, PACKET_PROBE_CONTRACT_VERSION,
-        PacketBudgetLimitsDto, PacketBudgetModeDto, PacketBudgetUsageDto,
-        PacketEvidenceResolutionDto, PacketEvidenceTierDto, PacketProbeAmbiguityCandidateDto,
-        PacketProbeRejectionDto, PacketSidecarQueryDiagnosticDto, PacketSufficiencyStatusDto,
+        GraphArtifactDto, GraphEdgeDto, GraphResponse, IndexFreshnessDto, IndexFreshnessStatusDto,
+        NodeId, PACKET_PROBE_CONTRACT_VERSION, PacketBudgetLimitsDto, PacketBudgetModeDto,
+        PacketBudgetUsageDto, PacketEvidenceResolutionDto, PacketEvidenceTierDto,
+        PacketProbeAmbiguityCandidateDto, PacketProbeRejectionDto, PacketSidecarQueryDiagnosticDto,
         SearchHitOrigin,
     };
-    use std::path::Path;
 
     const INDEXING_QUESTION: &str = "Explain the indexing runtime, persistence, and snapshot flow.";
+
+    fn fresh_index_observation() -> IndexFreshnessDto {
+        IndexFreshnessDto {
+            status: IndexFreshnessStatusDto::Fresh,
+            changed_file_count: 0,
+            new_file_count: 0,
+            removed_file_count: 0,
+            checked_file_count: 8,
+            indexed_file_count: 8,
+            duration_ms: 1,
+            reason: None,
+            not_checked_cause: None,
+            samples: Vec::new(),
+        }
+    }
 
     fn citation(name: &str, path: &str, kind: NodeKind) -> AgentCitationDto {
         AgentCitationDto {
@@ -1597,7 +1608,7 @@ mod tests {
             answer_id: "obligation-test".to_string(),
             prompt: INDEXING_QUESTION.to_string(),
             summary: "test".to_string(),
-            freshness: Some(crate::agent::packet_freshness::fresh_index_observation()),
+            freshness: Some(fresh_index_observation()),
             sections: Vec::new(),
             citations,
             subgraph_ids: Vec::new(),
@@ -1645,36 +1656,6 @@ mod tests {
             truncated: false,
             omitted_sections: Vec::new(),
             next_deeper_command: None,
-        }
-    }
-
-    fn finalized_obligation(
-        id: &str,
-        kind: PacketClaimObligationKindDto,
-        proof_status: PacketObligationProofStatusDto,
-        carrier: Option<&AgentCitationDto>,
-        reason: Option<&str>,
-    ) -> PacketClaimObligationDto {
-        PacketClaimObligationDto {
-            id: id.to_string(),
-            kind,
-            binding_terms: Vec::new(),
-            probe_binding: None,
-            material: true,
-            allowed_node_kinds: Vec::new(),
-            required_edge_kind: None,
-            requires_complete_discovery: false,
-            proof_status,
-            reason: reason.map(str::to_string),
-            carrier_node_ids: carrier
-                .into_iter()
-                .map(|citation| citation.node_id.clone())
-                .collect(),
-            carrier_paths: carrier
-                .and_then(|citation| citation.file_path.clone())
-                .into_iter()
-                .collect(),
-            open_next_candidates: Vec::new(),
         }
     }
 
@@ -1934,181 +1915,6 @@ mod tests {
         assert!(plan.query_obligations.iter().any(|obligation| {
             obligation.query == "shell installer bootstrap" && obligation.material
         }));
-    }
-
-    #[test]
-    fn cancelled_diagnostic_query_does_not_block_a_complete_material_ledger() {
-        let question = "Explain shell installer function dispatch and completion.";
-        let mut plan = build_packet_obligation_plan(
-            question,
-            PacketTaskClassDto::ArchitectureExplanation,
-            &[],
-        );
-        let mut answer = answer(vec![
-            lexical_citation("nvm_download", "install.sh", NodeKind::FUNCTION),
-            lexical_citation("nvm_use", "nvm.sh", NodeKind::FUNCTION),
-            citation("Helper::noop", "src/helper.rs", NodeKind::METHOD),
-        ]);
-        answer.prompt = question.to_string();
-        let material_queries = plan
-            .query_obligations
-            .iter()
-            .filter(|obligation| obligation.material)
-            .map(|obligation| obligation.query.clone())
-            .collect::<Vec<_>>();
-        for query in material_queries {
-            answer
-                .retrieval_trace
-                .packet_sidecar_diagnostics
-                .push(query_diagnostic(
-                    &query,
-                    PacketQueryCompletionDto::Completed,
-                ));
-        }
-        answer
-            .retrieval_trace
-            .packet_sidecar_diagnostics
-            .push(query_diagnostic(
-                "shell completion",
-                PacketQueryCompletionDto::Cancelled {
-                    reason: "diagnostic_deadline".to_string(),
-                },
-            ));
-
-        finalize_packet_obligation_plan(
-            question,
-            PacketTaskClassDto::ArchitectureExplanation,
-            &mut plan,
-            &answer,
-            &budget(),
-        );
-
-        assert!(plan.query_obligations.iter().any(|obligation| {
-            !obligation.material
-                && obligation.query == "shell completion"
-                && matches!(
-                    obligation.completion,
-                    Some(PacketQueryCompletionDto::Cancelled { ref reason })
-                        if reason == "diagnostic_deadline"
-                )
-        }));
-        assert!(material_packet_obligations_are_proven(&plan), "{plan:#?}");
-        let sufficiency = build_packet_sufficiency_with_obligation_context(
-            Path::new("/workspace/example"),
-            question,
-            PacketTaskClassDto::ArchitectureExplanation,
-            &answer,
-            &budget(),
-            &[],
-            &[],
-            &plan,
-        );
-        assert_eq!(sufficiency.status, PacketSufficiencyStatusDto::Sufficient);
-        assert!(
-            sufficiency
-                .coverage_report
-                .as_ref()
-                .is_some_and(|coverage| coverage.unresolved == ["shell completion"]),
-            "diagnostic cancellation stays visible without changing the verdict: {sufficiency:?}"
-        );
-    }
-
-    /// EV-8. A required query whose semantic stage timed out with zero hits reaches the ledger as
-    /// a typed cancellation, and the ledger is what demotes the verdict. The demotion lands on
-    /// the obligation that lost its evidence rather than on the packet as an undifferentiated
-    /// whole, so the caller is told which query to re-run.
-    #[test]
-    fn a_required_query_whose_semantic_stage_timed_out_demotes_through_its_obligation() {
-        let question = "Explain shell installer function dispatch and completion.";
-        let mut plan = build_packet_obligation_plan(
-            question,
-            PacketTaskClassDto::ArchitectureExplanation,
-            &[],
-        );
-        let mut answer = answer(vec![
-            lexical_citation("nvm_download", "install.sh", NodeKind::FUNCTION),
-            lexical_citation("nvm_use", "nvm.sh", NodeKind::FUNCTION),
-            citation("Helper::noop", "src/helper.rs", NodeKind::METHOD),
-        ]);
-        answer.prompt = question.to_string();
-        let material_queries = plan
-            .query_obligations
-            .iter()
-            .filter(|obligation| obligation.material)
-            .map(|obligation| obligation.query.clone())
-            .collect::<Vec<_>>();
-        let (timed_out_query, completed_queries) = material_queries
-            .split_first()
-            .expect("architecture explanation plans at least one material query");
-        for query in completed_queries {
-            answer
-                .retrieval_trace
-                .packet_sidecar_diagnostics
-                .push(query_diagnostic(query, PacketQueryCompletionDto::Completed));
-        }
-        let mut timed_out = query_diagnostic(
-            timed_out_query,
-            PacketQueryCompletionDto::Cancelled {
-                reason: "semantic_stage_timeout_zero_hits".to_string(),
-            },
-        );
-        timed_out.semantic_stage_timeout_zero_hits = true;
-        answer
-            .retrieval_trace
-            .packet_sidecar_diagnostics
-            .push(timed_out);
-
-        finalize_packet_obligation_plan(
-            question,
-            PacketTaskClassDto::ArchitectureExplanation,
-            &mut plan,
-            &answer,
-            &budget(),
-        );
-
-        assert!(
-            plan.query_obligations.iter().any(|obligation| {
-                obligation.material
-                    && &obligation.query == timed_out_query
-                    && matches!(
-                        obligation.completion,
-                        Some(PacketQueryCompletionDto::Cancelled { ref reason })
-                            if reason == "semantic_stage_timeout_zero_hits"
-                    )
-            }),
-            "the typed cancellation must reach the ledger: {plan:#?}"
-        );
-
-        let sufficiency = build_packet_sufficiency_with_obligation_context(
-            Path::new("/workspace/example"),
-            question,
-            PacketTaskClassDto::ArchitectureExplanation,
-            &answer,
-            &budget(),
-            &[],
-            &[],
-            &plan,
-        );
-
-        assert_eq!(
-            sufficiency.status,
-            PacketSufficiencyStatusDto::Partial,
-            "{sufficiency:?}"
-        );
-        assert!(
-            sufficiency.gaps.iter().any(|gap| {
-                gap.contains("query obligation") && gap.contains("semantic_stage_timeout_zero_hits")
-            }),
-            "the gap must name the query obligation that lost its lane: {:?}",
-            sufficiency.gaps
-        );
-        assert!(
-            sufficiency
-                .follow_up_commands
-                .iter()
-                .any(|command| command.contains(timed_out_query.as_str())),
-            "the caller is told which query to re-run: {sufficiency:?}"
-        );
     }
 
     #[test]
@@ -2398,232 +2204,6 @@ mod tests {
     }
 
     #[test]
-    fn indexing_storage_claim_cannot_borrow_a_proven_runtime_entrypoint() {
-        let question = "Explain how a full indexing run moves from the CLI into runtime orchestration, workspace file discovery, symbol extraction, persistence, and snapshot refresh.";
-        let mut runtime = citation(
-            "IndexService::run_indexing_blocking_without_runtime_refresh",
-            "crates/codestory-runtime/src/services.rs",
-            NodeKind::METHOD,
-        );
-        runtime.evidence_edge_ids = vec![EdgeId("indexing-entry-call".to_string())];
-        let target = citation(
-            "Worker::execute",
-            "crates/example/src/worker.rs",
-            NodeKind::METHOD,
-        );
-        let mut answer = answer(vec![runtime.clone(), target.clone()]);
-        answer.prompt = question.to_string();
-        answer.graphs.push(GraphArtifactDto::Uml {
-            id: "indexing-entrypoint-flow".to_string(),
-            title: "Indexing entrypoint flow".to_string(),
-            graph: GraphResponse {
-                center_id: runtime.node_id.clone(),
-                nodes: Vec::new(),
-                edges: vec![GraphEdgeDto {
-                    id: EdgeId("indexing-entry-call".to_string()),
-                    source: runtime.node_id.clone(),
-                    target: target.node_id,
-                    kind: EdgeKind::CALL,
-                    confidence: Some(1.0),
-                    certainty: Some("certain".to_string()),
-                    callsite_identity: Some("test:1".to_string()),
-                    candidate_targets: Vec::new(),
-                }],
-                truncated: false,
-                omitted_edge_count: 0,
-                canonical_layout: None,
-            },
-        });
-        let mut plan = build_packet_obligation_plan(
-            question,
-            PacketTaskClassDto::ArchitectureExplanation,
-            &[],
-        );
-        finalize_packet_obligation_plan(
-            question,
-            PacketTaskClassDto::ArchitectureExplanation,
-            &mut plan,
-            &answer,
-            &budget(),
-        );
-        assert_eq!(
-            plan.claim_obligations
-                .iter()
-                .find(|obligation| obligation.id == "indexing_entrypoint")
-                .map(|obligation| obligation.proof_status),
-            Some(PacketObligationProofStatusDto::Proven)
-        );
-        let storage_obligation = plan
-            .claim_obligations
-            .iter()
-            .find(|obligation| obligation.id == "indexing_storage")
-            .expect("indexing storage obligation");
-        assert_eq!(
-            storage_obligation.proof_status,
-            PacketObligationProofStatusDto::Unsupported
-        );
-        assert_eq!(
-            storage_obligation.reason.as_deref(),
-            Some("required_carrier_missing")
-        );
-
-        let supported_claims_with_telemetry = packet_supported_claims_with_telemetry(&answer);
-        let mut claims =
-            packet_claims_with_obligation_receipts(&answer, &plan, supported_claims_with_telemetry);
-        bind_claims_to_packet_obligations(&plan, &mut claims);
-        let storage_claim = claims
-            .iter()
-            .find(|claim| claim.required_obligation_ids == ["indexing_storage"])
-            .expect("material storage row emits an exact receipt claim");
-        assert_eq!(storage_claim.required_obligation_ids, ["indexing_storage"]);
-        assert_eq!(
-            storage_claim.proof_status,
-            Some(PacketProofStatusDto::Unsupported)
-        );
-        assert_eq!(storage_claim.eligible_for_sufficiency, Some(false));
-        assert!(storage_claim.claim.contains("required_carrier_missing"));
-        let entrypoint_claim = claims
-            .iter()
-            .find(|claim| claim.required_obligation_ids == ["indexing_entrypoint"])
-            .expect("material entrypoint row emits an exact receipt claim");
-        assert_eq!(
-            entrypoint_claim.proof_status,
-            Some(PacketProofStatusDto::Proven)
-        );
-        assert_eq!(entrypoint_claim.citations.len(), 1);
-    }
-
-    #[test]
-    fn obligation_receipts_use_only_their_exact_rows_own_carriers() {
-        let entrypoint = citation("Cli::run", "src/cli.rs", NodeKind::METHOD);
-        let storage = citation("Store::write", "src/store.rs", NodeKind::METHOD);
-        let answer = answer(vec![entrypoint.clone(), storage.clone()]);
-        let plan = PacketObligationPlanDto {
-            version: PACKET_OBLIGATION_PLAN_VERSION,
-            binding_terms: Vec::new(),
-            claim_obligations: vec![
-                finalized_obligation(
-                    "flow_entrypoint",
-                    PacketClaimObligationKindDto::Entrypoint,
-                    PacketObligationProofStatusDto::Proven,
-                    Some(&entrypoint),
-                    None,
-                ),
-                finalized_obligation(
-                    "flow_storage",
-                    PacketClaimObligationKindDto::StateWrite,
-                    PacketObligationProofStatusDto::Proven,
-                    Some(&storage),
-                    None,
-                ),
-            ],
-            query_obligations: Vec::new(),
-        };
-
-        let supported_claims_with_telemetry = packet_supported_claims_with_telemetry(&answer);
-        let mut claims =
-            packet_claims_with_obligation_receipts(&answer, &plan, supported_claims_with_telemetry);
-        bind_claims_to_packet_obligations(&plan, &mut claims);
-        let receipts = claims
-            .iter()
-            .filter(|claim| {
-                claim.coverage_role.as_deref() == Some(PACKET_OBLIGATION_RECEIPT_COVERAGE_ROLE)
-            })
-            .collect::<Vec<_>>();
-        assert_eq!(receipts.len(), 2);
-        let entrypoint_receipt = receipts
-            .iter()
-            .find(|claim| claim.required_obligation_ids == ["flow_entrypoint"])
-            .expect("entrypoint receipt");
-        assert_eq!(entrypoint_receipt.citations.len(), 1);
-        assert_eq!(entrypoint_receipt.citations[0].node_id, entrypoint.node_id);
-        let storage_receipt = receipts
-            .iter()
-            .find(|claim| claim.required_obligation_ids == ["flow_storage"])
-            .expect("storage receipt");
-        assert_eq!(storage_receipt.citations.len(), 1);
-        assert_eq!(storage_receipt.citations[0].node_id, storage.node_id);
-
-        let mut borrowed = vec![PacketClaimDto {
-            claim: "The entrypoint row is proven.".to_string(),
-            required_obligation_ids: vec!["flow_entrypoint".to_string()],
-            required_obligation_kinds: vec![PacketClaimObligationKindDto::Entrypoint],
-            proof_status: Some(PacketProofStatusDto::Proven),
-            required_evidence_role: None,
-            citations: vec![storage],
-            coverage_role: Some("fixture".to_string()),
-            eligible_for_sufficiency: Some(true),
-        }];
-        bind_claims_to_packet_obligations(&plan, &mut borrowed);
-        assert_eq!(
-            borrowed[0].proof_status,
-            Some(PacketProofStatusDto::Reported)
-        );
-        assert_eq!(borrowed[0].eligible_for_sufficiency, Some(false));
-    }
-
-    #[test]
-    fn receipt_rows_preserve_non_proven_status_reason_and_deduplicate_ids() {
-        let reported_carrier = citation("MaybeStore", "src/store.rs", NodeKind::METHOD);
-        let plan = PacketObligationPlanDto {
-            version: PACKET_OBLIGATION_PLAN_VERSION,
-            binding_terms: Vec::new(),
-            claim_obligations: vec![
-                finalized_obligation(
-                    "reported_storage",
-                    PacketClaimObligationKindDto::StateWrite,
-                    PacketObligationProofStatusDto::Reported,
-                    Some(&reported_carrier),
-                    Some("required_evidence_edge_missing"),
-                ),
-                finalized_obligation(
-                    "reported_storage",
-                    PacketClaimObligationKindDto::StateWrite,
-                    PacketObligationProofStatusDto::Reported,
-                    Some(&reported_carrier),
-                    Some("duplicate_row"),
-                ),
-                finalized_obligation(
-                    "unsupported_dispatch",
-                    PacketClaimObligationKindDto::Dispatch,
-                    PacketObligationProofStatusDto::Unsupported,
-                    None,
-                    Some("required_carrier_missing"),
-                ),
-            ],
-            query_obligations: Vec::new(),
-        };
-        let answer = answer(vec![reported_carrier]);
-        let supported_claims_with_telemetry = packet_supported_claims_with_telemetry(&answer);
-        let mut claims =
-            packet_claims_with_obligation_receipts(&answer, &plan, supported_claims_with_telemetry);
-        bind_claims_to_packet_obligations(&plan, &mut claims);
-        let receipts = claims
-            .iter()
-            .filter(|claim| {
-                claim.coverage_role.as_deref() == Some(PACKET_OBLIGATION_RECEIPT_COVERAGE_ROLE)
-            })
-            .collect::<Vec<_>>();
-        assert_eq!(receipts.len(), 2, "duplicate row IDs emit one receipt");
-        let reported = receipts
-            .iter()
-            .find(|claim| claim.required_obligation_ids == ["reported_storage"])
-            .expect("reported receipt");
-        assert_eq!(reported.proof_status, Some(PacketProofStatusDto::Reported));
-        assert_eq!(reported.eligible_for_sufficiency, Some(false));
-        assert!(reported.claim.contains("required_evidence_edge_missing"));
-        let unsupported = receipts
-            .iter()
-            .find(|claim| claim.required_obligation_ids == ["unsupported_dispatch"])
-            .expect("unsupported receipt");
-        assert_eq!(
-            unsupported.proof_status,
-            Some(PacketProofStatusDto::Unsupported)
-        );
-        assert!(unsupported.claim.contains("required_carrier_missing"));
-    }
-
-    #[test]
     fn eligible_claim_without_an_exact_row_id_is_demoted_even_for_an_empty_plan() {
         let mut claims = vec![PacketClaimDto {
             claim: "A generic role claim.".to_string(),
@@ -2719,151 +2299,6 @@ mod tests {
     }
 
     #[test]
-    fn sufficient_profile_closes_incidental_nonmaterial_guard_path() {
-        let question = "Find RuntimeService::run.";
-        let mut carrier = citation(
-            "RuntimeService::run",
-            "src/runtime_service.rs",
-            NodeKind::METHOD,
-        );
-        carrier.evidence_edge_ids = vec![EdgeId("generic-call".to_string())];
-        let target = citation("Worker::run", "src/worker.rs", NodeKind::METHOD);
-        let incidental_guard_carrier = citation(
-            "HttpTransport::send",
-            "src/incidental_transport.rs",
-            NodeKind::METHOD,
-        );
-        let mut answer = answer(vec![
-            carrier.clone(),
-            target.clone(),
-            incidental_guard_carrier.clone(),
-        ]);
-        answer.prompt = question.to_string();
-        answer
-            .retrieval_trace
-            .packet_sidecar_diagnostics
-            .push(query_diagnostic(
-                "RuntimeService::run",
-                PacketQueryCompletionDto::Completed,
-            ));
-        answer.graphs.push(GraphArtifactDto::Uml {
-            id: "generic-flow".to_string(),
-            title: "Generic flow".to_string(),
-            graph: GraphResponse {
-                center_id: carrier.node_id.clone(),
-                nodes: Vec::new(),
-                edges: vec![GraphEdgeDto {
-                    id: EdgeId("generic-call".to_string()),
-                    source: carrier.node_id,
-                    target: target.node_id,
-                    kind: EdgeKind::CALL,
-                    confidence: Some(1.0),
-                    certainty: Some("certain".to_string()),
-                    callsite_identity: Some("test:1".to_string()),
-                    candidate_targets: Vec::new(),
-                }],
-                truncated: false,
-                omitted_edge_count: 0,
-                canonical_layout: None,
-            },
-        });
-        let mut plan =
-            build_packet_obligation_plan(question, PacketTaskClassDto::SymbolOwnership, &[]);
-        plan.claim_obligations.push(PacketClaimObligationDto {
-            id: "incidental_external_io_guard".to_string(),
-            kind: PacketClaimObligationKindDto::ExternalIo,
-            binding_terms: vec![incidental_guard_carrier.display_name.clone()],
-            probe_binding: None,
-            material: false,
-            allowed_node_kinds: allowed_node_kinds_for_obligation(
-                PacketClaimObligationKindDto::ExternalIo,
-            ),
-            required_edge_kind: Some(EdgeKind::CALL),
-            requires_complete_discovery: false,
-            proof_status: PacketObligationProofStatusDto::Planned,
-            reason: None,
-            carrier_node_ids: Vec::new(),
-            carrier_paths: Vec::new(),
-            open_next_candidates: Vec::new(),
-        });
-        finalize_packet_obligation_plan(
-            question,
-            PacketTaskClassDto::SymbolOwnership,
-            &mut plan,
-            &answer,
-            &budget(),
-        );
-
-        assert_eq!(
-            plan.claim_obligations[0].proof_status,
-            PacketObligationProofStatusDto::Proven
-        );
-        assert_eq!(plan.claim_obligations[0].reason, None);
-        assert!(material_packet_obligations_are_proven(&plan), "{plan:#?}");
-        assert!(plan.query_obligations.iter().any(|obligation| {
-            obligation.material
-                && obligation.query == "RuntimeService::run"
-                && obligation.completion == Some(PacketQueryCompletionDto::Completed)
-        }));
-        let incidental_guard = plan
-            .claim_obligations
-            .iter()
-            .find(|obligation| obligation.id == "incidental_external_io_guard")
-            .expect("incidental guard remains in the finalized ledger");
-        assert!(!incidental_guard.material);
-        assert_eq!(
-            incidental_guard.proof_status,
-            PacketObligationProofStatusDto::Reported
-        );
-        assert_eq!(
-            incidental_guard.carrier_paths,
-            vec!["src/incidental_transport.rs".to_string()]
-        );
-        assert!(
-            packet_obligation_open_next_candidates(&plan)
-                .contains(&"src/incidental_transport.rs".to_string()),
-            "the raw unproven guard receipt must exercise the terminal open-next gate"
-        );
-        let sufficiency = build_packet_sufficiency_with_obligation_context(
-            Path::new("/workspace/example"),
-            question,
-            PacketTaskClassDto::SymbolOwnership,
-            &answer,
-            &budget(),
-            &[],
-            &[],
-            &plan,
-        );
-        assert_eq!(sufficiency.status, PacketSufficiencyStatusDto::Sufficient);
-        assert!(
-            sufficiency
-                .covered_claims
-                .iter()
-                .any(|claim| claim.proof_status == Some(PacketProofStatusDto::Proven))
-        );
-        assert!(
-            !sufficiency
-                .avoid_opening_paths
-                .contains(&"src/incidental_transport.rs".to_string()),
-            "an unproven incidental guard carrier cannot become avoid-opening"
-        );
-        let coverage = sufficiency
-            .coverage_report
-            .as_ref()
-            .expect("sufficiency publishes claim-level blockers");
-        assert!(
-            coverage.ineligible.iter().any(|entry| {
-                entry.contains("RuntimeService::run") && entry.contains("claim marked diagnostic")
-            }),
-            "the per-file safety blocker must remain visible: {coverage:?}"
-        );
-        assert!(
-            sufficiency.open_next.is_empty(),
-            "Sufficient is terminal even when a nonmaterial Reported guard carries a path: {sufficiency:?}"
-        );
-    }
-
-    #[test]
     fn qualified_binding_requires_the_requested_owner_and_member() {
         assert!(citation_display_matches_requested_identity(
             "RuntimeService::run",
@@ -2913,129 +2348,6 @@ mod tests {
             "Widget::~Widget",
             "Widget::Widget"
         ));
-    }
-
-    #[test]
-    fn case_distinct_exact_symbols_need_separate_carriers() {
-        let question = "Find Foo::run and foo::run.";
-        let mut answer = answer_with_call_edge(question, "Foo::run", "src/runtime.rs");
-        for query in ["Foo::run", "foo::run"] {
-            answer
-                .retrieval_trace
-                .packet_sidecar_diagnostics
-                .push(query_diagnostic(query, PacketQueryCompletionDto::Completed));
-        }
-        let mut plan =
-            build_packet_obligation_plan(question, PacketTaskClassDto::SymbolOwnership, &[]);
-
-        assert!(
-            plan.query_obligations
-                .iter()
-                .any(|obligation| { obligation.material && obligation.query == "Foo::run" })
-        );
-        assert!(
-            plan.query_obligations
-                .iter()
-                .any(|obligation| { obligation.material && obligation.query == "foo::run" })
-        );
-        finalize_packet_obligation_plan(
-            question,
-            PacketTaskClassDto::SymbolOwnership,
-            &mut plan,
-            &answer,
-            &budget(),
-        );
-
-        let upper = plan
-            .claim_obligations
-            .iter()
-            .find(|obligation| obligation.binding_terms == ["Foo::run"])
-            .unwrap();
-        let lower = plan
-            .claim_obligations
-            .iter()
-            .find(|obligation| obligation.binding_terms == ["foo::run"])
-            .unwrap();
-        assert_eq!(upper.proof_status, PacketObligationProofStatusDto::Proven);
-        assert_eq!(
-            lower.proof_status,
-            PacketObligationProofStatusDto::Unsupported
-        );
-        assert!(lower.carrier_node_ids.is_empty());
-        assert!(!material_packet_obligations_are_proven(&plan));
-
-        let sufficiency = build_packet_sufficiency_with_obligation_context(
-            Path::new("/workspace/example"),
-            question,
-            PacketTaskClassDto::SymbolOwnership,
-            &answer,
-            &budget(),
-            &[],
-            &[],
-            &plan,
-        );
-        assert_eq!(sufficiency.status, PacketSufficiencyStatusDto::Partial);
-    }
-
-    #[test]
-    fn case_distinct_slash_qualified_symbols_need_separate_carriers() {
-        let question = "Find Foo/run and foo/run.";
-        let mut answer = answer_with_call_edge(question, "Foo/run", "src/runtime.rs");
-        for query in ["Foo/run", "foo/run"] {
-            answer
-                .retrieval_trace
-                .packet_sidecar_diagnostics
-                .push(query_diagnostic(query, PacketQueryCompletionDto::Completed));
-        }
-        let mut plan =
-            build_packet_obligation_plan(question, PacketTaskClassDto::SymbolOwnership, &[]);
-
-        for expected in ["Foo/run", "foo/run"] {
-            assert!(
-                plan.query_obligations
-                    .iter()
-                    .any(|obligation| { obligation.material && obligation.query == expected })
-            );
-            assert!(plan.claim_obligations.iter().any(|obligation| {
-                obligation.material && obligation.binding_terms == [expected]
-            }));
-        }
-        finalize_packet_obligation_plan(
-            question,
-            PacketTaskClassDto::SymbolOwnership,
-            &mut plan,
-            &answer,
-            &budget(),
-        );
-
-        let upper = plan
-            .claim_obligations
-            .iter()
-            .find(|obligation| obligation.binding_terms == ["Foo/run"])
-            .unwrap();
-        let lower = plan
-            .claim_obligations
-            .iter()
-            .find(|obligation| obligation.binding_terms == ["foo/run"])
-            .unwrap();
-        assert_eq!(upper.proof_status, PacketObligationProofStatusDto::Proven);
-        assert_eq!(
-            lower.proof_status,
-            PacketObligationProofStatusDto::Unsupported
-        );
-        assert!(lower.carrier_node_ids.is_empty());
-
-        let sufficiency = build_packet_sufficiency_with_obligation_context(
-            Path::new("/workspace/example"),
-            question,
-            PacketTaskClassDto::SymbolOwnership,
-            &answer,
-            &budget(),
-            &[],
-            &[],
-            &plan,
-        );
-        assert_eq!(sufficiency.status, PacketSufficiencyStatusDto::Partial);
     }
 
     #[test]
@@ -3126,165 +2438,6 @@ mod tests {
             PacketObligationProofStatusDto::Unsupported
         );
         assert!(missing.carrier_node_ids.is_empty());
-    }
-
-    #[test]
-    fn one_proven_claim_cannot_hide_an_unproven_claim_in_the_same_file() {
-        let question = "Find RuntimeService::run and CliErrorBody.";
-        let shared_path = "src/runtime_service.rs";
-        let mut carrier = citation("RuntimeService::run", shared_path, NodeKind::METHOD);
-        carrier.evidence_edge_ids = vec![EdgeId("generic-call".to_string())];
-        let false_carrier = citation("CliErrorBody", shared_path, NodeKind::STRUCT);
-        let target = citation("Worker::run", "src/worker.rs", NodeKind::METHOD);
-        let mut answer = answer(vec![carrier.clone(), false_carrier, target.clone()]);
-        answer.prompt = question.to_string();
-        answer.graphs.push(GraphArtifactDto::Uml {
-            id: "generic-flow".to_string(),
-            title: "Generic flow".to_string(),
-            graph: GraphResponse {
-                center_id: carrier.node_id.clone(),
-                nodes: Vec::new(),
-                edges: vec![GraphEdgeDto {
-                    id: EdgeId("generic-call".to_string()),
-                    source: carrier.node_id,
-                    target: target.node_id,
-                    kind: EdgeKind::CALL,
-                    confidence: Some(1.0),
-                    certainty: Some("certain".to_string()),
-                    callsite_identity: Some("test:1".to_string()),
-                    candidate_targets: Vec::new(),
-                }],
-                truncated: false,
-                omitted_edge_count: 0,
-                canonical_layout: None,
-            },
-        });
-        let mut plan =
-            build_packet_obligation_plan(question, PacketTaskClassDto::SymbolOwnership, &[]);
-        finalize_packet_obligation_plan(
-            question,
-            PacketTaskClassDto::SymbolOwnership,
-            &mut plan,
-            &answer,
-            &budget(),
-        );
-        assert!(plan.claim_obligations.iter().any(|obligation| {
-            obligation.proof_status == PacketObligationProofStatusDto::Proven
-                && obligation
-                    .carrier_paths
-                    .iter()
-                    .any(|path| path == shared_path)
-        }));
-        assert!(plan.claim_obligations.iter().any(|obligation| {
-            obligation.proof_status == PacketObligationProofStatusDto::Reported
-                && obligation
-                    .carrier_paths
-                    .iter()
-                    .any(|path| path == shared_path)
-        }));
-
-        let sufficiency = build_packet_sufficiency_with_obligation_context(
-            Path::new("/workspace/example"),
-            question,
-            PacketTaskClassDto::SymbolOwnership,
-            &answer,
-            &budget(),
-            &[],
-            &[],
-            &plan,
-        );
-
-        assert_eq!(sufficiency.status, PacketSufficiencyStatusDto::Partial);
-        assert!(!material_packet_obligations_are_proven(&plan));
-        assert!(
-            !sufficiency
-                .avoid_opening_paths
-                .iter()
-                .any(|path| path == shared_path),
-            "a file with an unproven claim must remain openable: {sufficiency:?}"
-        );
-        assert!(
-            sufficiency
-                .open_next
-                .iter()
-                .any(|command| command.contains(shared_path)),
-            "the unproven same-file claim must stay open-next: {sufficiency:?}"
-        );
-    }
-
-    #[test]
-    fn missing_requested_claim_gets_a_material_unsupported_obligation() {
-        let question = "Find RuntimeService::run and MissingWidget.";
-        let mut carrier = citation(
-            "RuntimeService::run",
-            "src/runtime_service.rs",
-            NodeKind::METHOD,
-        );
-        carrier.evidence_edge_ids = vec![EdgeId("generic-call".to_string())];
-        let target = citation("Worker::run", "src/worker.rs", NodeKind::METHOD);
-        let mut answer = answer(vec![carrier.clone(), target.clone()]);
-        answer.prompt = question.to_string();
-        answer.graphs.push(GraphArtifactDto::Uml {
-            id: "generic-flow".to_string(),
-            title: "Generic flow".to_string(),
-            graph: GraphResponse {
-                center_id: carrier.node_id.clone(),
-                nodes: Vec::new(),
-                edges: vec![GraphEdgeDto {
-                    id: EdgeId("generic-call".to_string()),
-                    source: carrier.node_id,
-                    target: target.node_id,
-                    kind: EdgeKind::CALL,
-                    confidence: Some(1.0),
-                    certainty: Some("certain".to_string()),
-                    callsite_identity: Some("test:1".to_string()),
-                    candidate_targets: Vec::new(),
-                }],
-                truncated: false,
-                omitted_edge_count: 0,
-                canonical_layout: None,
-            },
-        });
-        let mut plan =
-            build_packet_obligation_plan(question, PacketTaskClassDto::SymbolOwnership, &[]);
-        finalize_packet_obligation_plan(
-            question,
-            PacketTaskClassDto::SymbolOwnership,
-            &mut plan,
-            &answer,
-            &budget(),
-        );
-
-        let missing = plan
-            .claim_obligations
-            .iter()
-            .find(|obligation| obligation.binding_terms == ["MissingWidget"])
-            .expect("material obligation for the missing requested claim");
-        assert!(missing.material);
-        assert_eq!(
-            missing.proof_status,
-            PacketObligationProofStatusDto::Unsupported
-        );
-        assert!(missing.carrier_node_ids.is_empty());
-        assert!(!material_packet_obligations_are_proven(&plan));
-
-        let sufficiency = build_packet_sufficiency_with_obligation_context(
-            Path::new("/workspace/example"),
-            question,
-            PacketTaskClassDto::SymbolOwnership,
-            &answer,
-            &budget(),
-            &[],
-            &[],
-            &plan,
-        );
-        assert_eq!(sufficiency.status, PacketSufficiencyStatusDto::Partial);
-        assert!(
-            sufficiency
-                .open_next
-                .iter()
-                .any(|command| command.contains("MissingWidget"))
-        );
     }
 
     #[test]
@@ -3496,110 +2649,6 @@ mod tests {
                     "{obligation_kind:?} {rejected:?}"
                 );
             }
-        }
-    }
-
-    #[test]
-    fn false_shape_carrier_stays_reported_partial_and_open_next() {
-        let false_carrier = citation(
-            "CliErrorBody",
-            "crates/example/src/indexer/runtime.rs",
-            NodeKind::STRUCT,
-        );
-        let answer = answer(vec![false_carrier]);
-        let budget = budget();
-        let mut plan = indexing_entrypoint_plan();
-        finalize_packet_obligation_plan(
-            INDEXING_QUESTION,
-            PacketTaskClassDto::ArchitectureExplanation,
-            &mut plan,
-            &answer,
-            &budget,
-        );
-
-        assert_eq!(
-            plan.claim_obligations[0].proof_status,
-            PacketObligationProofStatusDto::Reported
-        );
-        assert_eq!(
-            plan.claim_obligations[0].reason.as_deref(),
-            Some("carrier_does_not_satisfy_role_contract")
-        );
-        let sufficiency = build_packet_sufficiency_with_obligation_context(
-            Path::new("/workspace/example"),
-            INDEXING_QUESTION,
-            PacketTaskClassDto::ArchitectureExplanation,
-            &answer,
-            &budget,
-            &[],
-            &[],
-            &plan,
-        );
-        assert_eq!(sufficiency.status, PacketSufficiencyStatusDto::Partial);
-        assert!(sufficiency.avoid_opening_paths.is_empty());
-        assert!(
-            sufficiency
-                .open_next
-                .iter()
-                .any(|command| command.contains("crates/example/src/indexer/runtime.rs"))
-        );
-    }
-
-    #[test]
-    fn known_false_carriers_publish_no_proven_claims_and_stay_open_next() {
-        let question =
-            "Explain CliErrorBody, runtime_path, and CompilationDatabase responsibilities.";
-        let false_carriers = vec![
-            citation("CliErrorBody", "src/cli/errors.rs", NodeKind::STRUCT),
-            citation("runtime_path", "src/runtime/config.rs", NodeKind::VARIABLE),
-            citation(
-                "CompilationDatabase",
-                "src/store/database.rs",
-                NodeKind::CLASS,
-            ),
-        ];
-        let mut answer = answer(false_carriers.clone());
-        answer.prompt = question.to_string();
-        let budget = budget();
-        let mut plan =
-            build_packet_obligation_plan(question, PacketTaskClassDto::SymbolOwnership, &[]);
-        finalize_packet_obligation_plan(
-            question,
-            PacketTaskClassDto::SymbolOwnership,
-            &mut plan,
-            &answer,
-            &budget,
-        );
-
-        let sufficiency = build_packet_sufficiency_with_obligation_context(
-            Path::new("/workspace/example"),
-            question,
-            PacketTaskClassDto::SymbolOwnership,
-            &answer,
-            &budget,
-            &[],
-            &[],
-            &plan,
-        );
-
-        assert_eq!(sufficiency.status, PacketSufficiencyStatusDto::Partial);
-        assert!(
-            sufficiency
-                .covered_claims
-                .iter()
-                .all(|claim| { claim.proof_status != Some(PacketProofStatusDto::Proven) })
-        );
-        assert!(sufficiency.avoid_opening_paths.is_empty());
-        for carrier in false_carriers {
-            let path = carrier.file_path.expect("false carrier path");
-            assert!(
-                sufficiency
-                    .open_next
-                    .iter()
-                    .any(|command| command.contains(&path)),
-                "{path} must remain open-next: {:?}",
-                sufficiency.open_next
-            );
         }
     }
 
@@ -3822,47 +2871,6 @@ mod tests {
         assert_eq!(
             packet_proven_obligation_carrier_paths(&plan),
             vec!["crates/example/src/indexer.rs".to_string()]
-        );
-    }
-
-    #[test]
-    fn missing_carrier_keeps_requested_path_as_open_next_candidate() {
-        let queries = [PacketPlanQueryDto {
-            query: "src/indexer.rs".to_string(),
-            purpose: "explicit symbol probe from packet request".to_string(),
-        }];
-        let mut plan = build_packet_obligation_plan(
-            INDEXING_QUESTION,
-            PacketTaskClassDto::ArchitectureExplanation,
-            &queries,
-        );
-        plan.claim_obligations
-            .retain(|obligation| obligation.id == "indexing_entrypoint");
-        let answer = answer(Vec::new());
-        let budget = budget();
-        finalize_packet_obligation_plan(
-            INDEXING_QUESTION,
-            PacketTaskClassDto::ArchitectureExplanation,
-            &mut plan,
-            &answer,
-            &budget,
-        );
-        let sufficiency = build_packet_sufficiency_with_obligation_context(
-            Path::new("/workspace/example"),
-            INDEXING_QUESTION,
-            PacketTaskClassDto::ArchitectureExplanation,
-            &answer,
-            &budget,
-            &[],
-            &[],
-            &plan,
-        );
-
-        assert!(
-            sufficiency
-                .open_next
-                .iter()
-                .any(|command| command.contains("src/indexer.rs"))
         );
     }
 

--- a/crates/codestory-agent/src/packet_plan.rs
+++ b/crates/codestory-agent/src/packet_plan.rs
@@ -1,23 +1,23 @@
-#[cfg(test)]
-use crate::agent::eval_probes::{
+#[cfg(any(test, feature = "test-support"))]
+use crate::eval_probes::{
     eval_probes_enabled, push_eval_architecture_flow_probe_terms,
     push_eval_flow_hint_packet_queries, push_prompt_named_file_probe_queries,
 };
-use crate::agent::packet_command_profiles::{
+use crate::packet_command_profiles::{
     packet_command_exact_probe_queries, packet_command_role_probe_queries,
 };
-use crate::agent::packet_flow_requirements::packet_flow_requirement_queries_for_terms;
-use crate::agent::packet_obligations::build_packet_obligation_plan;
-use crate::agent::packet_required_probes::{
+use crate::packet_flow_requirements::packet_flow_requirement_queries_for_terms;
+use crate::packet_obligations::build_packet_obligation_plan;
+use crate::packet_required_probes::{
     packet_concrete_file_probe_queries_from_required, packet_prompt_exact_symbol_probe_queries,
     packet_sufficiency_required_probe_queries_from_terms,
     push_command_loop_source_probe_queries_for_terms, push_indexing_flow_required_probe_queries,
     push_search_flow_probe_queries, push_sql_schema_required_probe_queries,
 };
-use crate::agent::packet_scoring::{
+use crate::packet_scoring::{
     normalize_identifier, packet_adjacent_query_stop_term, packet_query_stop_term,
 };
-use crate::agent::packet_terms::{
+use crate::packet_terms::{
     packet_probe_terms, packet_terms_have, packet_terms_have_any,
     packet_terms_indicate_buffered_io_flow, packet_terms_indicate_client_send_flow,
     packet_terms_indicate_command_dispatch_flow, packet_terms_indicate_command_event_loop_flow,
@@ -37,19 +37,19 @@ use crate::agent::packet_terms::{
     packet_terms_indicate_stylesheet_animation_flow,
     packet_terms_indicate_url_session_request_flow, prompt_search_terms,
 };
-use crate::agent::planning::{
+use crate::planning::{
     PACKET_EXACT_SYMBOL_QUERY_PURPOSE, dedupe_packet_plan_queries,
     packet_plan_query_is_exact_symbol_identity,
 };
-use crate::{
+use crate::text::{
     exact_symbol_query_terms, is_non_primary_source_term, looks_like_standalone_symbol_query,
     query_mentions_non_primary_source,
 };
 use codestory_contracts::api::{
     PacketBudgetModeDto, PacketPlanDto, PacketPlanQueryDto, PacketTaskClassDto,
 };
-#[cfg(test)]
-pub(crate) fn build_packet_plan(
+#[cfg(any(test, feature = "test-support"))]
+pub fn build_packet_plan(
     question: &str,
     requested: Option<PacketTaskClassDto>,
     budget: PacketBudgetModeDto,
@@ -57,7 +57,7 @@ pub(crate) fn build_packet_plan(
     build_packet_plan_with_extra(question, requested, budget, &[])
 }
 
-pub(crate) fn build_packet_plan_with_extra(
+pub fn build_packet_plan_with_extra(
     question: &str,
     requested: Option<PacketTaskClassDto>,
     budget: PacketBudgetModeDto,
@@ -148,9 +148,9 @@ pub(crate) fn build_packet_plan_with_extra(
     };
     dedupe_packet_plan_queries(&mut plan);
     plan.obligations = build_packet_obligation_plan(question, task_class, &plan.queries);
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-support"))]
     let eval_probes = eval_probes_enabled();
-    #[cfg(not(test))]
+    #[cfg(not(any(test, feature = "test-support")))]
     let eval_probes = false;
     plan.trace.push(format!(
         "deduped_queries={} eval_probes={eval_probes}",
@@ -165,7 +165,7 @@ pub(crate) fn build_packet_plan_with_extra(
     plan
 }
 
-pub(crate) fn packet_rank_terms(question: &str) -> Vec<String> {
+pub fn packet_rank_terms(question: &str) -> Vec<String> {
     let mut terms = prompt_search_terms(question);
     for term in extract_packet_query_terms(question) {
         push_unique_term(&mut terms, &term);
@@ -180,7 +180,7 @@ pub(crate) fn packet_rank_terms(question: &str) -> Vec<String> {
     terms
 }
 
-pub(crate) fn packet_explicit_request_probe_queries(plan: &PacketPlanDto) -> Vec<String> {
+pub fn packet_explicit_request_probe_queries(plan: &PacketPlanDto) -> Vec<String> {
     plan.queries
         .iter()
         .filter(|query| query.purpose.contains("explicit symbol probe"))
@@ -197,7 +197,7 @@ fn packet_plan_query_cap(budget: PacketBudgetModeDto) -> usize {
     }
 }
 
-pub(crate) fn packet_symbol_probe_queries(
+pub fn packet_symbol_probe_queries(
     question: &str,
     task_class: PacketTaskClassDto,
     budget: PacketBudgetModeDto,
@@ -221,7 +221,7 @@ pub(crate) fn packet_symbol_probe_queries(
         &mut queries,
         &packet_prompt_exact_symbol_probe_queries(question, &terms, task_class),
     );
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-support"))]
     if eval_probes_enabled() {
         push_prompt_named_file_probe_queries(&terms, &mut queries);
     }
@@ -252,13 +252,13 @@ pub(crate) fn packet_symbol_probe_queries(
 
 fn push_flow_hint_packet_queries(terms: &[String], queries: &mut Vec<String>) {
     push_prompt_derived_flow_hint_packet_queries(terms, queries);
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-support"))]
     {
         push_eval_flow_hint_packet_queries(terms, queries);
     }
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-support"))]
     let use_index_derived = !eval_probes_enabled();
-    #[cfg(not(test))]
+    #[cfg(not(any(test, feature = "test-support")))]
     let use_index_derived = true;
     if use_index_derived {
         push_index_derived_architecture_probes(
@@ -1317,7 +1317,7 @@ fn push_adjacent_packet_term_queries(
     }
 }
 
-pub(crate) fn packet_concept_queries(question: &str) -> Vec<String> {
+pub fn packet_concept_queries(question: &str) -> Vec<String> {
     let include_non_primary_terms = query_mentions_non_primary_source(question);
     prompt_search_terms(question)
         .into_iter()
@@ -1355,7 +1355,7 @@ fn packet_camel_case(words: &[&str]) -> String {
     value
 }
 
-pub(crate) fn infer_packet_task_class(question: &str) -> PacketTaskClassDto {
+pub fn infer_packet_task_class(question: &str) -> PacketTaskClassDto {
     let lower = question.to_ascii_lowercase();
     if contains_any(
         &lower,
@@ -1414,7 +1414,7 @@ fn risk_of_change_prompt(lower: &str) -> bool {
         || lower.contains("risk in changing")
 }
 
-pub(crate) fn extract_packet_query_terms(question: &str) -> Vec<String> {
+pub fn extract_packet_query_terms(question: &str) -> Vec<String> {
     let mut terms = Vec::new();
     let mut quoted = false;
     let mut quote = '\0';
@@ -1519,7 +1519,7 @@ fn is_packet_code_like_term(token: &str) -> bool {
         || token.chars().skip(1).any(|ch| ch.is_ascii_uppercase())
 }
 
-pub(crate) fn push_unique_term(terms: &mut Vec<String>, value: &str) {
+pub fn push_unique_term(terms: &mut Vec<String>, value: &str) {
     let value = value.trim();
     if value.len() < 3 {
         return;
@@ -1606,7 +1606,7 @@ fn push_exact_symbol_packet_query(queries: &mut Vec<PacketPlanQueryDto>, query: 
     });
 }
 
-pub(crate) fn packet_plan_annotation(plan: &PacketPlanDto) -> String {
+pub fn packet_plan_annotation(plan: &PacketPlanDto) -> String {
     let queries = plan
         .queries
         .iter()
@@ -1634,7 +1634,7 @@ fn packet_architecture_flow_probe_terms(prompt: &str) -> Vec<String> {
             push_unique_term(&mut terms, term);
         }
     }
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-support"))]
     push_eval_architecture_flow_probe_terms(&lower, &mut terms);
     terms
 }

--- a/crates/codestory-agent/src/packet_required_probes.rs
+++ b/crates/codestory-agent/src/packet_required_probes.rs
@@ -1,19 +1,19 @@
-#[cfg(test)]
-use crate::agent::eval_probes::{
+#[cfg(any(test, feature = "test-support"))]
+use crate::eval_probes::{
     eval_probes_enabled, push_eval_required_probe_queries,
     push_prompt_concept_derived_symbol_probes,
 };
-use crate::agent::packet_batch::packet_file_stem_matches_query;
-use crate::agent::packet_evidence_roles::{
+use crate::packet_evidence_roles::{
     PacketEvidenceRole, packet_citation_owns_interceptor_management,
     packet_citation_owns_request_pipeline, packet_citation_owns_transport_adapter,
     packet_evidence_role,
 };
-use crate::agent::packet_flow_requirements::packet_flow_requirement_queries_for_terms;
-use crate::agent::packet_scoring::{
-    normalize_identifier, packet_display_path, packet_query_stop_term,
+use crate::packet_flow_requirements::packet_flow_requirement_queries_for_terms;
+use crate::packet_scoring::{
+    normalize_identifier, packet_display_path, packet_file_stem_matches_query,
+    packet_query_stop_term,
 };
-use crate::agent::packet_terms::{
+use crate::packet_terms::{
     packet_probe_terms, packet_terms_have, packet_terms_have_any,
     packet_terms_indicate_buffered_io_flow, packet_terms_indicate_client_send_flow,
     packet_terms_indicate_command_dispatch_flow, packet_terms_indicate_command_event_loop_flow,
@@ -32,12 +32,13 @@ use crate::agent::packet_terms::{
     packet_terms_indicate_sql_schema_flow, packet_terms_indicate_stylesheet_animation_flow,
     packet_terms_indicate_url_session_request_flow,
 };
-use crate::exact_symbol_query_terms;
+use crate::text::exact_symbol_query_terms;
+use crate::text::{RetrievalFileRole, retrieval_file_role_from_path};
 use codestory_contracts::api::{
     AgentAnswerDto, AgentCitationDto, NodeKind, PacketClaimDto, PacketTaskClassDto, SearchHitOrigin,
 };
 
-pub(crate) fn packet_missing_sufficiency_probe_queries_with_extra(
+pub fn packet_missing_sufficiency_probe_queries_with_extra(
     question: &str,
     task_class: PacketTaskClassDto,
     answer: &AgentAnswerDto,
@@ -63,10 +64,7 @@ fn packet_probe_query_is_covered(
         || packet_probe_query_is_claimed(query, supported_claims)
 }
 
-pub(crate) fn packet_probe_query_is_claimed(
-    query: &str,
-    supported_claims: &[PacketClaimDto],
-) -> bool {
+pub fn packet_probe_query_is_claimed(query: &str, supported_claims: &[PacketClaimDto]) -> bool {
     if let Some(parts) = packet_file_scoped_symbol_probe_parts(query) {
         return supported_claims
             .iter()
@@ -376,15 +374,15 @@ fn packet_required_probe_requires_citation(query: &str) -> bool {
     )
 }
 
-#[cfg(test)]
-pub(crate) fn packet_sufficiency_required_probe_queries(
+#[cfg(any(test, feature = "test-support"))]
+pub fn packet_sufficiency_required_probe_queries(
     question: &str,
     task_class: PacketTaskClassDto,
 ) -> Vec<String> {
     packet_sufficiency_required_probe_queries_with_extra(question, task_class, &[])
 }
 
-pub(crate) fn packet_sufficiency_required_probe_queries_with_extra(
+pub fn packet_sufficiency_required_probe_queries_with_extra(
     question: &str,
     task_class: PacketTaskClassDto,
     extra_probes: &[String],
@@ -399,7 +397,7 @@ pub(crate) fn packet_sufficiency_required_probe_queries_with_extra(
     queries
 }
 
-pub(crate) fn packet_sufficiency_required_probe_queries_from_terms(
+pub fn packet_sufficiency_required_probe_queries_from_terms(
     terms: &[String],
     task_class: PacketTaskClassDto,
 ) -> Vec<String> {
@@ -422,7 +420,7 @@ pub(crate) fn packet_sufficiency_required_probe_queries_from_terms(
         &packet_flow_requirement_queries_for_terms(terms, task_class),
     );
 
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-support"))]
     if eval_probes_enabled() {
         push_eval_required_probe_queries(terms, &mut queries);
     }
@@ -812,7 +810,7 @@ fn push_prompt_concept_role_probe_queries(terms: &[String], queries: &mut Vec<St
     }
 }
 
-pub(crate) fn packet_prompt_exact_symbol_probe_queries(
+pub fn packet_prompt_exact_symbol_probe_queries(
     question: &str,
     terms: &[String],
     task_class: PacketTaskClassDto,
@@ -836,9 +834,9 @@ pub(crate) fn packet_prompt_exact_symbol_probe_queries(
             push_unique_exact_symbol_term(&mut queries, &term);
         }
     }
-    #[cfg(not(test))]
+    #[cfg(not(any(test, feature = "test-support")))]
     let _ = terms;
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-support"))]
     if eval_probes_enabled() {
         push_prompt_concept_derived_symbol_probes(terms, &mut queries);
     }
@@ -871,7 +869,7 @@ fn packet_prompt_exact_symbol_term_is_source_path(term: &str) -> bool {
     codestory_contracts::language_support::language_support_profile_for_path(Some(term)).is_some()
 }
 
-pub(crate) fn packet_concrete_file_probe_queries_from_required(
+pub fn packet_concrete_file_probe_queries_from_required(
     required_queries: &[String],
 ) -> Vec<String> {
     let mut queries = Vec::new();
@@ -897,7 +895,7 @@ fn packet_required_probe_file_query(query: &str) -> Option<String> {
         .then(|| format!("{query}.rs"))
 }
 
-pub(crate) fn push_indexing_flow_required_probe_queries(queries: &mut Vec<String>) {
+pub fn push_indexing_flow_required_probe_queries(queries: &mut Vec<String>) {
     push_unique_terms(
         queries,
         &[
@@ -911,7 +909,7 @@ pub(crate) fn push_indexing_flow_required_probe_queries(queries: &mut Vec<String
     );
 }
 
-pub(crate) fn push_search_flow_probe_queries(queries: &mut Vec<String>) {
+pub fn push_search_flow_probe_queries(queries: &mut Vec<String>) {
     push_unique_terms(
         queries,
         &[
@@ -926,17 +924,14 @@ pub(crate) fn push_search_flow_probe_queries(queries: &mut Vec<String>) {
     );
 }
 
-pub(crate) fn packet_probe_query_is_cited(query: &str, answer: &AgentAnswerDto) -> bool {
+pub fn packet_probe_query_is_cited(query: &str, answer: &AgentAnswerDto) -> bool {
     answer
         .citations
         .iter()
         .any(|citation| packet_citation_satisfies_required_probe(query, citation))
 }
 
-pub(crate) fn packet_citation_satisfies_required_probe(
-    query: &str,
-    citation: &AgentCitationDto,
-) -> bool {
+pub fn packet_citation_satisfies_required_probe(query: &str, citation: &AgentCitationDto) -> bool {
     if packet_citation_matches_required_coverage_role(query, citation) {
         return true;
     }
@@ -989,7 +984,7 @@ pub(crate) fn packet_citation_satisfies_required_probe(
     !packet_required_probe_needs_exact_match(query) || match_rank >= 4
 }
 
-pub(crate) fn packet_required_probe_needs_exact_match(query: &str) -> bool {
+pub fn packet_required_probe_needs_exact_match(query: &str) -> bool {
     let normalized_query = normalize_identifier(query);
     query.contains("::")
         || query.contains('.')
@@ -1029,10 +1024,7 @@ fn packet_citation_probe_has_exact_identifier_match(
     normalized_display == normalized_query || normalized_display.ends_with(&normalized_query)
 }
 
-pub(crate) fn packet_citation_probe_match_rank(
-    query: &str,
-    citation: &AgentCitationDto,
-) -> Option<u8> {
+pub fn packet_citation_probe_match_rank(query: &str, citation: &AgentCitationDto) -> Option<u8> {
     let normalized_query = normalize_identifier(query);
     if normalized_query.is_empty() {
         return Some(0);
@@ -1101,9 +1093,10 @@ fn packet_citation_is_exact_primary_file_probe_match(
     citation.kind == NodeKind::FILE
         && citation.origin == SearchHitOrigin::IndexedSymbol
         && citation.resolvable
-        && citation.file_path.as_deref().is_some_and(|path| {
-            crate::retrieval_file_role_from_path(path) == crate::RetrievalFileRole::Source
-        })
+        && citation
+            .file_path
+            .as_deref()
+            .is_some_and(|path| retrieval_file_role_from_path(path) == RetrievalFileRole::Source)
         && packet_file_stem_matches_query(query, citation.file_path.as_deref())
 }
 
@@ -1576,14 +1569,14 @@ fn packet_display_tail_has_interface_prefix(display_tail: &str) -> bool {
     chars.next().is_some_and(|ch| ch.is_ascii_uppercase())
 }
 
-pub(crate) fn packet_required_probe_needs_buffered_wrapper_implementation(query: &str) -> bool {
+pub fn packet_required_probe_needs_buffered_wrapper_implementation(query: &str) -> bool {
     matches!(
         normalize_identifier(query).as_str(),
         "sourcereadbuffer" | "sinkwritebuffer"
     )
 }
 
-pub(crate) fn packet_citation_matches_buffered_wrapper_implementation(
+pub fn packet_citation_matches_buffered_wrapper_implementation(
     query: &str,
     citation: &AgentCitationDto,
 ) -> bool {
@@ -1714,10 +1707,7 @@ fn packet_file_scoped_short_symbol_matches(display_name: &str, symbol: &str) -> 
         .is_some_and(|tail| tail == symbol)
 }
 
-pub(crate) fn packet_probe_file_name_matches(
-    query_file_name: &str,
-    candidate_file_name: &str,
-) -> bool {
+pub fn packet_probe_file_name_matches(query_file_name: &str, candidate_file_name: &str) -> bool {
     let query_stem = packet_probe_file_stem(query_file_name);
     let candidate_stem = packet_probe_file_stem(candidate_file_name);
     if query_stem.is_empty() || candidate_stem.is_empty() {
@@ -1753,16 +1743,14 @@ fn packet_probe_role_file_stem_matches(query_stem: &str, candidate_stem: &str) -
     }
 }
 
-pub(crate) struct PacketFileScopedSymbolProbe {
-    pub(crate) query_path: String,
-    pub(crate) file_name: String,
-    pub(crate) raw_symbols: Vec<String>,
-    pub(crate) symbols: Vec<String>,
+pub struct PacketFileScopedSymbolProbe {
+    pub query_path: String,
+    pub file_name: String,
+    pub raw_symbols: Vec<String>,
+    pub symbols: Vec<String>,
 }
 
-pub(crate) fn packet_file_scoped_symbol_probe_parts(
-    query: &str,
-) -> Option<PacketFileScopedSymbolProbe> {
+pub fn packet_file_scoped_symbol_probe_parts(query: &str) -> Option<PacketFileScopedSymbolProbe> {
     let mut parts = query.split_whitespace();
     let file_part = parts
         .next()?
@@ -1805,10 +1793,7 @@ fn packet_extensionless_source_file_name(file_name: &str) -> bool {
         || file_name.contains("completion")
 }
 
-pub(crate) fn packet_citation_probe_token_coverage(
-    query: &str,
-    citation: &AgentCitationDto,
-) -> usize {
+pub fn packet_citation_probe_token_coverage(query: &str, citation: &AgentCitationDto) -> usize {
     let tokens = packet_probe_match_tokens(query);
     if tokens.len() < 2 {
         return 0;
@@ -1950,7 +1935,7 @@ fn push_client_send_source_probe_queries(queries: &mut Vec<String>) {
     );
 }
 
-pub(crate) fn push_command_loop_source_probe_queries_for_terms(
+pub fn push_command_loop_source_probe_queries_for_terms(
     terms: &[String],
     queries: &mut Vec<String>,
 ) {
@@ -2047,7 +2032,7 @@ fn push_html_css_template_structure_probe_queries(queries: &mut Vec<String>) {
     );
 }
 
-pub(crate) fn push_sql_schema_required_probe_queries(terms: &[String], queries: &mut Vec<String>) {
+pub fn push_sql_schema_required_probe_queries(terms: &[String], queries: &mut Vec<String>) {
     push_unique_terms(
         queries,
         &[

--- a/crates/codestory-agent/src/text.rs
+++ b/crates/codestory-agent/src/text.rs
@@ -1,10 +1,10 @@
 //! Pure lexical and path classification used by packet planning.
 //!
-//! These helpers were `codestory-runtime`'s `symbol_query` internals. They read
-//! nothing: no controller, no store, no publication, no filesystem. Planning
-//! needs them on every prompt, so they move with planning rather than staying
-//! behind a runtime import that would make `codestory-agent` depend on the
-//! crate it was extracted from.
+//! These helpers read nothing: no controller, no store, no publication, no
+//! filesystem. Planning needs them on every prompt, so they live alongside the
+//! policy that consumes them.
+
+use std::collections::HashSet;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RetrievalFileRole {
@@ -24,6 +24,144 @@ impl RetrievalFileRole {
 
 pub fn normalize_symbol_query(value: &str) -> String {
     value.trim().to_ascii_lowercase()
+}
+
+pub fn exact_symbol_query_terms(query: &str) -> Vec<String> {
+    let trimmed = trim_symbol_candidate(query);
+    if looks_like_standalone_symbol_query(trimmed) {
+        let mut terms = Vec::new();
+        let mut seen = HashSet::new();
+        push_exact_symbol_query_term(trimmed, &mut terms, &mut seen);
+        if let Some((_, terminal)) = qualified_symbol_query_parts(trimmed) {
+            push_exact_symbol_query_term(terminal, &mut terms, &mut seen);
+        }
+        return terms;
+    }
+
+    let mut terms = Vec::new();
+    let mut seen = HashSet::new();
+    let mut candidate = String::new();
+    let mut chars = query.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '!' && chars.peek().is_some_and(|next| *next == '=') {
+            // `!=` and `!==` terminate the left operand. Keeping this bang would fabricate a
+            // Ruby-style suffix identity (`foo_bar!`) from an ordinary comparison expression.
+            push_embedded_symbol_candidate(&candidate, &mut terms, &mut seen);
+            candidate.clear();
+            continue;
+        }
+        if is_symbol_query_char(ch) {
+            candidate.push(ch);
+            continue;
+        }
+        push_embedded_symbol_candidate(&candidate, &mut terms, &mut seen);
+        candidate.clear();
+    }
+    push_embedded_symbol_candidate(&candidate, &mut terms, &mut seen);
+    terms
+}
+
+fn push_exact_symbol_query_term(raw: &str, terms: &mut Vec<String>, seen: &mut HashSet<String>) {
+    let candidate = trim_symbol_candidate(raw);
+    if !looks_like_standalone_symbol_query(candidate) {
+        return;
+    }
+    // Exact symbol requests are case-bearing identities. `Foo::run` and `foo::run` may be two
+    // distinct symbols in the same project and must survive as separate requested candidates.
+    if seen.insert(candidate.to_string()) {
+        terms.push(candidate.to_string());
+    }
+}
+
+pub fn looks_like_standalone_symbol_query(query: &str) -> bool {
+    let trimmed = trim_symbol_candidate(query);
+    !trimmed.is_empty()
+        && !trimmed.chars().any(char::is_whitespace)
+        && trimmed.chars().any(|ch| ch.is_ascii_alphabetic())
+        && trimmed.chars().all(is_symbol_query_char)
+        && symbol_identity_punctuation_is_lawful(trimmed)
+}
+
+fn push_embedded_symbol_candidate(raw: &str, terms: &mut Vec<String>, seen: &mut HashSet<String>) {
+    let candidate = trim_symbol_candidate(raw);
+    if !looks_like_standalone_symbol_query(candidate)
+        || !has_embedded_exact_symbol_signal(candidate)
+    {
+        return;
+    }
+
+    // Embedded exact symbols carry the same case-sensitive identity as standalone exact probes.
+    // Java-style `Foo.run` and `foo.run`, for example, may resolve to different owners.
+    if seen.insert(candidate.to_string()) {
+        terms.push(candidate.to_string());
+    }
+}
+
+fn trim_symbol_candidate(value: &str) -> &str {
+    value.trim().trim_matches(|ch: char| {
+        !(ch.is_ascii_alphanumeric() || matches!(ch, '_' | '$' | '?' | '!' | '~'))
+    })
+}
+
+fn is_symbol_query_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || matches!(ch, '_' | ':' | '.' | '/' | '$' | '?' | '!' | '~')
+}
+
+fn symbol_identity_punctuation_is_lawful(value: &str) -> bool {
+    let ruby_suffix_count = value.chars().filter(|ch| matches!(ch, '?' | '!')).count();
+    if ruby_suffix_count > 0 {
+        let Some(stem) = value.strip_suffix('?').or_else(|| value.strip_suffix('!')) else {
+            return false;
+        };
+        let terminal = stem.rsplit([':', '.', '/']).next().unwrap_or_default();
+        return ruby_suffix_count == 1
+            && !value.contains('~')
+            && symbol_identity_component_is_lawful(terminal);
+    }
+
+    let destructor_count = value.chars().filter(|ch| *ch == '~').count();
+    if destructor_count == 0 {
+        return true;
+    }
+    if destructor_count != 1 {
+        return false;
+    }
+
+    let Some((owner_path, destructor_name)) = value.rsplit_once("::~") else {
+        return false;
+    };
+    let owner_name = owner_path.rsplit("::").next().unwrap_or_default();
+    symbol_identity_component_is_lawful(owner_name)
+        && owner_name == destructor_name
+        && symbol_identity_component_is_lawful(destructor_name)
+}
+
+fn symbol_identity_component_is_lawful(value: &str) -> bool {
+    !value.is_empty()
+        && value.chars().any(|ch| ch.is_ascii_alphabetic())
+        && value
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '$'))
+}
+
+fn has_embedded_exact_symbol_signal(value: &str) -> bool {
+    value.contains('_')
+        || value.contains("::")
+        || value.contains('.')
+        || value.contains('/')
+        || value.contains('$')
+        || value.chars().skip(1).any(|ch| ch.is_ascii_uppercase())
+}
+
+fn qualified_symbol_query_parts(query: &str) -> Option<(&str, &str)> {
+    let trimmed = trim_symbol_candidate(query);
+    let index = trimmed.rfind("::")?;
+    let prefix = trimmed[..index].trim();
+    let terminal = trimmed[index + 2..].trim();
+    if prefix.is_empty() || terminal.is_empty() {
+        return None;
+    }
+    Some((prefix, terminal))
 }
 
 pub fn terminal_symbol_segment(value: &str) -> String {

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -563,9 +563,14 @@ fn agent_planning_crate_owns_planning_and_depends_on_contracts_only() {
 
     for module in [
         "packet_citations.rs",
+        "packet_command_profiles.rs",
+        "packet_evidence.rs",
         "packet_evidence_carriers.rs",
         "packet_evidence_roles.rs",
         "packet_flow_requirements.rs",
+        "packet_obligations.rs",
+        "packet_plan.rs",
+        "packet_required_probes.rs",
         "packet_scoring.rs",
         "packet_terms.rs",
         "pinned_reader.rs",

--- a/crates/codestory-runtime/src/agent/mod.rs
+++ b/crates/codestory-runtime/src/agent/mod.rs
@@ -8,16 +8,13 @@ pub(crate) mod packet_claim_profile_registry;
 
 pub(crate) mod packet_claim_profiles;
 pub(crate) mod packet_claims;
-pub(crate) mod packet_command_profiles;
 pub(crate) mod packet_coverage;
 pub(crate) mod packet_degradation;
-pub(crate) mod packet_evidence;
 pub(crate) mod packet_freshness;
-pub(crate) mod packet_obligations;
-pub(crate) mod packet_plan;
+#[cfg(test)]
+mod packet_obligations_runtime_tests;
 pub(crate) mod packet_probe;
 pub(crate) mod packet_profile_telemetry;
-pub(crate) mod packet_required_probes;
 pub(crate) mod packet_search;
 pub(crate) mod packet_source_patterns;
 pub(crate) mod packet_sufficiency;
@@ -32,9 +29,11 @@ pub(crate) mod trace_export;
 // crate move rather than a rename of every call site.
 #[cfg(test)]
 pub(crate) use codestory_agent::eval_probes;
+#[allow(unused_imports)]
 pub(crate) use codestory_agent::{
-    packet_citations, packet_evidence_roles, packet_flow_requirements, packet_scoring,
-    packet_terms, planning,
+    packet_citations, packet_command_profiles, packet_evidence, packet_evidence_roles,
+    packet_flow_requirements, packet_obligations, packet_plan, packet_required_probes,
+    packet_scoring, packet_terms, planning,
 };
 
 pub(crate) use orchestrator::{agent_ask, agent_packet};

--- a/crates/codestory-runtime/src/agent/packet_freshness.rs
+++ b/crates/codestory-runtime/src/agent/packet_freshness.rs
@@ -82,7 +82,7 @@ impl PacketFreshnessInput {
 /// Test answers default to no freshness observation, which this module correctly reads as
 /// `Unknown`. Fixtures that are exercising claim or route behavior have to opt in to an observed
 /// publication or every one of them would be testing the freshness cap instead.
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
 pub(crate) fn fresh_index_observation() -> IndexFreshnessDto {
     IndexFreshnessDto {
         status: IndexFreshnessStatusDto::Fresh,

--- a/crates/codestory-runtime/src/agent/packet_obligations_runtime_tests.rs
+++ b/crates/codestory-runtime/src/agent/packet_obligations_runtime_tests.rs
@@ -1,0 +1,1154 @@
+//! Runtime integration tests for the agent-owned packet obligation planner.
+
+use crate::agent::packet_claims::packet_supported_claims;
+use crate::agent::packet_freshness::fresh_index_observation;
+use crate::agent::packet_obligations::*;
+use crate::agent::packet_sufficiency::build_packet_sufficiency_with_obligation_context;
+use codestory_contracts::api::*;
+use std::path::Path;
+
+const INDEXING_QUESTION: &str = "Explain the indexing runtime, persistence, and snapshot flow.";
+
+fn packet_supported_claims_with_telemetry(answer: &AgentAnswerDto) -> (Vec<PacketClaimDto>, ()) {
+    (packet_supported_claims(answer), ())
+}
+
+fn citation(name: &str, path: &str, kind: NodeKind) -> AgentCitationDto {
+    AgentCitationDto {
+        node_id: NodeId(name.to_string()),
+        display_name: name.to_string(),
+        kind,
+        file_path: Some(path.to_string()),
+        line: Some(1),
+        score: 1.0,
+        origin: SearchHitOrigin::IndexedSymbol,
+        target: None,
+        resolvable: true,
+        subgraph_id: None,
+        evidence_edge_ids: Vec::new(),
+        retrieval_score_breakdown: None,
+        evidence_tier: Some(PacketEvidenceTierDto::ResolvedGraph),
+        evidence_producer: Some("test".to_string()),
+        resolution_status: Some(PacketEvidenceResolutionDto::Resolved),
+        loss_reason: None,
+        coverage_role: None,
+        eligible_for_sufficiency: Some(true),
+    }
+}
+
+fn answer(citations: Vec<AgentCitationDto>) -> AgentAnswerDto {
+    AgentAnswerDto {
+        source_coverage: Vec::new(),
+        answer_id: "obligation-test".to_string(),
+        prompt: INDEXING_QUESTION.to_string(),
+        summary: "test".to_string(),
+        freshness: Some(fresh_index_observation()),
+        sections: Vec::new(),
+        citations,
+        subgraph_ids: Vec::new(),
+        retrieval_version: "test".to_string(),
+        graphs: Vec::new(),
+        retrieval_trace: AgentRetrievalTraceDto {
+            request_id: "obligation-test".to_string(),
+            retrieval_publication: None,
+            resolved_profile: AgentRetrievalPresetDto::Architecture,
+            policy_mode: AgentRetrievalPolicyModeDto::LatencyFirst,
+            total_latency_ms: 1,
+            sla_target_ms: None,
+            sla_missed: false,
+            semantic_fallback_count: 0,
+            semantic_fallbacks: Vec::new(),
+            semantic_stage_timeout_zero_hits: 0,
+            semantic_abstained_count: 0,
+            annotations: Vec::new(),
+            packet_claim_profile_telemetry: None,
+            source_freshness_telemetry: None,
+            steps: Vec::new(),
+            packet_sidecar_diagnostics: Vec::new(),
+            retrieval_shadow: None,
+        },
+    }
+}
+
+fn budget() -> PacketBudgetDto {
+    PacketBudgetDto {
+        requested: PacketBudgetModeDto::Standard,
+        limits: PacketBudgetLimitsDto {
+            max_anchors: 16,
+            max_files: 16,
+            max_snippets: 16,
+            max_trail_edges: 16,
+            max_output_bytes: 64_000,
+        },
+        used: PacketBudgetUsageDto {
+            anchors: 1,
+            files: 1,
+            snippets: 1,
+            trail_edges: 0,
+            output_bytes: 1_000,
+        },
+        truncated: false,
+        omitted_sections: Vec::new(),
+        next_deeper_command: None,
+    }
+}
+
+fn finalized_obligation(
+    id: &str,
+    kind: PacketClaimObligationKindDto,
+    proof_status: PacketObligationProofStatusDto,
+    carrier: Option<&AgentCitationDto>,
+    reason: Option<&str>,
+) -> PacketClaimObligationDto {
+    PacketClaimObligationDto {
+        id: id.to_string(),
+        kind,
+        binding_terms: Vec::new(),
+        probe_binding: None,
+        material: true,
+        allowed_node_kinds: Vec::new(),
+        required_edge_kind: None,
+        requires_complete_discovery: false,
+        proof_status,
+        reason: reason.map(str::to_string),
+        carrier_node_ids: carrier
+            .into_iter()
+            .map(|citation| citation.node_id.clone())
+            .collect(),
+        carrier_paths: carrier
+            .and_then(|citation| citation.file_path.clone())
+            .into_iter()
+            .collect(),
+        open_next_candidates: Vec::new(),
+    }
+}
+
+fn query_diagnostic(
+    query: &str,
+    completion: PacketQueryCompletionDto,
+) -> PacketSidecarQueryDiagnosticDto {
+    PacketSidecarQueryDiagnosticDto {
+        query: query.to_string(),
+        completion,
+        retrieval_mode: "full".to_string(),
+        sidecar_query_ms: Some(1),
+        candidate_resolution_ms: Some(0),
+        total_elapsed_ms: Some(1),
+        sidecar_stage_count: 1,
+        sidecar_stage_total_ms: Some(1),
+        batch_query_wall_ms: Some(1),
+        candidate_count: 0,
+        resolved_hit_count: 0,
+        unresolved_candidate_count: 0,
+        blocking_unresolved_candidate_count: 0,
+        semantic_stage_timeout_zero_hits: false,
+        semantic_abstained: false,
+        diagnostic: None,
+    }
+}
+
+fn lexical_citation(name: &str, path: &str, kind: NodeKind) -> AgentCitationDto {
+    let mut citation = citation(name, path, kind);
+    citation.evidence_tier = Some(PacketEvidenceTierDto::LexicalSource);
+    citation.resolution_status = Some(PacketEvidenceResolutionDto::SourceRangeOnly);
+    citation
+}
+
+fn answer_with_call_edge(question: &str, carrier_name: &str, carrier_path: &str) -> AgentAnswerDto {
+    let mut carrier = citation(carrier_name, carrier_path, NodeKind::METHOD);
+    carrier.evidence_edge_ids = vec![EdgeId("requested-call".to_string())];
+    let target = citation("Worker::run", "src/worker.rs", NodeKind::METHOD);
+    let mut answer = answer(vec![carrier.clone(), target.clone()]);
+    answer.prompt = question.to_string();
+    answer.graphs.push(GraphArtifactDto::Uml {
+        id: "requested-flow".to_string(),
+        title: "Requested flow".to_string(),
+        graph: GraphResponse {
+            center_id: carrier.node_id.clone(),
+            nodes: Vec::new(),
+            edges: vec![GraphEdgeDto {
+                id: EdgeId("requested-call".to_string()),
+                source: carrier.node_id,
+                target: target.node_id,
+                kind: EdgeKind::CALL,
+                confidence: Some(1.0),
+                certainty: Some("certain".to_string()),
+                callsite_identity: Some("test:1".to_string()),
+                candidate_targets: Vec::new(),
+            }],
+            truncated: false,
+            omitted_edge_count: 0,
+            canonical_layout: None,
+        },
+    });
+    answer
+}
+
+fn indexing_entrypoint_plan() -> PacketObligationPlanDto {
+    let mut plan = build_packet_obligation_plan(
+        INDEXING_QUESTION,
+        PacketTaskClassDto::ArchitectureExplanation,
+        &[],
+    );
+    plan.claim_obligations
+        .retain(|obligation| obligation.id == "indexing_entrypoint");
+    plan.query_obligations.clear();
+    plan
+}
+
+#[test]
+fn cancelled_diagnostic_query_does_not_block_a_complete_material_ledger() {
+    let question = "Explain shell installer function dispatch and completion.";
+    let mut plan =
+        build_packet_obligation_plan(question, PacketTaskClassDto::ArchitectureExplanation, &[]);
+    let mut answer = answer(vec![
+        lexical_citation("nvm_download", "install.sh", NodeKind::FUNCTION),
+        lexical_citation("nvm_use", "nvm.sh", NodeKind::FUNCTION),
+        citation("Helper::noop", "src/helper.rs", NodeKind::METHOD),
+    ]);
+    answer.prompt = question.to_string();
+    let material_queries = plan
+        .query_obligations
+        .iter()
+        .filter(|obligation| obligation.material)
+        .map(|obligation| obligation.query.clone())
+        .collect::<Vec<_>>();
+    for query in material_queries {
+        answer
+            .retrieval_trace
+            .packet_sidecar_diagnostics
+            .push(query_diagnostic(
+                &query,
+                PacketQueryCompletionDto::Completed,
+            ));
+    }
+    answer
+        .retrieval_trace
+        .packet_sidecar_diagnostics
+        .push(query_diagnostic(
+            "shell completion",
+            PacketQueryCompletionDto::Cancelled {
+                reason: "diagnostic_deadline".to_string(),
+            },
+        ));
+
+    finalize_packet_obligation_plan(
+        question,
+        PacketTaskClassDto::ArchitectureExplanation,
+        &mut plan,
+        &answer,
+        &budget(),
+    );
+
+    assert!(plan.query_obligations.iter().any(|obligation| {
+        !obligation.material
+            && obligation.query == "shell completion"
+            && matches!(
+                obligation.completion,
+                Some(PacketQueryCompletionDto::Cancelled { ref reason })
+                    if reason == "diagnostic_deadline"
+            )
+    }));
+    assert!(material_packet_obligations_are_proven(&plan), "{plan:#?}");
+    let sufficiency = build_packet_sufficiency_with_obligation_context(
+        Path::new("/workspace/example"),
+        question,
+        PacketTaskClassDto::ArchitectureExplanation,
+        &answer,
+        &budget(),
+        &[],
+        &[],
+        &plan,
+    );
+    assert_eq!(sufficiency.status, PacketSufficiencyStatusDto::Sufficient);
+    assert!(
+        sufficiency
+            .coverage_report
+            .as_ref()
+            .is_some_and(|coverage| coverage.unresolved == ["shell completion"]),
+        "diagnostic cancellation stays visible without changing the verdict: {sufficiency:?}"
+    );
+}
+
+/// EV-8. A required query whose semantic stage timed out with zero hits reaches the ledger as
+/// a typed cancellation, and the ledger is what demotes the verdict. The demotion lands on
+/// the obligation that lost its evidence rather than on the packet as an undifferentiated
+/// whole, so the caller is told which query to re-run.
+#[test]
+fn a_required_query_whose_semantic_stage_timed_out_demotes_through_its_obligation() {
+    let question = "Explain shell installer function dispatch and completion.";
+    let mut plan =
+        build_packet_obligation_plan(question, PacketTaskClassDto::ArchitectureExplanation, &[]);
+    let mut answer = answer(vec![
+        lexical_citation("nvm_download", "install.sh", NodeKind::FUNCTION),
+        lexical_citation("nvm_use", "nvm.sh", NodeKind::FUNCTION),
+        citation("Helper::noop", "src/helper.rs", NodeKind::METHOD),
+    ]);
+    answer.prompt = question.to_string();
+    let material_queries = plan
+        .query_obligations
+        .iter()
+        .filter(|obligation| obligation.material)
+        .map(|obligation| obligation.query.clone())
+        .collect::<Vec<_>>();
+    let (timed_out_query, completed_queries) = material_queries
+        .split_first()
+        .expect("architecture explanation plans at least one material query");
+    for query in completed_queries {
+        answer
+            .retrieval_trace
+            .packet_sidecar_diagnostics
+            .push(query_diagnostic(query, PacketQueryCompletionDto::Completed));
+    }
+    let mut timed_out = query_diagnostic(
+        timed_out_query,
+        PacketQueryCompletionDto::Cancelled {
+            reason: "semantic_stage_timeout_zero_hits".to_string(),
+        },
+    );
+    timed_out.semantic_stage_timeout_zero_hits = true;
+    answer
+        .retrieval_trace
+        .packet_sidecar_diagnostics
+        .push(timed_out);
+
+    finalize_packet_obligation_plan(
+        question,
+        PacketTaskClassDto::ArchitectureExplanation,
+        &mut plan,
+        &answer,
+        &budget(),
+    );
+
+    assert!(
+        plan.query_obligations.iter().any(|obligation| {
+            obligation.material
+                && &obligation.query == timed_out_query
+                && matches!(
+                    obligation.completion,
+                    Some(PacketQueryCompletionDto::Cancelled { ref reason })
+                        if reason == "semantic_stage_timeout_zero_hits"
+                )
+        }),
+        "the typed cancellation must reach the ledger: {plan:#?}"
+    );
+
+    let sufficiency = build_packet_sufficiency_with_obligation_context(
+        Path::new("/workspace/example"),
+        question,
+        PacketTaskClassDto::ArchitectureExplanation,
+        &answer,
+        &budget(),
+        &[],
+        &[],
+        &plan,
+    );
+
+    assert_eq!(
+        sufficiency.status,
+        PacketSufficiencyStatusDto::Partial,
+        "{sufficiency:?}"
+    );
+    assert!(
+        sufficiency.gaps.iter().any(|gap| {
+            gap.contains("query obligation") && gap.contains("semantic_stage_timeout_zero_hits")
+        }),
+        "the gap must name the query obligation that lost its lane: {:?}",
+        sufficiency.gaps
+    );
+    assert!(
+        sufficiency
+            .follow_up_commands
+            .iter()
+            .any(|command| command.contains(timed_out_query.as_str())),
+        "the caller is told which query to re-run: {sufficiency:?}"
+    );
+}
+
+#[test]
+fn indexing_storage_claim_cannot_borrow_a_proven_runtime_entrypoint() {
+    let question = "Explain how a full indexing run moves from the CLI into runtime orchestration, workspace file discovery, symbol extraction, persistence, and snapshot refresh.";
+    let mut runtime = citation(
+        "IndexService::run_indexing_blocking_without_runtime_refresh",
+        "crates/codestory-runtime/src/services.rs",
+        NodeKind::METHOD,
+    );
+    runtime.evidence_edge_ids = vec![EdgeId("indexing-entry-call".to_string())];
+    let target = citation(
+        "Worker::execute",
+        "crates/example/src/worker.rs",
+        NodeKind::METHOD,
+    );
+    let mut answer = answer(vec![runtime.clone(), target.clone()]);
+    answer.prompt = question.to_string();
+    answer.graphs.push(GraphArtifactDto::Uml {
+        id: "indexing-entrypoint-flow".to_string(),
+        title: "Indexing entrypoint flow".to_string(),
+        graph: GraphResponse {
+            center_id: runtime.node_id.clone(),
+            nodes: Vec::new(),
+            edges: vec![GraphEdgeDto {
+                id: EdgeId("indexing-entry-call".to_string()),
+                source: runtime.node_id.clone(),
+                target: target.node_id,
+                kind: EdgeKind::CALL,
+                confidence: Some(1.0),
+                certainty: Some("certain".to_string()),
+                callsite_identity: Some("test:1".to_string()),
+                candidate_targets: Vec::new(),
+            }],
+            truncated: false,
+            omitted_edge_count: 0,
+            canonical_layout: None,
+        },
+    });
+    let mut plan =
+        build_packet_obligation_plan(question, PacketTaskClassDto::ArchitectureExplanation, &[]);
+    finalize_packet_obligation_plan(
+        question,
+        PacketTaskClassDto::ArchitectureExplanation,
+        &mut plan,
+        &answer,
+        &budget(),
+    );
+    assert_eq!(
+        plan.claim_obligations
+            .iter()
+            .find(|obligation| obligation.id == "indexing_entrypoint")
+            .map(|obligation| obligation.proof_status),
+        Some(PacketObligationProofStatusDto::Proven)
+    );
+    let storage_obligation = plan
+        .claim_obligations
+        .iter()
+        .find(|obligation| obligation.id == "indexing_storage")
+        .expect("indexing storage obligation");
+    assert_eq!(
+        storage_obligation.proof_status,
+        PacketObligationProofStatusDto::Unsupported
+    );
+    assert_eq!(
+        storage_obligation.reason.as_deref(),
+        Some("required_carrier_missing")
+    );
+
+    let supported_claims_with_telemetry = packet_supported_claims_with_telemetry(&answer);
+    let mut claims =
+        packet_claims_with_obligation_receipts(&answer, &plan, supported_claims_with_telemetry);
+    bind_claims_to_packet_obligations(&plan, &mut claims);
+    let storage_claim = claims
+        .iter()
+        .find(|claim| claim.required_obligation_ids == ["indexing_storage"])
+        .expect("material storage row emits an exact receipt claim");
+    assert_eq!(storage_claim.required_obligation_ids, ["indexing_storage"]);
+    assert_eq!(
+        storage_claim.proof_status,
+        Some(PacketProofStatusDto::Unsupported)
+    );
+    assert_eq!(storage_claim.eligible_for_sufficiency, Some(false));
+    assert!(storage_claim.claim.contains("required_carrier_missing"));
+    let entrypoint_claim = claims
+        .iter()
+        .find(|claim| claim.required_obligation_ids == ["indexing_entrypoint"])
+        .expect("material entrypoint row emits an exact receipt claim");
+    assert_eq!(
+        entrypoint_claim.proof_status,
+        Some(PacketProofStatusDto::Proven)
+    );
+    assert_eq!(entrypoint_claim.citations.len(), 1);
+}
+
+#[test]
+fn obligation_receipts_use_only_their_exact_rows_own_carriers() {
+    let entrypoint = citation("Cli::run", "src/cli.rs", NodeKind::METHOD);
+    let storage = citation("Store::write", "src/store.rs", NodeKind::METHOD);
+    let answer = answer(vec![entrypoint.clone(), storage.clone()]);
+    let plan = PacketObligationPlanDto {
+        version: PACKET_OBLIGATION_PLAN_VERSION,
+        binding_terms: Vec::new(),
+        claim_obligations: vec![
+            finalized_obligation(
+                "flow_entrypoint",
+                PacketClaimObligationKindDto::Entrypoint,
+                PacketObligationProofStatusDto::Proven,
+                Some(&entrypoint),
+                None,
+            ),
+            finalized_obligation(
+                "flow_storage",
+                PacketClaimObligationKindDto::StateWrite,
+                PacketObligationProofStatusDto::Proven,
+                Some(&storage),
+                None,
+            ),
+        ],
+        query_obligations: Vec::new(),
+    };
+
+    let supported_claims_with_telemetry = packet_supported_claims_with_telemetry(&answer);
+    let mut claims =
+        packet_claims_with_obligation_receipts(&answer, &plan, supported_claims_with_telemetry);
+    bind_claims_to_packet_obligations(&plan, &mut claims);
+    let receipts = claims
+        .iter()
+        .filter(|claim| {
+            claim.coverage_role.as_deref() == Some(PACKET_OBLIGATION_RECEIPT_COVERAGE_ROLE)
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(receipts.len(), 2);
+    let entrypoint_receipt = receipts
+        .iter()
+        .find(|claim| claim.required_obligation_ids == ["flow_entrypoint"])
+        .expect("entrypoint receipt");
+    assert_eq!(entrypoint_receipt.citations.len(), 1);
+    assert_eq!(entrypoint_receipt.citations[0].node_id, entrypoint.node_id);
+    let storage_receipt = receipts
+        .iter()
+        .find(|claim| claim.required_obligation_ids == ["flow_storage"])
+        .expect("storage receipt");
+    assert_eq!(storage_receipt.citations.len(), 1);
+    assert_eq!(storage_receipt.citations[0].node_id, storage.node_id);
+
+    let mut borrowed = vec![PacketClaimDto {
+        claim: "The entrypoint row is proven.".to_string(),
+        required_obligation_ids: vec!["flow_entrypoint".to_string()],
+        required_obligation_kinds: vec![PacketClaimObligationKindDto::Entrypoint],
+        proof_status: Some(PacketProofStatusDto::Proven),
+        required_evidence_role: None,
+        citations: vec![storage],
+        coverage_role: Some("fixture".to_string()),
+        eligible_for_sufficiency: Some(true),
+    }];
+    bind_claims_to_packet_obligations(&plan, &mut borrowed);
+    assert_eq!(
+        borrowed[0].proof_status,
+        Some(PacketProofStatusDto::Reported)
+    );
+    assert_eq!(borrowed[0].eligible_for_sufficiency, Some(false));
+}
+
+#[test]
+fn receipt_rows_preserve_non_proven_status_reason_and_deduplicate_ids() {
+    let reported_carrier = citation("MaybeStore", "src/store.rs", NodeKind::METHOD);
+    let plan = PacketObligationPlanDto {
+        version: PACKET_OBLIGATION_PLAN_VERSION,
+        binding_terms: Vec::new(),
+        claim_obligations: vec![
+            finalized_obligation(
+                "reported_storage",
+                PacketClaimObligationKindDto::StateWrite,
+                PacketObligationProofStatusDto::Reported,
+                Some(&reported_carrier),
+                Some("required_evidence_edge_missing"),
+            ),
+            finalized_obligation(
+                "reported_storage",
+                PacketClaimObligationKindDto::StateWrite,
+                PacketObligationProofStatusDto::Reported,
+                Some(&reported_carrier),
+                Some("duplicate_row"),
+            ),
+            finalized_obligation(
+                "unsupported_dispatch",
+                PacketClaimObligationKindDto::Dispatch,
+                PacketObligationProofStatusDto::Unsupported,
+                None,
+                Some("required_carrier_missing"),
+            ),
+        ],
+        query_obligations: Vec::new(),
+    };
+    let answer = answer(vec![reported_carrier]);
+    let supported_claims_with_telemetry = packet_supported_claims_with_telemetry(&answer);
+    let mut claims =
+        packet_claims_with_obligation_receipts(&answer, &plan, supported_claims_with_telemetry);
+    bind_claims_to_packet_obligations(&plan, &mut claims);
+    let receipts = claims
+        .iter()
+        .filter(|claim| {
+            claim.coverage_role.as_deref() == Some(PACKET_OBLIGATION_RECEIPT_COVERAGE_ROLE)
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(receipts.len(), 2, "duplicate row IDs emit one receipt");
+    let reported = receipts
+        .iter()
+        .find(|claim| claim.required_obligation_ids == ["reported_storage"])
+        .expect("reported receipt");
+    assert_eq!(reported.proof_status, Some(PacketProofStatusDto::Reported));
+    assert_eq!(reported.eligible_for_sufficiency, Some(false));
+    assert!(reported.claim.contains("required_evidence_edge_missing"));
+    let unsupported = receipts
+        .iter()
+        .find(|claim| claim.required_obligation_ids == ["unsupported_dispatch"])
+        .expect("unsupported receipt");
+    assert_eq!(
+        unsupported.proof_status,
+        Some(PacketProofStatusDto::Unsupported)
+    );
+    assert!(unsupported.claim.contains("required_carrier_missing"));
+}
+
+#[test]
+fn sufficient_profile_closes_incidental_nonmaterial_guard_path() {
+    let question = "Find RuntimeService::run.";
+    let mut carrier = citation(
+        "RuntimeService::run",
+        "src/runtime_service.rs",
+        NodeKind::METHOD,
+    );
+    carrier.evidence_edge_ids = vec![EdgeId("generic-call".to_string())];
+    let target = citation("Worker::run", "src/worker.rs", NodeKind::METHOD);
+    let incidental_guard_carrier = citation(
+        "HttpTransport::send",
+        "src/incidental_transport.rs",
+        NodeKind::METHOD,
+    );
+    let mut answer = answer(vec![
+        carrier.clone(),
+        target.clone(),
+        incidental_guard_carrier.clone(),
+    ]);
+    answer.prompt = question.to_string();
+    answer
+        .retrieval_trace
+        .packet_sidecar_diagnostics
+        .push(query_diagnostic(
+            "RuntimeService::run",
+            PacketQueryCompletionDto::Completed,
+        ));
+    answer.graphs.push(GraphArtifactDto::Uml {
+        id: "generic-flow".to_string(),
+        title: "Generic flow".to_string(),
+        graph: GraphResponse {
+            center_id: carrier.node_id.clone(),
+            nodes: Vec::new(),
+            edges: vec![GraphEdgeDto {
+                id: EdgeId("generic-call".to_string()),
+                source: carrier.node_id,
+                target: target.node_id,
+                kind: EdgeKind::CALL,
+                confidence: Some(1.0),
+                certainty: Some("certain".to_string()),
+                callsite_identity: Some("test:1".to_string()),
+                candidate_targets: Vec::new(),
+            }],
+            truncated: false,
+            omitted_edge_count: 0,
+            canonical_layout: None,
+        },
+    });
+    let mut plan = build_packet_obligation_plan(question, PacketTaskClassDto::SymbolOwnership, &[]);
+    plan.claim_obligations.push(PacketClaimObligationDto {
+        id: "incidental_external_io_guard".to_string(),
+        kind: PacketClaimObligationKindDto::ExternalIo,
+        binding_terms: vec![incidental_guard_carrier.display_name.clone()],
+        probe_binding: None,
+        material: false,
+        allowed_node_kinds: vec![NodeKind::FUNCTION, NodeKind::METHOD, NodeKind::MACRO],
+        required_edge_kind: Some(EdgeKind::CALL),
+        requires_complete_discovery: false,
+        proof_status: PacketObligationProofStatusDto::Planned,
+        reason: None,
+        carrier_node_ids: Vec::new(),
+        carrier_paths: Vec::new(),
+        open_next_candidates: Vec::new(),
+    });
+    finalize_packet_obligation_plan(
+        question,
+        PacketTaskClassDto::SymbolOwnership,
+        &mut plan,
+        &answer,
+        &budget(),
+    );
+
+    assert_eq!(
+        plan.claim_obligations[0].proof_status,
+        PacketObligationProofStatusDto::Proven
+    );
+    assert_eq!(plan.claim_obligations[0].reason, None);
+    assert!(material_packet_obligations_are_proven(&plan), "{plan:#?}");
+    assert!(plan.query_obligations.iter().any(|obligation| {
+        obligation.material
+            && obligation.query == "RuntimeService::run"
+            && obligation.completion == Some(PacketQueryCompletionDto::Completed)
+    }));
+    let incidental_guard = plan
+        .claim_obligations
+        .iter()
+        .find(|obligation| obligation.id == "incidental_external_io_guard")
+        .expect("incidental guard remains in the finalized ledger");
+    assert!(!incidental_guard.material);
+    assert_eq!(
+        incidental_guard.proof_status,
+        PacketObligationProofStatusDto::Reported
+    );
+    assert_eq!(
+        incidental_guard.carrier_paths,
+        vec!["src/incidental_transport.rs".to_string()]
+    );
+    assert!(
+        packet_obligation_open_next_candidates(&plan)
+            .contains(&"src/incidental_transport.rs".to_string()),
+        "the raw unproven guard receipt must exercise the terminal open-next gate"
+    );
+    let sufficiency = build_packet_sufficiency_with_obligation_context(
+        Path::new("/workspace/example"),
+        question,
+        PacketTaskClassDto::SymbolOwnership,
+        &answer,
+        &budget(),
+        &[],
+        &[],
+        &plan,
+    );
+    assert_eq!(sufficiency.status, PacketSufficiencyStatusDto::Sufficient);
+    assert!(
+        sufficiency
+            .covered_claims
+            .iter()
+            .any(|claim| claim.proof_status == Some(PacketProofStatusDto::Proven))
+    );
+    assert!(
+        !sufficiency
+            .avoid_opening_paths
+            .contains(&"src/incidental_transport.rs".to_string()),
+        "an unproven incidental guard carrier cannot become avoid-opening"
+    );
+    let coverage = sufficiency
+        .coverage_report
+        .as_ref()
+        .expect("sufficiency publishes claim-level blockers");
+    assert!(
+        coverage.ineligible.iter().any(|entry| {
+            entry.contains("RuntimeService::run") && entry.contains("claim marked diagnostic")
+        }),
+        "the per-file safety blocker must remain visible: {coverage:?}"
+    );
+    assert!(
+        sufficiency.open_next.is_empty(),
+        "Sufficient is terminal even when a nonmaterial Reported guard carries a path: {sufficiency:?}"
+    );
+}
+
+#[test]
+fn case_distinct_exact_symbols_need_separate_carriers() {
+    let question = "Find Foo::run and foo::run.";
+    let mut answer = answer_with_call_edge(question, "Foo::run", "src/runtime.rs");
+    for query in ["Foo::run", "foo::run"] {
+        answer
+            .retrieval_trace
+            .packet_sidecar_diagnostics
+            .push(query_diagnostic(query, PacketQueryCompletionDto::Completed));
+    }
+    let mut plan = build_packet_obligation_plan(question, PacketTaskClassDto::SymbolOwnership, &[]);
+
+    assert!(
+        plan.query_obligations
+            .iter()
+            .any(|obligation| { obligation.material && obligation.query == "Foo::run" })
+    );
+    assert!(
+        plan.query_obligations
+            .iter()
+            .any(|obligation| { obligation.material && obligation.query == "foo::run" })
+    );
+    finalize_packet_obligation_plan(
+        question,
+        PacketTaskClassDto::SymbolOwnership,
+        &mut plan,
+        &answer,
+        &budget(),
+    );
+
+    let upper = plan
+        .claim_obligations
+        .iter()
+        .find(|obligation| obligation.binding_terms == ["Foo::run"])
+        .unwrap();
+    let lower = plan
+        .claim_obligations
+        .iter()
+        .find(|obligation| obligation.binding_terms == ["foo::run"])
+        .unwrap();
+    assert_eq!(upper.proof_status, PacketObligationProofStatusDto::Proven);
+    assert_eq!(
+        lower.proof_status,
+        PacketObligationProofStatusDto::Unsupported
+    );
+    assert!(lower.carrier_node_ids.is_empty());
+    assert!(!material_packet_obligations_are_proven(&plan));
+
+    let sufficiency = build_packet_sufficiency_with_obligation_context(
+        Path::new("/workspace/example"),
+        question,
+        PacketTaskClassDto::SymbolOwnership,
+        &answer,
+        &budget(),
+        &[],
+        &[],
+        &plan,
+    );
+    assert_eq!(sufficiency.status, PacketSufficiencyStatusDto::Partial);
+}
+
+#[test]
+fn case_distinct_slash_qualified_symbols_need_separate_carriers() {
+    let question = "Find Foo/run and foo/run.";
+    let mut answer = answer_with_call_edge(question, "Foo/run", "src/runtime.rs");
+    for query in ["Foo/run", "foo/run"] {
+        answer
+            .retrieval_trace
+            .packet_sidecar_diagnostics
+            .push(query_diagnostic(query, PacketQueryCompletionDto::Completed));
+    }
+    let mut plan = build_packet_obligation_plan(question, PacketTaskClassDto::SymbolOwnership, &[]);
+
+    for expected in ["Foo/run", "foo/run"] {
+        assert!(
+            plan.query_obligations
+                .iter()
+                .any(|obligation| { obligation.material && obligation.query == expected })
+        );
+        assert!(
+            plan.claim_obligations.iter().any(|obligation| {
+                obligation.material && obligation.binding_terms == [expected]
+            })
+        );
+    }
+    finalize_packet_obligation_plan(
+        question,
+        PacketTaskClassDto::SymbolOwnership,
+        &mut plan,
+        &answer,
+        &budget(),
+    );
+
+    let upper = plan
+        .claim_obligations
+        .iter()
+        .find(|obligation| obligation.binding_terms == ["Foo/run"])
+        .unwrap();
+    let lower = plan
+        .claim_obligations
+        .iter()
+        .find(|obligation| obligation.binding_terms == ["foo/run"])
+        .unwrap();
+    assert_eq!(upper.proof_status, PacketObligationProofStatusDto::Proven);
+    assert_eq!(
+        lower.proof_status,
+        PacketObligationProofStatusDto::Unsupported
+    );
+    assert!(lower.carrier_node_ids.is_empty());
+
+    let sufficiency = build_packet_sufficiency_with_obligation_context(
+        Path::new("/workspace/example"),
+        question,
+        PacketTaskClassDto::SymbolOwnership,
+        &answer,
+        &budget(),
+        &[],
+        &[],
+        &plan,
+    );
+    assert_eq!(sufficiency.status, PacketSufficiencyStatusDto::Partial);
+}
+
+#[test]
+fn one_proven_claim_cannot_hide_an_unproven_claim_in_the_same_file() {
+    let question = "Find RuntimeService::run and CliErrorBody.";
+    let shared_path = "src/runtime_service.rs";
+    let mut carrier = citation("RuntimeService::run", shared_path, NodeKind::METHOD);
+    carrier.evidence_edge_ids = vec![EdgeId("generic-call".to_string())];
+    let false_carrier = citation("CliErrorBody", shared_path, NodeKind::STRUCT);
+    let target = citation("Worker::run", "src/worker.rs", NodeKind::METHOD);
+    let mut answer = answer(vec![carrier.clone(), false_carrier, target.clone()]);
+    answer.prompt = question.to_string();
+    answer.graphs.push(GraphArtifactDto::Uml {
+        id: "generic-flow".to_string(),
+        title: "Generic flow".to_string(),
+        graph: GraphResponse {
+            center_id: carrier.node_id.clone(),
+            nodes: Vec::new(),
+            edges: vec![GraphEdgeDto {
+                id: EdgeId("generic-call".to_string()),
+                source: carrier.node_id,
+                target: target.node_id,
+                kind: EdgeKind::CALL,
+                confidence: Some(1.0),
+                certainty: Some("certain".to_string()),
+                callsite_identity: Some("test:1".to_string()),
+                candidate_targets: Vec::new(),
+            }],
+            truncated: false,
+            omitted_edge_count: 0,
+            canonical_layout: None,
+        },
+    });
+    let mut plan = build_packet_obligation_plan(question, PacketTaskClassDto::SymbolOwnership, &[]);
+    finalize_packet_obligation_plan(
+        question,
+        PacketTaskClassDto::SymbolOwnership,
+        &mut plan,
+        &answer,
+        &budget(),
+    );
+    assert!(plan.claim_obligations.iter().any(|obligation| {
+        obligation.proof_status == PacketObligationProofStatusDto::Proven
+            && obligation
+                .carrier_paths
+                .iter()
+                .any(|path| path == shared_path)
+    }));
+    assert!(plan.claim_obligations.iter().any(|obligation| {
+        obligation.proof_status == PacketObligationProofStatusDto::Reported
+            && obligation
+                .carrier_paths
+                .iter()
+                .any(|path| path == shared_path)
+    }));
+
+    let sufficiency = build_packet_sufficiency_with_obligation_context(
+        Path::new("/workspace/example"),
+        question,
+        PacketTaskClassDto::SymbolOwnership,
+        &answer,
+        &budget(),
+        &[],
+        &[],
+        &plan,
+    );
+
+    assert_eq!(sufficiency.status, PacketSufficiencyStatusDto::Partial);
+    assert!(!material_packet_obligations_are_proven(&plan));
+    assert!(
+        !sufficiency
+            .avoid_opening_paths
+            .iter()
+            .any(|path| path == shared_path),
+        "a file with an unproven claim must remain openable: {sufficiency:?}"
+    );
+    assert!(
+        sufficiency
+            .open_next
+            .iter()
+            .any(|command| command.contains(shared_path)),
+        "the unproven same-file claim must stay open-next: {sufficiency:?}"
+    );
+}
+
+#[test]
+fn missing_requested_claim_gets_a_material_unsupported_obligation() {
+    let question = "Find RuntimeService::run and MissingWidget.";
+    let mut carrier = citation(
+        "RuntimeService::run",
+        "src/runtime_service.rs",
+        NodeKind::METHOD,
+    );
+    carrier.evidence_edge_ids = vec![EdgeId("generic-call".to_string())];
+    let target = citation("Worker::run", "src/worker.rs", NodeKind::METHOD);
+    let mut answer = answer(vec![carrier.clone(), target.clone()]);
+    answer.prompt = question.to_string();
+    answer.graphs.push(GraphArtifactDto::Uml {
+        id: "generic-flow".to_string(),
+        title: "Generic flow".to_string(),
+        graph: GraphResponse {
+            center_id: carrier.node_id.clone(),
+            nodes: Vec::new(),
+            edges: vec![GraphEdgeDto {
+                id: EdgeId("generic-call".to_string()),
+                source: carrier.node_id,
+                target: target.node_id,
+                kind: EdgeKind::CALL,
+                confidence: Some(1.0),
+                certainty: Some("certain".to_string()),
+                callsite_identity: Some("test:1".to_string()),
+                candidate_targets: Vec::new(),
+            }],
+            truncated: false,
+            omitted_edge_count: 0,
+            canonical_layout: None,
+        },
+    });
+    let mut plan = build_packet_obligation_plan(question, PacketTaskClassDto::SymbolOwnership, &[]);
+    finalize_packet_obligation_plan(
+        question,
+        PacketTaskClassDto::SymbolOwnership,
+        &mut plan,
+        &answer,
+        &budget(),
+    );
+
+    let missing = plan
+        .claim_obligations
+        .iter()
+        .find(|obligation| obligation.binding_terms == ["MissingWidget"])
+        .expect("material obligation for the missing requested claim");
+    assert!(missing.material);
+    assert_eq!(
+        missing.proof_status,
+        PacketObligationProofStatusDto::Unsupported
+    );
+    assert!(missing.carrier_node_ids.is_empty());
+    assert!(!material_packet_obligations_are_proven(&plan));
+
+    let sufficiency = build_packet_sufficiency_with_obligation_context(
+        Path::new("/workspace/example"),
+        question,
+        PacketTaskClassDto::SymbolOwnership,
+        &answer,
+        &budget(),
+        &[],
+        &[],
+        &plan,
+    );
+    assert_eq!(sufficiency.status, PacketSufficiencyStatusDto::Partial);
+    assert!(
+        sufficiency
+            .open_next
+            .iter()
+            .any(|command| command.contains("MissingWidget"))
+    );
+}
+
+#[test]
+fn false_shape_carrier_stays_reported_partial_and_open_next() {
+    let false_carrier = citation(
+        "CliErrorBody",
+        "crates/example/src/indexer/runtime.rs",
+        NodeKind::STRUCT,
+    );
+    let answer = answer(vec![false_carrier]);
+    let budget = budget();
+    let mut plan = indexing_entrypoint_plan();
+    finalize_packet_obligation_plan(
+        INDEXING_QUESTION,
+        PacketTaskClassDto::ArchitectureExplanation,
+        &mut plan,
+        &answer,
+        &budget,
+    );
+
+    assert_eq!(
+        plan.claim_obligations[0].proof_status,
+        PacketObligationProofStatusDto::Reported
+    );
+    assert_eq!(
+        plan.claim_obligations[0].reason.as_deref(),
+        Some("carrier_does_not_satisfy_role_contract")
+    );
+    let sufficiency = build_packet_sufficiency_with_obligation_context(
+        Path::new("/workspace/example"),
+        INDEXING_QUESTION,
+        PacketTaskClassDto::ArchitectureExplanation,
+        &answer,
+        &budget,
+        &[],
+        &[],
+        &plan,
+    );
+    assert_eq!(sufficiency.status, PacketSufficiencyStatusDto::Partial);
+    assert!(sufficiency.avoid_opening_paths.is_empty());
+    assert!(
+        sufficiency
+            .open_next
+            .iter()
+            .any(|command| command.contains("crates/example/src/indexer/runtime.rs"))
+    );
+}
+
+#[test]
+fn known_false_carriers_publish_no_proven_claims_and_stay_open_next() {
+    let question = "Explain CliErrorBody, runtime_path, and CompilationDatabase responsibilities.";
+    let false_carriers = vec![
+        citation("CliErrorBody", "src/cli/errors.rs", NodeKind::STRUCT),
+        citation("runtime_path", "src/runtime/config.rs", NodeKind::VARIABLE),
+        citation(
+            "CompilationDatabase",
+            "src/store/database.rs",
+            NodeKind::CLASS,
+        ),
+    ];
+    let mut answer = answer(false_carriers.clone());
+    answer.prompt = question.to_string();
+    let budget = budget();
+    let mut plan = build_packet_obligation_plan(question, PacketTaskClassDto::SymbolOwnership, &[]);
+    finalize_packet_obligation_plan(
+        question,
+        PacketTaskClassDto::SymbolOwnership,
+        &mut plan,
+        &answer,
+        &budget,
+    );
+
+    let sufficiency = build_packet_sufficiency_with_obligation_context(
+        Path::new("/workspace/example"),
+        question,
+        PacketTaskClassDto::SymbolOwnership,
+        &answer,
+        &budget,
+        &[],
+        &[],
+        &plan,
+    );
+
+    assert_eq!(sufficiency.status, PacketSufficiencyStatusDto::Partial);
+    assert!(
+        sufficiency
+            .covered_claims
+            .iter()
+            .all(|claim| { claim.proof_status != Some(PacketProofStatusDto::Proven) })
+    );
+    assert!(sufficiency.avoid_opening_paths.is_empty());
+    for carrier in false_carriers {
+        let path = carrier.file_path.expect("false carrier path");
+        assert!(
+            sufficiency
+                .open_next
+                .iter()
+                .any(|command| command.contains(&path)),
+            "{path} must remain open-next: {:?}",
+            sufficiency.open_next
+        );
+    }
+}
+
+#[test]
+fn missing_carrier_keeps_requested_path_as_open_next_candidate() {
+    let queries = [PacketPlanQueryDto {
+        query: "src/indexer.rs".to_string(),
+        purpose: "explicit symbol probe from packet request".to_string(),
+    }];
+    let mut plan = build_packet_obligation_plan(
+        INDEXING_QUESTION,
+        PacketTaskClassDto::ArchitectureExplanation,
+        &queries,
+    );
+    plan.claim_obligations
+        .retain(|obligation| obligation.id == "indexing_entrypoint");
+    let answer = answer(Vec::new());
+    let budget = budget();
+    finalize_packet_obligation_plan(
+        INDEXING_QUESTION,
+        PacketTaskClassDto::ArchitectureExplanation,
+        &mut plan,
+        &answer,
+        &budget,
+    );
+    let sufficiency = build_packet_sufficiency_with_obligation_context(
+        Path::new("/workspace/example"),
+        INDEXING_QUESTION,
+        PacketTaskClassDto::ArchitectureExplanation,
+        &answer,
+        &budget,
+        &[],
+        &[],
+        &plan,
+    );
+
+    assert!(
+        sufficiency
+            .open_next
+            .iter()
+            .any(|command| command.contains("src/indexer.rs"))
+    );
+}

--- a/crates/codestory-runtime/src/agent/packet_sufficiency.rs
+++ b/crates/codestory-runtime/src/agent/packet_sufficiency.rs
@@ -382,10 +382,10 @@ fn assemble_packet_sufficiency_with_probe_context(
     // fell off the end instead. Interleaving keeps a path in front and starves neither kind.
     let mut blocking_follow_up_probe_query_seeds = Vec::new();
     for query in &blocking_probe_queries {
-        push_unique_term(&mut blocking_follow_up_probe_query_seeds, query);
+        push_unique_sufficiency_term(&mut blocking_follow_up_probe_query_seeds, query);
     }
     for query in &blocking_route_probe_queries {
-        push_unique_term(&mut blocking_follow_up_probe_query_seeds, query);
+        push_unique_sufficiency_term(&mut blocking_follow_up_probe_query_seeds, query);
     }
     // The legacy no-ledger path may still report uncovered planner probes whose flow requirement
     // is already covered. Those are hints, not repair work. Production ledgers put every
@@ -399,11 +399,11 @@ fn assemble_packet_sufficiency_with_probe_context(
             .iter()
             .filter(|query| packet_missing_probe_requires_compact_proof(query))
         {
-            push_unique_term(&mut blocking_follow_up_probe_query_seeds, query);
+            push_unique_sufficiency_term(&mut blocking_follow_up_probe_query_seeds, query);
         }
     }
     for query in &route_proof.follow_up_queries {
-        push_unique_term(&mut blocking_follow_up_probe_query_seeds, query);
+        push_unique_sufficiency_term(&mut blocking_follow_up_probe_query_seeds, query);
     }
     let terminally_sufficient = status == PacketSufficiencyStatusDto::Sufficient;
     let obligation_open_next_paths = if terminally_sufficient {
@@ -450,10 +450,10 @@ fn assemble_packet_sufficiency_with_probe_context(
         missing_exact_path_claims.clone()
     };
     for path in obligation_open_next_paths {
-        push_unique_term(&mut open_next_paths, &path);
+        push_unique_sufficiency_term(&mut open_next_paths, &path);
     }
     for path in &reported_claim_open_next_paths {
-        push_unique_term(&mut open_next_paths, path);
+        push_unique_sufficiency_term(&mut open_next_paths, path);
     }
     // Filtered once, after every source has contributed, because leads arrive
     // from three of them. Capping on coverage flips `terminally_sufficient`
@@ -546,7 +546,7 @@ fn assemble_packet_sufficiency_with_probe_context(
             packet_follow_up_trail_argv(&project, &open_next_paths)
         };
         for command in candidate_commands {
-            push_unique_term(&mut open_next, &render_packet_command(&command));
+            push_unique_sufficiency_term(&mut open_next, &render_packet_command(&command));
         }
         open_next.truncate(12);
     }
@@ -1490,7 +1490,7 @@ fn append_packet_obligation_gaps(gaps: &mut Vec<String>, obligations: &PacketObl
         obligation.proof_status != PacketObligationProofStatusDto::Proven
             && (obligation.material || !obligation.carrier_node_ids.is_empty())
     }) {
-        push_unique_term(
+        push_unique_sufficiency_term(
             gaps,
             &format!(
                 "obligation {} ({:?}) is {:?}: {}",
@@ -1517,7 +1517,7 @@ fn append_packet_obligation_gaps(gaps: &mut Vec<String>, obligations: &PacketObl
             Some(PacketQueryCompletionDto::Completed) => continue,
             None => "completion_missing",
         };
-        push_unique_term(
+        push_unique_sufficiency_term(
             gaps,
             &format!(
                 "query obligation {} ({:?}) is cancelled: {}",
@@ -2182,10 +2182,10 @@ fn packet_coverage_report(input: PacketCoverageReportInput<'_>) -> PacketCoverag
         .into_iter()
         .collect::<Vec<_>>();
     for route_gap in &route_proof.missing {
-        push_unique_term(&mut missing, route_gap);
+        push_unique_sufficiency_term(&mut missing, route_gap);
     }
     for path in missing_exact_path_claims {
-        push_unique_term(&mut missing, &format!("exact path: {path}"));
+        push_unique_sufficiency_term(&mut missing, &format!("exact path: {path}"));
     }
     let budget_omitted = if has_sufficiency_blocking_budget_omission {
         budget.omitted_sections.clone()
@@ -8547,10 +8547,10 @@ fn packet_interleave_follow_up_queries(paths: &[String], probes: &[String]) -> V
             break;
         }
         if let Some(path) = path {
-            push_unique_term(&mut merged, path);
+            push_unique_sufficiency_term(&mut merged, path);
         }
         if let Some(probe) = probe {
-            push_unique_term(&mut merged, probe);
+            push_unique_sufficiency_term(&mut merged, probe);
         }
     }
     merged
@@ -8578,7 +8578,7 @@ fn push_unique_argv(commands: &mut Vec<Vec<String>>, argv: Vec<String>) {
     }
 }
 
-fn push_unique_term(terms: &mut Vec<String>, value: &str) {
+fn push_unique_sufficiency_term(terms: &mut Vec<String>, value: &str) {
     let value = value.trim();
     if value.is_empty() {
         return;

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -90,6 +90,47 @@ mod source_coverage;
 mod workspace_state;
 use affected::{AffectedOperationIdentityIndex, IndexFreshnessObservation};
 pub use agent::{packet_step_trace_json, plan_packet};
+
+#[cfg(feature = "test-support")]
+#[doc(hidden)]
+pub mod agent_test_support {
+    use codestory_contracts::api::{
+        AgentAnswerDto, IndexFreshnessDto, PacketBudgetDto, PacketClaimDto,
+        PacketObligationPlanDto, PacketSufficiencyDto, PacketTaskClassDto,
+    };
+    use std::path::Path;
+
+    pub fn packet_supported_claims(answer: &AgentAnswerDto) -> Vec<PacketClaimDto> {
+        crate::agent::packet_claims::packet_supported_claims_with_telemetry(answer).0
+    }
+
+    pub fn fresh_index_observation() -> IndexFreshnessDto {
+        crate::agent::packet_freshness::fresh_index_observation()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn build_packet_sufficiency_with_obligation_context(
+        project_root: &Path,
+        question: &str,
+        task_class: PacketTaskClassDto,
+        answer: &AgentAnswerDto,
+        budget: &PacketBudgetDto,
+        extra_probes: &[String],
+        exact_probe_paths: &[String],
+        obligations: &PacketObligationPlanDto,
+    ) -> PacketSufficiencyDto {
+        crate::agent::packet_sufficiency::build_packet_sufficiency_with_obligation_context(
+            project_root,
+            question,
+            task_class,
+            answer,
+            budget,
+            extra_probes,
+            exact_probe_paths,
+            obligations,
+        )
+    }
+}
 use index_commit::*;
 pub(crate) use index_coverage::{
     current_epoch_ms, file_coverage_retryable, full_refresh_execution_plan_with_coverage,
@@ -409,6 +450,7 @@ pub use symbol_query::{
     normalize_symbol_query, retrieval_file_role_for_hit, retrieval_file_role_from_path,
     symbol_name_match_rank, symbol_query_tokens, terminal_symbol_segment,
 };
+#[allow(unused_imports)]
 pub(crate) use symbol_query::{
     compare_search_hits_with_project_root, exact_symbol_query_terms, is_non_primary_source_term,
     looks_like_standalone_symbol_query, query_mentions_non_primary_source,

--- a/crates/codestory-runtime/src/symbol_query.rs
+++ b/crates/codestory-runtime/src/symbol_query.rs
@@ -8,7 +8,8 @@ pub use codestory_agent::text::{
     terminal_symbol_segment,
 };
 pub(crate) use codestory_agent::text::{
-    is_non_primary_source_term, query_mentions_non_primary_source,
+    exact_symbol_query_terms, is_non_primary_source_term, looks_like_standalone_symbol_query,
+    query_mentions_non_primary_source,
 };
 use codestory_contracts::api::{NodeId, NodeKind, SearchHit, SearchHitOrigin};
 use std::cmp::Ordering;
@@ -192,62 +193,6 @@ pub fn symbol_name_match_rank(query: &str, display_name: &str) -> SymbolNameMatc
     best_symbol_name_match(query, display_name).0
 }
 
-pub(crate) fn exact_symbol_query_terms(query: &str) -> Vec<String> {
-    let trimmed = trim_symbol_candidate(query);
-    if looks_like_standalone_symbol_query(trimmed) {
-        let mut terms = Vec::new();
-        let mut seen = HashSet::new();
-        push_exact_symbol_query_term(trimmed, &mut terms, &mut seen);
-        if let Some((_, terminal)) = qualified_symbol_query_parts(trimmed) {
-            push_exact_symbol_query_term(terminal, &mut terms, &mut seen);
-        }
-        return terms;
-    }
-
-    let mut terms = Vec::new();
-    let mut seen = HashSet::new();
-    let mut candidate = String::new();
-    let mut chars = query.chars().peekable();
-    while let Some(ch) = chars.next() {
-        if ch == '!' && chars.peek().is_some_and(|next| *next == '=') {
-            // `!=` and `!==` terminate the left operand. Keeping this bang would fabricate a
-            // Ruby-style suffix identity (`foo_bar!`) from an ordinary comparison expression.
-            push_embedded_symbol_candidate(&candidate, &mut terms, &mut seen);
-            candidate.clear();
-            continue;
-        }
-        if is_symbol_query_char(ch) {
-            candidate.push(ch);
-            continue;
-        }
-        push_embedded_symbol_candidate(&candidate, &mut terms, &mut seen);
-        candidate.clear();
-    }
-    push_embedded_symbol_candidate(&candidate, &mut terms, &mut seen);
-    terms
-}
-
-fn push_exact_symbol_query_term(raw: &str, terms: &mut Vec<String>, seen: &mut HashSet<String>) {
-    let candidate = trim_symbol_candidate(raw);
-    if !looks_like_standalone_symbol_query(candidate) {
-        return;
-    }
-    // Exact symbol requests are case-bearing identities. `Foo::run` and `foo::run` may be two
-    // distinct symbols in the same project and must survive as separate requested candidates.
-    if seen.insert(candidate.to_string()) {
-        terms.push(candidate.to_string());
-    }
-}
-
-pub(crate) fn looks_like_standalone_symbol_query(query: &str) -> bool {
-    let trimmed = trim_symbol_candidate(query);
-    !trimmed.is_empty()
-        && !trimmed.chars().any(char::is_whitespace)
-        && trimmed.chars().any(|ch| ch.is_ascii_alphabetic())
-        && trimmed.chars().all(is_symbol_query_char)
-        && symbol_identity_punctuation_is_lawful(trimmed)
-}
-
 /// Natural-language prompt with embedded symbol-like tokens (not a standalone symbol query).
 #[cfg(test)]
 pub(crate) fn mixed_natural_language_query(query: &str) -> bool {
@@ -261,75 +206,10 @@ pub(crate) fn mixed_natural_language_query(query: &str) -> bool {
     !exact_symbol_query_terms(query).is_empty()
 }
 
-fn push_embedded_symbol_candidate(raw: &str, terms: &mut Vec<String>, seen: &mut HashSet<String>) {
-    let candidate = trim_symbol_candidate(raw);
-    if !looks_like_standalone_symbol_query(candidate)
-        || !has_embedded_exact_symbol_signal(candidate)
-    {
-        return;
-    }
-
-    // Embedded exact symbols carry the same case-sensitive identity as standalone exact probes.
-    // Java-style `Foo.run` and `foo.run`, for example, may resolve to different owners.
-    if seen.insert(candidate.to_string()) {
-        terms.push(candidate.to_string());
-    }
-}
-
 fn trim_symbol_candidate(value: &str) -> &str {
     value.trim().trim_matches(|ch: char| {
         !(ch.is_ascii_alphanumeric() || matches!(ch, '_' | '$' | '?' | '!' | '~'))
     })
-}
-
-fn is_symbol_query_char(ch: char) -> bool {
-    ch.is_ascii_alphanumeric() || matches!(ch, '_' | ':' | '.' | '/' | '$' | '?' | '!' | '~')
-}
-
-fn symbol_identity_punctuation_is_lawful(value: &str) -> bool {
-    let ruby_suffix_count = value.chars().filter(|ch| matches!(ch, '?' | '!')).count();
-    if ruby_suffix_count > 0 {
-        let Some(stem) = value.strip_suffix('?').or_else(|| value.strip_suffix('!')) else {
-            return false;
-        };
-        let terminal = stem.rsplit([':', '.', '/']).next().unwrap_or_default();
-        return ruby_suffix_count == 1
-            && !value.contains('~')
-            && symbol_identity_component_is_lawful(terminal);
-    }
-
-    let destructor_count = value.chars().filter(|ch| *ch == '~').count();
-    if destructor_count == 0 {
-        return true;
-    }
-    if destructor_count != 1 {
-        return false;
-    }
-
-    let Some((owner_path, destructor_name)) = value.rsplit_once("::~") else {
-        return false;
-    };
-    let owner_name = owner_path.rsplit("::").next().unwrap_or_default();
-    symbol_identity_component_is_lawful(owner_name)
-        && owner_name == destructor_name
-        && symbol_identity_component_is_lawful(destructor_name)
-}
-
-fn symbol_identity_component_is_lawful(value: &str) -> bool {
-    !value.is_empty()
-        && value.chars().any(|ch| ch.is_ascii_alphabetic())
-        && value
-            .chars()
-            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '$'))
-}
-
-fn has_embedded_exact_symbol_signal(value: &str) -> bool {
-    value.contains('_')
-        || value.contains("::")
-        || value.contains('.')
-        || value.contains('/')
-        || value.contains('$')
-        || value.chars().skip(1).any(|ch| ch.is_ascii_uppercase())
 }
 
 fn qualified_symbol_query_parts(query: &str) -> Option<(&str, &str)> {

--- a/scripts/retrieval-generalization-pending.json
+++ b/scripts/retrieval-generalization-pending.json
@@ -103,14 +103,6 @@
         "json_output": 2
       }
     },
-    "crates/codestory-runtime/src/agent/packet_command_profiles.rs": {
-      "issue": "https://github.com/TheGreenCedar/CodeStory/issues/1573",
-      "reason": "Command-flow profiling recognises holdout command dispatch symbols by spelling. Replacing that with structural command detection is separate work.",
-      "markers": {
-        "run_main": 10,
-        "runmain": 2
-      }
-    },
     "crates/codestory-agent/src/packet_evidence_carriers.rs": {
       "issue": "https://github.com/TheGreenCedar/CodeStory/issues/1573",
       "reason": "The stylesheet carrier lists the words a CSS animation is written with, and one of them collides with a benchmark marker: `animated` is the class name Animate.css and its imitators ship, so a stylesheet whose only anchor is that class would stop closing the animation structure step without it. It goes when a stylesheet requirement is decided from the at-rules the indexer already extracts rather than from a word list.",
@@ -144,58 +136,6 @@
         "formaterror": 1,
         "mapperconfiguration": 1,
         "sessionrequest": 1
-      }
-    },
-    "crates/codestory-runtime/src/agent/packet_plan.rs": {
-      "issue": "https://github.com/TheGreenCedar/CodeStory/issues/1573",
-      "reason": "Packet planning still expands questions with holdout symbol and library names. This is the same class of steering as the search-plan tables this branch deletes, and it needs its own change because the packet path has separate quality coverage.",
-      "markers": {
-        "FOREIGN KEY": 3,
-        "dispatchrequest": 1,
-        "dynamicformatargstore": 1,
-        "formatargstore": 1,
-        "interceptormanager": 1,
-        "isBlank": 1,
-        "isEmpty": 1,
-        "isblank": 1,
-        "isempty": 1,
-        "mapperconfiguration": 2,
-        "regionMatches": 4,
-        "regionmatches": 1,
-        "routergroup": 2,
-        "sessionrequest": 1,
-        "sessionsend": 1,
-        "siteread": 1,
-        "siterender": 1,
-        "sitewrite": 1,
-        "wsgiapp": 1
-      }
-    },
-    "crates/codestory-runtime/src/agent/packet_required_probes.rs": {
-      "issue": "https://github.com/TheGreenCedar/CodeStory/issues/1573",
-      "reason": "Required-probe selection names holdout languages, files, and APIs so a packet is forced to fetch them. Probes have to be built from the asked question before these can be removed.",
-      "markers": {
-        "FOREIGN KEY": 2,
-        "RouterGroup": 1,
-        "TypeMap": 1,
-        "_vars\\.css": 2,
-        "addRecord": 1,
-        "addRoute": 3,
-        "addrecord": 1,
-        "addroute": 1,
-        "buildindex": 1,
-        "dynamicformatargstore": 1,
-        "foreignkey": 7,
-        "formatargstore": 1,
-        "formvalidation": 1,
-        "mapperconfiguration": 2,
-        "persistentstorage": 1,
-        "routergroup": 3,
-        "sessionrequest": 1,
-        "sessionsend": 1,
-        "storageaccess": 1,
-        "typemap": 2,
-        "wsgiapp": 1
       }
     },
     "crates/codestory-agent/src/packet_scoring.rs": {
@@ -319,6 +259,66 @@
         "(?:^|[^A-Za-z0-9])gin(?![A-Za-z0-9])": 1,
         "flask": 1,
         "gin": 1
+      }
+    },
+    "crates/codestory-agent/src/packet_command_profiles.rs": {
+      "issue": "https://github.com/TheGreenCedar/CodeStory/issues/1573",
+      "reason": "Command-flow profiling recognises holdout command dispatch symbols by spelling. Replacing that with structural command detection is separate work.",
+      "markers": {
+        "run_main": 10,
+        "runmain": 2
+      }
+    },
+    "crates/codestory-agent/src/packet_plan.rs": {
+      "issue": "https://github.com/TheGreenCedar/CodeStory/issues/1573",
+      "reason": "Packet planning still expands questions with holdout symbol and library names. This is the same class of steering as the search-plan tables this branch deletes, and it needs its own change because the packet path has separate quality coverage.",
+      "markers": {
+        "FOREIGN KEY": 3,
+        "dispatchrequest": 1,
+        "dynamicformatargstore": 1,
+        "formatargstore": 1,
+        "interceptormanager": 1,
+        "isBlank": 1,
+        "isEmpty": 1,
+        "isblank": 1,
+        "isempty": 1,
+        "mapperconfiguration": 2,
+        "regionMatches": 4,
+        "regionmatches": 1,
+        "routergroup": 2,
+        "sessionrequest": 1,
+        "sessionsend": 1,
+        "siteread": 1,
+        "siterender": 1,
+        "sitewrite": 1,
+        "wsgiapp": 1
+      }
+    },
+    "crates/codestory-agent/src/packet_required_probes.rs": {
+      "issue": "https://github.com/TheGreenCedar/CodeStory/issues/1573",
+      "reason": "Required-probe selection names holdout languages, files, and APIs so a packet is forced to fetch them. Probes have to be built from the asked question before these can be removed.",
+      "markers": {
+        "FOREIGN KEY": 2,
+        "RouterGroup": 1,
+        "TypeMap": 1,
+        "_vars\\.css": 2,
+        "addRecord": 1,
+        "addRoute": 3,
+        "addrecord": 1,
+        "addroute": 1,
+        "buildindex": 1,
+        "dynamicformatargstore": 1,
+        "foreignkey": 7,
+        "formatargstore": 1,
+        "formvalidation": 1,
+        "mapperconfiguration": 2,
+        "persistentstorage": 1,
+        "routergroup": 3,
+        "sessionrequest": 1,
+        "sessionsend": 1,
+        "storageaccess": 1,
+        "typemap": 2,
+        "wsgiapp": 1
       }
     }
   }


### PR DESCRIPTION
## Context

The first bulk move batch of #1673, executed against the DAG S4-10a settled. Five planning modules leave runtime for the contracts-only agent crate.

Closes #1872
Refs #1673
Refs #1179

## What changed

- Moved `packet_required_probes`, `packet_obligations`, `packet_plan` plus their two bounded pure dependencies `packet_command_profiles` and `packet_evidence` (recorded fallback expansion — no controller/store/retrieval/service reach in any of them) into `codestory-agent`; ~10k lines leave runtime with old-path re-exports preserving type identity and zero call-site changes.
- Relocated the two remaining pure lexical helpers (`exact_symbol_query_terms`, `looks_like_standalone_symbol_query`) to `codestory_agent::text` with runtime re-exports.
- The agent crate stays contracts + serde in EVERY dependency section: 13 runtime-dependent obligation tests relocated back into runtime (`packet_obligations_runtime_tests.rs`) exercising the re-exported paths; the 33 pure tests moved with their module. The architecture guard was STRENGTHENED to all-section coverage after a first-revision attempt narrowed it — a temporary dev-dependency probe now fails it by name.
- `architecture_contracts.rs`: module allowlist grows by five; runtime path lists shrink; negative assertions (module absent under runtime) demonstrated live by a temporary copy-back that failed the contract by name.

## Verification

Passed on `31a992ee` (implementer; supervisor decisive re-runs): agent 120/0, runtime 1037/0 + the tolerated #1853 flake, relocated tests 13/13, architecture contracts 41/0 locally AND on the merge result against origin/dev/codestory-next, clippy `-D warnings` three crates, fmt, `git diff --check`, body identity compared per file against base with normalized imports.

Independent fresh-context adversarial review on the exact head is running; draft until it accepts and CI is green.