### PR TITLE
[v0.17 REL-CI W8.5] Type pre-assignment runner unavailability behind a heartbeat receipt

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -10,6 +10,7 @@ import {
   MAXIMUM_RUN_ATTEMPTS,
   RERUN_DISPATCH_SCHEMA,
   RERUN_PLAN_SCHEMA,
+  RESERVATION_RECEIPT_SCHEMA,
 } from "./lost-runner-recovery.mjs";
 import {
   LINK_PHASE as WINDOWS_LINK_PHASE,
@@ -10310,6 +10311,231 @@ export function lostRunnerRecoveryViolations(workflows, graph) {
   return violations;
 }
 
+/// The pre-dispatch reservation contract: the heartbeat workflow whose tiny jobs run ON the three
+/// protected hosts, the release gate that types each host before any proof is dispatched, the
+/// per-host dispatch conditions on the proof calls, the receipt feed into the non-claim producer,
+/// and the closeouts' own receipt collection.
+///
+/// Every pin here is a place where a gate is being relaxed -- an absent proof may now be withheld
+/// instead of blocking -- so the shapes that keep the relaxation honest are pinned: the gate never
+/// waits on a human, the receipt has exactly one producer, the proof jobs dispatch only for hosts
+/// the receipt typed alive, and the closeouts download the receipt themselves rather than
+/// inheriting the non-claim producer's verdict.
+export function protectedRunnerReservationViolations(workflows, graph) {
+  const violations = [];
+  const policy = graph.non_claim_policy;
+  const reservation = object(policy.reservation ?? {});
+  const heartbeat = object(reservation.heartbeat ?? {});
+  const heartbeatFile = String(heartbeat.workflow ?? "").split("/").at(-1);
+  const hostFlag = host => `dispatch_${host.id.replaceAll(/[^A-Za-z0-9_]/gu, "_")}`;
+
+  // The receipt schema and the recheck bound are the same facts the recovery contract exports,
+  // so a graph that drifts from the code is a violation even with the workflows untouched.
+  add(
+    violations,
+    reservation.schema === RESERVATION_RECEIPT_SCHEMA,
+    "the release claim graph reservation schema must match the recovery contract",
+  );
+  add(
+    violations,
+    reservation.maximum_observation_attempts === MAXIMUM_RUN_ATTEMPTS,
+    "the release claim graph reservation recheck bound must mirror MAXIMUM_RUN_ATTEMPTS",
+  );
+
+  const heartbeatWorkflow = workflows.get(heartbeatFile);
+  if (!heartbeatWorkflow) {
+    violations.push(`${heartbeatFile} must exist`);
+  } else {
+    const schedule = list(at(heartbeatWorkflow, "on", "schedule") ?? []);
+    add(
+      violations,
+      schedule.length === 1 && object(schedule[0]).cron === heartbeat.cron,
+      `${heartbeatFile} must run on the graph-declared ${String(heartbeat.cron)} schedule`,
+    );
+    add(
+      violations,
+      trigger(heartbeatWorkflow, "workflow_dispatch") !== undefined,
+      `${heartbeatFile} must accept the bounded recheck dispatch`,
+    );
+    // Queued heartbeats behind a busy or dead host must never pile up: each run supersedes the
+    // one before it.
+    add(
+      violations,
+      concurrencyCancels(heartbeatWorkflow),
+      `${heartbeatFile} must cancel superseded heartbeats`,
+    );
+    add(
+      violations,
+      JSON.stringify(object(heartbeatWorkflow.permissions)) === "{}",
+      `${heartbeatFile} must hold no token scopes at all`,
+    );
+    add(
+      violations,
+      !scalarStrings(heartbeatWorkflow).some(value => value.includes("secrets.")),
+      `${heartbeatFile} must reference no secrets`,
+    );
+    const jobs = Object.entries(object(heartbeatWorkflow.jobs));
+    add(
+      violations,
+      jobs.length === list(policy.hosts).length,
+      `${heartbeatFile} must define exactly one heartbeat job per protected host`,
+    );
+    for (const host of policy.hosts) {
+      const matches = jobs.filter(([, job]) => object(job).name === host.heartbeat_job_name);
+      if (matches.length !== 1) {
+        violations.push(`${heartbeatFile} must define one job named ${host.heartbeat_job_name}`);
+        continue;
+      }
+      const [jobId, job] = matches[0];
+      add(
+        violations,
+        JSON.stringify(job["runs-on"]) === JSON.stringify(host.runner_labels),
+        `${heartbeatFile} jobs.${jobId} must run on ${JSON.stringify(host.runner_labels)}`,
+      );
+      add(
+        violations,
+        job["timeout-minutes"] === 5,
+        `${heartbeatFile} jobs.${jobId} must keep the tiny 5-minute heartbeat budget`,
+      );
+      add(
+        violations,
+        job.environment === undefined,
+        `${heartbeatFile} jobs.${jobId} must not wait on an approval environment`,
+      );
+      // The only fact a heartbeat proves is that the runner completed a job; checking anything
+      // out or downloading anything onto the protected host proves nothing more and widens the
+      // host's exposure.
+      add(
+        violations,
+        list(job.steps).every(step => object(step).uses === undefined),
+        `${heartbeatFile} jobs.${jobId} must run no actions on the protected host`,
+      );
+    }
+  }
+
+  const releaseFile = "release.yml";
+  const release = workflows.get(releaseFile);
+  if (!release) return violations;
+  const gateJobId = String(reservation.producer_job ?? "");
+  const gate = requireJob(violations, releaseFile, release, gateJobId);
+  // The gate sits between the packaged proof and every protected dispatch. A human approval here
+  // would put a click between a finished build and its proofs on every release; an `if:` here
+  // would make "the hosts were never typed" reachable, which is the invisible-queue state this
+  // gate exists to remove.
+  add(
+    violations,
+    object(gate).environment === undefined,
+    `${releaseFile} ${gateJobId} must not wait on an approval environment`,
+  );
+  add(
+    violations,
+    object(gate).if === undefined,
+    `${releaseFile} ${gateJobId} must type the hosts unconditionally`,
+  );
+  const reserveStepName = "Type each protected host from its heartbeat evidence";
+  requireStepRun(violations, releaseFile, gate, reserveStepName, [
+    "node .github/scripts/lost-runner-recovery.mjs plan-reservation",
+    "--out target/runner-reservation/receipt.json",
+    ".non_claim_policy.reservation.heartbeat.workflow",
+    ".non_claim_policy.reservation.heartbeat.tolerance_minutes",
+    // The bounded recheck is a fresh heartbeat dispatch, not a longer wait on stale evidence.
+    "gh workflow run",
+  ]);
+  for (const host of policy.hosts) {
+    add(
+      violations,
+      object(gate.outputs)[hostFlag(host)]
+        === `\${{ steps.reserve.outputs.${hostFlag(host)} }}`,
+      `${releaseFile} ${gateJobId} must publish the ${hostFlag(host)} receipt flag`,
+    );
+  }
+  const receiptArtifactName = String(reservation.receipt_artifact ?? "")
+    .replaceAll("{attempt}", "${{ github.run_attempt }}");
+  const receiptUpload = list(object(gate).steps ?? []).find(step =>
+    object(object(step).with).name === receiptArtifactName);
+  add(
+    violations,
+    receiptUpload !== undefined
+      && receiptUpload.if === "always()"
+      && String(object(receiptUpload?.with).path ?? "").endsWith("receipt.json"),
+    `${releaseFile} ${gateJobId} must upload the ${receiptArtifactName} receipt even when it fails red`,
+  );
+  // Exactly one producer for the receipt artifact, anywhere in the repository: a second uploader
+  // could hand the closeouts a receipt no reservation ever wrote.
+  for (const [file, workflow] of workflows) {
+    for (const [jobId, jobValue] of Object.entries(object(workflow.jobs))) {
+      for (const step of Array.isArray(object(jobValue).steps) ? jobValue.steps : []) {
+        const uploadName = String(object(object(step).with).name ?? "");
+        if (!uploadName.startsWith("protected-runner-reservation-")) continue;
+        if (typeof object(step).uses !== "string" || !object(step).uses.startsWith("actions/upload-artifact")) continue;
+        add(
+          violations,
+          file === releaseFile && jobId === gateJobId,
+          `${file} job ${jobId} must not upload the reservation receipt ${uploadName}`,
+        );
+      }
+    }
+  }
+
+  // Proof jobs dispatch only for hosts the receipt typed alive, host by host, derived from the
+  // graph rather than listed here.
+  for (const host of policy.hosts) {
+    const proofRef = `./${host.unavailable_producer_workflow}`;
+    const entry = Object.entries(object(release.jobs))
+      .find(([, jobValue]) => object(jobValue).uses === proofRef);
+    add(
+      violations,
+      entry !== undefined
+        && object(entry[1]).if
+          === `needs.${gateJobId}.outputs.${hostFlag(host)} == 'true'`
+        && needs(object(entry[1])).includes(gateJobId),
+      `${releaseFile} proof calling ${host.unavailable_producer_workflow} must dispatch only on ${hostFlag(host)}`,
+    );
+  }
+
+  // The non-claim producer feeds the receipt into the shared classifier and records the
+  // pre-assignment reason only for hosts the classifier withheld under it.
+  const nonClaim = requireJob(violations, releaseFile, release, "accelerator-non-claim");
+  const nonClaimDownload = namedStep(nonClaim, "Download this run's reservation receipt");
+  add(
+    violations,
+    nonClaimDownload?.uses === "actions/download-artifact@v8.0.1"
+      && object(nonClaimDownload?.with).pattern === "protected-runner-reservation-attempt-*"
+      && object(nonClaimDownload?.with)["merge-multiple"] === false,
+    `${releaseFile} non-claim producer must download this run's reservation receipt`,
+  );
+  requireStepRun(violations, releaseFile, nonClaim, "Decide withheld accelerator hosts", [
+    "protected-runner-reservation-attempt-",
+    "--reservation",
+  ]);
+  requireStepRun(violations, releaseFile, nonClaim, "Record populated accelerator non-claims", [
+    "runner_unproven_pre_assignment",
+    "--reason accelerator_host_offline_pre_assignment",
+  ]);
+
+  // The closeouts re-confirm the pre-assignment route from a receipt they downloaded themselves:
+  // the trust boundary that already refuses to inherit the lost-runner verdict refuses to
+  // inherit this one the same way.
+  for (const [jobId, stepName] of [
+    ["pre-publish-closeout", "Authenticate pre-publish Actions provenance"],
+    ["post-publish-closeout", "Authenticate post-publish Actions provenance"],
+  ]) {
+    const job = requireJob(violations, releaseFile, release, jobId);
+    const download = namedStep(job, "Collect this run's reservation receipt");
+    add(
+      violations,
+      download?.uses === "actions/download-artifact@v8.0.1"
+        && object(download?.with).pattern === "protected-runner-reservation-attempt-*"
+        && object(download?.with)["merge-multiple"] === false,
+      `${releaseFile} ${jobId} must collect this run's reservation receipt itself`,
+    );
+    requireStepRun(violations, releaseFile, job, stepName, [
+      "--reservation-receipt",
+    ]);
+  }
+  return violations;
+}
+
 function validateReleaseArtifactRerunSafety(workflows, violations) {
   const releaseChainWorkflows = new Set([
     "source-proof.yml",
@@ -11009,6 +11235,7 @@ export function validateWorkflows(workflows, graph = loadReleaseClaimGraph(repos
   violations.push(...absorbedFailureViolations(workflows));
   violations.push(...annotationScopeViolations(workflows));
   violations.push(...lostRunnerRecoveryViolations(workflows, graph));
+  violations.push(...protectedRunnerReservationViolations(workflows, graph));
   violations.push(...releaseWorkflowContractViolations(workflows, graph));
   return violations;
 }

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -38,6 +38,7 @@ import {
   packagedPrSigningViolations,
   parseWorkflow,
   proofFloorPolicyViolations,
+  protectedRunnerReservationViolations,
   qualificationDriverArtifactViolations,
   releaseProofCpuSelectorViolations,
   releaseFreezeBarrierWorkflowViolations,
@@ -7913,6 +7914,120 @@ test("lost-runner recovery stays automatic, bounded, and blind to job names", ()
     drift(mutated);
     assert.notDeepEqual(lostRunnerRecoveryViolations(loadWorkflows(), mutated), []);
   }
+});
+
+test("the protected-runner reservation stays machine-decided, single-producer, and self-confirmed", () => {
+  const graph = loadReleaseClaimGraph(root);
+  const reservation = graph.non_claim_policy.reservation;
+  const heartbeatFile = reservation.heartbeat.workflow.split("/").at(-1);
+
+  // The live repository satisfies the whole contract.
+  assert.deepEqual(protectedRunnerReservationViolations(loadWorkflows(), graph), []);
+
+  const mutations = [
+    // The gate is what stands between an offline host and a proof queueing invisibly for a day.
+    ["the gate is removed from release.yml", workflows => {
+      delete workflows.get("release.yml").jobs["reserve-protected-runners"];
+    }, /release\.yml must contain job reserve-protected-runners/u],
+    // An approval environment would put a human click between every finished build and its
+    // proofs -- the same failure the lost-runner recovery refuses.
+    ["an approval environment on the gate", workflows => {
+      workflows.get("release.yml").jobs["reserve-protected-runners"].environment =
+        "release-recovery";
+    }, /reserve-protected-runners must not wait on an approval environment/u],
+    ["a conditional gate", workflows => {
+      workflows.get("release.yml").jobs["reserve-protected-runners"].if = "inputs.publish_release";
+    }, /must type the hosts unconditionally/u],
+    // Without the per-host condition an unproven host's proof is dispatched anyway, and the
+    // invisible queue this contract removes is back.
+    ["a proof dispatch condition is dropped", workflows => {
+      delete workflows.get("release.yml").jobs["macos-metal-proof"].if;
+    }, /must dispatch only on dispatch_macos_arm64_metal/u],
+    ["a proof dispatch condition is rewired to a literal", workflows => {
+      workflows.get("release.yml").jobs["linux-vulkan-proof"].if = "true";
+    }, /must dispatch only on dispatch_linux_x64_vulkan/u],
+    ["the heartbeat workflow is removed", workflows => {
+      workflows.delete(heartbeatFile);
+    }, /protected-runner-heartbeat\.yml must exist/u],
+    ["a heartbeat job moves off its protected labels", workflows => {
+      workflows.get(heartbeatFile).jobs["heartbeat-linux-x64-vulkan"]["runs-on"] = "ubuntu-latest";
+    }, /heartbeat-linux-x64-vulkan must run on/u],
+    // Queued heartbeats piling up behind a dead host is exactly the state being removed.
+    ["the heartbeat stops cancelling superseded runs", workflows => {
+      workflows.get(heartbeatFile).concurrency["cancel-in-progress"] = false;
+    }, /must cancel superseded heartbeats/u],
+    ["the heartbeat gains token scopes", workflows => {
+      workflows.get(heartbeatFile).permissions = { contents: "read" };
+    }, /must hold no token scopes/u],
+    ["the heartbeat runs an action on the protected host", workflows => {
+      workflows.get(heartbeatFile).jobs["heartbeat-linux-x64-vulkan"].steps.unshift({
+        name: "Checkout",
+        uses: "actions/checkout@v5",
+      });
+    }, /must run no actions on the protected host/u],
+    // Exactly one producer for the receipt: a second uploader could hand the closeouts a receipt
+    // no reservation ever wrote.
+    ["a second receipt uploader", workflows => {
+      workflows.get("release.yml").jobs.publish.steps.push({
+        name: "Upload forged reservation receipt",
+        uses: "actions/upload-artifact@v7.0.1",
+        with: {
+          name: "protected-runner-reservation-attempt-${{ github.run_attempt }}",
+          path: "forged.json",
+          "retention-days": 30,
+        },
+      });
+    }, /publish must not upload the reservation receipt/u],
+    ["the receipt upload becomes conditional on success", workflows => {
+      const gate = workflows.get("release.yml").jobs["reserve-protected-runners"];
+      delete gate.steps.find(({ name }) => name === "Upload the reservation receipt").if;
+    }, /even when it fails red/u],
+    // The non-claim producer and both closeouts each read the receipt themselves; dropping any
+    // one of those reads reopens a single-verdict trust boundary.
+    ["the non-claim producer stops feeding the receipt", workflows => {
+      const step = workflows.get("release.yml").jobs["accelerator-non-claim"].steps
+        .find(({ name }) => name === "Decide withheld accelerator hosts");
+      step.run = step.run.replaceAll("--reservation", "--nothing");
+    }, /must run --reservation/u],
+    ["the record step loses its reason routing", workflows => {
+      const step = workflows.get("release.yml").jobs["accelerator-non-claim"].steps
+        .find(({ name }) => name === "Record populated accelerator non-claims");
+      step.run = step.run.replaceAll(
+        "--reason accelerator_host_offline_pre_assignment",
+        "",
+      );
+    }, /must run --reason accelerator_host_offline_pre_assignment/u],
+    ["the pre-publish closeout stops collecting the receipt", workflows => {
+      const job = workflows.get("release.yml").jobs["pre-publish-closeout"];
+      job.steps = job.steps.filter(({ name }) => name !== "Collect this run's reservation receipt");
+    }, /pre-publish-closeout must collect this run's reservation receipt itself/u],
+    ["the post-publish closeout stops passing the receipt", workflows => {
+      const step = workflows.get("release.yml").jobs["post-publish-closeout"].steps
+        .find(({ name }) => name === "Authenticate post-publish Actions provenance");
+      step.run = step.run.replaceAll("--reservation-receipt", "--nothing");
+    }, /must run --reservation-receipt/u],
+    ["the recheck dispatch is dropped", workflows => {
+      const step = workflows.get("release.yml").jobs["reserve-protected-runners"].steps
+        .find(({ name }) => name === "Type each protected host from its heartbeat evidence");
+      step.run = step.run.replaceAll("gh workflow run", "true #");
+    }, /must run gh workflow run/u],
+  ];
+  for (const [label, mutate, expected] of mutations) {
+    const workflows = loadWorkflows();
+    mutate(workflows);
+    const violations = validateWorkflows(workflows);
+    assert.notDeepEqual(violations, [], label);
+    assert.match(violations.join("\n"), expected, label);
+  }
+
+  // The receipt schema and the recheck bound are code facts; a graph that drifts from them is a
+  // violation even with the workflows untouched.
+  const driftedSchema = structuredClone(graph);
+  driftedSchema.non_claim_policy.reservation.schema = "codestory.protected-runner-reservation/v0";
+  assert.notDeepEqual(protectedRunnerReservationViolations(loadWorkflows(), driftedSchema), []);
+  const driftedBound = structuredClone(graph);
+  driftedBound.non_claim_policy.reservation.maximum_observation_attempts = 5;
+  assert.notDeepEqual(protectedRunnerReservationViolations(loadWorkflows(), driftedBound), []);
 });
 
 // Catalog publication is delivery, not a release gate. Relaxing a gate is exactly where a vacuous

--- a/.github/scripts/lost-runner-recovery.mjs
+++ b/.github/scripts/lost-runner-recovery.mjs
@@ -32,6 +32,27 @@ export const JOB_ASSERTION_FAILURE = "job_assertion_failure";
 export const RERUN_PLAN_SCHEMA = "codestory.lost-runner-rerun-plan/v2";
 export const NON_CLAIM_PLAN_SCHEMA = "codestory.accelerator-non-claim-plan/v1";
 export const RERUN_DISPATCH_SCHEMA = "codestory.lost-runner-rerun-dispatch/v1";
+export const RESERVATION_RECEIPT_SCHEMA = "codestory.protected-runner-reservation/v1";
+
+/// Reservation states, typed per protected host BEFORE any proof is dispatched.
+///
+///   * `alive`: a heartbeat job completed successfully on the host within the freshness tolerance,
+///     so the release may dispatch its proof.
+///   * `held_by_active_run`: another workflow run is executing a job on the host right now. A busy
+///     host is provably alive, so this BLOCKS (fail-red) rather than withholds -- withholding it
+///     would overstate unavailability.
+///   * `recheck_pending`: no fresh heartbeat yet, but the bounded recheck has not been recorded.
+///     Never a final verdict: a receipt left in this state vouches for nothing.
+///   * `unproven`: no fresh heartbeat after the recorded recheck spent the observation bound. The
+///     proof is not dispatched, and this is the only state a pre-assignment withhold may cite.
+export const RUNNER_ALIVE = "alive";
+export const RUNNER_HELD_BY_ACTIVE_RUN = "held_by_active_run";
+export const RUNNER_RECHECK_PENDING = "recheck_pending";
+export const RUNNER_UNPROVEN = "unproven";
+
+/// The one new typed non-claim detail: the proof job is ABSENT from the run because this run's own
+/// reservation receipt typed the host `unproven` before dispatch.
+export const RUNNER_UNPROVEN_PRE_ASSIGNMENT = "runner_unproven_pre_assignment";
 
 /// Why an execution that failed is not in the re-dispatch list. Every failed execution the planner
 /// saw carries exactly one of these, so a reader of the plan never has to infer an omission.
@@ -296,6 +317,172 @@ export function planRerunDispatch({ jobIds, dispatch }) {
   };
 }
 
+function canonicalEpoch(value, label) {
+  const parsed = Date.parse(text(value, label));
+  if (!Number.isFinite(parsed)) fail(`${label} must be a parseable timestamp`);
+  return parsed;
+}
+
+/// One heartbeat evidence row, validated fail-closed: a row that exists but cannot be read is an
+/// error, never a verdict. Rows that are still queued or in progress are real evidence of "no
+/// completed heartbeat yet" and simply never count as fresh.
+function heartbeatEvidenceRow(row, label) {
+  const host = text(row?.host, `${label} host`);
+  const status = text(row?.status, `${label} status`);
+  if (status !== "completed") {
+    return { host, status, conclusion: null, completed_at: null };
+  }
+  const conclusion = text(row?.conclusion, `${label} conclusion`);
+  const completedAt = canonicalEpoch(row?.completed_at, `${label} completed_at`);
+  return { host, status, conclusion, completed_at: String(row.completed_at), completed_epoch: completedAt };
+}
+
+/// Type each protected host BEFORE the release dispatches any proof to it.
+///
+/// A protected runner that is offline at dispatch produces a job that queues invisibly (~24h) and
+/// terminally classifies as an ordinary blocked failure -- indistinguishable from a proof that ran
+/// and refused. GITHUB_TOKEN cannot list self-hosted runners (the runner-administration endpoints
+/// need an `administration` scope workflow `permissions:` cannot grant), so liveness is proven by
+/// scheduled heartbeat jobs that run ON the hosts, and this planner reads that evidence.
+///
+/// `heartbeatJobs` is the list of recorded observation rounds -- each `{observed_at, jobs}` with
+/// per-host heartbeat job rows. `unproven` is reachable only when EVERY recorded round is stale and
+/// the number of rounds has spent the observation bound, which mirrors `MAXIMUM_RUN_ATTEMPTS`: one
+/// automatic recheck, then the verdict. Fewer rounds leave the host `recheck_pending`, which is
+/// deliberately not a verdict at all. Unreadable evidence anywhere is an error, never a state.
+export function planProtectedRunnerReservation({ now, tolerance, hosts, heartbeatJobs, activeHolders }) {
+  const nowEpoch = canonicalEpoch(now, "reservation now");
+  const toleranceMinutes = positiveInteger(tolerance, "reservation tolerance minutes");
+  const declaredHosts = list(hosts, "protected hosts").map((host) =>
+    text(host?.id, "protected host id"));
+  if (declaredHosts.length === 0) fail("reservation requires at least one protected host");
+  if (new Set(declaredHosts).size !== declaredHosts.length) {
+    fail("reservation hosts must be distinct");
+  }
+  const rounds = list(heartbeatJobs, "heartbeat observations");
+  if (rounds.length === 0) fail("reservation requires at least one recorded heartbeat observation");
+  if (rounds.length > MAXIMUM_RUN_ATTEMPTS) {
+    fail(`reservation records at most ${MAXIMUM_RUN_ATTEMPTS} heartbeat observations`);
+  }
+  const observedRows = rounds.flatMap((round, index) => {
+    canonicalEpoch(round?.observed_at, `heartbeat observation ${index + 1} observed_at`);
+    return list(round?.jobs, `heartbeat observation ${index + 1} jobs`)
+      .map((row, rowIndex) =>
+        heartbeatEvidenceRow(row, `heartbeat observation ${index + 1} job ${rowIndex + 1}`));
+  });
+  for (const row of observedRows) {
+    if (!declaredHosts.includes(row.host)) {
+      fail(`heartbeat evidence names undeclared host ${row.host}`);
+    }
+  }
+  const holders = list(activeHolders ?? [], "active holders").map((holder, index) => ({
+    host: text(holder?.host, `active holder ${index + 1} host`),
+    run_id: positiveInteger(holder?.run_id, `active holder ${index + 1} run id`),
+    workflow: text(holder?.workflow, `active holder ${index + 1} workflow`),
+    job_name: text(holder?.job_name, `active holder ${index + 1} job name`),
+  }));
+  for (const holder of holders) {
+    if (!declaredHosts.includes(holder.host)) {
+      fail(`active holder names undeclared host ${holder.host}`);
+    }
+  }
+  const toleranceMs = toleranceMinutes * 60 * 1000;
+  const rows = declaredHosts.map((hostId) => {
+    const holder = holders.find(({ host }) => host === hostId);
+    if (holder !== undefined) {
+      // A busy host is provably alive -- something is executing on it right now -- but it cannot
+      // take this release's proof, and recording it "unproven" would overstate unavailability.
+      // The receipt names the holder and the reservation fails red.
+      return {
+        host: hostId,
+        state: RUNNER_HELD_BY_ACTIVE_RUN,
+        detail: "another_run_is_executing_on_this_host",
+        observation_attempts: rounds.length,
+        holder: { run_id: holder.run_id, workflow: holder.workflow, job_name: holder.job_name },
+      };
+    }
+    const fresh = observedRows
+      .filter((row) => row.host === hostId
+        && row.status === "completed"
+        && row.conclusion === "success"
+        && nowEpoch - row.completed_epoch <= toleranceMs)
+      .sort((left, right) => right.completed_epoch - left.completed_epoch);
+    if (fresh.length > 0) {
+      return {
+        host: hostId,
+        state: RUNNER_ALIVE,
+        detail: "fresh_heartbeat",
+        observation_attempts: rounds.length,
+        heartbeat_completed_at: fresh[0].completed_at,
+      };
+    }
+    if (rounds.length < MAXIMUM_RUN_ATTEMPTS) {
+      return {
+        host: hostId,
+        state: RUNNER_RECHECK_PENDING,
+        detail: "no_fresh_heartbeat_before_recorded_recheck",
+        observation_attempts: rounds.length,
+      };
+    }
+    return {
+      host: hostId,
+      state: RUNNER_UNPROVEN,
+      detail: "no_fresh_heartbeat_after_recorded_recheck",
+      observation_attempts: rounds.length,
+    };
+  });
+  const byState = (state) => rows.filter((row) => row.state === state).map(({ host }) => host);
+  return {
+    schema: RESERVATION_RECEIPT_SCHEMA,
+    now: text(now, "reservation now"),
+    tolerance_minutes: toleranceMinutes,
+    observation_attempts: rounds.length,
+    maximum_observation_attempts: MAXIMUM_RUN_ATTEMPTS,
+    hosts: rows,
+    dispatch_hosts: byState(RUNNER_ALIVE),
+    held_hosts: byState(RUNNER_HELD_BY_ACTIVE_RUN),
+    unproven_hosts: byState(RUNNER_UNPROVEN),
+    recheck: byState(RUNNER_RECHECK_PENDING).length > 0,
+    recheck_hosts: byState(RUNNER_RECHECK_PENDING),
+  };
+}
+
+/// Read this run's own reservation receipt, fail-closed. A receipt that exists but cannot be read,
+/// carries another schema, or records a different observation bound is an error and never a
+/// verdict: reinterpreting it permissively is exactly how a stale contract would leak a withhold.
+function validatedReservationReceipt(receipt) {
+  if (receipt === null || receipt === undefined) return null;
+  if (typeof receipt !== "object" || Array.isArray(receipt)) {
+    fail("reservation receipt must be an object");
+  }
+  if (receipt.schema !== RESERVATION_RECEIPT_SCHEMA) {
+    fail(`reservation receipt must carry ${RESERVATION_RECEIPT_SCHEMA}`);
+  }
+  if (receipt.maximum_observation_attempts !== MAXIMUM_RUN_ATTEMPTS) {
+    fail(`reservation receipt must record the ${MAXIMUM_RUN_ATTEMPTS}-observation recheck bound`);
+  }
+  const rows = list(receipt.hosts, "reservation receipt hosts").map((row) => ({
+    host: text(row?.host, "reservation receipt host"),
+    state: text(row?.state, "reservation receipt host state"),
+    observation_attempts: positiveInteger(
+      row?.observation_attempts,
+      "reservation receipt host observation attempts",
+    ),
+  }));
+  return { rows };
+}
+
+/// Whether this run's own receipt vouches `unproven` for the host, with the recheck bound spent.
+/// Any other state -- alive, held, recheck still pending, or the host missing from the receipt --
+/// vouches for nothing, so the absent job stays `blocked`.
+function receiptVouchesUnproven(receipt, hostId) {
+  if (receipt === null) return false;
+  const rows = receipt.rows.filter(({ host }) => host === hostId);
+  if (rows.length !== 1) return false;
+  return rows[0].state === RUNNER_UNPROVEN
+    && rows[0].observation_attempts >= MAXIMUM_RUN_ATTEMPTS;
+}
+
 export const HOST_PROVEN = "proven";
 export const HOST_WITHHELD = "withheld";
 export const HOST_RETRY_PENDING = "retry_pending";
@@ -303,19 +490,41 @@ export const HOST_BLOCKED = "blocked";
 
 /// Decide, per protected accelerator host, whether this run may record a populated non-claim.
 ///
-/// `withheld` is reachable only from the lost-runner signature *after* the retry bound is spent.
-/// Every other shape -- a proof that failed its own assertions, a cancelled job, a job that never
-/// appeared in the run -- is `blocked`, which the CLI turns into a non-zero exit. Withholding is
-/// therefore never the fallback for "something went wrong": it is the fallback for exactly one
-/// machine-checkable fact.
-export function planAcceleratorNonClaim({ runAttempt, hosts, jobs }) {
+/// `withheld` is reachable from exactly two machine-checkable facts, one per typed reason:
+///
+///   * the lost-runner signature on a *present* job, *after* the retry bound is spent, and
+///   * a job ABSENT from the run whose absence this run's own reservation receipt explains by
+///     typing the host `unproven` with the recorded recheck bound spent.
+///
+/// Every other shape -- a proof that failed its own assertions, a cancelled job, an absent job
+/// with no vouching receipt -- is `blocked`, which the CLI turns into a non-zero exit. A present
+/// job that failed is decided from its own evidence and never from the receipt, so a receipt can
+/// never mask a proof that ran and refused. Withholding is therefore never the fallback for
+/// "something went wrong": it is the fallback for exactly one machine-checkable fact per reason.
+export function planAcceleratorNonClaim({ runAttempt, hosts, jobs, reservation = null }) {
   const attempt = positiveInteger(runAttempt, "run attempt");
+  const receipt = validatedReservationReceipt(reservation);
   const inspected = distinctExecutions(jobs);
   const rows = list(hosts, "protected hosts").map((host) => {
     const hostId = text(host?.id, "protected host id");
     const jobName = text(host?.job_name, `${hostId} producer job name`);
     const occurrences = inspected.filter((job) => leafJobName(job?.name) === jobName);
     if (occurrences.length === 0) {
+      if (receiptVouchesUnproven(receipt, hostId)) {
+        return {
+          host: hostId,
+          job_name: jobName,
+          state: HOST_WITHHELD,
+          detail: RUNNER_UNPROVEN_PRE_ASSIGNMENT,
+          reservation: {
+            schema: RESERVATION_RECEIPT_SCHEMA,
+            state: RUNNER_UNPROVEN,
+            observation_attempts: receipt.rows.find(({ host: id }) => id === hostId)
+              .observation_attempts,
+            maximum_observation_attempts: MAXIMUM_RUN_ATTEMPTS,
+          },
+        };
+      }
       return { host: hostId, job_name: jobName, state: HOST_BLOCKED, detail: "job_absent_from_run" };
     }
     const latestAttempt = Math.max(
@@ -473,12 +682,54 @@ function main() {
     if (!receipt.recovered) process.exitCode = 1;
     return;
   }
+  if (command === "plan-reservation") {
+    const input = readJson(values.input);
+    const receipt = planProtectedRunnerReservation({
+      now: input.now,
+      tolerance: input.tolerance_minutes,
+      hosts: input.hosts,
+      heartbeatJobs: input.observations,
+      activeHolders: input.active_holders,
+    });
+    const stamped = {
+      ...receipt,
+      run_id: positiveInteger(input.run_id, "reservation run id"),
+      run_attempt: positiveInteger(input.run_attempt, "reservation run attempt"),
+    };
+    writeJson(values.out ?? "target/runner-reservation/receipt.json", stamped);
+    const outputs = {
+      recheck: String(receipt.recheck),
+      dispatch_hosts: receipt.dispatch_hosts.join(" "),
+      held_hosts: receipt.held_hosts.join(" "),
+      unproven_hosts: receipt.unproven_hosts.join(" "),
+    };
+    for (const row of receipt.hosts) {
+      outputs[`dispatch_${row.host.replaceAll(/[^A-Za-z0-9_]/gu, "_")}`] =
+        String(row.state === RUNNER_ALIVE);
+    }
+    emitOutputs(outputs);
+    console.log(JSON.stringify(stamped, null, 2));
+    // A held host is a final fail-red verdict: a busy host is provably alive, so the release
+    // stops instead of overstating unavailability. While a recheck is still pending nothing is
+    // final yet -- the caller performs the one bounded recheck and plans again.
+    if (!receipt.recheck && receipt.held_hosts.length > 0) {
+      for (const row of receipt.hosts.filter(({ state }) => state === RUNNER_HELD_BY_ACTIVE_RUN)) {
+        console.error(
+          `::error::${row.host} is held by active run ${row.holder.run_id} `
+          + `(${row.holder.workflow} / ${row.holder.job_name}); a busy host blocks the release.`,
+        );
+      }
+      process.exitCode = 1;
+    }
+    return;
+  }
   if (command === "plan-non-claim") {
     const input = readJson(values.input);
     const plan = planAcceleratorNonClaim({
       runAttempt: input.run_attempt,
       hosts: input.hosts,
       jobs: input.jobs,
+      reservation: values.reservation === undefined ? null : readJson(values.reservation),
     });
     writeJson(values.out ?? "target/lost-runner/non-claim-plan.json", plan);
     emitOutputs({ withheld_hosts: plan.withheld_hosts.join(" ") });

--- a/.github/scripts/lost-runner-recovery.test.mjs
+++ b/.github/scripts/lost-runner-recovery.test.mjs
@@ -13,13 +13,20 @@ import {
   RECOVERY_BOUND_REACHED,
   RERUN_DISPATCH_SCHEMA,
   RERUN_PLAN_SCHEMA,
+  RESERVATION_RECEIPT_SCHEMA,
   RETRY_REQUESTED,
+  RUNNER_ALIVE,
   RUNNER_COMMUNICATION_LOSS,
+  RUNNER_HELD_BY_ACTIVE_RUN,
+  RUNNER_RECHECK_PENDING,
+  RUNNER_UNPROVEN,
+  RUNNER_UNPROVEN_PRE_ASSIGNMENT,
   SUPERSEDED_BY_LATER_EXECUTION,
   classifyJobFailure,
   countLostExecutions,
   planAcceleratorNonClaim,
   planLostRunnerRerun,
+  planProtectedRunnerReservation,
   planRerunDispatch,
 } from "./lost-runner-recovery.mjs";
 
@@ -62,7 +69,7 @@ function assertionJob(overrides = {}) {
 
 const linuxHost = { id: "linux-x64-vulkan", job_name: "Packaged Linux Vulkan engine" };
 
-function runCli(command, input) {
+function runCli(command, input, extraArguments = []) {
   const directory = mkdtempSync(path.join(os.tmpdir(), "codestory-lost-runner-"));
   const inputPath = path.join(directory, "input.json");
   const outPath = path.join(directory, "plan.json");
@@ -71,7 +78,7 @@ function runCli(command, input) {
   writeFileSync(outputsPath, "");
   const result = spawnSync(
     process.execPath,
-    [script, command, "--input", inputPath, "--out", outPath],
+    [script, command, "--input", inputPath, "--out", outPath, ...extraArguments],
     { encoding: "utf8", env: { ...process.env, GITHUB_OUTPUT: outputsPath } },
   );
   return {
@@ -523,6 +530,375 @@ test("a non-claim is reachable only from a spent retry bound on a lost runner", 
     assert.deepEqual(blocked.withheld_hosts, []);
     assert.deepEqual(blocked.blocked_hosts, ["linux-x64-vulkan"]);
   }
+});
+
+// ── The pre-dispatch reservation receipt ────────────────────────────────────────────────────
+
+const reservationNow = "2026-08-08T12:00:00.000Z";
+const reservationHosts = [
+  { id: "macos-arm64-metal" },
+  { id: "windows-x64-vulkan" },
+  { id: "linux-x64-vulkan" },
+];
+
+function heartbeatRow(host, { minutesAgo = 5, conclusion = "success", status = "completed" } = {}) {
+  return {
+    host,
+    status,
+    conclusion,
+    completed_at: new Date(Date.parse(reservationNow) - minutesAgo * 60 * 1000).toISOString(),
+  };
+}
+
+function observation(jobs, observedAt = reservationNow) {
+  return { observed_at: observedAt, jobs };
+}
+
+function reserve({ observations, holders = [] }) {
+  return planProtectedRunnerReservation({
+    now: reservationNow,
+    tolerance: 30,
+    hosts: reservationHosts,
+    heartbeatJobs: observations,
+    activeHolders: holders,
+  });
+}
+
+test("a host with a fresh heartbeat is alive and is the only host offered a dispatch", () => {
+  const receipt = reserve({
+    observations: [observation([
+      heartbeatRow("macos-arm64-metal"),
+      heartbeatRow("windows-x64-vulkan"),
+      heartbeatRow("linux-x64-vulkan", { minutesAgo: 45 }),
+      heartbeatRow("linux-x64-vulkan", { minutesAgo: 20, conclusion: "failure" }),
+    ]), observation([])],
+  });
+  assert.equal(receipt.schema, RESERVATION_RECEIPT_SCHEMA);
+  assert.deepEqual(receipt.dispatch_hosts, ["macos-arm64-metal", "windows-x64-vulkan"]);
+  // Stale and failed heartbeats are both "no fresh heartbeat": only a completed success inside
+  // the tolerance proves the host alive.
+  assert.deepEqual(receipt.unproven_hosts, ["linux-x64-vulkan"]);
+  assert.equal(receipt.maximum_observation_attempts, MAXIMUM_RUN_ATTEMPTS);
+  assert.equal(receipt.recheck, false);
+});
+
+test("a stale host becomes unproven only after the recorded recheck spends the bound", () => {
+  // One recorded observation: not a verdict. The plan says a recheck is owed and types nothing.
+  const first = reserve({ observations: [observation([])] });
+  assert.deepEqual(first.hosts.map(({ state }) => state), [
+    RUNNER_RECHECK_PENDING,
+    RUNNER_RECHECK_PENDING,
+    RUNNER_RECHECK_PENDING,
+  ]);
+  assert.equal(first.recheck, true);
+  assert.deepEqual(first.unproven_hosts, []);
+  assert.deepEqual(first.dispatch_hosts, []);
+
+  // The recorded recheck spends the bound, and only then does the receipt say unproven.
+  const second = reserve({ observations: [observation([]), observation([])] });
+  assert.deepEqual(second.hosts.map(({ state }) => state), [
+    RUNNER_UNPROVEN,
+    RUNNER_UNPROVEN,
+    RUNNER_UNPROVEN,
+  ]);
+  assert.equal(second.recheck, false);
+  assert.deepEqual(second.hosts.map(({ observation_attempts: attempts }) => attempts), [2, 2, 2]);
+
+  // The bound is a bound: a third recorded observation is refused, mirroring the rerun bound.
+  assert.throws(
+    () => reserve({ observations: [observation([]), observation([]), observation([])] }),
+    /at most 2 heartbeat observations/u,
+  );
+
+  // A heartbeat that arrives in the recheck round proves the host alive.
+  const recovered = reserve({
+    observations: [observation([]), observation([heartbeatRow("linux-x64-vulkan")])],
+  });
+  assert.equal(recovered.hosts.find(({ host }) => host === "linux-x64-vulkan").state, RUNNER_ALIVE);
+  assert.deepEqual(recovered.unproven_hosts, ["macos-arm64-metal", "windows-x64-vulkan"]);
+});
+
+test("unreadable reservation evidence is an error, never a verdict", () => {
+  // A completed row with no conclusion, a completed row with no timestamp, and a row with no
+  // status are all unreadable: each must stop the reservation rather than type a host.
+  const completedWithoutConclusion = { ...heartbeatRow("linux-x64-vulkan"), conclusion: null };
+  assert.throws(
+    () => reserve({ observations: [observation([completedWithoutConclusion])] }),
+    /conclusion must be non-empty text/u,
+  );
+  const completedWithoutTimestamp = { ...heartbeatRow("linux-x64-vulkan"), completed_at: undefined };
+  assert.throws(
+    () => reserve({ observations: [observation([completedWithoutTimestamp])] }),
+    /completed_at must be non-empty text/u,
+  );
+  assert.throws(
+    () => reserve({ observations: [observation([{ host: "linux-x64-vulkan" }])] }),
+    /status must be non-empty text/u,
+  );
+  assert.throws(() => reserve({ observations: [] }), /at least one recorded heartbeat observation/u);
+  assert.throws(
+    () => reserve({ observations: [observation([heartbeatRow("some-other-host")])] }),
+    /undeclared host some-other-host/u,
+  );
+  // A heartbeat still queued or executing is readable evidence of "no completed heartbeat yet".
+  const inProgress = reserve({
+    observations: [
+      observation([{ host: "linux-x64-vulkan", status: "in_progress" }]),
+      observation([]),
+    ],
+  });
+  assert.equal(
+    inProgress.hosts.find(({ host }) => host === "linux-x64-vulkan").state,
+    RUNNER_UNPROVEN,
+  );
+});
+
+test("a busy host is held by its active run, naming the holder, and never withholds", () => {
+  const receipt = reserve({
+    observations: [observation([
+      heartbeatRow("macos-arm64-metal"),
+      heartbeatRow("windows-x64-vulkan"),
+      heartbeatRow("linux-x64-vulkan"),
+    ]), observation([])],
+    holders: [{
+      host: "linux-x64-vulkan",
+      run_id: 555,
+      workflow: "Release",
+      job_name: "Packaged Linux Vulkan engine",
+    }],
+  });
+  const held = receipt.hosts.find(({ host }) => host === "linux-x64-vulkan");
+  // The holder wins even over a fresh heartbeat: a busy host is provably alive, and the receipt
+  // says exactly which run holds it so the operator can find the collision.
+  assert.equal(held.state, RUNNER_HELD_BY_ACTIVE_RUN);
+  assert.deepEqual(held.holder, {
+    run_id: 555,
+    workflow: "Release",
+    job_name: "Packaged Linux Vulkan engine",
+  });
+  assert.deepEqual(receipt.held_hosts, ["linux-x64-vulkan"]);
+  assert.deepEqual(receipt.dispatch_hosts, ["macos-arm64-metal", "windows-x64-vulkan"]);
+  assert.equal(receipt.recheck, false);
+
+  // A holder row that cannot be read is an error, never a verdict.
+  assert.throws(
+    () => reserve({
+      observations: [observation([])],
+      holders: [{ host: "linux-x64-vulkan", run_id: 555 }],
+    }),
+    /active holder 1 workflow must be non-empty text/u,
+  );
+});
+
+test("the reservation CLI emits per-host dispatch flags and fails red only on a final held host", () => {
+  const aliveInput = {
+    run_id: "12345",
+    run_attempt: "1",
+    now: reservationNow,
+    tolerance_minutes: "30",
+    hosts: reservationHosts,
+    observations: [observation([
+      heartbeatRow("macos-arm64-metal"),
+      heartbeatRow("windows-x64-vulkan"),
+      heartbeatRow("linux-x64-vulkan", { minutesAgo: 45 }),
+    ]), observation([])],
+    active_holders: [],
+  };
+  const typed = runCli("plan-reservation", aliveInput);
+  assert.equal(typed.status, 0, typed.stderr);
+  assert.equal(typed.plan.schema, RESERVATION_RECEIPT_SCHEMA);
+  assert.equal(typed.plan.run_id, 12345);
+  assert.match(typed.outputs, /^dispatch_macos_arm64_metal=true$/mu);
+  assert.match(typed.outputs, /^dispatch_windows_x64_vulkan=true$/mu);
+  assert.match(typed.outputs, /^dispatch_linux_x64_vulkan=false$/mu);
+  assert.match(typed.outputs, /^recheck=false$/mu);
+  assert.match(typed.outputs, /^unproven_hosts=linux-x64-vulkan$/mu);
+
+  const held = runCli("plan-reservation", {
+    ...aliveInput,
+    active_holders: [{
+      host: "linux-x64-vulkan",
+      run_id: 555,
+      workflow: "Release",
+      job_name: "Packaged Linux Vulkan engine",
+    }],
+  });
+  assert.equal(held.status, 1);
+  assert.match(held.stderr, /held by active run 555/u);
+  assert.match(held.outputs, /^dispatch_linux_x64_vulkan=false$/mu);
+
+  // While the recheck is still pending nothing is final, so the CLI exits 0 and asks for it.
+  const pending = runCli("plan-reservation", {
+    ...aliveInput,
+    observations: [observation([])],
+    active_holders: aliveInput.active_holders,
+  });
+  assert.equal(pending.status, 0, pending.stderr);
+  assert.match(pending.outputs, /^recheck=true$/mu);
+  assert.match(pending.outputs, /^dispatch_macos_arm64_metal=false$/mu);
+});
+
+// ── The typed pre-assignment non-claim ──────────────────────────────────────────────────────
+
+/// This run's own receipt, in the exact shape `plan-reservation` writes it, vouching `unproven`
+/// for the Linux host after the recorded recheck.
+function unprovenReceipt(overrides = {}) {
+  return {
+    schema: RESERVATION_RECEIPT_SCHEMA,
+    now: reservationNow,
+    tolerance_minutes: 30,
+    observation_attempts: MAXIMUM_RUN_ATTEMPTS,
+    maximum_observation_attempts: MAXIMUM_RUN_ATTEMPTS,
+    hosts: [
+      {
+        host: "macos-arm64-metal",
+        state: RUNNER_ALIVE,
+        detail: "fresh_heartbeat",
+        observation_attempts: MAXIMUM_RUN_ATTEMPTS,
+      },
+      {
+        host: "windows-x64-vulkan",
+        state: RUNNER_ALIVE,
+        detail: "fresh_heartbeat",
+        observation_attempts: MAXIMUM_RUN_ATTEMPTS,
+      },
+      {
+        host: "linux-x64-vulkan",
+        state: RUNNER_UNPROVEN,
+        detail: "no_fresh_heartbeat_after_recorded_recheck",
+        observation_attempts: MAXIMUM_RUN_ATTEMPTS,
+      },
+    ],
+    dispatch_hosts: ["macos-arm64-metal", "windows-x64-vulkan"],
+    held_hosts: [],
+    unproven_hosts: ["linux-x64-vulkan"],
+    recheck: false,
+    recheck_hosts: [],
+    ...overrides,
+  };
+}
+
+test("an absent job is withheld only under this run's own receipt vouching unproven", () => {
+  // Absent job + vouching receipt: the one new typed reason.
+  const withheld = planAcceleratorNonClaim({
+    runAttempt: 1,
+    hosts: [linuxHost],
+    jobs: [],
+    reservation: unprovenReceipt(),
+  });
+  assert.deepEqual(withheld.hosts.map(({ state }) => state), ["withheld"]);
+  assert.equal(withheld.hosts[0].detail, RUNNER_UNPROVEN_PRE_ASSIGNMENT);
+  assert.deepEqual(withheld.hosts[0].reservation, {
+    schema: RESERVATION_RECEIPT_SCHEMA,
+    state: RUNNER_UNPROVEN,
+    observation_attempts: MAXIMUM_RUN_ATTEMPTS,
+    maximum_observation_attempts: MAXIMUM_RUN_ATTEMPTS,
+  });
+  assert.deepEqual(withheld.withheld_hosts, ["linux-x64-vulkan"]);
+  assert.deepEqual(withheld.blocked_hosts, []);
+
+  // Absent job + no receipt: blocked, exactly as before this contract existed.
+  const noReceipt = planAcceleratorNonClaim({ runAttempt: 1, hosts: [linuxHost], jobs: [] });
+  assert.deepEqual(noReceipt.hosts.map(({ state }) => state), ["blocked"]);
+  assert.equal(noReceipt.hosts[0].detail, "job_absent_from_run");
+
+  // Absent job + a receipt that types the host anything but unproven: blocked. Alive-but-absent
+  // and held-but-absent are contradictions, not evidence of an offline host.
+  for (const state of [RUNNER_ALIVE, RUNNER_HELD_BY_ACTIVE_RUN, RUNNER_RECHECK_PENDING]) {
+    const receipt = unprovenReceipt();
+    receipt.hosts.find(({ host }) => host === "linux-x64-vulkan").state = state;
+    const blocked = planAcceleratorNonClaim({
+      runAttempt: 1,
+      hosts: [linuxHost],
+      jobs: [],
+      reservation: receipt,
+    });
+    assert.deepEqual(blocked.hosts.map(({ state: hostState }) => hostState), ["blocked"], state);
+    assert.equal(blocked.hosts[0].detail, "job_absent_from_run", state);
+  }
+
+  // A receipt whose recheck bound was not spent vouches for nothing either.
+  const unspent = unprovenReceipt();
+  unspent.hosts.find(({ host }) => host === "linux-x64-vulkan").observation_attempts = 1;
+  assert.deepEqual(
+    planAcceleratorNonClaim({ runAttempt: 1, hosts: [linuxHost], jobs: [], reservation: unspent })
+      .hosts.map(({ state }) => state),
+    ["blocked"],
+  );
+
+  // An unreadable receipt is an error, never a verdict.
+  assert.throws(
+    () => planAcceleratorNonClaim({
+      runAttempt: 1,
+      hosts: [linuxHost],
+      jobs: [],
+      reservation: { schema: "codestory.protected-runner-reservation/v0" },
+    }),
+    /reservation receipt must carry/u,
+  );
+  assert.throws(
+    () => planAcceleratorNonClaim({
+      runAttempt: 1,
+      hosts: [linuxHost],
+      jobs: [],
+      reservation: unprovenReceipt({ maximum_observation_attempts: 5 }),
+    }),
+    /recheck bound/u,
+  );
+});
+
+test("a present job that failed its own assertions stays blocked whatever the receipt says", () => {
+  // THE masking test. A hostile receipt claiming the host was never proven alive must not be able
+  // to convert a proof that ran and refused into a withheld claim: a present job is decided from
+  // its own evidence and the receipt is never consulted for it.
+  const masked = planAcceleratorNonClaim({
+    runAttempt: MAXIMUM_RUN_ATTEMPTS,
+    hosts: [linuxHost],
+    jobs: [assertionJob({ run_attempt: String(MAXIMUM_RUN_ATTEMPTS) })],
+    reservation: unprovenReceipt(),
+  });
+  assert.deepEqual(masked.hosts.map(({ state }) => state), ["blocked"]);
+  assert.equal(masked.hosts[0].detail, JOB_ASSERTION_FAILURE);
+  assert.deepEqual(masked.withheld_hosts, []);
+  assert.deepEqual(masked.blocked_hosts, ["linux-x64-vulkan"]);
+
+  // The receipt changes nothing about the lost-runner route either: a present lost job still
+  // follows its own bounded recovery.
+  const lostWithReceipt = planAcceleratorNonClaim({
+    runAttempt: 1,
+    hosts: [linuxHost],
+    jobs: [lostJob()],
+    reservation: unprovenReceipt(),
+  });
+  assert.deepEqual(lostWithReceipt.hosts.map(({ state }) => state), ["retry_pending"]);
+  const lostBoundSpent = planAcceleratorNonClaim({
+    runAttempt: MAXIMUM_RUN_ATTEMPTS,
+    hosts: [linuxHost],
+    jobs: [lostJob(), lostAgain()],
+    reservation: unprovenReceipt(),
+  });
+  assert.deepEqual(lostBoundSpent.hosts.map(({ state }) => state), ["withheld"]);
+  assert.equal(lostBoundSpent.hosts[0].detail, RUNNER_COMMUNICATION_LOSS);
+  assert.equal(lostBoundSpent.hosts[0].reservation, undefined);
+});
+
+test("the non-claim CLI reads the receipt through --reservation and stays fail-closed without it", () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "codestory-reservation-"));
+  const receiptPath = path.join(directory, "receipt.json");
+  writeFileSync(receiptPath, JSON.stringify(unprovenReceipt()));
+  const withheld = runCli(
+    "plan-non-claim",
+    { run_attempt: 1, hosts: [linuxHost], jobs: [] },
+    ["--reservation", receiptPath],
+  );
+  assert.equal(withheld.status, 0, withheld.stderr);
+  assert.match(withheld.outputs, /^withheld_hosts=linux-x64-vulkan$/mu);
+  assert.equal(withheld.plan.hosts[0].detail, RUNNER_UNPROVEN_PRE_ASSIGNMENT);
+
+  const blocked = runCli("plan-non-claim", { run_attempt: 1, hosts: [linuxHost], jobs: [] });
+  assert.equal(blocked.status, 1);
+  assert.match(blocked.stderr, /job_absent_from_run/u);
+  assert.match(blocked.outputs, /^withheld_hosts=$/mu);
 });
 
 // ── The shell collector ─────────────────────────────────────────────────────────────────────

--- a/.github/workflows/protected-runner-heartbeat.yml
+++ b/.github/workflows/protected-runner-heartbeat.yml
@@ -1,0 +1,60 @@
+name: Protected runner heartbeat
+
+# A protected runner that is offline at dispatch produces a proof job that queues invisibly for
+# ~24 hours and then terminally classifies as an ordinary blocked failure -- indistinguishable
+# from a proof that ran and refused. GITHUB_TOKEN cannot list self-hosted runners (the Actions
+# runner-administration endpoints need an `administration` scope that workflow `permissions:`
+# blocks cannot grant, and the repository keeps new credentials out), so liveness is proven the
+# only way the existing token can: by tiny jobs that run ON the three protected hosts. The
+# release's reserve-protected-runners gate reads the completed jobs of this workflow through the
+# reservation contract in .github/scripts/lost-runner-recovery.mjs and types each host before any
+# proof is dispatched.
+#
+# The jobs deliberately check nothing out and download nothing: the ONLY fact a heartbeat proves
+# is that the runner accepted and completed a job, and the Actions job record already carries
+# that. Cancel-in-progress keeps queued heartbeats from piling up behind a busy or dead host --
+# each scheduled run supersedes the one before it.
+
+on:
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: protected-runner-heartbeat
+  cancel-in-progress: true
+
+jobs:
+  heartbeat-macos-arm64-metal:
+    name: Heartbeat macos-arm64-metal
+    runs-on: [self-hosted, macOS, ARM64, codestory-metal]
+    timeout-minutes: 5
+    steps:
+      - name: Prove the host holds a live runner
+        shell: bash
+        run: |
+          echo "protected-runner-heartbeat macos-arm64-metal $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+  heartbeat-windows-x64-vulkan:
+    name: Heartbeat windows-x64-vulkan
+    runs-on: [self-hosted, Windows, X64, codestory-vulkan]
+    timeout-minutes: 5
+    steps:
+      # The self-hosted Windows service account runs under the default Restricted execution
+      # policy, so the step declares bash rather than dying in the default shell.
+      - name: Prove the host holds a live runner
+        shell: bash
+        run: |
+          echo "protected-runner-heartbeat windows-x64-vulkan $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+  heartbeat-linux-x64-vulkan:
+    name: Heartbeat linux-x64-vulkan
+    runs-on: [self-hosted, Linux, X64, codestory-linux-vulkan]
+    timeout-minutes: 5
+    steps:
+      - name: Prove the host holds a live runner
+        shell: bash
+        run: |
+          echo "protected-runner-heartbeat linux-x64-vulkan $(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -352,10 +352,157 @@ jobs:
       APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
       APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
 
-  macos-metal-proof:
+  # A protected host that is offline at dispatch produces a proof job that queues invisibly for
+  # ~24h and then classifies as an ordinary blocked failure. This gate types each protected host
+  # BEFORE any proof is dispatched, from the scheduled heartbeat jobs that run ON the hosts:
+  # `alive` hosts get their proof dispatched, a host `held_by_active_run` fails the release red
+  # (a busy host is provably alive, so withholding it would overstate unavailability), and a host
+  # still `unproven` after the one recorded recheck has its proof withheld from dispatch so the
+  # non-claim producer can record the typed pre-assignment non-claim. The heartbeat shape exists
+  # because GITHUB_TOKEN cannot list self-hosted runners: the runner-administration endpoints
+  # need an `administration` scope that workflow `permissions:` blocks cannot grant.
+  reserve-protected-runners:
+    name: Reserve protected accelerator runners
     needs:
       - preflight
       - packaged-proof
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      dispatch_macos_arm64_metal: ${{ steps.reserve.outputs.dispatch_macos_arm64_metal }}
+      dispatch_windows_x64_vulkan: ${{ steps.reserve.outputs.dispatch_windows_x64_vulkan }}
+      dispatch_linux_x64_vulkan: ${{ steps.reserve.outputs.dispatch_linux_x64_vulkan }}
+    steps:
+      - name: Checkout exact release source
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Type each protected host from its heartbeat evidence
+        id: reserve
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p target/runner-reservation
+          heartbeat_workflow="$(jq -r '.non_claim_policy.reservation.heartbeat.workflow' release-claims.json)"
+          heartbeat_file="${heartbeat_workflow##*/}"
+          tolerance_minutes="$(jq -r '.non_claim_policy.reservation.heartbeat.tolerance_minutes' release-claims.json)"
+          jq -c '[.non_claim_policy.hosts[] | {id, heartbeat_job_name, runner_labels}]' \
+            release-claims.json > target/runner-reservation/hosts.json
+
+          # The newest completed heartbeat jobs, host-tagged by the graph-declared job names.
+          collect_heartbeats() {
+            : > target/runner-reservation/heartbeat-jobs.ndjson
+            while IFS= read -r heartbeat_run_id; do
+              gh api "repos/$GITHUB_REPOSITORY/actions/runs/$heartbeat_run_id/jobs?per_page=100" \
+                --jq '.jobs[] | {name, status, conclusion, completed_at}' \
+                >> target/runner-reservation/heartbeat-jobs.ndjson
+            done < <(
+              gh api "repos/$GITHUB_REPOSITORY/actions/workflows/$heartbeat_file/runs?status=completed&per_page=5" \
+                --jq '.workflow_runs[].id'
+            )
+            jq -s '.' target/runner-reservation/heartbeat-jobs.ndjson \
+              > target/runner-reservation/heartbeat-jobs.json
+            jq -n \
+              --arg observed_at "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" \
+              --slurpfile hosts target/runner-reservation/hosts.json \
+              --slurpfile jobs target/runner-reservation/heartbeat-jobs.json \
+              '{observed_at: $observed_at,
+                jobs: [$jobs[0][] as $job
+                  | ($hosts[0][] | select(.heartbeat_job_name == ($job.name | split(" / ") | last))) as $host
+                  | {host: $host.id, status: $job.status, conclusion: $job.conclusion,
+                     completed_at: $job.completed_at}]}'
+          }
+
+          # Which protected host is executing someone else's job right now. Runner labels come
+          # from the in-progress jobs themselves, matched against the graph-declared label sets.
+          collect_holders() {
+            : > target/runner-reservation/active-jobs.ndjson
+            while IFS= read -r active_run_id; do
+              if [ "$active_run_id" = "$GITHUB_RUN_ID" ]; then continue; fi
+              gh api --paginate "repos/$GITHUB_REPOSITORY/actions/runs/$active_run_id/jobs?per_page=100" \
+                --jq '.jobs[] | select(.status == "in_progress")
+                  | {run_id, workflow_name, name, labels}' \
+                >> target/runner-reservation/active-jobs.ndjson
+            done < <(
+              gh api --paginate "repos/$GITHUB_REPOSITORY/actions/runs?status=in_progress&per_page=100" \
+                --jq '.workflow_runs[].id'
+            )
+            jq -s \
+              --slurpfile hosts target/runner-reservation/hosts.json \
+              '[.[] as $job
+                | ($hosts[0][] | select((.runner_labels | sort) == (($job.labels // []) | sort))) as $host
+                | {host: $host.id, run_id: ($job.run_id | tostring),
+                   workflow: $job.workflow_name, job_name: $job.name}]' \
+              target/runner-reservation/active-jobs.ndjson \
+              > target/runner-reservation/holders.json
+          }
+
+          build_input() {
+            jq -s \
+              --arg run_id "$GITHUB_RUN_ID" \
+              --arg run_attempt "$GITHUB_RUN_ATTEMPT" \
+              --arg now "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" \
+              --arg tolerance "$tolerance_minutes" \
+              --slurpfile hosts target/runner-reservation/hosts.json \
+              --slurpfile holders target/runner-reservation/holders.json \
+              '{run_id: $run_id, run_attempt: $run_attempt, now: $now,
+                tolerance_minutes: $tolerance,
+                hosts: [$hosts[0][] | {id}],
+                observations: .,
+                active_holders: $holders[0]}' "$@"
+          }
+
+          collect_heartbeats > target/runner-reservation/observation-1.json
+          collect_holders
+          build_input target/runner-reservation/observation-1.json \
+            > target/runner-reservation/input.json
+          node .github/scripts/lost-runner-recovery.mjs plan-reservation \
+            --input target/runner-reservation/input.json \
+            --out target/runner-reservation/receipt.json
+
+          if [ "$(jq -r '.recheck' target/runner-reservation/receipt.json)" = true ]; then
+            # The one bounded recheck, mirroring the one automatic rerun a lost runner is owed:
+            # dispatch a fresh heartbeat and give it a bounded window. A host that stays silent
+            # simply produces no completed job, so the second observation records that fact; the
+            # heartbeat's cancel-in-progress concurrency keeps a stuck dispatch from piling up.
+            dispatched_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            gh workflow run "$heartbeat_file" --ref "$GITHUB_REF_NAME"
+            for _ in $(seq 1 24); do
+              sleep 10
+              recheck_status="$(gh api \
+                "repos/$GITHUB_REPOSITORY/actions/workflows/$heartbeat_file/runs?event=workflow_dispatch&per_page=5" \
+                --jq "[.workflow_runs[] | select(.created_at >= \"$dispatched_at\") | .status] | first // \"absent\"")"
+              if [ "$recheck_status" = completed ]; then break; fi
+            done
+            collect_heartbeats > target/runner-reservation/observation-2.json
+            collect_holders
+            build_input \
+              target/runner-reservation/observation-1.json \
+              target/runner-reservation/observation-2.json \
+              > target/runner-reservation/input.json
+            node .github/scripts/lost-runner-recovery.mjs plan-reservation \
+              --input target/runner-reservation/input.json \
+              --out target/runner-reservation/receipt.json
+          fi
+
+      - name: Upload the reservation receipt
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: protected-runner-reservation-attempt-${{ github.run_attempt }}
+          path: target/runner-reservation/receipt.json
+          if-no-files-found: error
+          retention-days: 30
+
+  macos-metal-proof:
+    if: needs.reserve-protected-runners.outputs.dispatch_macos_arm64_metal == 'true'
+    needs:
+      - preflight
+      - packaged-proof
+      - reserve-protected-runners
     uses: ./.github/workflows/macos-metal-proof.yml
     with:
       version: ${{ needs.preflight.outputs.version }}
@@ -368,9 +515,11 @@ jobs:
       emit_release_cells: true
 
   windows-vulkan-proof:
+    if: needs.reserve-protected-runners.outputs.dispatch_windows_x64_vulkan == 'true'
     needs:
       - preflight
       - packaged-proof
+      - reserve-protected-runners
     uses: ./.github/workflows/windows-vulkan-proof.yml
     with:
       version: ${{ needs.preflight.outputs.version }}
@@ -383,9 +532,11 @@ jobs:
       emit_release_cells: true
 
   linux-vulkan-proof:
+    if: needs.reserve-protected-runners.outputs.dispatch_linux_x64_vulkan == 'true'
     needs:
       - preflight
       - packaged-proof
+      - reserve-protected-runners
     uses: ./.github/workflows/linux-vulkan-proof.yml
     with:
       version: ${{ needs.preflight.outputs.version }}
@@ -399,14 +550,18 @@ jobs:
   # The repository owns one host per accelerator. When a host drops its connection instead of
   # reporting, .github/scripts/lost-runner-rerun.yml re-dispatches it once; if the second attempt is
   # lost the same way, this job records a populated non-claim for that host so the closeout has a
-  # visible withheld claim to accept instead of an unexplained gap. It refuses -- and fails the run
-  # -- for every other shape of failure, so a proof that ran and disagreed can never be withheld.
+  # visible withheld claim to accept instead of an unexplained gap. A host whose proof was never
+  # dispatched -- reserve-protected-runners typed it `unproven` before assignment -- is withheld
+  # the same way under its own typed reason, vouched for by this run's reservation receipt. It
+  # refuses -- and fails the run -- for every other shape of failure, so a proof that ran and
+  # disagreed can never be withheld.
   accelerator-non-claim:
     name: Withhold unproven accelerator claims
     if: always() && needs.preflight.result == 'success' && needs.packaged-proof.result == 'success'
     needs:
       - preflight
       - packaged-proof
+      - reserve-protected-runners
       - macos-metal-proof
       - windows-vulkan-proof
       - linux-vulkan-proof
@@ -418,6 +573,13 @@ jobs:
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0
+
+      - name: Download this run's reservation receipt
+        uses: actions/download-artifact@v8.0.1
+        with:
+          pattern: protected-runner-reservation-attempt-*
+          path: target/release-non-claim/reservation
+          merge-multiple: false
 
       - name: Collect protected accelerator job evidence
         env:
@@ -443,9 +605,23 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # This run's own receipt, at the newest attempt at or below the current one: a re-run of
+          # failed jobs does not re-run the succeeded reservation gate, so its receipt stays the
+          # attempt-1 artifact.
+          receipt=""
+          for attempt in $(seq "$GITHUB_RUN_ATTEMPT" -1 1); do
+            candidate="target/release-non-claim/reservation/protected-runner-reservation-attempt-$attempt/receipt.json"
+            if [ -f "$candidate" ]; then receipt="$candidate"; break; fi
+          done
+          reservation_args=()
+          if [ -n "$receipt" ]; then
+            reservation_args+=(--reservation "$receipt")
+          fi
+          echo "receipt=$receipt" >> "$GITHUB_OUTPUT"
           node .github/scripts/lost-runner-recovery.mjs plan-non-claim \
             --input target/release-non-claim/plan-input.json \
-            --out target/release-non-claim/plan.json
+            --out target/release-non-claim/plan.json \
+            "${reservation_args[@]}"
 
       - name: Download authenticated candidate records for withheld identity
         if: steps.non-claim.outputs.withheld_hosts != ''
@@ -459,6 +635,7 @@ jobs:
         if: steps.non-claim.outputs.withheld_hosts != ''
         env:
           WITHHELD_HOSTS: ${{ steps.non-claim.outputs.withheld_hosts }}
+          RESERVATION_RECEIPT: ${{ steps.non-claim.outputs.receipt }}
           VERSION: ${{ needs.preflight.outputs.version }}
         shell: bash
         run: |
@@ -476,6 +653,17 @@ jobs:
               linux-x64-vulkan) target=linux-x64 ;;
               *) echo "::error::unknown non-claim host $host"; exit 1 ;;
             esac
+            # The classifier's own plan says WHICH typed reason withheld the host; the recorded
+            # manifest carries that reason, with the reservation receipt vouching the
+            # pre-assignment route.
+            detail="$(jq -r --arg host "$host" \
+              '.hosts[] | select(.host == $host) | .detail' \
+              target/release-non-claim/plan.json)"
+            reason_args=()
+            if [ "$detail" = runner_unproven_pre_assignment ]; then
+              reason_args+=(--reason accelerator_host_offline_pre_assignment)
+              reason_args+=(--reservation "$RESERVATION_RECEIPT")
+            fi
             node scripts/codestory-release-cell-manifest.mjs withhold \
               --repo "$GITHUB_WORKSPACE" \
               --expected-sha "$GITHUB_SHA" \
@@ -485,7 +673,8 @@ jobs:
               --producer-run-attempt "$GITHUB_RUN_ATTEMPT" \
               --identity target/release-non-claim/identity.json \
               --candidate-record "target/release-non-claim/candidate-records/codestory-candidate-archive-record-$target/candidate-archive-record.json" \
-              --out-dir "target/release-non-claim/cells/$host"
+              --out-dir "target/release-non-claim/cells/$host" \
+              "${reason_args[@]}"
           done
 
       - name: Upload withheld pre-publish macOS accelerator cells
@@ -562,6 +751,13 @@ jobs:
           ref: ${{ github.sha }}
           fetch-depth: 0
 
+      - name: Collect this run's reservation receipt
+        uses: actions/download-artifact@v8.0.1
+        with:
+          pattern: protected-runner-reservation-attempt-*
+          path: target/release-closeout/reservation
+          merge-multiple: false
+
       - name: Authenticate pre-publish Actions provenance
         env:
           GH_TOKEN: ${{ github.token }}
@@ -570,9 +766,21 @@ jobs:
         run: |
           set -euo pipefail
           # The closeout reads the lost-runner signature itself rather than trusting the non-claim
-          # producer's verdict, so it collects the same Actions evidence independently.
+          # producer's verdict, so it collects the same Actions evidence independently. The
+          # reservation receipt is collected the same way -- downloaded from this run's artifacts
+          # by this job, never handed over by the non-claim producer -- so the pre-assignment
+          # route is re-confirmed from evidence the closeout gathered itself.
           bash .github/scripts/collect-actions-job-evidence.sh \
             "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT" target/release-closeout/job-evidence.json
+          receipt=""
+          for attempt in $(seq "$GITHUB_RUN_ATTEMPT" -1 1); do
+            candidate="target/release-closeout/reservation/protected-runner-reservation-attempt-$attempt/receipt.json"
+            if [ -f "$candidate" ]; then receipt="$candidate"; break; fi
+          done
+          receipt_args=()
+          if [ -n "$receipt" ]; then
+            receipt_args+=(--reservation-receipt "$receipt")
+          fi
           node scripts/codestory-release-cell-manifest.mjs producer-map \
             --repo "$GITHUB_WORKSPACE" \
             --expected-sha "$GITHUB_SHA" \
@@ -581,6 +789,7 @@ jobs:
             --producer-run-attempt "$GITHUB_RUN_ATTEMPT" \
             --reuse "$REUSE_SELECTION" \
             --job-evidence target/release-closeout/job-evidence.json \
+            "${receipt_args[@]}" \
             --out target/release-closeout/trusted-pre-publish-producers.json
 
       - name: Download and verify selected pre-publish release cells
@@ -1009,6 +1218,13 @@ jobs:
           ref: ${{ github.sha }}
           fetch-depth: 0
 
+      - name: Collect this run's reservation receipt
+        uses: actions/download-artifact@v8.0.1
+        with:
+          pattern: protected-runner-reservation-attempt-*
+          path: target/release-closeout/reservation
+          merge-multiple: false
+
       - name: Authenticate post-publish Actions provenance
         id: post-publish-provenance
         env:
@@ -1018,6 +1234,15 @@ jobs:
           set -euo pipefail
           bash .github/scripts/collect-actions-job-evidence.sh \
             "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT" target/release-closeout/job-evidence.json
+          receipt=""
+          for attempt in $(seq "$GITHUB_RUN_ATTEMPT" -1 1); do
+            candidate="target/release-closeout/reservation/protected-runner-reservation-attempt-$attempt/receipt.json"
+            if [ -f "$candidate" ]; then receipt="$candidate"; break; fi
+          done
+          receipt_args=()
+          if [ -n "$receipt" ]; then
+            receipt_args+=(--reservation-receipt "$receipt")
+          fi
           node scripts/codestory-release-cell-manifest.mjs producer-map \
             --repo "$GITHUB_WORKSPACE" \
             --expected-sha "$GITHUB_SHA" \
@@ -1025,6 +1250,7 @@ jobs:
             --producer-run-id "$GITHUB_RUN_ID" \
             --producer-run-attempt "$GITHUB_RUN_ATTEMPT" \
             --job-evidence target/release-closeout/job-evidence.json \
+            "${receipt_args[@]}" \
             --out target/release-closeout/trusted-post-publish-producers.json
           artifact_ids="$(jq -r '[.artifacts[].id] | join(",")' target/release-closeout/trusted-post-publish-producers.json)"
           test -n "$artifact_ids"

--- a/benchmarks/release-evidence/fixtures/candidate.json
+++ b/benchmarks/release-evidence/fixtures/candidate.json
@@ -62,7 +62,7 @@
   },
   "release_claims": {
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "9dc31326a801a1e6333200e0543bd95daad078322a3d31760199813cd262efb8",
+    "graph_sha256": "7739066fa844d159b354bcabd1408b86501ae2484cb00faa231d2430f8890029",
     "observed_at": "2026-08-08T19:19:24.395Z",
     "expires_at": "2026-08-09T19:19:24.395Z",
     "requested_claims": [
@@ -85,7 +85,7 @@
         "type": "performance",
         "tier": "live_behavior",
         "status": "measured",
-        "graph_sha256": "9dc31326a801a1e6333200e0543bd95daad078322a3d31760199813cd262efb8",
+        "graph_sha256": "7739066fa844d159b354bcabd1408b86501ae2484cb00faa231d2430f8890029",
         "observed_at": "2026-08-08T19:19:24.395Z",
         "expires_at": "2026-08-09T19:19:24.395Z",
         "identity": {
@@ -106,7 +106,7 @@
         "type": "answer_quality",
         "tier": "answer_quality",
         "status": "pass",
-        "graph_sha256": "9dc31326a801a1e6333200e0543bd95daad078322a3d31760199813cd262efb8",
+        "graph_sha256": "7739066fa844d159b354bcabd1408b86501ae2484cb00faa231d2430f8890029",
         "observed_at": "2026-08-08T19:19:24.395Z",
         "expires_at": "2026-08-09T19:19:24.395Z",
         "identity": {

--- a/benchmarks/release-evidence/fixtures/report.json
+++ b/benchmarks/release-evidence/fixtures/report.json
@@ -7,7 +7,7 @@
   "baseline_id": "ci-contract-v1@1111111111111111111111111111111111111111",
   "baseline_sha256": "0bbbe6dd8b4000151edf7b1270959d08e94e08db876e7f2372b25613e0f237c1",
   "candidate_path": "benchmarks/release-evidence/fixtures/candidate.json",
-  "candidate_sha256": "ba4757e837fece35e7da9ce06bed0f15ef5b924d9425fc2fb03ebf3287ca90b9",
+  "candidate_sha256": "2e91d8dc86070b2efa18150690fd0cc0259c52c3882eaa30293d57f7598cc492",
   "artifact_paths": [
     {
       "path": "candidate-stats.json",
@@ -26,7 +26,7 @@
       "type": "performance",
       "tier": "live_behavior",
       "status": "pass",
-      "graph_sha256": "9dc31326a801a1e6333200e0543bd95daad078322a3d31760199813cd262efb8",
+      "graph_sha256": "7739066fa844d159b354bcabd1408b86501ae2484cb00faa231d2430f8890029",
       "observed_at": "2026-08-08T19:19:24.395Z",
       "expires_at": "2026-08-09T19:19:24.395Z",
       "identity": {
@@ -47,7 +47,7 @@
       "type": "answer_quality",
       "tier": "answer_quality",
       "status": "pass",
-      "graph_sha256": "9dc31326a801a1e6333200e0543bd95daad078322a3d31760199813cd262efb8",
+      "graph_sha256": "7739066fa844d159b354bcabd1408b86501ae2484cb00faa231d2430f8890029",
       "observed_at": "2026-08-08T19:19:24.395Z",
       "expires_at": "2026-08-09T19:19:24.395Z",
       "identity": {
@@ -69,7 +69,7 @@
     "schema": "codestory.release-claim-evaluation/v1",
     "status": "pass",
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "9dc31326a801a1e6333200e0543bd95daad078322a3d31760199813cd262efb8",
+    "graph_sha256": "7739066fa844d159b354bcabd1408b86501ae2484cb00faa231d2430f8890029",
     "evidence_selection": "all_matching_rows_must_pass",
     "expected_commit": "2222222222222222222222222222222222222222",
     "evaluated_at": "2026-08-08T19:19:24.395Z",

--- a/docs/contributors/release-runbook.md
+++ b/docs/contributors/release-runbook.md
@@ -249,6 +249,21 @@ risk was eliminated.
 
 ## Failure recovery
 
+A protected host that is offline when the release would dispatch its proof is
+typed before dispatch, not discovered a day later: the scheduled
+`protected-runner-heartbeat.yml` jobs run on the three protected hosts every
+~15 minutes, and `reserve-protected-runners` reads that evidence into a
+per-attempt reservation receipt typing each host `alive` (proof dispatched),
+`held_by_active_run` (another run is executing there -- the release fails red,
+naming the holder, because a busy host is provably alive), or `unproven` (no
+fresh heartbeat after one recorded recheck -- the proof is not dispatched and
+the non-claim producer records the typed
+`accelerator_host_offline_pre_assignment` withhold, vouched by this run's own
+receipt and re-confirmed independently by the closeout). Pre-assignment
+withholds count against the same `maximum_withheld_hosts` cap as mid-job
+lost-runner withholds; a proof job that actually ran and failed can never be
+converted into either.
+
 After a platform-specific package, link, filesystem, cache, or identity failure,
 run a native probe that reproduces the failing seam in under 90 seconds before
 requesting another full build.

--- a/release-claims.json
+++ b/release-claims.json
@@ -971,12 +971,26 @@
     "schema": "codestory.release-non-claim/v1",
     "runtime_execution": "not_proven_by_package",
     "reason": "accelerator_host_unavailable",
+    "pre_assignment_reason": "accelerator_host_offline_pre_assignment",
     "annotation": "The self-hosted runner lost communication with the server. Verify the machine is running and has a healthy network connection.",
+    "annotation_reason": "accelerator_host_unavailable",
     "maximum_run_attempts": 2,
     "recovery_contract": ".github/scripts/lost-runner-recovery.mjs",
     "producer_workflow": ".github/workflows/release.yml",
     "producer_job": "accelerator-non-claim",
     "producer_job_name": "Withhold unproven accelerator claims",
+    "reservation": {
+      "schema": "codestory.protected-runner-reservation/v1",
+      "producer_workflow": ".github/workflows/release.yml",
+      "producer_job": "reserve-protected-runners",
+      "receipt_artifact": "protected-runner-reservation-attempt-{attempt}",
+      "maximum_observation_attempts": 2,
+      "heartbeat": {
+        "workflow": ".github/workflows/protected-runner-heartbeat.yml",
+        "cron": "*/15 * * * *",
+        "tolerance_minutes": 30
+      }
+    },
     "withhold_policy": {
       "maximum_withheld_hosts": 1,
       "archive_identity_source": "candidate_archive_record",
@@ -990,6 +1004,13 @@
     "hosts": [
       {
         "id": "macos-arm64-metal",
+        "runner_labels": [
+          "self-hosted",
+          "macOS",
+          "ARM64",
+          "codestory-metal"
+        ],
+        "heartbeat_job_name": "Heartbeat macos-arm64-metal",
         "unavailable_producer_workflow": ".github/workflows/macos-metal-proof.yml",
         "unavailable_producer_job_name": "Packaged Apple Silicon Metal engine",
         "producer_artifacts": {
@@ -1004,6 +1025,13 @@
       },
       {
         "id": "windows-x64-vulkan",
+        "runner_labels": [
+          "self-hosted",
+          "Windows",
+          "X64",
+          "codestory-vulkan"
+        ],
+        "heartbeat_job_name": "Heartbeat windows-x64-vulkan",
         "unavailable_producer_workflow": ".github/workflows/windows-vulkan-proof.yml",
         "unavailable_producer_job_name": "Packaged Windows Vulkan engine",
         "producer_artifacts": {
@@ -1018,6 +1046,13 @@
       },
       {
         "id": "linux-x64-vulkan",
+        "runner_labels": [
+          "self-hosted",
+          "Linux",
+          "X64",
+          "codestory-linux-vulkan"
+        ],
+        "heartbeat_job_name": "Heartbeat linux-x64-vulkan",
         "unavailable_producer_workflow": ".github/workflows/linux-vulkan-proof.yml",
         "unavailable_producer_job_name": "Packaged Linux Vulkan engine",
         "producer_artifacts": {
@@ -1432,21 +1467,29 @@
         "packaged-proof": [
           "preflight"
         ],
-        "macos-metal-proof": [
+        "reserve-protected-runners": [
           "preflight",
           "packaged-proof"
+        ],
+        "macos-metal-proof": [
+          "preflight",
+          "packaged-proof",
+          "reserve-protected-runners"
         ],
         "windows-vulkan-proof": [
           "preflight",
-          "packaged-proof"
+          "packaged-proof",
+          "reserve-protected-runners"
         ],
         "linux-vulkan-proof": [
           "preflight",
-          "packaged-proof"
+          "packaged-proof",
+          "reserve-protected-runners"
         ],
         "accelerator-non-claim": [
           "preflight",
           "packaged-proof",
+          "reserve-protected-runners",
           "macos-metal-proof",
           "windows-vulkan-proof",
           "linux-vulkan-proof"

--- a/scripts/codestory-release-cell-manifest.mjs
+++ b/scripts/codestory-release-cell-manifest.mjs
@@ -19,7 +19,9 @@ import {
   validateReleaseCellManifest,
 } from "./codestory-release-closeout.mjs";
 import {
+  RESERVATION_RECEIPT_SCHEMA,
   RUNNER_COMMUNICATION_LOSS,
+  RUNNER_UNPROVEN,
   classifyJobFailure,
   countLostExecutions,
 } from "../.github/scripts/lost-runner-recovery.mjs";
@@ -297,8 +299,10 @@ function produceOne(values) {
 /// Record the populated non-claim for one protected host that never reported.
 ///
 /// This is the only writer of a withheld release cell. It refuses to invent one for a host the
-/// graph does not declare, and it stamps the recovery bound into every manifest it writes, so a
-/// withheld cell always carries the evidence that the automatic reruns were spent first.
+/// graph does not declare, and it stamps the spent recovery bound into every manifest it writes --
+/// the run-attempt rerun bound for a host lost mid-job, or the reservation receipt's recorded
+/// recheck bound for a host that was typed `unproven` before its job was ever assigned -- so a
+/// withheld cell always carries the evidence that the automatic recovery was spent first.
 function withholdHost(values) {
   const { graph, gitIdentity } = common(values);
   const version = text(values.version, "--version").replace(/^v/u, "");
@@ -307,8 +311,39 @@ function withholdHost(values) {
   const host = (policy?.hosts ?? []).find(({ id }) => id === hostId);
   if (!host) fail(`release claim graph declares no non-claim host ${hostId}`);
   const attempt = positiveInteger(values["producer-run-attempt"], "--producer-run-attempt");
-  if (Number(attempt) < policy.maximum_run_attempts) {
+  const reason = values.reason === undefined ? policy.reason : text(values.reason, "--reason");
+  if (reason !== policy.reason && reason !== policy.pre_assignment_reason) {
+    fail(`--reason must be ${policy.reason} or ${policy.pre_assignment_reason}`);
+  }
+  const preAssignment = reason === policy.pre_assignment_reason;
+  if (!preAssignment && values.reservation !== undefined) {
+    fail(`--reservation is scoped to the ${policy.pre_assignment_reason} reason`);
+  }
+  if (!preAssignment && Number(attempt) < policy.maximum_run_attempts) {
     fail(`a non-claim may be recorded only after ${policy.maximum_run_attempts} run attempts`);
+  }
+  let reservationFacts = null;
+  if (preAssignment) {
+    // The pre-assignment bound is the receipt's recorded recheck: the proof job never existed, so
+    // no rerun could be spent on it, and the receipt is what proves the recovery that WAS owed --
+    // one bounded re-observation -- actually happened before anything is withheld.
+    const receipt = JSON.parse(readFileSync(
+      text(values.reservation, "--reservation"),
+      "utf8",
+    ));
+    confirmsPreAssignmentWithholding({
+      graph,
+      reservationReceipt: receipt,
+      hostId,
+      cellId: `non-claim host ${hostId}`,
+    });
+    const row = receipt.hosts.find(({ host: id }) => id === hostId);
+    reservationFacts = {
+      schema: receipt.schema,
+      state: row.state,
+      observation_attempts: Number(row.observation_attempts),
+      maximum_observation_attempts: receipt.maximum_observation_attempts,
+    };
   }
   const identity = values.identity ? JSON.parse(readFileSync(values.identity, "utf8")) : {};
   const candidateRecord = readCandidateArchiveRecord(
@@ -356,8 +391,12 @@ function withholdHost(values) {
       nonClaim: {
         host: host.id,
         runtime_execution: policy.runtime_execution,
-        non_claim_reason: policy.reason,
-        annotation: policy.annotation,
+        non_claim_reason: reason,
+        // The annotation is what Actions wrote on the lost job; a never-assigned job has none,
+        // so the pre-assignment non-claim carries the receipt facts in its place.
+        ...(preAssignment
+          ? { reservation: reservationFacts }
+          : { annotation: policy.annotation }),
         unavailable_producer_workflow: host.unavailable_producer_workflow,
         unavailable_producer_job_name: host.unavailable_producer_job_name,
         withheld_claims: releaseCellWithheldClaims(graph, cell),
@@ -533,6 +572,52 @@ function confirmsWithholding({ graph, jobEvidence, jobName, cellId }) {
   return true;
 }
 
+/// The closeout's own reading of the pre-assignment route: the second withholdable fact.
+///
+/// The proof job is ABSENT from the run -- the closeout already sees that in the job listing it
+/// queried itself -- and the reservation receipt, downloaded from this run's artifacts by the
+/// closeout job rather than handed over by the non-claim producer, must type this exact host
+/// `unproven` with the recorded recheck bound spent. Anything else -- no receipt, another schema,
+/// another state, an unspent bound, a host the receipt never typed -- refuses the routing, so an
+/// absent proof with an unvouched absence keeps the run red instead of quietly withholding.
+function confirmsPreAssignmentWithholding({ graph, reservationReceipt, hostId, cellId }) {
+  if (reservationReceipt === null) {
+    fail(
+      `closeout cannot route ${cellId} to a pre-assignment non-claim without its own `
+      + "reservation receipt",
+    );
+  }
+  const reservation = graph.non_claim_policy.reservation ?? {};
+  if (reservationReceipt.schema !== reservation.schema
+      || reservationReceipt.schema !== RESERVATION_RECEIPT_SCHEMA) {
+    fail(`reservation receipt for ${cellId} must carry ${RESERVATION_RECEIPT_SCHEMA}`);
+  }
+  const bound = reservation.maximum_observation_attempts;
+  if (reservationReceipt.maximum_observation_attempts !== bound) {
+    fail(`reservation receipt for ${cellId} must record the ${bound}-observation recheck bound`);
+  }
+  const rows = (Array.isArray(reservationReceipt.hosts) ? reservationReceipt.hosts : [])
+    .filter((row) => row?.host === hostId);
+  if (rows.length !== 1) {
+    fail(`reservation receipt does not type host ${hostId}, so ${cellId} may not be withheld`);
+  }
+  const row = rows[0];
+  if (row.state !== RUNNER_UNPROVEN) {
+    fail(
+      `reservation receipt types ${hostId} ${String(row.state)}, so ${cellId} may not be `
+      + "withheld pre-assignment",
+    );
+  }
+  const attempts = String(row.observation_attempts ?? "");
+  if (!/^[1-9]\d*$/u.test(attempts) || Number(attempts) < bound) {
+    fail(
+      `${hostId} was observed ${attempts || "0"} time(s); ${cellId} may not be withheld before `
+      + `the ${bound}-observation recheck bound is spent`,
+    );
+  }
+  return true;
+}
+
 export function buildTrustedProducerMap({
   graph,
   gitIdentity,
@@ -544,6 +629,9 @@ export function buildTrustedProducerMap({
   // The closeout's own collected Actions job evidence -- annotations, step conclusions and the log
   // blob probe -- for confirming a withheld routing without asking the non-claim producer.
   jobEvidence = null,
+  // This run's reservation receipt, downloaded by the closeout job itself, for confirming the
+  // pre-assignment route the same producer-independent way.
+  reservationReceipt = null,
   // Cross-run evidence, keyed by cell-group id. Admissible only for groups that declare a
   // reuse_binding in the claim graph; the caller is responsible for having verified the binding
   // (tree equality and ancestry, or native-fingerprint equality) before supplying an entry.
@@ -588,8 +676,23 @@ export function buildTrustedProducerMap({
     const notGreen = cell.non_claim !== undefined
       && primaryLatest.state === "resolved"
       && (primaryLatest.job.status !== "completed" || primaryLatest.job.conclusion !== "success");
-    const withheld = notGreen
-      && confirmsWithholding({ graph, jobEvidence, jobName: primaryJobName, cellId: cell.id });
+    // Two withholdable routes, each confirmed from evidence this closeout collected itself, and
+    // each scoped to its own shape of absence-of-proof. A PRESENT job that did not succeed can
+    // only be the lost-runner route: the reservation receipt is never consulted for it, so a
+    // hostile receipt cannot mask a proof that ran and refused. An ABSENT job can only be the
+    // pre-assignment route, and only when this run's own receipt vouches the host `unproven`.
+    const withheldPreAssignment = cell.non_claim !== undefined
+      && primaryLatest.state === "absent"
+      && reservationReceipt !== null
+      && confirmsPreAssignmentWithholding({
+        graph,
+        reservationReceipt,
+        hostId: cell.non_claim.host,
+        cellId: cell.id,
+      });
+    const withheld = (notGreen
+      && confirmsWithholding({ graph, jobEvidence, jobName: primaryJobName, cellId: cell.id }))
+      || withheldPreAssignment;
     const jobName = withheld ? cell.non_claim.producer_job_name : primaryJobName;
     const artifactTemplate = withheld
       ? cell.non_claim.producer_artifact
@@ -669,11 +772,19 @@ export function buildTrustedProducerMap({
         },
       };
       selected.non_claim = withheld;
+      // Only the pre-assignment route is tagged; an untagged withheld row IS the mid-job
+      // lost-runner route, which keeps every existing producer map byte-identical.
+      if (withheldPreAssignment) {
+        selected.non_claim_reason = graph.non_claim_policy.pre_assignment_reason;
+      }
       selectionCache.set(cacheKey, selected);
     }
     return {
       cell_id: cell.id,
       ...(selected.non_claim ? { non_claim: true } : {}),
+      ...(selected.non_claim_reason !== undefined
+        ? { non_claim_reason: selected.non_claim_reason }
+        : {}),
       producer_workflow: selected.constraints.producer_workflow,
       producer_job: selected.constraints.producer_job,
       producer_job_name: selected.constraints.producer_job_name,
@@ -773,6 +884,11 @@ async function produceMap(values) {
   const jobEvidence = values["job-evidence"]
     ? JSON.parse(readFileSync(text(values["job-evidence"], "--job-evidence"), "utf8"))
     : null;
+  // Same trust boundary for the pre-assignment route: the receipt path names an artifact the
+  // closeout job downloaded from this run itself.
+  const reservationReceipt = values["reservation-receipt"]
+    ? JSON.parse(readFileSync(text(values["reservation-receipt"], "--reservation-receipt"), "utf8"))
+    : null;
   const map = buildTrustedProducerMap({
     graph,
     gitIdentity,
@@ -782,6 +898,7 @@ async function produceMap(values) {
     artifacts,
     jobsByAttempt,
     jobEvidence,
+    reservationReceipt,
     reuse,
   });
   writeJson(text(values.out, "--out"), map);

--- a/scripts/codestory-release-claims.mjs
+++ b/scripts/codestory-release-claims.mjs
@@ -401,6 +401,57 @@ function validateWithholdPolicy(policy, hosts, cellGroups) {
   }
 }
 
+/// The pre-dispatch reservation contract: a scheduled heartbeat whose tiny jobs run ON the three
+/// protected hosts, and a receipt the release writes before it dispatches any proof. The heartbeat
+/// shape exists because GITHUB_TOKEN cannot list self-hosted runners -- the runner-administration
+/// endpoints need an `administration` scope that workflow `permissions:` blocks cannot grant, and
+/// the program keeps new credentials out -- so liveness is proven by jobs the hosts themselves ran.
+function validateRunnerReservation(policy) {
+  const reservation = object(
+    policy.reservation,
+    "release claim graph.non_claim_policy.reservation",
+  );
+  if (reservation.schema !== "codestory.protected-runner-reservation/v1") {
+    fail(
+      "release claim graph.non_claim_policy.reservation.schema must be "
+      + "codestory.protected-runner-reservation/v1",
+    );
+  }
+  if (reservation.producer_workflow !== policy.producer_workflow) {
+    fail(
+      "non_claim_policy.reservation.producer_workflow must be the release workflow that "
+      + "dispatches the proofs the receipt gates",
+    );
+  }
+  nonEmptyText(reservation.producer_job, "non_claim_policy.reservation.producer_job");
+  const receiptArtifact = nonEmptyText(
+    reservation.receipt_artifact,
+    "non_claim_policy.reservation.receipt_artifact",
+  );
+  if (!receiptArtifact.includes("{attempt}")) {
+    fail("non_claim_policy.reservation.receipt_artifact must be attempt-qualified");
+  }
+  // One bounded recheck, mirroring the one automatic rerun a lost runner is owed: the same shape
+  // of bound in both routes keeps "the recovery was spent first" one idea, not two.
+  if (reservation.maximum_observation_attempts !== policy.maximum_run_attempts) {
+    fail(
+      "non_claim_policy.reservation.maximum_observation_attempts must mirror maximum_run_attempts",
+    );
+  }
+  const heartbeat = object(reservation.heartbeat, "non_claim_policy.reservation.heartbeat");
+  const heartbeatWorkflow = nonEmptyText(
+    heartbeat.workflow,
+    "non_claim_policy.reservation.heartbeat.workflow",
+  );
+  if (!heartbeatWorkflow.startsWith(".github/workflows/") || !heartbeatWorkflow.endsWith(".yml")) {
+    fail("non_claim_policy.reservation.heartbeat.workflow must be a repository workflow path");
+  }
+  nonEmptyText(heartbeat.cron, "non_claim_policy.reservation.heartbeat.cron");
+  if (!Number.isInteger(heartbeat.tolerance_minutes) || heartbeat.tolerance_minutes <= 0) {
+    fail("non_claim_policy.reservation.heartbeat.tolerance_minutes must be a positive integer");
+  }
+}
+
 function validateNonClaimPolicy(graph, cellGroups) {
   const policy = object(graph.non_claim_policy, "release claim graph.non_claim_policy");
   if (policy.schema !== "codestory.release-non-claim/v1") {
@@ -412,7 +463,26 @@ function validateNonClaimPolicy(graph, cellGroups) {
     fail("release claim graph.non_claim_policy.runtime_execution must be not_proven_by_package");
   }
   nonEmptyText(policy.reason, "release claim graph.non_claim_policy.reason");
+  nonEmptyText(
+    policy.pre_assignment_reason,
+    "release claim graph.non_claim_policy.pre_assignment_reason",
+  );
+  if (policy.pre_assignment_reason === policy.reason) {
+    fail(
+      "release claim graph.non_claim_policy.pre_assignment_reason must be a distinct typed reason: "
+      + "a host that was never assigned its job and a host lost mid-job are different facts",
+    );
+  }
   nonEmptyText(policy.annotation, "release claim graph.non_claim_policy.annotation");
+  // The annotation is what Actions writes on a job whose runner died mid-execution. A job that was
+  // never assigned has no annotation, so the field is scoped to the lost-runner reason and a
+  // pre-assignment non-claim must not quote it.
+  if (policy.annotation_reason !== policy.reason) {
+    fail(
+      "release claim graph.non_claim_policy.annotation_reason must scope the annotation to the "
+      + "mid-job lost-runner reason; a never-assigned job carries no Actions annotation",
+    );
+  }
   nonEmptyText(policy.recovery_contract, "release claim graph.non_claim_policy.recovery_contract");
   if (policy.maximum_run_attempts !== 2) {
     fail("release claim graph.non_claim_policy.maximum_run_attempts must be 2");
@@ -420,6 +490,7 @@ function validateNonClaimPolicy(graph, cellGroups) {
   for (const key of ["producer_workflow", "producer_job", "producer_job_name"]) {
     nonEmptyText(policy[key], `release claim graph.non_claim_policy.${key}`);
   }
+  validateRunnerReservation(policy);
   const producedCells = cellsByProducerJobName(cellGroups);
   const hosts = uniqueById(policy.hosts, "release claim graph.non_claim_policy.hosts");
   validateWithholdPolicy(policy, hosts, cellGroups);
@@ -429,12 +500,41 @@ function validateNonClaimPolicy(graph, cellGroups) {
   if (JSON.stringify([...hosts.keys()].sort()) !== JSON.stringify(acceleratorInstances)) {
     fail("non_claim_policy.hosts must name exactly the protected accelerator instances");
   }
+  const protectedRunnersByWorkflow = new Map(
+    (graph.workflow_policy?.protected_jobs ?? []).map((row) => [row.workflow, row.runner]),
+  );
+  const heartbeatJobNames = new Set();
   for (const [hostId, host] of hosts) {
     nonEmptyText(host.unavailable_producer_workflow, `non_claim_policy.hosts ${hostId}.unavailable_producer_workflow`);
     const jobName = nonEmptyText(
       host.unavailable_producer_job_name,
       `non_claim_policy.hosts ${hostId}.unavailable_producer_job_name`,
     );
+    // The labels the heartbeat has to run on are the labels the proof runs on: a heartbeat that
+    // proves some other machine alive vouches for nothing. The protected_jobs contract already
+    // pins the proof's labels, so the host's copy is held to that same row rather than trusted.
+    const runnerLabels = stringArray(
+      host.runner_labels,
+      `non_claim_policy.hosts ${hostId}.runner_labels`,
+      { nonEmpty: true },
+    );
+    const protectedRunner = protectedRunnersByWorkflow.get(
+      host.unavailable_producer_workflow.split("/").at(-1),
+    );
+    if (JSON.stringify(runnerLabels) !== JSON.stringify(protectedRunner ?? null)) {
+      fail(
+        `non_claim_policy.hosts ${hostId}.runner_labels must equal the protected_jobs runner `
+        + "labels of the proof the heartbeat vouches for",
+      );
+    }
+    const heartbeatJobName = nonEmptyText(
+      host.heartbeat_job_name,
+      `non_claim_policy.hosts ${hostId}.heartbeat_job_name`,
+    );
+    if (heartbeatJobNames.has(heartbeatJobName)) {
+      fail(`non_claim_policy.hosts duplicates heartbeat job name ${heartbeatJobName}`);
+    }
+    heartbeatJobNames.add(heartbeatJobName);
     // One artifact container may only hold cells of a single closeout phase, because the phase's
     // trusted producer map is what authorizes every manifest inside the container it downloads.
     const hostArtifacts = object(
@@ -2071,14 +2171,22 @@ export function renderReleasePlatformNotes(graph, ledger) {
   const withheldCells = new Set(stringArray(closeout.withheld_cells, "closeout ledger.withheld_cells"));
   const hostByTarget = acceleratorHostByTarget(graph);
   const reason = graph.non_claim_policy.reason;
+  // The ledger records WHICH typed reason withheld a cell -- lost mid-job and never assigned are
+  // different facts -- so the published wording quotes the recorded reason, not the graph default.
+  const recordedReasons = new Map(
+    (Array.isArray(closeout.cells) ? closeout.cells : [])
+      .filter((row) => typeof row?.non_claim?.non_claim_reason === "string")
+      .map((row) => [row.id, row.non_claim.non_claim_reason]),
+  );
   const packages = graph.public_support.packages.map(({ label, target, accelerator_claim: claim }) => {
     const accelerator = claim === "metal" ? "Metal" : "Vulkan";
     const host = hostByTarget.get(target);
-    const withheld = host !== undefined
-      && host.withheld_cells.some((cellId) =>
+    const withheldCellId = host === undefined
+      ? undefined
+      : host.withheld_cells.find((cellId) =>
         cellId.startsWith("accelerator_execution:") && withheldCells.has(cellId));
-    return withheld
-      ? `- ${label}: ${accelerator} not proven for this release (${reason})`
+    return withheldCellId !== undefined
+      ? `- ${label}: ${accelerator} not proven for this release (${recordedReasons.get(withheldCellId) ?? reason})`
       : `- ${label}: supported with ${accelerator}`;
   });
   const unsupported = graph.public_support.unsupported.map(

--- a/scripts/codestory-release-closeout.mjs
+++ b/scripts/codestory-release-closeout.mjs
@@ -149,9 +149,17 @@ export function deriveReleaseCells(graph, phase) {
     cell.non_claim = {
       host: host.id,
       reason: nonClaimPolicy.reason,
+      // The second typed reason: the proof job was never assigned because this run's own
+      // reservation receipt typed the host `unproven` before dispatch. The annotation is scoped
+      // to the mid-job reason -- a job that never existed carries no Actions annotation -- and
+      // the pre-assignment route is bounded by the receipt's recorded recheck instead of the
+      // run-attempt recovery bound.
+      pre_assignment_reason: nonClaimPolicy.pre_assignment_reason,
       runtime_execution: nonClaimPolicy.runtime_execution,
       annotation: nonClaimPolicy.annotation,
       maximum_run_attempts: nonClaimPolicy.maximum_run_attempts,
+      reservation_schema: nonClaimPolicy.reservation?.schema,
+      maximum_observation_attempts: nonClaimPolicy.reservation?.maximum_observation_attempts,
       unavailable_producer_workflow: host.unavailable_producer_workflow,
       unavailable_producer_job_name: host.unavailable_producer_job_name,
       producer_workflow: nonClaimPolicy.producer_workflow,
@@ -270,16 +278,59 @@ function nonClaimProblems({ manifest, cell, graph, withheld }) {
     problems.push(error.message);
     return problems;
   }
+  // Two typed reasons, each with its own scoped evidence. The mid-job reason quotes the Actions
+  // annotation and must have spent the run-attempt recovery bound; the pre-assignment reason has
+  // no annotation to quote -- the job never existed -- and must instead carry the reservation
+  // receipt facts with the recorded recheck bound spent. A manifest mixing the two shapes is
+  // refused in both directions rather than read charitably.
+  const reason = String(nonClaim.non_claim_reason ?? "");
+  const preAssignment = reason === cell.non_claim.pre_assignment_reason;
+  if (!preAssignment && reason !== cell.non_claim.reason) {
+    problems.push(
+      `non-claim non_claim_reason must equal ${cell.non_claim.reason}`
+      + ` or ${cell.non_claim.pre_assignment_reason}`,
+    );
+  }
   const expected = {
     host: cell.non_claim.host,
     runtime_execution: cell.non_claim.runtime_execution,
-    non_claim_reason: cell.non_claim.reason,
-    annotation: cell.non_claim.annotation,
     unavailable_producer_workflow: cell.non_claim.unavailable_producer_workflow,
     unavailable_producer_job_name: cell.non_claim.unavailable_producer_job_name,
+    ...(preAssignment ? {} : { annotation: cell.non_claim.annotation }),
   };
   for (const [key, value] of Object.entries(expected)) {
     if (nonClaim[key] !== value) problems.push(`non-claim ${key} must equal ${String(value)}`);
+  }
+  if (preAssignment) {
+    if (nonClaim.annotation !== undefined) {
+      problems.push(
+        `non-claim annotation is scoped to ${cell.non_claim.reason}: a never-assigned job has none`,
+      );
+    }
+    const reservation = nonClaim.reservation;
+    if (reservation === null || typeof reservation !== "object" || Array.isArray(reservation)) {
+      problems.push("pre-assignment non-claim must carry its reservation receipt facts");
+    } else {
+      if (reservation.schema !== cell.non_claim.reservation_schema) {
+        problems.push(`non-claim reservation schema must be ${cell.non_claim.reservation_schema}`);
+      }
+      if (reservation.state !== "unproven") {
+        problems.push("non-claim reservation state must be unproven");
+      }
+      // The pre-assignment bound is the receipt's recorded recheck, not the run attempt: the job
+      // was never created, so there is no rerun to spend, and the recheck is what was spent.
+      const attempts = String(reservation.observation_attempts ?? "");
+      if (reservation.maximum_observation_attempts !== cell.non_claim.maximum_observation_attempts
+          || !/^[1-9]\d*$/u.test(attempts)
+          || Number(attempts) < cell.non_claim.maximum_observation_attempts) {
+        problems.push(
+          "non-claim reservation must reach the "
+          + `${cell.non_claim.maximum_observation_attempts} observation recheck bound`,
+        );
+      }
+    }
+  } else if (nonClaim.reservation !== undefined) {
+    problems.push(`non-claim reservation facts are scoped to ${cell.non_claim.pre_assignment_reason}`);
   }
   let withheldClaims = [];
   try {
@@ -293,10 +344,13 @@ function nonClaimProblems({ manifest, cell, graph, withheld }) {
   if (declared === null || JSON.stringify(declared) !== JSON.stringify(withheldClaims)) {
     problems.push(`non-claim withheld_claims must name ${withheldClaims.join(", ")}`);
   }
-  // Withholding is the end of the bounded recovery path, never a shortcut around it: a non-claim
-  // recorded before the automatic reruns are spent would let one flaky minute drop a claim.
+  // Withholding is the end of a bounded recovery path, never a shortcut around it: a mid-job
+  // non-claim recorded before the automatic reruns are spent would let one flaky minute drop a
+  // claim. The pre-assignment route spent its bound in the receipt's recorded recheck instead, so
+  // its run_attempt only has to be the real producing attempt.
   const attempt = String(nonClaim.run_attempt ?? "");
-  if (!/^[1-9]\d*$/u.test(attempt) || Number(attempt) < cell.non_claim.maximum_run_attempts) {
+  if (!/^[1-9]\d*$/u.test(attempt)
+      || (!preAssignment && Number(attempt) < cell.non_claim.maximum_run_attempts)) {
     problems.push(
       `non-claim run_attempt must reach the ${cell.non_claim.maximum_run_attempts} attempt recovery bound`,
     );
@@ -648,6 +702,18 @@ function trustedProducerIndex({
     if (nonClaimRow && !cell.non_claim) {
       errors.push(`trusted producer map ${cell.id} does not admit a withheld non-claim`);
     }
+    // A row is tagged with a reason only for the pre-assignment route; the untagged withheld row
+    // stays the mid-job lost-runner route. Any other tag is an invented reason and is refused.
+    if (row.non_claim_reason !== undefined) {
+      if (!nonClaimRow) {
+        errors.push(`trusted producer map ${cell.id} non_claim_reason requires a withheld row`);
+      }
+      if (row.non_claim_reason !== graph.non_claim_policy?.pre_assignment_reason) {
+        errors.push(
+          `trusted producer map ${cell.id} non_claim_reason must be the declared pre-assignment reason`,
+        );
+      }
+    }
     for (const key of [
       "producer_workflow",
       "producer_job",
@@ -767,7 +833,7 @@ function trustedProducerIndex({
   return { byCell, reusedByCell, errors };
 }
 
-function producerAuthenticationProblems(manifest, trustedProducer, reuse) {
+function producerAuthenticationProblems(manifest, trustedProducer, reuse, graph) {
   if (!trustedProducer) return ["manifest producer is absent from the trusted producer map"];
   const identity = manifest.evidence?.identity ?? {};
   const problems = [];
@@ -775,6 +841,18 @@ function producerAuthenticationProblems(manifest, trustedProducer, reuse) {
   // Disagreement is how a real proof's producer could otherwise be paired with a withheld manifest.
   if ((trustedProducer.non_claim === true) !== isWithheldManifest(manifest)) {
     problems.push("manifest withheld state does not match the trusted producer map");
+  }
+  // And they have to agree on WHICH typed reason. The closeout confirmed one route from evidence
+  // it collected itself -- the lost-runner signature, or its own reading of the reservation
+  // receipt -- and a manifest recorded under the other reason is describing a different fact, so
+  // the mismatch is refused in both directions rather than reconciled.
+  if (trustedProducer.non_claim === true && isWithheldManifest(manifest)) {
+    const confirmedReason = trustedProducer.non_claim_reason ?? graph?.non_claim_policy?.reason;
+    if (manifest.non_claim?.non_claim_reason !== confirmedReason) {
+      problems.push(
+        `manifest non_claim_reason must be the ${String(confirmedReason)} route the closeout confirmed`,
+      );
+    }
   }
   for (const key of [
     "producer_workflow",
@@ -1296,6 +1374,7 @@ export function evaluateReleaseCloseout({
       manifest,
       trusted.byCell.get(cell.id),
       trusted.reusedByCell.get(cell.id),
+      graph,
     ));
     problems.push(...artifactBindingProblems(
       manifest,

--- a/scripts/tests/codestory-release-cell-manifest.test.mjs
+++ b/scripts/tests/codestory-release-cell-manifest.test.mjs
@@ -632,6 +632,278 @@ test("withheld manifests carry the populated non-claim and refuse an unspent ret
   assert.throws(() => build("1"), /recovery bound/u);
 });
 
+// ── The typed pre-assignment withhold ───────────────────────────────────────────────────────
+
+const reservationPolicy = nonClaimPolicy.reservation;
+
+/// This run's reservation receipt, as the closeout itself downloads it, typing the Linux host
+/// `unproven` after the recorded recheck.
+function unprovenReceipt(overrides = {}) {
+  return {
+    schema: reservationPolicy.schema,
+    now: "2026-07-19T12:00:00.000Z",
+    tolerance_minutes: reservationPolicy.heartbeat.tolerance_minutes,
+    observation_attempts: reservationPolicy.maximum_observation_attempts,
+    maximum_observation_attempts: reservationPolicy.maximum_observation_attempts,
+    hosts: nonClaimPolicy.hosts.map(({ id }) => id === linuxHost.id
+      ? {
+        host: id,
+        state: "unproven",
+        detail: "no_fresh_heartbeat_after_recorded_recheck",
+        observation_attempts: reservationPolicy.maximum_observation_attempts,
+      }
+      : {
+        host: id,
+        state: "alive",
+        detail: "fresh_heartbeat",
+        observation_attempts: reservationPolicy.maximum_observation_attempts,
+      }),
+    dispatch_hosts: nonClaimPolicy.hosts.map(({ id }) => id).filter((id) => id !== linuxHost.id),
+    held_hosts: [],
+    unproven_hosts: [linuxHost.id],
+    recheck: false,
+    recheck_hosts: [],
+    run_id: 12345,
+    run_attempt: 1,
+    ...overrides,
+  };
+}
+
+/// Actions metadata for a run whose Linux proof was never dispatched: the reservation receipt
+/// typed the host unproven, so the proof job is ABSENT from the run and the hosted non-claim job
+/// recorded the withheld cells at attempt 1.
+function preAssignmentRunMetadata(phase) {
+  const metadata = actionsMetadata(phase);
+  for (const [attempt, jobs] of Object.entries(metadata.jobsByAttempt)) {
+    metadata.jobsByAttempt[attempt] = jobs.filter(
+      (job) => !job.name.endsWith(linuxHost.unavailable_producer_job_name),
+    );
+  }
+  const lostArtifacts = new Set(linuxHost.withheld_cells.map((id) =>
+    resolveReleaseCellConstraints(cell(id), "1").producer_artifact));
+  metadata.artifacts = metadata.artifacts.filter(({ name }) => !lostArtifacts.has(name));
+  metadata.jobsByAttempt["1"].push({
+    id: 9001,
+    run_id: 12345,
+    run_attempt: "1",
+    head_sha: gitIdentity.commit,
+    name: `Release / ${nonClaimPolicy.producer_job_name}`,
+    status: "completed",
+    conclusion: "success",
+    started_at: "2026-07-19T13:00:00.000Z",
+    completed_at: "2026-07-19T13:10:00.000Z",
+  });
+  metadata.artifacts.push({
+    id: 9002,
+    name: linuxHost.producer_artifacts.pre_publish.replaceAll("{attempt}", "1"),
+    digest: `sha256:${"9".repeat(64)}`,
+    size_in_bytes: 1024,
+    expired: false,
+    created_at: "2026-07-19T13:05:00.000Z",
+    expires_at: "2026-08-18T12:05:00.000Z",
+    workflow_run: { id: 12345, head_sha: gitIdentity.commit },
+  });
+  return { ...metadata, jobEvidence: [] };
+}
+
+test("an absent proof routes to the non-claim producer only under the closeout's own receipt", () => {
+  const withReceipt = (reservationReceipt) => () => buildTrustedProducerMap({
+    graph,
+    gitIdentity,
+    phase: "pre_publish",
+    runId: "12345",
+    currentRunAttempt: "1",
+    ...preAssignmentRunMetadata("pre_publish"),
+    reservationReceipt,
+  });
+
+  // The vouched route: the rows are tagged with the pre-assignment reason, so the closeout can
+  // refuse a manifest recorded under the other reason.
+  const routed = withReceipt(unprovenReceipt())();
+  const withheldRows = routed.producers.filter(({ non_claim: withheld }) => withheld === true);
+  assert.deepEqual(
+    withheldRows.map(({ cell_id: id }) => id).sort(),
+    ["accelerator_execution:linux-x64-vulkan", "candidate_installed_behavior:linux-x64"],
+  );
+  for (const row of withheldRows) {
+    assert.equal(row.non_claim_reason, nonClaimPolicy.pre_assignment_reason);
+    assert.equal(row.producer_job, nonClaimPolicy.producer_job);
+    assert.equal(row.producer_run_attempt, "1");
+  }
+  // Hosts that reported keep their untagged real proof producers.
+  assert.equal(
+    routed.producers.find(({ cell_id: id }) => id === "accelerator_execution:windows-x64-vulkan")
+      .non_claim_reason,
+    undefined,
+  );
+
+  // No receipt: the absent proof stays what it always was, a run with no execution of the job.
+  assert.throws(withReceipt(null), /no execution of Packaged Linux Vulkan engine/u);
+  // A receipt that types the host anything but unproven vouches for nothing.
+  const alive = unprovenReceipt();
+  alive.hosts.find(({ host }) => host === linuxHost.id).state = "alive";
+  assert.throws(withReceipt(alive), /types linux-x64-vulkan alive/u);
+  // An unspent recheck bound vouches for nothing.
+  const unspent = unprovenReceipt();
+  unspent.hosts.find(({ host }) => host === linuxHost.id).observation_attempts = 1;
+  assert.throws(withReceipt(unspent), /recheck bound is spent/u);
+  // A receipt that never typed the host, or was written under another contract, is refused.
+  const untyped = unprovenReceipt();
+  untyped.hosts = untyped.hosts.filter(({ host }) => host !== linuxHost.id);
+  assert.throws(withReceipt(untyped), /does not type host linux-x64-vulkan/u);
+  assert.throws(
+    withReceipt(unprovenReceipt({ schema: "codestory.protected-runner-reservation/v0" })),
+    /must carry codestory\.protected-runner-reservation\/v1/u,
+  );
+});
+
+test("a hostile receipt cannot mask a proof that ran and refused", () => {
+  // The proof job is PRESENT and failed its own assertions; the receipt claims the host was
+  // never proven alive. The present job is decided from its own evidence -- the receipt is not
+  // consulted for it -- so the routing is refused and the run stays red.
+  assert.throws(
+    () => buildTrustedProducerMap({
+      graph,
+      gitIdentity,
+      phase: "pre_publish",
+      runId: "12345",
+      currentRunAttempt: withheldAttempt,
+      ...withheldRunMetadata("pre_publish", {
+        jobEvidence: lostHostEvidence({ signature: "assertion" }),
+      }),
+      reservationReceipt: unprovenReceipt(),
+    }),
+    /failed its own assertions, so accelerator_execution:linux-x64-vulkan may not be withheld/u,
+  );
+});
+
+test("pre-assignment withheld manifests carry the receipt facts and skip no other check", () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "codestory-release-preassign-"));
+  const archive = path.join(directory, "codestory-cli-v0.16.0-linux-x64.tar.gz");
+  writeFileSync(archive, "release archive bytes");
+  const selected = cell("accelerator_execution:linux-x64-vulkan");
+  const build = (nonClaim) => produceReleaseCellManifest({
+    graph,
+    gitIdentity,
+    version,
+    cell: selected,
+    identity: { native_engine: "coderank_q8_embedded" },
+    producer: {
+      producer_workflow: nonClaimPolicy.producer_workflow,
+      producer_job: nonClaimPolicy.producer_job,
+      producer_job_name: nonClaimPolicy.producer_job_name,
+      producer_run_id: "12345",
+      producer_run_attempt: "1",
+      producer_artifact: linuxHost.producer_artifacts.pre_publish.replaceAll("{attempt}", "1"),
+    },
+    observedAt,
+    archivePath: archive,
+    nonClaim,
+  });
+  const preAssignmentNonClaim = (overrides = {}) => ({
+    host: linuxHost.id,
+    runtime_execution: nonClaimPolicy.runtime_execution,
+    non_claim_reason: nonClaimPolicy.pre_assignment_reason,
+    reservation: {
+      schema: reservationPolicy.schema,
+      state: "unproven",
+      observation_attempts: reservationPolicy.maximum_observation_attempts,
+      maximum_observation_attempts: reservationPolicy.maximum_observation_attempts,
+    },
+    unavailable_producer_workflow: linuxHost.unavailable_producer_workflow,
+    unavailable_producer_job_name: linuxHost.unavailable_producer_job_name,
+    withheld_claims: ["accelerator_execution", "package_identity", "source_behavior"],
+    run_attempt: "1",
+    ...overrides,
+  });
+
+  // Attempt 1 is the whole point: the job was never created, so no rerun could be spent, and the
+  // receipt's recorded recheck is the bound that was.
+  const manifest = build(preAssignmentNonClaim());
+  assert.equal(manifest.evidence.status, "withheld");
+  assert.equal(manifest.non_claim.non_claim_reason, nonClaimPolicy.pre_assignment_reason);
+  assert.equal(manifest.non_claim.annotation, undefined);
+  assert.equal(manifest.non_claim.reservation.state, "unproven");
+  assert.equal(manifest.evidence.identity.backend, "Vulkan");
+
+  // The annotation is scoped to the mid-job reason; quoting it here is refused.
+  assert.throws(
+    () => build(preAssignmentNonClaim({ annotation: nonClaimPolicy.annotation })),
+    /annotation is scoped to accelerator_host_unavailable/u,
+  );
+  // No receipt facts, no withhold.
+  const { reservation: _dropped, ...withoutReservation } = preAssignmentNonClaim();
+  assert.throws(() => build(withoutReservation), /reservation receipt facts/u);
+  // An unspent recheck bound is refused, mirroring the unspent rerun bound on the other route.
+  assert.throws(
+    () => build(preAssignmentNonClaim({
+      reservation: {
+        schema: reservationPolicy.schema,
+        state: "unproven",
+        observation_attempts: 1,
+        maximum_observation_attempts: reservationPolicy.maximum_observation_attempts,
+      },
+    })),
+    /observation recheck bound/u,
+  );
+  // And the mid-job reason still demands its own bound: the two scopes do not leak.
+  assert.throws(
+    () => build(preAssignmentNonClaim({
+      non_claim_reason: nonClaimPolicy.reason,
+      annotation: nonClaimPolicy.annotation,
+      reservation: undefined,
+    })),
+    /recovery bound/u,
+  );
+});
+
+test("the existing mid-job withheld manifest shape is byte-identical under the new contract", () => {
+  // The pre-assignment route must not have moved a single byte of the lost-runner route: same
+  // non_claim keys, same values, no new fields.
+  const directory = mkdtempSync(path.join(os.tmpdir(), "codestory-release-midjob-"));
+  const archive = path.join(directory, "codestory-cli-v0.16.0-linux-x64.tar.gz");
+  writeFileSync(archive, "release archive bytes");
+  const selected = cell("accelerator_execution:linux-x64-vulkan");
+  const manifest = produceReleaseCellManifest({
+    graph,
+    gitIdentity,
+    version,
+    cell: selected,
+    identity: { native_engine: "coderank_q8_embedded" },
+    producer: {
+      producer_workflow: nonClaimPolicy.producer_workflow,
+      producer_job: nonClaimPolicy.producer_job,
+      producer_job_name: nonClaimPolicy.producer_job_name,
+      producer_run_id: "12345",
+      producer_run_attempt: withheldAttempt,
+      producer_artifact: linuxHost.producer_artifacts.pre_publish
+        .replaceAll("{attempt}", withheldAttempt),
+    },
+    observedAt,
+    archivePath: archive,
+    nonClaim: {
+      host: linuxHost.id,
+      runtime_execution: nonClaimPolicy.runtime_execution,
+      non_claim_reason: nonClaimPolicy.reason,
+      annotation: nonClaimPolicy.annotation,
+      unavailable_producer_workflow: linuxHost.unavailable_producer_workflow,
+      unavailable_producer_job_name: linuxHost.unavailable_producer_job_name,
+      withheld_claims: ["accelerator_execution", "package_identity", "source_behavior"],
+      run_attempt: withheldAttempt,
+    },
+  });
+  assert.deepEqual(manifest.non_claim, {
+    host: "linux-x64-vulkan",
+    runtime_execution: "not_proven_by_package",
+    non_claim_reason: "accelerator_host_unavailable",
+    annotation: nonClaimPolicy.annotation,
+    unavailable_producer_workflow: ".github/workflows/linux-vulkan-proof.yml",
+    unavailable_producer_job_name: "Packaged Linux Vulkan engine",
+    withheld_claims: ["accelerator_execution", "package_identity", "source_behavior"],
+    run_attempt: withheldAttempt,
+  });
+});
+
 test("withhold writes one container per closeout phase, never a phase-mixed one", () => {
   // Each phase's trusted producer map authorizes only the manifests it selected, so a container
   // holding another phase's cell is rejected at download time and the release is lost anyway.
@@ -750,4 +1022,135 @@ test("withhold writes one container per closeout phase, never a phase-mixed one"
       );
     }
   }
+});
+
+test("the withhold CLI records the pre-assignment reason only under a vouching receipt", () => {
+  const directory = mkdtempSync(
+    path.join(realpathSync.native(os.tmpdir()), "codestory-release-preassign-cli-"),
+  );
+  const archiveName = "codestory-cli-v0.16.0-linux-x64.tar.gz";
+  const archiveBytes = Buffer.from("release archive bytes");
+  const archiveSha256 = createHash("sha256").update(archiveBytes).digest("hex");
+  const checksumBytes = Buffer.from(`${archiveSha256}  ${archiveName}\n`);
+  const checksumSha256 = createHash("sha256").update(checksumBytes).digest("hex");
+  const candidateRecord = path.join(directory, "candidate-archive-record.json");
+  const head = execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+  const sourceTree = execFileSync(
+    "git",
+    ["rev-parse", "HEAD^{tree}"],
+    { cwd: root, encoding: "utf8" },
+  ).trim();
+  writeFileSync(
+    candidateRecord,
+    `${JSON.stringify(buildCandidateArchiveRecord({
+      repository: gitIdentity.repository,
+      sourceSha: head,
+      sourceTree,
+      target: "linux-x64",
+      archive: {
+        name: archiveName,
+        relative_path: archiveName,
+        bytes: archiveBytes.length,
+        sha256: archiveSha256,
+      },
+      companions: [
+        {
+          role: "archive_checksum",
+          relative_path: `${archiveName}.sha256`,
+          bytes: checksumBytes.length,
+          sha256: checksumSha256,
+        },
+        {
+          role: "checksum_manifest",
+          relative_path: "SHA256SUMS.txt",
+          bytes: checksumBytes.length,
+          sha256: checksumSha256,
+        },
+      ],
+    }), null, 2)}\n`,
+  );
+  const identityPath = path.join(directory, "identity.json");
+  writeFileSync(identityPath, JSON.stringify({
+    installer: "candidate_managed_plugin",
+    native_engine: "coderank_q8_embedded",
+  }));
+  const receiptPath = path.join(directory, "receipt.json");
+  writeFileSync(receiptPath, JSON.stringify(unprovenReceipt()));
+  const outDir = path.join(directory, "cells");
+  const withholdArgs = (extra) => [
+    path.join(root, "scripts/codestory-release-cell-manifest.mjs"), "withhold",
+    "--repo", root,
+    "--expected-sha", head,
+    "--version", version,
+    "--host", "linux-x64-vulkan",
+    "--producer-run-id", "12345",
+    "--producer-run-attempt", "1",
+    "--identity", identityPath,
+    "--candidate-record", candidateRecord,
+    "--out-dir", outDir,
+    ...extra,
+  ];
+
+  // Attempt 1 with the pre-assignment reason and a vouching receipt: recorded.
+  const recorded = spawnSync(
+    process.execPath,
+    withholdArgs([
+      "--reason", nonClaimPolicy.pre_assignment_reason,
+      "--reservation", receiptPath,
+    ]),
+    { encoding: "utf8", env: producerEnv({ GITHUB_RUN_ID: "12345", GITHUB_RUN_ATTEMPT: "1" }) },
+  );
+  assert.equal(recorded.status, 0, recorded.stderr);
+  const written = readdirSync(path.join(outDir, "pre_publish"))
+    .map((name) => JSON.parse(readFileSync(path.join(outDir, "pre_publish", name), "utf8")));
+  for (const manifest of written) {
+    assert.equal(manifest.non_claim.non_claim_reason, nonClaimPolicy.pre_assignment_reason);
+    assert.equal(manifest.non_claim.annotation, undefined);
+    assert.equal(
+      manifest.non_claim.reservation.observation_attempts,
+      reservationPolicy.maximum_observation_attempts,
+    );
+    assert.equal(manifest.non_claim.run_attempt, "1");
+  }
+
+  // Attempt 1 with the default mid-job reason is still refused: the reason gates the bound.
+  const midJob = spawnSync(
+    process.execPath,
+    withholdArgs([]),
+    { encoding: "utf8", env: producerEnv({ GITHUB_RUN_ID: "12345", GITHUB_RUN_ATTEMPT: "1" }) },
+  );
+  assert.notEqual(midJob.status, 0);
+  assert.match(midJob.stderr, /only after 2 run attempts/u);
+
+  // The pre-assignment reason without a receipt, or with a non-vouching one, is refused.
+  const withoutReceipt = spawnSync(
+    process.execPath,
+    withholdArgs(["--reason", nonClaimPolicy.pre_assignment_reason]),
+    { encoding: "utf8", env: producerEnv({ GITHUB_RUN_ID: "12345", GITHUB_RUN_ATTEMPT: "1" }) },
+  );
+  assert.notEqual(withoutReceipt.status, 0);
+  assert.match(withoutReceipt.stderr, /--reservation/u);
+  const alivePath = path.join(directory, "alive-receipt.json");
+  const alive = unprovenReceipt();
+  alive.hosts.find(({ host }) => host === linuxHost.id).state = "alive";
+  writeFileSync(alivePath, JSON.stringify(alive));
+  const notVouched = spawnSync(
+    process.execPath,
+    withholdArgs([
+      "--reason", nonClaimPolicy.pre_assignment_reason,
+      "--reservation", alivePath,
+    ]),
+    { encoding: "utf8", env: producerEnv({ GITHUB_RUN_ID: "12345", GITHUB_RUN_ATTEMPT: "1" }) },
+  );
+  assert.notEqual(notVouched.status, 0);
+  assert.match(notVouched.stderr, /types linux-x64-vulkan alive/u);
+
+  // The receipt flag is scoped to the pre-assignment reason.
+  const leaked = spawnSync(
+    process.execPath,
+    withholdArgs(["--reservation", receiptPath]),
+    { encoding: "utf8", env: producerEnv({ GITHUB_RUN_ID: "12345" }) },
+  );
+  assert.notEqual(leaked.status, 0);
+  assert.match(leaked.stderr, /scoped to the accelerator_host_offline_pre_assignment reason/u);
 });

--- a/scripts/tests/codestory-release-claims.test.mjs
+++ b/scripts/tests/codestory-release-claims.test.mjs
@@ -957,6 +957,74 @@ test("graph rejects ambiguous dependencies and unstructured proof lanes", () => 
     /must name exactly the protected accelerator instances/u,
   );
 
+  // The pre-assignment reason is a second TYPED reason, not a synonym: collapsing it into the
+  // mid-job reason would let one route borrow the other's evidence rules.
+  const collapsedReason = structuredClone(graph);
+  collapsedReason.non_claim_policy.pre_assignment_reason =
+    collapsedReason.non_claim_policy.reason;
+  assert.throws(
+    () => validateReleaseClaimGraph(collapsedReason),
+    /pre_assignment_reason must be a distinct typed reason/u,
+  );
+
+  const unscopedAnnotation = structuredClone(graph);
+  unscopedAnnotation.non_claim_policy.annotation_reason =
+    unscopedAnnotation.non_claim_policy.pre_assignment_reason;
+  assert.throws(
+    () => validateReleaseClaimGraph(unscopedAnnotation),
+    /annotation_reason must scope the annotation/u,
+  );
+
+  // The reservation recheck bound mirrors the rerun bound: two observations, one automatic
+  // recheck. A drifted bound would let the receipt vouch on cheaper evidence than the contract.
+  const driftedRecheckBound = structuredClone(graph);
+  driftedRecheckBound.non_claim_policy.reservation.maximum_observation_attempts = 5;
+  assert.throws(
+    () => validateReleaseClaimGraph(driftedRecheckBound),
+    /maximum_observation_attempts must mirror maximum_run_attempts/u,
+  );
+
+  const unqualifiedReceipt = structuredClone(graph);
+  unqualifiedReceipt.non_claim_policy.reservation.receipt_artifact =
+    "protected-runner-reservation";
+  assert.throws(
+    () => validateReleaseClaimGraph(unqualifiedReceipt),
+    /receipt_artifact must be attempt-qualified/u,
+  );
+
+  const staleReceiptSchema = structuredClone(graph);
+  staleReceiptSchema.non_claim_policy.reservation.schema =
+    "codestory.protected-runner-reservation/v0";
+  assert.throws(
+    () => validateReleaseClaimGraph(staleReceiptSchema),
+    /reservation\.schema must be/u,
+  );
+
+  // The heartbeat's labels are the proof's labels: a heartbeat proving some other machine alive
+  // vouches for nothing, so the host copy is held to the protected_jobs row.
+  const driftedLabels = structuredClone(graph);
+  driftedLabels.non_claim_policy.hosts
+    .find(({ id }) => id === "linux-x64-vulkan").runner_labels = [
+      "self-hosted",
+      "Linux",
+      "X64",
+      "some-other-runner",
+    ];
+  assert.throws(
+    () => validateReleaseClaimGraph(driftedLabels),
+    /runner_labels must equal the protected_jobs runner labels/u,
+  );
+
+  const duplicateHeartbeatJobs = structuredClone(graph);
+  duplicateHeartbeatJobs.non_claim_policy.hosts
+    .find(({ id }) => id === "linux-x64-vulkan").heartbeat_job_name =
+    duplicateHeartbeatJobs.non_claim_policy.hosts
+      .find(({ id }) => id === "macos-arm64-metal").heartbeat_job_name;
+  assert.throws(
+    () => validateReleaseClaimGraph(duplicateHeartbeatJobs),
+    /duplicates heartbeat job name/u,
+  );
+
   const mismatchedSupport = structuredClone(graph);
   mismatchedSupport.public_support.packages[0].target = "macos-x64";
   assert.throws(

--- a/scripts/tests/codestory-release-closeout.test.mjs
+++ b/scripts/tests/codestory-release-closeout.test.mjs
@@ -181,11 +181,11 @@ function manifestsFor(phase, prePublishLedger = null, { attempt = "1", withheldH
   });
 }
 
-function trustedProducersFor(phase, withheldHost = null) {
+function trustedProducersFor(phase, withheldHost = null, options = {}) {
   const artifactByName = new Map();
-  const attempt = withheldHostList(withheldHost).length > 0
+  const attempt = options.attempt ?? (withheldHostList(withheldHost).length > 0
     ? String(nonClaimPolicy.maximum_run_attempts)
-    : "1";
+    : "1");
   let nextId = 1000;
   const producers = deriveReleaseCells(graph, phase).map((cell) => {
     const withheld = withheldHostOf(withheldHost, cell.id) !== null;
@@ -213,6 +213,9 @@ function trustedProducersFor(phase, withheldHost = null) {
     return {
       cell_id: cell.id,
       ...(withheld ? { non_claim: true } : {}),
+      ...(withheld && options.nonClaimReason !== undefined
+        ? { non_claim_reason: options.nonClaimReason }
+        : {}),
       producer_workflow: constraints.producer_workflow,
       producer_job: constraints.producer_job,
       producer_job_name: constraints.producer_job_name,
@@ -1620,5 +1623,228 @@ test("a post-publish closeout that cannot resolve one catalog delivery state is 
     rejected.ledger.input_errors.some((message) =>
       message.includes("disagree on the catalog delivery state")),
     JSON.stringify(rejected.ledger.input_errors),
+  );
+});
+
+// ── The typed pre-assignment withhold ───────────────────────────────────────────────────────
+
+const reservationPolicy = nonClaimPolicy.reservation;
+
+function preAssignmentReservationFacts() {
+  return {
+    schema: reservationPolicy.schema,
+    state: "unproven",
+    observation_attempts: reservationPolicy.maximum_observation_attempts,
+    maximum_observation_attempts: reservationPolicy.maximum_observation_attempts,
+  };
+}
+
+/// A run whose Linux proof was never assigned: the reservation receipt typed the host unproven
+/// before dispatch, so everything is recorded at attempt 1 -- there was never a job to re-run.
+function preAssignmentPrePublish(hosts = linuxHost) {
+  const manifests = manifestsFor("pre_publish", null, { attempt: "1", withheldHost: hosts });
+  for (const manifest of manifests) {
+    if (manifest.evidence.status !== "withheld") continue;
+    delete manifest.non_claim.annotation;
+    manifest.non_claim.non_claim_reason = nonClaimPolicy.pre_assignment_reason;
+    manifest.non_claim.reservation = preAssignmentReservationFacts();
+  }
+  return {
+    manifests,
+    trustedProducers: trustedProducersFor("pre_publish", hosts, {
+      attempt: "1",
+      nonClaimReason: nonClaimPolicy.pre_assignment_reason,
+    }),
+  };
+}
+
+test("a host typed unproven before dispatch is withheld at attempt 1 under its own reason", () => {
+  const { manifests, trustedProducers } = preAssignmentPrePublish();
+  const result = evaluate("pre_publish", manifests, null, trustedProducers);
+
+  // Attempt 1 is the point: the proof job never existed, so the run-attempt recovery bound has
+  // nothing to spend, and the receipt's recorded recheck is the bound that was spent instead.
+  assert.equal(result.decision, "accept");
+  assert.deepEqual(
+    result.summary.withheld_cells,
+    ["accelerator_execution:linux-x64-vulkan", "candidate_installed_behavior:linux-x64"],
+  );
+  assert.deepEqual(result.summary.withheld_hosts, ["linux-x64-vulkan"]);
+  const row = result.ledger.cells.find(({ id }) => id === "accelerator_execution:linux-x64-vulkan");
+  assert.equal(row.status, "withheld");
+  assert.equal(row.non_claim.non_claim_reason, "accelerator_host_offline_pre_assignment");
+  assert.equal(row.non_claim.annotation, undefined);
+  assert.equal(row.non_claim.reservation.state, "unproven");
+  assert.equal(
+    row.non_claim.reservation.observation_attempts,
+    reservationPolicy.maximum_observation_attempts,
+  );
+  assert.equal(row.identity.producer_run_attempt, "1");
+
+  // The published notes quote the recorded reason, not the graph default.
+  const out = mkdtempSync(path.join(os.tmpdir(), "codestory-preassign-notes-"));
+  writeReleaseCloseout(out, result);
+  const notes = spawnSync(
+    process.execPath,
+    [
+      path.join(root, "scripts/codestory-release-claims.mjs"),
+      "release-platform-notes",
+      "--ledger",
+      path.join(out, "ledger.json"),
+    ],
+    { encoding: "utf8" },
+  );
+  assert.equal(notes.status, 0, notes.stderr);
+  assert.match(
+    notes.stdout,
+    /^- Linux x64: Vulkan not proven for this release \(accelerator_host_offline_pre_assignment\)$/mu,
+  );
+});
+
+test("pre-assignment withholds count against the same withheld-hosts cap", () => {
+  const two = nonClaimPolicy.hosts.filter(({ id }) => id !== "windows-x64-vulkan");
+  const { manifests, trustedProducers } = preAssignmentPrePublish(two);
+  const result = evaluate("pre_publish", manifests, null, trustedProducers);
+  assert.equal(result.decision, "reject");
+  assert.ok(
+    result.summary.input_errors.some((message) =>
+      message === "withheld hosts linux-x64-vulkan, macos-arm64-metal exceed the 1-host withhold cap"),
+    JSON.stringify(result.summary.input_errors),
+  );
+});
+
+test("a reason-mismatched withheld manifest is refused in both directions", () => {
+  // The closeout confirmed the pre-assignment route; a manifest recorded under the mid-job
+  // lost-runner reason is describing a different fact.
+  const midJobManifest = preAssignmentPrePublish();
+  for (const manifest of midJobManifest.manifests) {
+    if (manifest.evidence.status !== "withheld") continue;
+    delete manifest.non_claim.reservation;
+    manifest.non_claim.non_claim_reason = nonClaimPolicy.reason;
+    manifest.non_claim.annotation = nonClaimPolicy.annotation;
+    // Even with its own internal bound satisfied, the route mismatch alone must refuse it.
+    manifest.non_claim.run_attempt = withheldAttempt;
+    manifest.evidence.identity.producer_run_attempt = withheldAttempt;
+  }
+  // The producer rows built below carry the manifests' own attempt, so the only disagreement
+  // left standing is the reason itself.
+  const cellId = "accelerator_execution:linux-x64-vulkan";
+  const midJobResult = evaluate(
+    "pre_publish",
+    midJobManifest.manifests,
+    null,
+    trustedProducersFor("pre_publish", linuxHost, {
+      nonClaimReason: nonClaimPolicy.pre_assignment_reason,
+    }),
+  );
+  assert.equal(midJobResult.decision, "reject");
+  assert.ok(
+    midJobResult.evaluations.get(cellId).value.failures.some((message) =>
+      /non_claim_reason must be the accelerator_host_offline_pre_assignment route/u.test(message)),
+    JSON.stringify(midJobResult.evaluations.get(cellId).value.failures),
+  );
+
+  // And the reverse: the closeout confirmed the mid-job route (untagged row), so a manifest
+  // recorded under the pre-assignment reason is refused.
+  const preAssignmentManifests = manifestsFor("pre_publish", null, {
+    attempt: withheldAttempt,
+    withheldHost: linuxHost,
+  });
+  for (const manifest of preAssignmentManifests) {
+    if (manifest.evidence.status !== "withheld") continue;
+    delete manifest.non_claim.annotation;
+    manifest.non_claim.non_claim_reason = nonClaimPolicy.pre_assignment_reason;
+    manifest.non_claim.reservation = preAssignmentReservationFacts();
+  }
+  const reverse = evaluate(
+    "pre_publish",
+    preAssignmentManifests,
+    null,
+    trustedProducersFor("pre_publish", linuxHost),
+  );
+  assert.equal(reverse.decision, "reject");
+  assert.ok(
+    reverse.evaluations.get(cellId).value.failures.some((message) =>
+      /non_claim_reason must be the accelerator_host_unavailable route/u.test(message)),
+    JSON.stringify(reverse.evaluations.get(cellId).value.failures),
+  );
+
+  // A producer map row tagged with an invented reason is refused as an input error.
+  const invented = preAssignmentPrePublish();
+  for (const row of invented.trustedProducers.producers) {
+    if (row.non_claim === true) row.non_claim_reason = "we_were_in_a_hurry";
+  }
+  const inventedResult = evaluate("pre_publish", invented.manifests, null, invented.trustedProducers);
+  assert.equal(inventedResult.decision, "reject");
+  assert.ok(
+    inventedResult.summary.input_errors.some((message) =>
+      /non_claim_reason must be the declared pre-assignment reason/u.test(message)),
+    JSON.stringify(inventedResult.summary.input_errors),
+  );
+});
+
+test("a pre-assignment withheld cell must carry honest receipt facts", () => {
+  const cellId = "accelerator_execution:linux-x64-vulkan";
+  const cases = [
+    ["quoted annotation", (nonClaim) => {
+      nonClaim.annotation = nonClaimPolicy.annotation;
+    }, /annotation is scoped to accelerator_host_unavailable/u],
+    ["missing reservation facts", (nonClaim) => {
+      delete nonClaim.reservation;
+    }, /must carry its reservation receipt facts/u],
+    ["unspent recheck bound", (nonClaim) => {
+      nonClaim.reservation.observation_attempts = 1;
+    }, /observation recheck bound/u],
+    ["softened reservation state", (nonClaim) => {
+      nonClaim.reservation.state = "alive";
+    }, /reservation state must be unproven/u],
+    ["stale reservation schema", (nonClaim) => {
+      nonClaim.reservation.schema = "codestory.protected-runner-reservation/v0";
+    }, /reservation schema must be/u],
+  ];
+  for (const [label, mutate, pattern] of cases) {
+    const { manifests, trustedProducers } = preAssignmentPrePublish();
+    mutate(manifests.find(({ cell_id: id }) => id === cellId).non_claim);
+    const result = evaluate("pre_publish", manifests, null, trustedProducers);
+    assert.equal(result.decision, "reject", label);
+    assert.ok(
+      result.evaluations.get(cellId).value.failures.some((message) => pattern.test(message)),
+      `${label}: ${JSON.stringify(result.evaluations.get(cellId).value.failures)}`,
+    );
+  }
+
+  // A mid-job withheld manifest smuggling reservation facts is refused the same way.
+  const { manifests, trustedProducers } = withheldPrePublish();
+  manifests.find(({ cell_id: id }) => id === cellId).non_claim.reservation =
+    preAssignmentReservationFacts();
+  const smuggled = evaluate("pre_publish", manifests, null, trustedProducers);
+  assert.equal(smuggled.decision, "reject");
+  assert.ok(
+    smuggled.evaluations.get(cellId).value.failures.some((message) =>
+      /reservation facts are scoped to accelerator_host_offline_pre_assignment/u.test(message)),
+    JSON.stringify(smuggled.evaluations.get(cellId).value.failures),
+  );
+});
+
+test("a forged pre-assignment withheld cell without closeout confirmation is refused", () => {
+  // The manifest says withheld; the closeout's own producer map -- built from evidence it
+  // collected itself -- confirmed no withheld route for the cell. The forgery is refused on the
+  // state mismatch, before any of the manifest's own claims are believed.
+  const { manifests } = preAssignmentPrePublish();
+  const unconfirmed = trustedProducersFor("pre_publish", linuxHost, {
+    attempt: "1",
+    nonClaimReason: nonClaimPolicy.pre_assignment_reason,
+  });
+  for (const row of unconfirmed.producers) {
+    delete row.non_claim;
+    delete row.non_claim_reason;
+  }
+  const result = evaluate("pre_publish", manifests, null, unconfirmed);
+  assert.equal(result.decision, "reject");
+  const cellId = "accelerator_execution:linux-x64-vulkan";
+  assert.ok(
+    result.evaluations.get(cellId).value.failures.some((message) =>
+      /withheld state does not match the trusted producer map/u.test(message)),
+    JSON.stringify(result.evaluations.get(cellId).value.failures),
   );
 });

--- a/scripts/tests/fixtures/release-claims/positive.json
+++ b/scripts/tests/fixtures/release-claims/positive.json
@@ -17,7 +17,7 @@
       "type": "source_behavior",
       "tier": "source",
       "status": "pass",
-      "graph_sha256": "9dc31326a801a1e6333200e0543bd95daad078322a3d31760199813cd262efb8",
+      "graph_sha256": "7739066fa844d159b354bcabd1408b86501ae2484cb00faa231d2430f8890029",
       "observed_at": "2026-07-16T11:00:00.000Z",
       "expires_at": "2026-07-17T11:00:00.000Z",
       "identity": {


### PR DESCRIPTION
## Context

W8.5 of #1670, from the contract elaborated there: a protected runner offline at dispatch produced a never-assigned job that queued invisibly for ~24h and terminally classified as an ordinary blocked failure — indistinguishable from a proof that ran and refused.

Closes #1876
Refs #1670
Refs #1233
Refs #1179

## What changed

- New `protected-runner-heartbeat.yml`: tiny secret-less jobs ON the three protected hosts, cron + dispatch, cancel-in-progress, zero token scopes. The credential constraint (GITHUB_TOKEN cannot carry the runner-admin scope) is verified and cited where it binds the design.
- `lost-runner-recovery.mjs`: reservation planning (`alive` / `held_by_active_run` / `recheck_pending` / `unproven`, one bounded recheck mirroring the existing attempt bound, fail-closed on unreadable evidence) and one new typed non-claim state reachable ONLY for an absent job with a vouching receipt — a present failed job never consults the receipt, so masking is impossible by construction.
- `release.yml`: a `reserve-protected-runners` gate before the three proof calls (no approval environment), per-host dispatch conditions, receipt uploaded even on red; the non-claim and both closeouts consume the receipt through their own collection.
- Claims graph + policy checker pin the whole wiring (16 named mutations in the new policy test); closeout admits a pre-assignment withheld cell only with closeout-collected confirmation, reason-mismatch refused both directions, existing mid-job route byte-identical; withholds count against the same `maximum_withheld_hosts` cap. Recorded defaults: no new credentials; busy-but-alive blocks fail-red naming the holder.

## Verification

On `9dfdeb86` (implementer ran everything in-environment; supervisor decisive re-runs): lost-runner tests 20/0, policy checker + tests 1367/0, claims/cell-manifest/closeout 107/0, actionlint + tests, generalization lint, plugin-static 130/0, doc links, evidence-gate 23/0 with regenerated pins including the re-attested `candidate_sha256`, marketplace suites 38/0, `git diff --check`. Hostile checks live: the masking attempt stays blocked with the receipt never consulted; a forged withheld cell is rejected; removing the gate fails policy with 12 named violations.

Draft until independent adversarial review accepts the exact head and CI is green.