### PR TITLE
[v0.17 REL-CI S1a] Graph-owned digest pins behind one evaluator, plus the policy equivalence harness

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -43,7 +43,6 @@ const fullSha = /^[0-9a-f]{40}$/iu;
 const sccacheAction = "mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696";
 const sccacheVersion = "v0.16.0";
 const nextestVersion = "0.9.98";
-const nextestLinuxSha256 = "7d07712519615722b19ffe3b3d1097b7d4fa390995e3cac1f9d6dda1ba61b2a7";
 const sccacheCacheSize = "1G";
 const windowsSccacheCacheSize = "2G";
 
@@ -906,10 +905,16 @@ export function qualificationDriverArtifactViolations(
     "release-claims.json must bind the private archive-qualified driver contract exactly",
   );
   const normalized = String(source ?? "").replace(/\r\n/gu, "\n");
+  // The pinned digest holds both sides of the private-artifact contract: the producer
+  // may read Cargo's trusted hard-linked build output but retains only a new singly
+  // linked copy bound to the exact candidate archive, and the consumer rejects
+  // symlinks, retained hardlinks, extra files, identity drift, and byte drift before
+  // restoring execute permission. Any helper edit therefore requires policy and
+  // mutation-test review in the same PR.
   add(
     violations,
     createHash("sha256").update(normalized).digest("hex")
-      === qualificationDriverArtifactDigest,
+      === pinnedProgramRow(graph, "qualification_driver_artifact").sha256,
     "qualification-driver-artifact.mjs must match the reviewed archive-bound producer and verifier contract",
   );
   for (const fragment of [
@@ -975,61 +980,84 @@ const draftCachePaths = [
   "~/.cargo/git",
   "target",
 ];
-const sourceResolverContractDigest = "2fe869b675010f5db29259aff38d83456c01dbc9885989afbf7c92a2826791af";
-const platformResolverContractDigest = "14015fd938e7dc2bafd50bef2d85d6934ee4658bd86b5560729edb4be7c14679";
-// check-workflow-policy.test.mjs runs this exact script against hostile dispatch values and proves
-// it exits non-zero, so the digest stands for a rejection that was measured, not merely read.
-const marketplaceGuardDigest = "6380c916a1b3566b4b9d6545b63fbc9c7db12b54fb328b5c89316daae0162d84";
-// This closeout is a small shell control-flow program. Substring checks can be
-// satisfied by parking the accepted qualification branch in dead code while
-// the live branch blocks on optional Linux hardware, so pin its reviewed
-// executable text as well as its reader-facing invariants.
-const packagedPlatformCloseoutDigest =
-  "ce7a7f5aa99f5fcbc037d4c1f06de5d841e4a4d114208820592a84c41c797b1a";
-// This workflow builds release archives on three operating systems and carries
-// state between many shell steps through GITHUB_ENV and GITHUB_PATH. Pin its
-// parsed executable structure so an unreviewed earlier step cannot replace an
-// owner binary while leaving the locally digested finalizer unchanged.
-const packagedPlatformWorkflowDigest =
-  "443c65ea54f92260e664bdeaceabb43e57ac1dc9cb5d15f2783690f6102823fa";
-// The frozen-candidate coordinator and protected GPU workflows are small
-// release-control programs, not loose collections of independently safe
-// fragments. Pin their complete parsed structure so a required check cannot be
-// made advisory, parked in dead code, or followed by a payload substitution
-// while leaving the expected tokens in place.
-const packagedPlatformCoordinatorWorkflowDigest =
-  "ca70707ba924b57848d92e8b7a3490e8e18623dce4d1afec393212a78bce110a";
-const releaseSourceProofSentinelDigest =
-  "91ee8bc1a6a055e9297e81747c37d167b123d0a2e5dc60d5c6e2bdcfbef9c351";
-const frozenCandidateQualityWorkflowDigest =
-  "b7a17c66c4cc4275b369f39fdc1fcdb375b334ba908d31577b910ea10e7eb54e";
-const macosMetalWorkflowDigest =
-  "55581330f6a035b84e1224dbd5469d812ab2fa444914157e22a39cccc64f4627";
-const windowsVulkanWorkflowDigest =
-  "c2272dbf4c550ba4a21372e772a87f6df3307f5f4f709b216473f85958157ffe";
-const linuxVulkanWorkflowDigest =
-  "b2efe3dec20a466cb798752c714f50e64e265856e80ffafc15b28ea2390367d3";
-// Linux owns its compiler server inside Docker, while macOS and Windows own one
-// in the host shell. Pin both executable programs so a swallowed stop or a
-// dead-code copy cannot satisfy the ownership fragments below.
-const packagedSccacheIdentityDigest =
-  "f844b8a3b2e0f0013b43f4ec661c237fb090a01c49316d8c2b301ba01cac4342";
-const packagedLinuxBuildDigest =
-  "f101cc525f52f75686acbb1cf240412409f3f388793890993cefae9175685a6f";
-const packagedCompileClockStopDigest =
-  "ef9f7ee4636c3466830447e2ed8a10c2030ca3949bca082652d9262848d258a5";
-const packagedHostCompilerFinalizerDigest =
-  "b77d8bb12c2748bfe016ab65ccb2f4581356f3ccf1d666e747306caffd6c0c46";
-// The companion qualification driver is intentionally retained only inside
-// the private Actions package artifact. This digest pins both sides of that
-// contract: the producer may read Cargo's trusted hard-linked build output,
-// but retains only a new singly linked copy bound to the exact candidate
-// archive. The consumer rejects symlinks, retained hardlinks, extra files,
-// identity drift, and byte drift before restoring execute permission.
-// Any helper edit therefore requires policy and mutation-test review in the
-// same PR.
-const qualificationDriverArtifactDigest =
-  "efc5126e24162d52f9da8bac38c3414b3a7492fb17eed5ff19867fadad69623e";
+// Every exact sha256 pin is a rule INSTANCE and lives in release-claims.json under
+// workflow_policy.pinned_programs; scripts/codestory-release-claims.mjs fails graph
+// loading unless that block names exactly the reviewed pinned set. This table keeps
+// only what stays code: the predicate implementation per subject kind and the
+// reviewed violation message for each pinned program. Adding or re-pinning a program
+// is a graph edit plus one row here; the digests themselves never return to code.
+const pinnedProgramContracts = {
+  packaged_platform_proof_workflow: {
+    violation: row => `${row.file} must match the reviewed canonical workflow structure`,
+  },
+  packaged_platform_pr_workflow: {
+    violation: row => `${row.file} must match the reviewed frozen-candidate coordinator structure`,
+  },
+  frozen_candidate_quality_workflow: {
+    violation: row => `${row.file} must match the reviewed isolated evaluation-owner structure`,
+  },
+  macos_metal_proof_workflow: {
+    violation: row => `${row.file} must match the reviewed protected Metal workflow structure`,
+  },
+  windows_vulkan_proof_workflow: {
+    violation: row => `${row.file} must match the reviewed protected Windows Vulkan workflow structure`,
+  },
+  linux_vulkan_proof_workflow: {
+    violation: row => `${row.file} must match the reviewed protected Linux Vulkan workflow structure`,
+  },
+  release_source_proof_sentinel: {
+    violation: row => `${row.file} source proof placeholder must match the reviewed fail-closed sentinel`,
+  },
+  source_proof_resolver: { resolver: true },
+  packaged_platform_pr_resolver: { resolver: true },
+  marketplace_sync_dispatch_guard: { script: "dispatch coordinate guard" },
+  packaged_platform_pr_closeout: { script: "coordinator closeout" },
+  packaged_sccache_identity: { script: "pinned sccache identity capture" },
+  packaged_linux_build: { script: "Linux container build and compiler-server ownership" },
+  packaged_compile_clock_stop: { script: "compiler clock stop" },
+  packaged_host_compiler_finalizer: { script: "host compiler-server finalizer" },
+};
+
+function pinnedProgramRow(graph, name) {
+  return object(object(object(graph.workflow_policy).pinned_programs)[name]);
+}
+
+// One generic evaluator walks the graph-owned digest pins. A missing workflow is
+// reported by the structural validator that owns the file, so each row evaluates
+// only when its subject workflow parsed; every other absence (missing job, missing
+// step, empty script) hashes to a mismatch exactly as the retired inline checks did.
+export function pinnedProgramViolations(workflows, graph = loadReleaseClaimGraph(repositoryRoot)) {
+  const violations = [];
+  for (const [name, contract] of Object.entries(pinnedProgramContracts)) {
+    const row = pinnedProgramRow(graph, name);
+    const workflow = workflows.get(row.file);
+    if (!workflow) continue;
+    if (row.subject === "parsed_workflow_json") {
+      add(
+        violations,
+        createHash("sha256").update(JSON.stringify(workflow)).digest("hex") === row.sha256,
+        contract.violation(row),
+      );
+      continue;
+    }
+    const job = object(object(workflow.jobs)[row.job]);
+    if (row.subject === "parsed_job_json") {
+      add(
+        violations,
+        createHash("sha256").update(JSON.stringify(job)).digest("hex") === row.sha256,
+        contract.violation(row),
+      );
+    } else if (row.subject === "step_script_executable_text") {
+      requireExactStepScript(violations, row.file, job, row.step, row.sha256, contract.script);
+    } else if (contract.resolver) {
+      requireExactResolverContract(violations, row.file, job, row.sha256);
+    } else {
+      requireExactRawStepScript(violations, row.file, job, row.step, row.sha256, contract.script);
+    }
+  }
+  return violations;
+}
+
 const draftProofCommands = [
   "cargo test --locked -p codestory-llama-sys --test native_staging",
   "cargo test --locked -p codestory-llama-sys --test model_staging",
@@ -2431,7 +2459,6 @@ function validatePluginAndDraftWorkflows(workflows, violations, graph) {
       'test "$GITHUB_SHA" = "$CALLER_REF"',
       "--ref $head_ref",
     ]);
-    requireExactResolverContract(violations, sourceFile, resolve, sourceResolverContractDigest);
     requireStepRun(violations, sourceFile, resolve, "Reuse a completed gate for this exact head", [
       '.path == ".github/workflows/source-proof.yml"',
       '.event == "workflow_dispatch" and .conclusion == "success"',
@@ -2799,7 +2826,7 @@ function validatePluginAndDraftWorkflows(workflows, violations, graph) {
     ]);
     requireStepRun(violations, sourceFile, full, "Install pinned cargo-nextest", [
       `cargo-nextest-${nextestVersion}-x86_64-unknown-linux-gnu.tar.gz`,
-      `${nextestLinuxSha256}  $RUNNER_TEMP/cargo-nextest.tar.gz`,
+      `${pinnedProgramRow(graph, "nextest_linux_archive").sha256}  $RUNNER_TEMP/cargo-nextest.tar.gz`,
       "sha256sum --check --strict",
       "cargo nextest --version",
     ]);
@@ -3235,12 +3262,6 @@ function validateReleaseCoordinator(workflows, violations, graph) {
   );
 
   const source = requireJob(violations, releaseFile, release, "source-proof");
-  add(
-    violations,
-    createHash("sha256").update(JSON.stringify(source)).digest("hex")
-      === releaseSourceProofSentinelDigest,
-    `${releaseFile} source proof placeholder must match the reviewed fail-closed sentinel`,
-  );
   add(
     violations,
     source.uses === undefined
@@ -3782,12 +3803,6 @@ function validatePackagedProof(workflows, violations, graph) {
     violations.push(`${file} must exist`);
     return;
   }
-  add(
-    violations,
-    createHash("sha256").update(JSON.stringify(workflow)).digest("hex")
-      === packagedPlatformWorkflowDigest,
-    `${file} must match the reviewed canonical workflow structure`,
-  );
   add(violations, trigger(workflow, "workflow_call") !== undefined, `${file} must be reusable`);
   const refInput = object(at(workflow, "on", "workflow_call", "inputs", "ref"));
   add(
@@ -3906,14 +3921,6 @@ function validatePackagedProof(workflows, violations, graph) {
       && stepIndex(job, "Capture pinned sccache identity")
         === stepIndex(job, "Install pinned sccache") + 1,
     `${file} must capture the pinned sccache identity immediately after installation`,
-  );
-  requireExactRawStepScript(
-    violations,
-    file,
-    job,
-    "Capture pinned sccache identity",
-    packagedSccacheIdentityDigest,
-    "pinned sccache identity capture",
   );
   requireStepRun(violations, file, job, "Capture pinned sccache identity", [
     'sccache_path="$(command -v sccache)"',
@@ -4118,14 +4125,6 @@ function validatePackagedProof(workflows, violations, graph) {
       && linuxBuild?.["continue-on-error"] === undefined,
     `${file} Linux container must strictly report and stop its owned compiler server`,
   );
-  requireExactRawStepScript(
-    violations,
-    file,
-    job,
-    "Build Linux x64 at the glibc 2.31 baseline",
-    packagedLinuxBuildDigest,
-    "Linux container build and compiler-server ownership",
-  );
   const stopCompilationClock = namedStep(job, "Stop compilation clock");
   add(
     violations,
@@ -4134,14 +4133,6 @@ function validatePackagedProof(workflows, violations, graph) {
       && stopCompilationClock?.env === undefined
       && stopCompilationClock?.["continue-on-error"] === undefined,
     `${file} compiler clock stop must remain a strict telemetry-only boundary`,
-  );
-  requireExactRawStepScript(
-    violations,
-    file,
-    job,
-    "Stop compilation clock",
-    packagedCompileClockStopDigest,
-    "compiler clock stop",
   );
   const finalizeCompilerObjects = namedStep(job, "Finalize compiler objects");
   add(
@@ -4159,14 +4150,6 @@ function validatePackagedProof(workflows, violations, graph) {
       && finalizeCompilerObjects?.["continue-on-error"] === undefined
       && packageBuild?.if === "matrix.asset_target != 'linux-x64'",
     `${file} host finalizer must strictly stop only the host package-build compiler server`,
-  );
-  requireExactRawStepScript(
-    violations,
-    file,
-    job,
-    "Finalize compiler objects",
-    packagedHostCompilerFinalizerDigest,
-    "host compiler-server finalizer",
   );
   add(
     violations,
@@ -5475,12 +5458,6 @@ function validatePackagedCoordinator(workflows, violations, graph) {
     violations.push(`${file} must exist`);
     return;
   }
-  add(
-    violations,
-    createHash("sha256").update(JSON.stringify(workflow)).digest("hex")
-      === packagedPlatformCoordinatorWorkflowDigest,
-    `${file} must match the reviewed frozen-candidate coordinator structure`,
-  );
   const promotion = graph.workflow_policy.promotion;
   const calibrationPolicy = object(graph.workflow_policy.calibration);
   const qualificationPolicy = object(graph.workflow_policy.qualification);
@@ -5569,7 +5546,8 @@ function validatePackagedCoordinator(workflows, violations, graph) {
           archive_cache_contract: "candidate_archive_cache",
           archive_transfer: "authenticated_miss_only",
           evaluation_owner: "isolated_reusable_workflow",
-          evaluation_owner_sha256: frozenCandidateQualityWorkflowDigest,
+          evaluation_owner_sha256:
+            pinnedProgramRow(graph, "frozen_candidate_quality_workflow").sha256,
           evaluation_contract: "publishable-three-repeat-packet/v1",
           task_count: 1,
           repeats_per_task: 3,
@@ -5672,7 +5650,6 @@ function validatePackagedCoordinator(workflows, violations, graph) {
     INPUT_CALIBRATION_ARTIFACT: "${{ inputs.calibration_bundle_artifact }}",
     INPUT_CALIBRATION_RUN_ID: "${{ inputs.calibration_bundle_run_id }}",
   });
-  requireExactResolverContract(violations, file, route, platformResolverContractDigest);
   add(
     violations,
     namedStep(route, "Require executable release freeze")?.if === undefined,
@@ -5962,12 +5939,6 @@ function validatePackagedCoordinator(workflows, violations, graph) {
     violations.push(`${qualityFile} must exist`);
     return;
   }
-  add(
-    violations,
-    createHash("sha256").update(JSON.stringify(qualityWorkflow)).digest("hex")
-      === frozenCandidateQualityWorkflowDigest,
-    `${qualityFile} must match the reviewed isolated evaluation-owner structure`,
-  );
   const qualityCall = object(trigger(qualityWorkflow, "workflow_call"));
   const qualityInputs = object(qualityCall.inputs);
   add(
@@ -6456,14 +6427,6 @@ function validatePackagedCoordinator(workflows, violations, graph) {
     'require_result "$LINUX_VULKAN_RESULT" success linux-vulkan-proof',
     "dev/codestory-next moved from proved head",
   ]);
-  requireExactStepScript(
-    violations,
-    file,
-    closeout,
-    "Require one coherent accepted proof",
-    packagedPlatformCloseoutDigest,
-    "coordinator closeout",
-  );
   add(
     violations,
     /if\s+\[\s*"\$MODE"\s*=\s*qualification\s*\];\s*then\s+require_result\s+"\$LINUX_VULKAN_RESULT"\s+skipped\s+linux-vulkan-proof\s+else\s+require_result\s+"\$LINUX_VULKAN_RESULT"\s+success\s+linux-vulkan-proof\s+fi/um
@@ -6533,12 +6496,6 @@ function validateRemainingWorkflows(workflows, violations) {
   if (!metal) {
     violations.push(`${metalFile} must exist`);
   } else {
-    add(
-      violations,
-      createHash("sha256").update(JSON.stringify(metal)).digest("hex")
-        === macosMetalWorkflowDigest,
-      `${metalFile} must match the reviewed protected Metal workflow structure`,
-    );
     add(
       violations,
       trigger(metal, "workflow_call") !== undefined
@@ -7198,12 +7155,6 @@ function validateRemainingWorkflows(workflows, violations) {
   } else {
     add(
       violations,
-      createHash("sha256").update(JSON.stringify(vulkan)).digest("hex")
-        === windowsVulkanWorkflowDigest,
-      `${vulkanFile} must match the reviewed protected Windows Vulkan workflow structure`,
-    );
-    add(
-      violations,
       trigger(vulkan, "workflow_call") !== undefined
         && trigger(vulkan, "workflow_dispatch") === undefined,
       `${vulkanFile} must be coordinator-only and not directly dispatchable`,
@@ -7829,12 +7780,6 @@ function validateRemainingWorkflows(workflows, violations) {
   if (!linuxVulkan) {
     violations.push(`${linuxVulkanFile} must exist`);
   } else {
-    add(
-      violations,
-      createHash("sha256").update(JSON.stringify(linuxVulkan)).digest("hex")
-        === linuxVulkanWorkflowDigest,
-      `${linuxVulkanFile} must match the reviewed protected Linux Vulkan workflow structure`,
-    );
     add(
       violations,
       trigger(linuxVulkan, "workflow_call") !== undefined
@@ -11114,7 +11059,6 @@ export function validateMarketplaceSync(workflows, violations, graph) {
   // well formed. The guard must match whole values; the digest keeps that property from being
   // quietly traded back for a line-oriented test.
   forbidStepRun(violations, file, job, guard, ["grep"]);
-  requireExactStepScript(violations, file, job, guard, marketplaceGuardDigest, "dispatch coordinate guard");
   add(
     violations,
     stepIndex(job, guard) === 0,
@@ -11237,6 +11181,7 @@ export function validateWorkflows(workflows, graph = loadReleaseClaimGraph(repos
   violations.push(...lostRunnerRecoveryViolations(workflows, graph));
   violations.push(...protectedRunnerReservationViolations(workflows, graph));
   violations.push(...releaseWorkflowContractViolations(workflows, graph));
+  violations.push(...pinnedProgramViolations(workflows, graph));
   return violations;
 }
 

--- a/.github/scripts/policy-equivalence.mjs
+++ b/.github/scripts/policy-equivalence.mjs
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+// Differential oracle for the S1 policy-graph migration (#1670): relocating a rule
+// between checker code and release-claims.json must not change a single verdict.
+// The merge-base checker (and its policy inputs) is materialized from git and run
+// beside the working-tree checker over identical workflow structures: once over the
+// pristine tree, then over a deterministic seeded hostile corpus that deletes every
+// node and perturbs every scalar of every workflow. The two violation multisets must
+// be verbatim-identical for every input; the corpus is bounded so a full run stays
+// under roughly twenty minutes.
+//
+// Each side reads its own non-workflow inputs from its own tree (the merge-base side
+// from the materialized base tree, the working-tree side from the repository), so a
+// digest moved from code into the graph is exercised against the data that shipped
+// with that side's checker.
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+export const DEFAULT_BASE_BRANCH = "origin/dev/codestory-next";
+// Bounds the corpus: full enumeration today is ~8k mutants at ~120ms per mutant.
+// When the enumerated corpus outgrows the bound, a seeded deterministic sample keeps
+// the run inside the budget instead of silently truncating coverage from one end.
+export const DEFAULT_MAX_MUTANTS = 9000;
+const CORPUS_SEED = 0xc0de57a1;
+// The base tree pathspecs cover every file the checker reads at run time: workflow
+// sources, its own module closure, the release-claim graph, the crate tree walked by
+// the cargo-test-filter and retrieval-wrapper lints, and the locked setup surfaces.
+const BASE_TREE_PATHS = [
+  ".cargo",
+  ".github",
+  "crates",
+  "plugins",
+  "scripts",
+  "release-claims.json",
+];
+
+function git(args, options = {}) {
+  const result = spawnSync("git", args, {
+    cwd: repositoryRoot,
+    encoding: "utf8",
+    maxBuffer: 1 << 28,
+    ...options,
+  });
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed: ${String(result.stderr).trim()}`);
+  }
+  return result;
+}
+
+export function resolveBaseSha(baseRef = process.env.POLICY_EQUIVALENCE_BASE_REF) {
+  if (baseRef) {
+    return git(["rev-parse", "--verify", `${baseRef}^{commit}`]).stdout.trim();
+  }
+  return git(["merge-base", "HEAD", DEFAULT_BASE_BRANCH]).stdout.trim();
+}
+
+// The base tree lives under node_modules/.cache so Node resolves the `yaml`
+// dependency through the repository's installed node_modules and git never sees the
+// materialized files. The tree is content-addressed by commit and reused when it is
+// already complete.
+export function materializeBaseTree(baseSha) {
+  const root = path.join(
+    repositoryRoot,
+    "node_modules",
+    ".cache",
+    "codestory-policy-equivalence",
+    baseSha,
+  );
+  const marker = path.join(root, ".complete");
+  if (fs.existsSync(marker)) return root;
+  fs.rmSync(root, { recursive: true, force: true });
+  fs.mkdirSync(root, { recursive: true });
+  const archive = spawnSync("git", ["archive", baseSha, "--", ...BASE_TREE_PATHS], {
+    cwd: repositoryRoot,
+    maxBuffer: 1 << 30,
+  });
+  if (archive.status !== 0) {
+    throw new Error(`git archive ${baseSha} failed: ${String(archive.stderr).trim()}`);
+  }
+  const extract = spawnSync("tar", ["-x", "-C", root], {
+    input: archive.stdout,
+    maxBuffer: 1 << 30,
+  });
+  if (extract.status !== 0) {
+    throw new Error(`extracting base tree ${baseSha} failed: ${String(extract.stderr).trim()}`);
+  }
+  fs.writeFileSync(marker, `${baseSha}\n`);
+  return root;
+}
+
+function mulberry32(seed) {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// Every node of every parsed workflow yields a deletion mutant; every scalar leaf
+// additionally yields a perturbation mutant. Enumeration order is the parse order of
+// the sorted workflow files, so the corpus is deterministic for a given tree.
+export function enumerateMutations(workflows) {
+  const mutations = [];
+  for (const [file, workflow] of workflows) {
+    const walk = (value, trail) => {
+      const entries = Array.isArray(value)
+        ? value.map((item, index) => [index, item])
+        : Object.entries(value);
+      for (const [key, child] of entries) {
+        const childTrail = [...trail, key];
+        mutations.push({ file, path: childTrail, op: "delete" });
+        if (child !== null && typeof child === "object") {
+          walk(child, childTrail);
+        } else {
+          mutations.push({ file, path: childTrail, op: "perturb" });
+        }
+      }
+    };
+    if (workflow !== null && typeof workflow === "object") walk(workflow, []);
+  }
+  return mutations;
+}
+
+function perturbScalar(value) {
+  if (typeof value === "string") return `${value} hostile-mutant`;
+  if (typeof value === "number") return value + 1;
+  if (typeof value === "boolean") return !value;
+  return "hostile-mutant";
+}
+
+export function applyMutation(workflow, mutation) {
+  const mutated = structuredClone(workflow);
+  let parent = mutated;
+  for (const key of mutation.path.slice(0, -1)) parent = parent[key];
+  const leaf = mutation.path[mutation.path.length - 1];
+  if (mutation.op === "delete") {
+    if (Array.isArray(parent)) parent.splice(Number(leaf), 1);
+    else delete parent[leaf];
+  } else {
+    parent[leaf] = perturbScalar(parent[leaf]);
+  }
+  return mutated;
+}
+
+function describeMutation(mutation) {
+  return `${mutation.file} ${mutation.op} ${mutation.path.join(".")}`;
+}
+
+// A verdict is the sorted violation multiset, or the thrown error when a hostile
+// structure escapes a validator; both sides must agree on whichever occurs. Each
+// side runs with its own working directory because the locked-setup lint reads its
+// contract files relative to the process cwd.
+function verdict(validate, workflows, graph, cwd) {
+  const previous = process.cwd();
+  process.chdir(cwd);
+  try {
+    return { violations: validate(workflows, graph).map(String).sort() };
+  } catch (error) {
+    return { thrown: String((error && error.message) || error) };
+  } finally {
+    process.chdir(previous);
+  }
+}
+
+export async function runEquivalence({
+  baseRef,
+  maxMutants = Number(process.env.POLICY_EQUIVALENCE_MAX_MUTANTS ?? DEFAULT_MAX_MUTANTS),
+  log = () => {},
+} = {}) {
+  const started = Date.now();
+  const baseSha = resolveBaseSha(baseRef);
+  const baseRoot = materializeBaseTree(baseSha);
+  const importFrom = (root, file) => import(pathToFileURL(path.join(root, file)).href);
+  const current = await importFrom(repositoryRoot, ".github/scripts/check-workflow-policy.mjs");
+  const currentClaims = await importFrom(repositoryRoot, "scripts/codestory-release-claims.mjs");
+  const base = await importFrom(baseRoot, ".github/scripts/check-workflow-policy.mjs");
+  const baseClaims = await importFrom(baseRoot, "scripts/codestory-release-claims.mjs");
+  const currentGraph = currentClaims.loadReleaseClaimGraph(repositoryRoot);
+  const baseGraph = baseClaims.loadReleaseClaimGraph(baseRoot);
+  const workflows = current.loadWorkflows(path.join(repositoryRoot, ".github", "workflows"));
+
+  const mismatches = [];
+  const compare = (label, mutatedWorkflows) => {
+    const baseVerdict = verdict(base.validateWorkflows, mutatedWorkflows, baseGraph, baseRoot);
+    const currentVerdict = verdict(
+      current.validateWorkflows,
+      mutatedWorkflows,
+      currentGraph,
+      repositoryRoot,
+    );
+    const equal = JSON.stringify(baseVerdict) === JSON.stringify(currentVerdict);
+    if (!equal && mismatches.length < 25) {
+      mismatches.push({ input: label, base: baseVerdict, current: currentVerdict });
+    }
+    return { equal, baseVerdict, currentVerdict };
+  };
+
+  const pristine = compare("pristine tree", workflows);
+  const enumerated = enumerateMutations(workflows);
+  let corpus = enumerated;
+  if (corpus.length > maxMutants) {
+    const random = mulberry32(CORPUS_SEED);
+    corpus = [...corpus]
+      .map(mutation => ({ mutation, rank: random() }))
+      .sort((left, right) => left.rank - right.rank || 0)
+      .slice(0, maxMutants)
+      .map(({ mutation }) => mutation);
+  }
+  for (const [index, mutation] of corpus.entries()) {
+    const mutatedWorkflows = new Map(workflows);
+    mutatedWorkflows.set(mutation.file, applyMutation(workflows.get(mutation.file), mutation));
+    compare(describeMutation(mutation), mutatedWorkflows);
+    if ((index + 1) % 1000 === 0) {
+      log(`policy-equivalence: ${index + 1}/${corpus.length} mutants compared, ${mismatches.length} mismatches`);
+    }
+  }
+  return {
+    baseSha,
+    enumeratedMutations: enumerated.length,
+    corpusSize: corpus.length,
+    pristine: {
+      equal: pristine.equal,
+      base: pristine.baseVerdict,
+      current: pristine.currentVerdict,
+    },
+    mismatches,
+    durationMs: Date.now() - started,
+  };
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const readFlag = name => {
+    const index = args.indexOf(name);
+    return index >= 0 ? args[index + 1] : undefined;
+  };
+  const maxFlag = readFlag("--max");
+  runEquivalence({
+    baseRef: readFlag("--base"),
+    ...(maxFlag === undefined ? {} : { maxMutants: Number(maxFlag) }),
+    log: message => console.log(message),
+  }).then(result => {
+    console.log(
+      `policy-equivalence: base ${result.baseSha}, pristine tree ${result.pristine.equal ? "identical" : "MISMATCHED"}, `
+      + `${result.corpusSize} hostile mutants (${result.enumeratedMutations} enumerated), `
+      + `${result.mismatches.length} mismatches, ${Math.round(result.durationMs / 1000)}s`,
+    );
+    for (const mismatch of result.mismatches) {
+      console.error(JSON.stringify(mismatch, null, 2));
+    }
+    if (!result.pristine.equal || result.mismatches.length > 0) process.exitCode = 1;
+  }).catch(error => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  main();
+}

--- a/.github/scripts/policy-equivalence.test.mjs
+++ b/.github/scripts/policy-equivalence.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { runEquivalence } from "./policy-equivalence.mjs";
+
+// The standing S1 oracle (#1670): every slice that relocates a workflow-policy rule
+// between checker code and release-claims.json must leave the violation multiset of
+// validateWorkflows verbatim-identical to the merge base, over the pristine tree and
+// over a deterministic hostile corpus that deletes every node and perturbs every
+// scalar of every workflow. A mismatch means a rule was strengthened, weakened, or
+// reworded rather than relocated.
+test("relocated policy rules keep the merge-base verdict multiset over pristine and hostile trees", async () => {
+  const result = await runEquivalence({ log: message => console.log(message) });
+  assert.deepEqual(
+    result.pristine.current,
+    result.pristine.base,
+    "pristine-tree verdicts diverged from the merge base",
+  );
+  assert.deepEqual(result.mismatches, []);
+  assert.ok(result.corpusSize > 0, "hostile corpus must not be empty");
+  console.log(
+    `policy-equivalence: base ${result.baseSha}, pristine tree identical, `
+    + `${result.corpusSize} hostile mutants (${result.enumeratedMutations} enumerated), `
+    + `${Math.round(result.durationMs / 1000)}s`,
+  );
+});

--- a/benchmarks/release-evidence/fixtures/candidate.json
+++ b/benchmarks/release-evidence/fixtures/candidate.json
@@ -62,7 +62,7 @@
   },
   "release_claims": {
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "7739066fa844d159b354bcabd1408b86501ae2484cb00faa231d2430f8890029",
+    "graph_sha256": "5094baf04b547df9d18b55dd5acdd83a026bfcc4ad8e79a252ec3454fbb9d24c",
     "observed_at": "2026-08-08T19:19:24.395Z",
     "expires_at": "2026-08-09T19:19:24.395Z",
     "requested_claims": [
@@ -85,7 +85,7 @@
         "type": "performance",
         "tier": "live_behavior",
         "status": "measured",
-        "graph_sha256": "7739066fa844d159b354bcabd1408b86501ae2484cb00faa231d2430f8890029",
+        "graph_sha256": "5094baf04b547df9d18b55dd5acdd83a026bfcc4ad8e79a252ec3454fbb9d24c",
         "observed_at": "2026-08-08T19:19:24.395Z",
         "expires_at": "2026-08-09T19:19:24.395Z",
         "identity": {
@@ -106,7 +106,7 @@
         "type": "answer_quality",
         "tier": "answer_quality",
         "status": "pass",
-        "graph_sha256": "7739066fa844d159b354bcabd1408b86501ae2484cb00faa231d2430f8890029",
+        "graph_sha256": "5094baf04b547df9d18b55dd5acdd83a026bfcc4ad8e79a252ec3454fbb9d24c",
         "observed_at": "2026-08-08T19:19:24.395Z",
         "expires_at": "2026-08-09T19:19:24.395Z",
         "identity": {

--- a/benchmarks/release-evidence/fixtures/report.json
+++ b/benchmarks/release-evidence/fixtures/report.json
@@ -7,7 +7,7 @@
   "baseline_id": "ci-contract-v1@1111111111111111111111111111111111111111",
   "baseline_sha256": "0bbbe6dd8b4000151edf7b1270959d08e94e08db876e7f2372b25613e0f237c1",
   "candidate_path": "benchmarks/release-evidence/fixtures/candidate.json",
-  "candidate_sha256": "2e91d8dc86070b2efa18150690fd0cc0259c52c3882eaa30293d57f7598cc492",
+  "candidate_sha256": "3a63fafb6b80761ecd4abff7a2b3778ae32ebcd95cde52790e6898561d6572f4",
   "artifact_paths": [
     {
       "path": "candidate-stats.json",
@@ -26,7 +26,7 @@
       "type": "performance",
       "tier": "live_behavior",
       "status": "pass",
-      "graph_sha256": "7739066fa844d159b354bcabd1408b86501ae2484cb00faa231d2430f8890029",
+      "graph_sha256": "5094baf04b547df9d18b55dd5acdd83a026bfcc4ad8e79a252ec3454fbb9d24c",
       "observed_at": "2026-08-08T19:19:24.395Z",
       "expires_at": "2026-08-09T19:19:24.395Z",
       "identity": {
@@ -47,7 +47,7 @@
       "type": "answer_quality",
       "tier": "answer_quality",
       "status": "pass",
-      "graph_sha256": "7739066fa844d159b354bcabd1408b86501ae2484cb00faa231d2430f8890029",
+      "graph_sha256": "5094baf04b547df9d18b55dd5acdd83a026bfcc4ad8e79a252ec3454fbb9d24c",
       "observed_at": "2026-08-08T19:19:24.395Z",
       "expires_at": "2026-08-09T19:19:24.395Z",
       "identity": {
@@ -69,7 +69,7 @@
     "schema": "codestory.release-claim-evaluation/v1",
     "status": "pass",
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "7739066fa844d159b354bcabd1408b86501ae2484cb00faa231d2430f8890029",
+    "graph_sha256": "5094baf04b547df9d18b55dd5acdd83a026bfcc4ad8e79a252ec3454fbb9d24c",
     "evidence_selection": "all_matching_rows_must_pass",
     "expected_commit": "2222222222222222222222222222222222222222",
     "evaluated_at": "2026-08-08T19:19:24.395Z",

--- a/release-claims.json
+++ b/release-claims.json
@@ -1721,6 +1721,129 @@
           "sha256": "cadcf7ea4efe3a68728893813643cebe1185e5b1d4be5b96245f65c9a4d5ea41"
         }
       }
+    },
+    "pinned_programs": {
+      "nextest_linux_archive": {
+        "subject": "downloaded_archive",
+        "file": "source-proof.yml",
+        "job": "full-source-gate",
+        "step": "Install pinned cargo-nextest",
+        "sha256": "7d07712519615722b19ffe3b3d1097b7d4fa390995e3cac1f9d6dda1ba61b2a7",
+        "reason": "The pinned test runner is fetched over the network, so the install step must verify this exact cargo-nextest 0.9.98 Linux x64 archive with sha256sum --check --strict before it executes."
+      },
+      "source_proof_resolver": {
+        "subject": "step_script_raw_text",
+        "file": "source-proof.yml",
+        "job": "resolve",
+        "step": "Resolve trusted exact head",
+        "sha256": "2fe869b675010f5db29259aff38d83456c01dbc9885989afbf7c92a2826791af",
+        "reason": "The trusted-head resolver authenticates which commit the broad source proof runs against; fragment checks alone cannot prove the authentication logic was not rewritten around them."
+      },
+      "packaged_platform_pr_resolver": {
+        "subject": "step_script_raw_text",
+        "file": "packaged-platform-pr.yml",
+        "job": "route",
+        "step": "Resolve trusted exact head",
+        "sha256": "14015fd938e7dc2bafd50bef2d85d6934ee4658bd86b5560729edb4be7c14679",
+        "reason": "The coordinator's trusted-head resolver authenticates the exact frozen-candidate head for every broad proof mode; its executable text must match the reviewed contract, not merely contain its tokens."
+      },
+      "marketplace_sync_dispatch_guard": {
+        "subject": "step_script_executable_text",
+        "file": "marketplace-sync.yml",
+        "job": "sync",
+        "step": "Validate the dispatched release coordinates",
+        "sha256": "6380c916a1b3566b4b9d6545b63fbc9c7db12b54fb328b5c89316daae0162d84",
+        "reason": "check-workflow-policy.test.mjs runs this exact script against hostile dispatch values and proves it exits non-zero, so the digest stands for a rejection that was measured, not merely read."
+      },
+      "packaged_platform_pr_closeout": {
+        "subject": "step_script_executable_text",
+        "file": "packaged-platform-pr.yml",
+        "job": "closeout",
+        "step": "Require one coherent accepted proof",
+        "sha256": "ce7a7f5aa99f5fcbc037d4c1f06de5d841e4a4d114208820592a84c41c797b1a",
+        "reason": "The closeout is a small shell control-flow program. Substring checks can be satisfied by parking the accepted qualification branch in dead code while the live branch blocks on optional Linux hardware, so its reviewed executable text is pinned as well as its reader-facing invariants."
+      },
+      "packaged_platform_proof_workflow": {
+        "subject": "parsed_workflow_json",
+        "file": "packaged-platform-proof.yml",
+        "sha256": "443c65ea54f92260e664bdeaceabb43e57ac1dc9cb5d15f2783690f6102823fa",
+        "reason": "This workflow builds release archives on three operating systems and carries state between many shell steps through GITHUB_ENV and GITHUB_PATH. Its parsed executable structure is pinned so an unreviewed earlier step cannot replace an owner binary while leaving the locally digested finalizer unchanged."
+      },
+      "packaged_platform_pr_workflow": {
+        "subject": "parsed_workflow_json",
+        "file": "packaged-platform-pr.yml",
+        "sha256": "ca70707ba924b57848d92e8b7a3490e8e18623dce4d1afec393212a78bce110a",
+        "reason": "The frozen-candidate coordinator is a small release-control program, not a loose collection of independently safe fragments. Its complete parsed structure is pinned so a required check cannot be made advisory, parked in dead code, or followed by a payload substitution while leaving the expected tokens in place."
+      },
+      "frozen_candidate_quality_workflow": {
+        "subject": "parsed_workflow_json",
+        "file": "frozen-candidate-quality.yml",
+        "sha256": "b7a17c66c4cc4275b369f39fdc1fcdb375b334ba908d31577b910ea10e7eb54e",
+        "reason": "The isolated evaluation owner runs optional quality evidence against the exact frozen candidate; pinning its complete parsed structure keeps the adjunct from acquiring authority or losing its isolation unreviewed. The qualification quality contract cites this same pin as evaluation_owner_sha256."
+      },
+      "macos_metal_proof_workflow": {
+        "subject": "parsed_workflow_json",
+        "file": "macos-metal-proof.yml",
+        "sha256": "55581330f6a035b84e1224dbd5469d812ab2fa444914157e22a39cccc64f4627",
+        "reason": "The protected Metal proof is a release-control program on protected hardware; its complete parsed structure is pinned so a required check cannot be made advisory, parked in dead code, or followed by a payload substitution while leaving the expected tokens in place."
+      },
+      "windows_vulkan_proof_workflow": {
+        "subject": "parsed_workflow_json",
+        "file": "windows-vulkan-proof.yml",
+        "sha256": "c2272dbf4c550ba4a21372e772a87f6df3307f5f4f709b216473f85958157ffe",
+        "reason": "The protected Windows Vulkan proof is a release-control program on protected hardware; its complete parsed structure is pinned so a required check cannot be made advisory, parked in dead code, or followed by a payload substitution while leaving the expected tokens in place."
+      },
+      "linux_vulkan_proof_workflow": {
+        "subject": "parsed_workflow_json",
+        "file": "linux-vulkan-proof.yml",
+        "sha256": "b2efe3dec20a466cb798752c714f50e64e265856e80ffafc15b28ea2390367d3",
+        "reason": "The standalone Linux Vulkan evidence workflow is a release-control program on protected hardware; its complete parsed structure is pinned so a nonblocking evidence lane cannot quietly acquire blocking authority or leak beyond its reviewed scope."
+      },
+      "release_source_proof_sentinel": {
+        "subject": "parsed_job_json",
+        "file": "release.yml",
+        "job": "source-proof",
+        "sha256": "91ee8bc1a6a055e9297e81747c37d167b123d0a2e5dc60d5c6e2bdcfbef9c351",
+        "reason": "The release chain's source-proof job is a fail-closed placeholder that must refuse to run a second source proof; its complete parsed job body is pinned so the refusal cannot be disabled, made conditional, or made advisory."
+      },
+      "packaged_sccache_identity": {
+        "subject": "step_script_raw_text",
+        "file": "packaged-platform-proof.yml",
+        "job": "build",
+        "step": "Capture pinned sccache identity",
+        "sha256": "f844b8a3b2e0f0013b43f4ec661c237fb090a01c49316d8c2b301ba01cac4342",
+        "reason": "The identity capture binds later compiler-cache assertions to the exact installed sccache binary; raw text is hashed because a line that begins with # is not necessarily a comment when the preceding line opened a quote."
+      },
+      "packaged_linux_build": {
+        "subject": "step_script_raw_text",
+        "file": "packaged-platform-proof.yml",
+        "job": "build",
+        "step": "Build Linux x64 at the glibc 2.31 baseline",
+        "sha256": "f101cc525f52f75686acbb1cf240412409f3f388793890993cefae9175685a6f",
+        "reason": "Linux owns its compiler server inside Docker while macOS and Windows own one in the host shell; both executable programs are pinned so a swallowed stop or a dead-code copy cannot satisfy the ownership fragments."
+      },
+      "packaged_compile_clock_stop": {
+        "subject": "step_script_raw_text",
+        "file": "packaged-platform-proof.yml",
+        "job": "build",
+        "step": "Stop compilation clock",
+        "sha256": "ef9f7ee4636c3466830447e2ed8a10c2030ca3949bca082652d9262848d258a5",
+        "reason": "The compiler clock stop is a strict telemetry-only boundary; its raw text is pinned so the timing boundary cannot absorb build or reporting authority unreviewed."
+      },
+      "packaged_host_compiler_finalizer": {
+        "subject": "step_script_raw_text",
+        "file": "packaged-platform-proof.yml",
+        "job": "build",
+        "step": "Finalize compiler objects",
+        "sha256": "b77d8bb12c2748bfe016ab65ccb2f4581356f3ccf1d666e747306caffd6c0c46",
+        "reason": "The host finalizer must strictly stop only the host package-build compiler server; its raw text is pinned so a swallowed stop or a dead-code copy cannot satisfy the ownership fragments."
+      },
+      "qualification_driver_artifact": {
+        "subject": "helper_file_text",
+        "file": ".github/scripts/qualification-driver-artifact.mjs",
+        "sha256": "efc5126e24162d52f9da8bac38c3414b3a7492fb17eed5ff19867fadad69623e",
+        "reason": "The companion qualification driver is intentionally retained only inside the private Actions package artifact. This digest pins both sides of that contract: the producer may read Cargo's trusted hard-linked build output but retains only a new singly linked copy bound to the exact candidate archive, and the consumer rejects symlinks, retained hardlinks, extra files, identity drift, and byte drift before restoring execute permission. Any helper edit therefore requires policy and mutation-test review in the same PR."
+      }
     }
   }
 }

--- a/scripts/codestory-release-claims.mjs
+++ b/scripts/codestory-release-claims.mjs
@@ -2,7 +2,7 @@
 
 import { createHash } from "node:crypto";
 import { spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -81,6 +81,30 @@ const REQUIRED_FAILURE_CONTROLS = [
 ];
 const BENCHMARK_LEAKAGE_COMMAND =
   "node --test scripts/tests/lint-retrieval-generalization.test.mjs";
+// The graph owns every exact program pin the workflow-policy checker enforces; the
+// checker owns only the hashing predicates and their reviewed violation messages.
+// Membership is exact and fail-closed: a graph that drops, renames, or invents a
+// pinned program must not load, so a rule instance cannot disappear by data edit.
+// Subject kinds name what the checker actually hashes for that row.
+const PINNED_PROGRAM_CONTRACTS = new Map([
+  ["nextest_linux_archive", { subject: "downloaded_archive", job: true, step: true }],
+  ["source_proof_resolver", { subject: "step_script_raw_text", job: true, step: true }],
+  ["packaged_platform_pr_resolver", { subject: "step_script_raw_text", job: true, step: true }],
+  ["marketplace_sync_dispatch_guard", { subject: "step_script_executable_text", job: true, step: true }],
+  ["packaged_platform_pr_closeout", { subject: "step_script_executable_text", job: true, step: true }],
+  ["packaged_platform_proof_workflow", { subject: "parsed_workflow_json", job: false, step: false }],
+  ["packaged_platform_pr_workflow", { subject: "parsed_workflow_json", job: false, step: false }],
+  ["frozen_candidate_quality_workflow", { subject: "parsed_workflow_json", job: false, step: false }],
+  ["macos_metal_proof_workflow", { subject: "parsed_workflow_json", job: false, step: false }],
+  ["windows_vulkan_proof_workflow", { subject: "parsed_workflow_json", job: false, step: false }],
+  ["linux_vulkan_proof_workflow", { subject: "parsed_workflow_json", job: false, step: false }],
+  ["release_source_proof_sentinel", { subject: "parsed_job_json", job: true, step: false }],
+  ["packaged_sccache_identity", { subject: "step_script_raw_text", job: true, step: true }],
+  ["packaged_linux_build", { subject: "step_script_raw_text", job: true, step: true }],
+  ["packaged_compile_clock_stop", { subject: "step_script_raw_text", job: true, step: true }],
+  ["packaged_host_compiler_finalizer", { subject: "step_script_raw_text", job: true, step: true }],
+  ["qualification_driver_artifact", { subject: "helper_file_text", job: false, step: false }],
+]);
 const FAILURE_ORDER = new Map([
   ["unsupported_claim", 0],
   ["missing", 1],
@@ -785,7 +809,48 @@ function validateCalibrationPolicy(value) {
   }
 }
 
-function validateQualificationPolicy(value) {
+function validatePinnedPrograms(policy) {
+  const programs = object(policy.pinned_programs, "workflow_policy.pinned_programs");
+  for (const name of Object.keys(programs)) {
+    if (!PINNED_PROGRAM_CONTRACTS.has(name)) {
+      fail(`workflow_policy.pinned_programs names unknown pinned program ${name}`);
+    }
+  }
+  for (const [name, contract] of PINNED_PROGRAM_CONTRACTS) {
+    if (programs[name] === undefined) {
+      fail(`workflow_policy.pinned_programs must declare ${name}`);
+    }
+    const label = `workflow_policy.pinned_programs.${name}`;
+    const row = object(programs[name], label);
+    const expectedKeys = [
+      "subject",
+      "file",
+      ...(contract.job ? ["job"] : []),
+      ...(contract.step ? ["step"] : []),
+      "sha256",
+      "reason",
+    ];
+    if (
+      JSON.stringify([...Object.keys(row)].sort())
+        !== JSON.stringify([...expectedKeys].sort())
+    ) {
+      fail(`${label} must carry exactly ${expectedKeys.join(", ")}`);
+    }
+    if (row.subject !== contract.subject) {
+      fail(`${label}.subject must be ${contract.subject}`);
+    }
+    nonEmptyText(row.file, `${label}.file`);
+    if (contract.job) nonEmptyText(row.job, `${label}.job`);
+    if (contract.step) nonEmptyText(row.step, `${label}.step`);
+    if (typeof row.sha256 !== "string" || !SHA256.test(row.sha256)) {
+      fail(`${label}.sha256 must be a 64-hex sha256 digest`);
+    }
+    nonEmptyText(row.reason, `${label}.reason`);
+  }
+  return programs;
+}
+
+function validateQualificationPolicy(value, pinnedPrograms) {
   const qualification = object(value, "workflow_policy.qualification");
   if (
     qualification.coordinator_workflow !== "packaged-platform-pr.yml"
@@ -898,8 +963,14 @@ function validateQualificationPolicy(value) {
     archive_cache_contract: "candidate_archive_cache",
     archive_transfer: "authenticated_miss_only",
     evaluation_owner: "isolated_reusable_workflow",
+    // The graph is its own digest authority here: the quality contract must cite the
+    // same evaluation-owner pin the pinned_programs block carries, so the two rows
+    // cannot drift apart and the workflow-policy checker enforces the single value.
     evaluation_owner_sha256:
-      "b7a17c66c4cc4275b369f39fdc1fcdb375b334ba908d31577b910ea10e7eb54e",
+      object(
+        pinnedPrograms.frozen_candidate_quality_workflow,
+        "workflow_policy.pinned_programs.frozen_candidate_quality_workflow",
+      ).sha256,
     evaluation_contract: "publishable-three-repeat-packet/v1",
     task_count: 1,
     repeats_per_task: 3,
@@ -1743,6 +1814,7 @@ export function validateReleaseClaimGraph(graph) {
   if (!Number.isInteger(policy.artifact_retention_days) || policy.artifact_retention_days <= 0) {
     fail("workflow_policy.artifact_retention_days must be a positive integer");
   }
+  const pinnedPrograms = validatePinnedPrograms(policy);
   validateProofFloor(policy.proof_floor);
   if (!Array.isArray(policy.package_matrix) || policy.package_matrix.length !== 3) {
     fail("workflow_policy.package_matrix must define three release package rows");
@@ -1764,7 +1836,7 @@ export function validateReleaseClaimGraph(graph) {
   validateCandidateArchiveCache(policy.candidate_archive_cache);
   validateModelMaterialCache(policy.model_material_cache);
   validateCalibrationPolicy(policy.calibration);
-  validateQualificationPolicy(policy.qualification);
+  validateQualificationPolicy(policy.qualification, pinnedPrograms);
   validatePublicSupport(graph, targets, cellGroups);
   if (!Array.isArray(policy.protected_jobs) || policy.protected_jobs.length === 0) {
     fail("workflow_policy.protected_jobs must be a non-empty array");
@@ -2029,7 +2101,19 @@ export function loadReleaseClaimGraph(repoRoot = path.resolve(path.dirname(fileU
   } catch (error) {
     fail(`failed to read release claim graph ${graphPath}: ${error.message}`);
   }
-  return validateReleaseClaimGraph(graph);
+  const validated = validateReleaseClaimGraph(graph);
+  // Shape validation is filesystem-free so hostile-graph tests stay hermetic; loading
+  // a graph for this repository additionally requires every pinned program's subject
+  // file to exist, so a pin cannot outlive or predate the program it vouches for.
+  for (const [name, row] of Object.entries(validated.workflow_policy.pinned_programs)) {
+    const relative = row.subject === "helper_file_text"
+      ? row.file
+      : path.join(".github", "workflows", row.file);
+    if (!existsSync(path.join(repoRoot, relative))) {
+      fail(`workflow_policy.pinned_programs.${name} pins missing file ${relative}`);
+    }
+  }
+  return validated;
 }
 
 const PUBLIC_SUPPORT_START = "<!-- codestory-public-support:start -->";

--- a/scripts/tests/codestory-release-claims.test.mjs
+++ b/scripts/tests/codestory-release-claims.test.mjs
@@ -669,6 +669,50 @@ test("claim graph freezes one GPU-only qualification run per available platform"
   }
 });
 
+test("pinned programs are an exact fail-closed membership with graph-owned digests", () => {
+  const programs = graph.workflow_policy.pinned_programs;
+  assert.equal(Object.keys(programs).length, 17);
+  for (const row of Object.values(programs)) {
+    assert.match(row.sha256, /^[0-9a-f]{64}$/u);
+  }
+  assert.equal(
+    graph.workflow_policy.qualification.quality_contract.evaluation_owner_sha256,
+    programs.frozen_candidate_quality_workflow.sha256,
+  );
+  const mutations = [
+    [draft => {
+      delete draft.workflow_policy.pinned_programs.packaged_linux_build;
+    }, /pinned_programs must declare packaged_linux_build/u],
+    [draft => {
+      draft.workflow_policy.pinned_programs.unpinned_extra = structuredClone(
+        draft.workflow_policy.pinned_programs.packaged_linux_build,
+      );
+    }, /names unknown pinned program unpinned_extra/u],
+    [draft => {
+      draft.workflow_policy.pinned_programs.marketplace_sync_dispatch_guard.sha256 = "not-a-digest";
+    }, /marketplace_sync_dispatch_guard\.sha256 must be a 64-hex sha256 digest/u],
+    [draft => {
+      draft.workflow_policy.pinned_programs.packaged_platform_proof_workflow.subject =
+        "step_script_raw_text";
+    }, /packaged_platform_proof_workflow\.subject must be parsed_workflow_json/u],
+    [draft => {
+      delete draft.workflow_policy.pinned_programs.source_proof_resolver.step;
+    }, /source_proof_resolver must carry exactly subject, file, job, step, sha256, reason/u],
+    [draft => {
+      draft.workflow_policy.pinned_programs.release_source_proof_sentinel.reason = "";
+    }, /release_source_proof_sentinel\.reason must be a non-empty string/u],
+    [draft => {
+      draft.workflow_policy.qualification.quality_contract.evaluation_owner_sha256 =
+        "0".repeat(64);
+    }, /quality contract must bind the optional isolated exact-package adjunct/u],
+  ];
+  for (const [mutate, expected] of mutations) {
+    const draft = structuredClone(graph);
+    mutate(draft);
+    assert.throws(() => validateReleaseClaimGraph(draft), expected);
+  }
+});
+
 test("benchmark leakage names only the one-process Node contract", () => {
   const benchmarkLeakage = graph.failure_controls
     .find(({ id }) => id === "benchmark_leakage");

--- a/scripts/tests/fixtures/release-claims/positive.json
+++ b/scripts/tests/fixtures/release-claims/positive.json
@@ -17,7 +17,7 @@
       "type": "source_behavior",
       "tier": "source",
       "status": "pass",
-      "graph_sha256": "7739066fa844d159b354bcabd1408b86501ae2484cb00faa231d2430f8890029",
+      "graph_sha256": "5094baf04b547df9d18b55dd5acdd83a026bfcc4ad8e79a252ec3454fbb9d24c",
       "observed_at": "2026-07-16T11:00:00.000Z",
       "expires_at": "2026-07-17T11:00:00.000Z",
       "identity": {


### PR DESCRIPTION
## Context

First S1 slice per the elaboration on #1670: the policy checker held 17 magic sha256 constants; S1's end state is one graph owning every rule instance. This slice proves the whole migration pattern and lands the standing oracle every later S1 slice reuses.

Closes #1879
Refs #1670
Refs #1179

## What changed

- The 17 digest constants are gone from `check-workflow-policy.mjs` (zero 64-hex literals remain, grep-proven); one generic `pinnedProgramViolations` evaluator dispatches by subject kind over a new `workflow_policy.pinned_programs` block (17 rows, six honest subject kinds named after what the checker actually hashes), with every violation message preserved verbatim — the existing digest-mutation tests run unchanged.
- Fail-closed three layers deep: removed row fails exact membership by name; flipped digest fails with the same message as the old constant; repointed file fails with the missing path. The loader's duplicate `evaluation_owner_sha256` literal now cross-references the pinned row, with a test asserting equality.
- **Equivalence harness** (`policy-equivalence.mjs` + test): materializes the merge-base checker and compares verdict multisets over the pristine tree plus a deterministic hostile corpus. This run: **8,206 mutants, full enumeration, zero mismatches, 8m52s** — behavior-identical by exhaustive differential, not by review.
- graph digest re-pinned through the normal flow including the re-attested `candidate_sha256`; `graph_version` stays 11; no workflow file touched; no rule removed.

## Verification

On `223f5be5`: policy suite 1367/0 (twice), claims 44/0, evidence-gate 23/0, closeout 44/0, cell-manifest 20/0, plugin-static 130/0, lint, actionlint, doc surfaces untouched, `git diff --check`. Supervisor re-ran the checker, the zero-literal grep, and claims suite on the committed head.

Draft until independent review accepts the exact head and CI is green.