### PR TITLE
[v0.17] Kill the surviving lease-memo guard mutations

### DIFF
--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -3086,6 +3086,63 @@ mod tests {
     }
 
     #[test]
+    fn lease_memoized_sidecar_input_recomputes_when_project_identity_changes() {
+        let project = TempDir::new().expect("project");
+        std::fs::write(project.path().join("lib.rs"), "pub fn stable() {}\n").expect("source");
+        let storage_path = project.path().join("codestory.db");
+        let mut storage = Store::open(&storage_path).expect("storage");
+        let publication = codestory_store::IndexPublicationRecord {
+            generation: 1,
+            generation_id: "core-generation".into(),
+            run_id: "core-run".into(),
+            mode: codestory_store::IndexPublicationMode::Full,
+            published_at_epoch_ms: 1,
+        };
+        crate::test_support::publish_complete_core_fixture(
+            &mut storage,
+            project.path(),
+            &publication,
+        )
+        .expect("complete core fixture");
+
+        let _lease_scope = codestory_workspace::SourceFreshnessScope::enter_with_memo(
+            codestory_workspace::SourceFreshnessMemo::default(),
+        );
+        let first = compute_sidecar_input_fingerprint(
+            &storage,
+            project.path(),
+            &storage_path,
+            "project-identity-a",
+            crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID,
+            crate::embeddings::RETRIEVAL_EMBEDDING_DIM as i32,
+            "producer-compatibility-v1",
+        )
+        .expect("fingerprint for identity A");
+        let second = compute_sidecar_input_fingerprint(
+            &storage,
+            project.path(),
+            &storage_path,
+            "project-identity-b",
+            crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID,
+            crate::embeddings::RETRIEVAL_EMBEDDING_DIM as i32,
+            "producer-compatibility-v1",
+        )
+        .expect("fingerprint for identity B");
+
+        assert_ne!(
+            first, second,
+            "a lease memo may not return identity A's fingerprint for identity B"
+        );
+        assert_eq!(
+            codestory_workspace::source_freshness_counts()
+                .expect("lease scope publishes readiness passes")
+                .readiness_fingerprint_passes,
+            2,
+            "a distinct fingerprint identity must perform its own readiness pass"
+        );
+    }
+
+    #[test]
     fn canonical_sidecar_generation_is_stable_across_clean_roots_with_same_input() {
         let Some(first_project) = git_project() else {
             return;

--- a/crates/codestory-runtime/src/services.rs
+++ b/crates/codestory-runtime/src/services.rs
@@ -2873,6 +2873,7 @@ mod activation_tests {
         runtime: Runtime,
         storage_path: PathBuf,
         lease: ReadyLease,
+        sidecar: codestory_retrieval::SidecarRuntimeConfig,
     }
 
     fn ready_activation_fixture() -> ReadyActivationFixture {
@@ -2982,6 +2983,7 @@ mod activation_tests {
             runtime,
             storage_path,
             lease,
+            sidecar,
         }
     }
 
@@ -3195,6 +3197,53 @@ mod activation_tests {
                 ready_lease_memo_holds_observations: true,
             },
             "unavailable",
+        );
+    }
+
+    #[test]
+    fn status_and_doctor_do_not_resurrect_a_lease_after_observing_one() {
+        let fixture = ready_activation_fixture();
+        let service = fixture.runtime.activation_service();
+
+        assert!(
+            service
+                .retrieval_status(fixture.project.path(), &fixture.storage_path)
+                .expect("status with a ready lease")
+                .ready_lease()
+                .ready_lease_present,
+            "the observational matrix must first see the lease it is about to remove"
+        );
+        assert!(
+            service
+                .retrieval_engine_diagnostics(fixture.project.path(), &fixture.storage_path)
+                .expect("doctor with a ready lease")
+                .ready_lease
+                .ready_lease_present,
+            "doctor must see the same initial lease"
+        );
+
+        service
+            .coordinator
+            .state
+            .lock()
+            .expect("activation coordinator")
+            .ready_lease = None;
+
+        assert!(
+            !service
+                .retrieval_status(fixture.project.path(), &fixture.storage_path)
+                .expect("status after lease removal")
+                .ready_lease()
+                .ready_lease_present,
+            "status must report no lease after the coordinator drops it"
+        );
+        assert!(
+            !service
+                .retrieval_engine_diagnostics(fixture.project.path(), &fixture.storage_path)
+                .expect("doctor after lease removal")
+                .ready_lease
+                .ready_lease_present,
+            "doctor must not resurrect a previously observed lease"
         );
     }
 
@@ -3495,6 +3544,58 @@ mod activation_tests {
                 .readiness_fingerprint_passes,
             1,
             "a new ready lease must compute its own fingerprint"
+        );
+    }
+
+    #[test]
+    fn an_admission_refusal_drops_the_lease_fingerprint_memo() {
+        let fixture = ready_activation_fixture();
+        let browser = fixture.runtime.browser_service();
+        let source = fixture.project.path().join("metadata.rs");
+        let original = fs::read(&source).expect("read indexed source");
+
+        let first = browser
+            .packet(warm_packet_request())
+            .expect("prime the ready lease fingerprint memo");
+        assert_eq!(
+            first
+                .answer
+                .retrieval_trace
+                .source_freshness_telemetry
+                .expect("priming packet telemetry")
+                .readiness_fingerprint_passes,
+            1,
+            "the fixture must first populate the ready lease fingerprint memo"
+        );
+
+        fs::write(&source, "// ADMISSION_REFUSAL_DRIFT\n").expect("make source stale");
+        let mut builds = 0;
+        let refusal = fixture
+            .runtime
+            .public_operation_service()
+            .run_with_cancel("packet", Arc::new(AtomicBool::new(false)), || {
+                builds += 1;
+                Ok(())
+            })
+            .expect_err("stale source must refuse retrieval at admission");
+        assert_eq!(refusal.code, "project_unavailable");
+        assert_eq!(builds, 0, "a refused admission must not enter the build");
+        fs::write(&source, &original).expect("restore source after the refusal");
+        let _lease_scope = codestory_workspace::SourceFreshnessScope::enter_with_memo(
+            fixture.lease.source_freshness_memo.clone(),
+        );
+        codestory_retrieval::strict_sidecar_status_for_runtime(
+            fixture.project.path(),
+            Some(&fixture.storage_path),
+            fixture.sidecar.clone(),
+        )
+        .expect("readiness after the admission refusal");
+        assert_eq!(
+            codestory_workspace::source_freshness_counts()
+                .expect("post-refusal readiness telemetry")
+                .readiness_fingerprint_passes,
+            1,
+            "the next readiness pass must recompute after admission refused freshness"
         );
     }
 


### PR DESCRIPTION
## Context

The READY-Bb/READY-Bc adversarial verifications recorded three surviving mutations in the lease-memo guards; #1857 owns killing them.

Closes #1857
Refs #1700
Refs #1179

## What changed

Test-only, two files: (1) fingerprint identity-filter guard — a lease-memoized fingerprint for identity A must not serve identity B (dropping the filter fails A/B inequality); (2) admission-site invalidate guard — a freshness refusal must drop the lease's opaque fingerprint (removing the invalidate call fails on the recompute count); (3) None-after-Some scenario in the hostile observational matrix — status/doctor must report no lease after the coordinator drops it (resurrecting cached evidence fails by name). All three mutation kills demonstrated and reverted.

## Verification

On `a124e15c`: retrieval lib 294/0, runtime lib 1095/0 plus only the tracked #1853 environment failure, clippy `-D warnings` both crates, fmt, `git diff --check`. The mutex-poisoning posture note from #1857 is recorded there as intentional pending a cheap seam.

Draft until light independent review accepts and CI is green.