### PR TITLE
[v0.17 S4-W] Move the seven wave planning modules into codestory-agent

### DIFF
--- a/crates/codestory-agent/src/citation.rs
+++ b/crates/codestory-agent/src/citation.rs
@@ -1,9 +1,9 @@
 //! Citation construction from search hits for agent retrieval.
 
-use crate::agent::packet_evidence::decorate_citation_from_hit;
+use crate::packet_evidence::decorate_citation_from_hit;
 use codestory_contracts::api::{AgentCitationDto, EdgeId, GraphResponse, NodeId, SearchHit};
 
-pub(crate) fn to_citation_from_hit(
+pub fn to_citation_from_hit(
     hit: &SearchHit,
     subgraph_id: Option<&str>,
     primary_graph: Option<&GraphResponse>,
@@ -39,7 +39,7 @@ pub(crate) fn to_citation_from_hit(
     citation
 }
 
-pub(crate) fn evidence_edge_ids_for_node(
+pub fn evidence_edge_ids_for_node(
     primary_graph: Option<&GraphResponse>,
     node_id: &NodeId,
 ) -> Vec<EdgeId> {

--- a/crates/codestory-agent/src/lib.rs
+++ b/crates/codestory-agent/src/lib.rs
@@ -13,21 +13,28 @@
 //! `codestory-contracts` and nothing else in this workspace — and
 //! `codestory-cli`'s architecture contracts enforce it from above.
 
+pub mod citation;
 #[cfg(any(test, feature = "test-support"))]
 pub mod eval_probes;
 pub mod packet_citations;
+pub mod packet_claim_profile_registry;
 pub mod packet_command;
 pub mod packet_command_profiles;
+pub mod packet_coverage;
+pub mod packet_degradation;
 pub mod packet_evidence;
 pub mod packet_evidence_carriers;
 pub mod packet_evidence_roles;
 pub mod packet_execution_graphs;
 pub mod packet_flow_requirements;
+pub mod packet_freshness;
 pub mod packet_obligations;
 pub mod packet_plan;
 pub mod packet_probes;
+pub mod packet_profile_telemetry;
 pub mod packet_required_probes;
 pub mod packet_scoring;
+pub mod packet_source_patterns;
 pub mod packet_terms;
 pub mod pinned_reader;
 pub mod planning;

--- a/crates/codestory-agent/src/packet_claim_profile_registry.rs
+++ b/crates/codestory-agent/src/packet_claim_profile_registry.rs
@@ -27,20 +27,20 @@ use std::collections::BTreeSet;
 
 use serde::Deserialize;
 
-use crate::agent::packet_flow_requirements::{CoverageMode, FlowRole};
+use crate::packet_flow_requirements::{CoverageMode, FlowRole};
 
 /// Schema version of the checked-in claim-profile document this binary implements.
 ///
 /// Published in the packet trace beside the counters, so a field trace records the contract
 /// shape its numbers were taken under.
-pub(crate) const PACKET_CLAIM_PROFILE_SCHEMA_VERSION: u32 = 2;
+pub const PACKET_CLAIM_PROFILE_SCHEMA_VERSION: u32 = 2;
 
 /// Compile-time ceiling on registry profiles still allowed to ship without an anti-overfit
 /// contract.
 ///
 /// The ratchet only ever falls: a new profile has to arrive contracted, and migrating a pending
 /// profile has to lower this number and the document's `pending_ratchet` in the same diff.
-pub(crate) const PACKET_CLAIM_PROFILE_PENDING_MIGRATION_RATCHET: usize = 13;
+pub const PACKET_CLAIM_PROFILE_PENDING_MIGRATION_RATCHET: usize = 13;
 
 /// Typed reasons a contracted profile is not runtime-valid.
 ///
@@ -48,7 +48,7 @@ pub(crate) const PACKET_CLAIM_PROFILE_PENDING_MIGRATION_RATCHET: usize = 13;
 /// enters the registry, and again per citation at collect time, so a contract constructed in
 /// process still cannot serve claims.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ClaimProfileContractViolation {
+pub enum ClaimProfileContractViolation {
     NonProductScope,
     DomainIsNotProfileIdentity,
     DiagnosticOnlyEvidenceTier,
@@ -62,7 +62,7 @@ pub(crate) enum ClaimProfileContractViolation {
 }
 
 impl ClaimProfileContractViolation {
-    pub(crate) const fn code(self) -> &'static str {
+    pub const fn code(self) -> &'static str {
         match self {
             Self::NonProductScope => "non_product_scope",
             Self::DomainIsNotProfileIdentity => "domain_is_not_profile_identity",
@@ -80,7 +80,7 @@ impl ClaimProfileContractViolation {
 
 /// Typed reasons the loader refused one document row.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ClaimProfileRowRejection {
+pub enum ClaimProfileRowRejection {
     /// The document names a profile no compiled matcher implements.
     UnknownProfileId,
     /// The document lists the same profile twice.
@@ -107,7 +107,7 @@ pub(crate) enum ClaimProfileRowRejection {
 }
 
 impl ClaimProfileRowRejection {
-    pub(crate) const fn code(self) -> &'static str {
+    pub const fn code(self) -> &'static str {
         match self {
             Self::UnknownProfileId => "unknown_profile_id",
             Self::DuplicateProfileId => "duplicate_profile_id",
@@ -128,7 +128,7 @@ impl ClaimProfileRowRejection {
 ///
 /// Every one of these empties the registry: an unreadable contract serves nothing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ClaimProfileDocumentRejection {
+pub enum ClaimProfileDocumentRejection {
     Malformed,
     SchemaVersionMismatch,
     RatchetAboveCeiling,
@@ -136,7 +136,7 @@ pub(crate) enum ClaimProfileDocumentRejection {
 }
 
 impl ClaimProfileDocumentRejection {
-    pub(crate) const fn code(self) -> &'static str {
+    pub const fn code(self) -> &'static str {
         match self {
             Self::Malformed => "malformed_document",
             Self::SchemaVersionMismatch => "schema_version_mismatch",
@@ -147,33 +147,33 @@ impl ClaimProfileDocumentRejection {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ClaimProfileScope {
+pub enum ClaimProfileScope {
     Product,
 }
 
 /// Anti-overfit contract for one profile, as loaded from the document.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct ClaimProfileContract {
-    pub(crate) domain: String,
-    pub(crate) scope: ClaimProfileScope,
-    pub(crate) allowed_evidence_tier: CoverageMode,
-    pub(crate) allowed_proof_roles: Vec<FlowRole>,
-    pub(crate) positive_fixture_id: String,
-    pub(crate) false_positive_fixture_id: String,
+pub struct ClaimProfileContract {
+    pub domain: String,
+    pub scope: ClaimProfileScope,
+    pub allowed_evidence_tier: CoverageMode,
+    pub allowed_proof_roles: Vec<FlowRole>,
+    pub positive_fixture_id: String,
+    pub false_positive_fixture_id: String,
     /// Fixture from a different language family than `positive_fixture_id`, proving the profile
     /// fires somewhere other than the corpus shape it was written against.
-    pub(crate) generalization_fixture_id: String,
+    pub generalization_fixture_id: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum ClaimProfileStatus {
+pub enum ClaimProfileStatus {
     Contracted(ClaimProfileContract),
     PendingMigration,
 }
 
 impl ClaimProfileStatus {
     /// EV-6 runtime validation, reused as the document loader's row validator.
-    pub(crate) fn validate(&self, profile_id: &str) -> Result<(), ClaimProfileContractViolation> {
+    pub fn validate(&self, profile_id: &str) -> Result<(), ClaimProfileContractViolation> {
         let Self::Contracted(contract) = self else {
             return Ok(());
         };
@@ -220,24 +220,24 @@ impl ClaimProfileStatus {
 
 /// One accepted document row, bound to the compiled matcher identity it names.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct RegisteredClaimProfile {
+pub struct RegisteredClaimProfile {
     /// Interned against the compiled matcher list, never a string from the document.
-    pub(crate) id: &'static str,
-    pub(crate) status: ClaimProfileStatus,
+    pub id: &'static str,
+    pub status: ClaimProfileStatus,
     /// Tracking issue number that owns this profile. A number, not a URL: the generalization
     /// lint bans this repository's own identity from production paths, and attribution does
     /// not need the host to be routable.
-    pub(crate) owner_issue: u32,
+    pub owner_issue: u32,
 }
 
 /// One refused document row. Refused rows never serve claims.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct RejectedClaimProfile {
-    pub(crate) reason: ClaimProfileRowRejection,
+pub struct RejectedClaimProfile {
+    pub reason: ClaimProfileRowRejection,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct ClaimProfileRegistry {
+pub struct ClaimProfileRegistry {
     profiles: Vec<RegisteredClaimProfile>,
     rejected: Vec<RejectedClaimProfile>,
     declared_ratchet: usize,
@@ -254,11 +254,11 @@ impl ClaimProfileRegistry {
         }
     }
 
-    pub(crate) fn profiles(&self) -> &[RegisteredClaimProfile] {
+    pub fn profiles(&self) -> &[RegisteredClaimProfile] {
         &self.profiles
     }
 
-    pub(crate) fn rejected(&self) -> &[RejectedClaimProfile] {
+    pub fn rejected(&self) -> &[RejectedClaimProfile] {
         &self.rejected
     }
 
@@ -266,7 +266,7 @@ impl ClaimProfileRegistry {
     ///
     /// A count alone says the registry shrank; the codes say why, which is the difference
     /// between "the document has a typo" and "the document was written for another binary".
-    pub(crate) fn rejection_codes(&self) -> Vec<&'static str> {
+    pub fn rejection_codes(&self) -> Vec<&'static str> {
         let codes: BTreeSet<&'static str> = self
             .rejected
             .iter()
@@ -275,22 +275,22 @@ impl ClaimProfileRegistry {
         codes.into_iter().collect()
     }
 
-    pub(crate) fn declared_ratchet(&self) -> usize {
+    pub fn declared_ratchet(&self) -> usize {
         self.declared_ratchet
     }
 
-    pub(crate) fn document_rejection(&self) -> Option<ClaimProfileDocumentRejection> {
+    pub fn document_rejection(&self) -> Option<ClaimProfileDocumentRejection> {
         self.document_rejection
     }
 
-    pub(crate) fn pending(&self) -> usize {
+    pub fn pending(&self) -> usize {
         self.profiles
             .iter()
             .filter(|entry| matches!(entry.status, ClaimProfileStatus::PendingMigration))
             .count()
     }
 
-    pub(crate) fn contracted(&self) -> usize {
+    pub fn contracted(&self) -> usize {
         self.profiles.len() - self.pending()
     }
 }
@@ -373,7 +373,7 @@ fn parse_proof_role(value: &str) -> Option<FlowRole> {
 /// `known_ids` is the compiled matcher list. A row is accepted only when the document identity
 /// matches one of them, and the accepted row carries the *compiled* `&'static str`, so no
 /// document string ever reaches a telemetry key.
-pub(crate) fn load_claim_profile_registry(
+pub fn load_claim_profile_registry(
     document: &str,
     known_ids: &[&'static str],
 ) -> ClaimProfileRegistry {

--- a/crates/codestory-agent/src/packet_coverage.rs
+++ b/crates/codestory-agent/src/packet_coverage.rs
@@ -16,7 +16,7 @@ use codestory_contracts::api::{
 };
 
 /// Prefix every coverage gap sentence shares, so callers can partition them.
-pub(crate) const PACKET_COVERAGE_GAP_PREFIX: &str = "source coverage";
+pub const PACKET_COVERAGE_GAP_PREFIX: &str = "source coverage";
 
 /// One file this packet rested on that the index could not prove it covered.
 #[derive(Debug, Clone)]
@@ -29,12 +29,12 @@ struct UnprovableFile {
 
 /// The coverage facts for the files one packet touched.
 #[derive(Debug, Clone, Default)]
-pub(crate) struct PacketCoverageInput {
+pub struct PacketCoverageInput {
     unprovable: Vec<UnprovableFile>,
 }
 
 impl PacketCoverageInput {
-    pub(crate) fn from_observations(observations: &[SourceCoverageObservationDto]) -> Self {
+    pub fn from_observations(observations: &[SourceCoverageObservationDto]) -> Self {
         let unprovable = observations
             .iter()
             .filter_map(|observation| {
@@ -62,13 +62,13 @@ impl PacketCoverageInput {
     }
 
     /// Whether any file this packet rested on could not be proven covered.
-    pub(crate) fn caps_sufficiency(&self) -> bool {
+    pub fn caps_sufficiency(&self) -> bool {
         !self.unprovable.is_empty()
     }
 
     /// One sentence per unprovable file, naming the cause and, where the index
     /// recorded them, the numbers that produced it.
-    pub(crate) fn gaps(&self) -> Vec<String> {
+    pub fn gaps(&self) -> Vec<String> {
         self.unprovable
             .iter()
             .map(|file| match file.sizes {
@@ -89,7 +89,7 @@ impl PacketCoverageInput {
     }
 
     /// The paths that could not be proven covered.
-    pub(crate) fn unprovable_paths(&self) -> Vec<&str> {
+    pub fn unprovable_paths(&self) -> Vec<&str> {
         self.unprovable
             .iter()
             .map(|file| file.path.as_str())

--- a/crates/codestory-agent/src/packet_degradation.rs
+++ b/crates/codestory-agent/src/packet_degradation.rs
@@ -44,11 +44,11 @@ const STAGE_COMPLETED_LATE: &str = "completed_late";
 
 /// How one query's semantic stage behaved.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub(crate) struct SemanticStageDegradation {
+pub struct SemanticStageDegradation {
     /// The semantic stage lost its budget and merged no candidate.
-    pub(crate) timed_out_zero_hits: bool,
+    pub timed_out_zero_hits: bool,
     /// The semantic stage declined to run, or produced only stub candidates.
-    pub(crate) abstained: bool,
+    pub abstained: bool,
 }
 
 /// Whether a stage record means the stage's candidates were lost to a deadline.
@@ -64,9 +64,7 @@ fn is_semantic_stage(stage: &RetrievalStageTimingDto) -> bool {
 }
 
 /// Read one query's stage record for semantic degradation.
-pub(crate) fn semantic_stage_degradation(
-    stages: &[RetrievalStageTimingDto],
-) -> SemanticStageDegradation {
+pub fn semantic_stage_degradation(stages: &[RetrievalStageTimingDto]) -> SemanticStageDegradation {
     let mut degradation = SemanticStageDegradation::default();
     for stage in stages.iter().filter(|stage| is_semantic_stage(stage)) {
         if stage_lost_to_deadline(stage) && stage.candidates_added == 0 {
@@ -83,7 +81,7 @@ pub(crate) fn semantic_stage_degradation(
 ///
 /// Fails closed on the shapes that lose candidates and stays quiet on the planned marginal-gain
 /// stop, so a healthy packet is not permanently demoted by normal early termination.
-pub(crate) fn primary_retrieval_truncated(shadow: &RetrievalShadowDto) -> bool {
+pub fn primary_retrieval_truncated(shadow: &RetrievalShadowDto) -> bool {
     if shadow.error.is_some() {
         return true;
     }
@@ -98,7 +96,7 @@ pub(crate) fn primary_retrieval_truncated(shadow: &RetrievalShadowDto) -> bool {
 }
 
 /// Whether this packet's primary retrieval run is verdict-visibly truncated.
-pub(crate) fn packet_primary_retrieval_truncated(answer: &AgentAnswerDto) -> bool {
+pub fn packet_primary_retrieval_truncated(answer: &AgentAnswerDto) -> bool {
     answer
         .retrieval_trace
         .retrieval_shadow
@@ -111,7 +109,7 @@ pub(crate) fn packet_primary_retrieval_truncated(answer: &AgentAnswerDto) -> boo
 /// The counters are recomputed from the answer rather than accumulated during retrieval so that
 /// budget enforcement, which may drop diagnostics and the primary shadow, cannot leave a counter
 /// describing evidence the packet no longer carries.
-pub(crate) fn apply_packet_semantic_degradation_counters(answer: &mut AgentAnswerDto) {
+pub fn apply_packet_semantic_degradation_counters(answer: &mut AgentAnswerDto) {
     let primary = answer
         .retrieval_trace
         .retrieval_shadow

--- a/crates/codestory-agent/src/packet_freshness.rs
+++ b/crates/codestory-agent/src/packet_freshness.rs
@@ -22,11 +22,11 @@ use codestory_contracts::api::{
 
 /// Machine-readable prefix every freshness gap carries, so callers can match the gap class
 /// without parsing prose.
-pub(crate) const PACKET_FRESHNESS_GAP_PREFIX: &str = "freshness";
+pub const PACKET_FRESHNESS_GAP_PREFIX: &str = "freshness";
 
 /// Freshness as packet sufficiency must consume it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum PacketFreshnessInput {
+pub enum PacketFreshnessInput {
     /// The full planned inventory was compared and matched.
     Fresh,
     /// Drift was never established. The publication may still be servable; it is not provable.
@@ -41,7 +41,7 @@ impl PacketFreshnessInput {
     /// The absent observation is `Unknown`, not `Fresh`: on the production path `None` means the
     /// freshness call itself failed, and defaulting a failed check to "fresh" is precisely the
     /// CR-001 exposure.
-    pub(crate) fn from_observation(freshness: Option<&IndexFreshnessDto>) -> Self {
+    pub fn from_observation(freshness: Option<&IndexFreshnessDto>) -> Self {
         if let Some(cause) = FreshnessUnknownCauseDto::for_observation(freshness) {
             return Self::Unknown { cause };
         }
@@ -54,12 +54,12 @@ impl PacketFreshnessInput {
     }
 
     /// Whether this input forbids reporting broad evidence as sufficient.
-    pub(crate) fn caps_sufficiency(self) -> bool {
+    pub fn caps_sufficiency(self) -> bool {
         !matches!(self, Self::Fresh)
     }
 
     /// The typed gap this input publishes on the packet verdict, if any.
-    pub(crate) fn gap(self) -> Option<String> {
+    pub fn gap(self) -> Option<String> {
         match self {
             Self::Fresh => None,
             Self::Unknown { cause } => Some(format!(
@@ -83,7 +83,7 @@ impl PacketFreshnessInput {
 /// `Unknown`. Fixtures that are exercising claim or route behavior have to opt in to an observed
 /// publication or every one of them would be testing the freshness cap instead.
 #[cfg(any(test, feature = "test-support"))]
-pub(crate) fn fresh_index_observation() -> IndexFreshnessDto {
+pub fn fresh_index_observation() -> IndexFreshnessDto {
     IndexFreshnessDto {
         status: IndexFreshnessStatusDto::Fresh,
         changed_file_count: 0,

--- a/crates/codestory-agent/src/packet_profile_telemetry.rs
+++ b/crates/codestory-agent/src/packet_profile_telemetry.rs
@@ -28,8 +28,8 @@ use codestory_contracts::api::{
 /// version, so the number is published beside the counts and pinned by contract tests. There
 /// is one number: it is the schema version of the checked-in registry document, so a trace
 /// cannot claim a contract shape the loaded data was not written against.
-pub(crate) const PACKET_CLAIM_PROFILE_CONTRACT_VERSION: u32 =
-    crate::agent::packet_claim_profile_registry::PACKET_CLAIM_PROFILE_SCHEMA_VERSION;
+pub const PACKET_CLAIM_PROFILE_CONTRACT_VERSION: u32 =
+    crate::packet_claim_profile_registry::PACKET_CLAIM_PROFILE_SCHEMA_VERSION;
 
 /// Which layer produced a packet claim.
 ///
@@ -37,7 +37,7 @@ pub(crate) const PACKET_CLAIM_PROFILE_CONTRACT_VERSION: u32 =
 /// different facts. Counting them apart is what lets a field trace answer "did the fitted
 /// layer fire, or did this packet degrade to naming?".
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) enum PacketClaimSource {
+pub enum PacketClaimSource {
     /// Source-text-derived claims from the versioned product claim-profile registry.
     SourceProfile,
     /// Claims templated from a command/subcommand shape in the question.
@@ -51,7 +51,7 @@ pub(crate) enum PacketClaimSource {
 }
 
 impl PacketClaimSource {
-    pub(crate) const ALL: [Self; 5] = [
+    pub const ALL: [Self; 5] = [
         Self::SourceProfile,
         Self::CommandProfile,
         Self::FlowTemplate,
@@ -72,33 +72,33 @@ impl PacketClaimSource {
 
 /// Per-profile fire counts for one packet.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub(crate) struct PacketProfileFireCount {
+pub struct PacketProfileFireCount {
     /// Citations this profile was offered.
-    pub(crate) evaluated: u32,
+    pub evaluated: u32,
     /// Citations for which this profile emitted at least one claim.
-    pub(crate) fired: u32,
+    pub fired: u32,
     /// Claims this profile emitted.
-    pub(crate) claims: u32,
+    pub claims: u32,
     /// Citations where a runtime contract violation skipped this profile before it ran.
-    pub(crate) skipped_invalid: u32,
+    pub skipped_invalid: u32,
     /// Typed code of the violation that caused the skip, when there was one.
-    pub(crate) skip_reason: Option<&'static str>,
+    pub skip_reason: Option<&'static str>,
 }
 
 /// Fire-rate and claim-source counters accumulated while assembling one packet's claims.
 #[derive(Debug, Clone, Default)]
-pub(crate) struct PacketClaimTelemetry {
+pub struct PacketClaimTelemetry {
     citations_considered: u32,
     profiles: BTreeMap<&'static str, PacketProfileFireCount>,
     sources: BTreeMap<PacketClaimSource, u32>,
 }
 
 impl PacketClaimTelemetry {
-    pub(crate) fn record_citation_considered(&mut self) {
+    pub fn record_citation_considered(&mut self) {
         self.citations_considered = self.citations_considered.saturating_add(1);
     }
 
-    pub(crate) fn record_profile_evaluated(&mut self, profile_id: &'static str, claims: usize) {
+    pub fn record_profile_evaluated(&mut self, profile_id: &'static str, claims: usize) {
         let entry = self.profiles.entry(profile_id).or_default();
         entry.evaluated = entry.evaluated.saturating_add(1);
         if claims > 0 {
@@ -109,7 +109,7 @@ impl PacketClaimTelemetry {
         }
     }
 
-    pub(crate) fn record_profile_skipped(
+    pub fn record_profile_skipped(
         &mut self,
         profile_id: &'static str,
         violation_code: &'static str,
@@ -120,7 +120,7 @@ impl PacketClaimTelemetry {
         entry.skip_reason = Some(violation_code);
     }
 
-    pub(crate) fn record_claim_source(&mut self, source: PacketClaimSource, claims: usize) {
+    pub fn record_claim_source(&mut self, source: PacketClaimSource, claims: usize) {
         if claims == 0 {
             return;
         }
@@ -128,17 +128,17 @@ impl PacketClaimTelemetry {
         *entry = entry.saturating_add(u32::try_from(claims).unwrap_or(u32::MAX));
     }
 
-    #[cfg(test)]
-    pub(crate) fn citations_considered(&self) -> u32 {
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn citations_considered(&self) -> u32 {
         self.citations_considered
     }
 
-    #[cfg(test)]
-    pub(crate) fn profile_fire_count(&self, profile_id: &str) -> PacketProfileFireCount {
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn profile_fire_count(&self, profile_id: &str) -> PacketProfileFireCount {
         self.profiles.get(profile_id).copied().unwrap_or_default()
     }
 
-    pub(crate) fn claim_source_count(&self, source: PacketClaimSource) -> u32 {
+    pub fn claim_source_count(&self, source: PacketClaimSource) -> u32 {
         self.sources.get(&source).copied().unwrap_or(0)
     }
 
@@ -161,7 +161,7 @@ impl PacketClaimTelemetry {
     /// This is deliberately *not* a `Vec<String>` appended to `retrieval_trace.annotations`.
     /// Annotations are scanned as evidence, so an always-on telemetry line published there is
     /// classified as an evidence gap on every packet and permanently downgrades confidence.
-    pub(crate) fn to_dto(
+    pub fn to_dto(
         &self,
         registry: PacketClaimProfileRegistrySummary,
     ) -> PacketClaimProfileTelemetryDto {
@@ -216,16 +216,16 @@ fn saturating_count(value: usize) -> u32 {
 /// and a packet that quietly answered from a smaller registry would otherwise look identical to
 /// one that answered from the whole registry and found nothing.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct PacketClaimProfileRegistrySummary {
-    pub(crate) registered: usize,
-    pub(crate) contracted: usize,
-    pub(crate) pending: usize,
-    pub(crate) pending_ratchet: usize,
-    pub(crate) rejected: usize,
+pub struct PacketClaimProfileRegistrySummary {
+    pub registered: usize,
+    pub contracted: usize,
+    pub pending: usize,
+    pub pending_ratchet: usize,
+    pub rejected: usize,
     /// Distinct static codes for the refused rows.
-    pub(crate) rejection_codes: Vec<&'static str>,
+    pub rejection_codes: Vec<&'static str>,
     /// Static code of the whole-document refusal, when the registry loaded empty.
-    pub(crate) document_rejection: Option<&'static str>,
+    pub document_rejection: Option<&'static str>,
 }
 
 #[cfg(test)]

--- a/crates/codestory-agent/src/packet_source_patterns.rs
+++ b/crates/codestory-agent/src/packet_source_patterns.rs
@@ -1,20 +1,20 @@
-use crate::agent::packet_scoring::normalize_identifier;
+use crate::packet_scoring::normalize_identifier;
 
-pub(crate) fn packet_source_has_all(source: &str, terms: &[&str]) -> bool {
+pub fn packet_source_has_all(source: &str, terms: &[&str]) -> bool {
     let lower = source.to_ascii_lowercase();
     terms
         .iter()
         .all(|term| lower.contains(&term.to_ascii_lowercase()))
 }
 
-pub(crate) fn packet_source_has_any(source: &str, terms: &[&str]) -> bool {
+pub fn packet_source_has_any(source: &str, terms: &[&str]) -> bool {
     let lower = source.to_ascii_lowercase();
     terms
         .iter()
         .any(|term| lower.contains(&term.to_ascii_lowercase()))
 }
 
-pub(crate) fn packet_source_identifier_with_words(source: &str, words: &[&str]) -> Option<String> {
+pub fn packet_source_identifier_with_words(source: &str, words: &[&str]) -> Option<String> {
     if words.is_empty() {
         return None;
     }
@@ -31,7 +31,7 @@ pub(crate) fn packet_source_identifier_with_words(source: &str, words: &[&str]) 
     None
 }
 
-pub(crate) fn packet_source_identifier_with_words_shortest(
+pub fn packet_source_identifier_with_words_shortest(
     source: &str,
     words: &[&str],
 ) -> Option<String> {
@@ -59,7 +59,7 @@ pub(crate) fn packet_source_identifier_with_words_shortest(
     best
 }
 
-pub(crate) fn packet_source_identifier_exact(source: &str, word: &str) -> Option<String> {
+pub fn packet_source_identifier_exact(source: &str, word: &str) -> Option<String> {
     for token in source.split(|ch: char| !(ch.is_ascii_alphanumeric() || ch == '_')) {
         let token = token.trim();
         if token.eq_ignore_ascii_case(word) {
@@ -69,7 +69,7 @@ pub(crate) fn packet_source_identifier_exact(source: &str, word: &str) -> Option
     None
 }
 
-pub(crate) fn packet_source_identifier_ending_with(
+pub fn packet_source_identifier_ending_with(
     source: &str,
     suffix: &str,
     excluded: &str,
@@ -86,7 +86,7 @@ pub(crate) fn packet_source_identifier_ending_with(
     None
 }
 
-pub(crate) fn packet_source_constructed_type(source: &str) -> Option<String> {
+pub fn packet_source_constructed_type(source: &str) -> Option<String> {
     let bytes = source.as_bytes();
     let needle = b"new ";
     let mut index = 0;
@@ -118,7 +118,7 @@ pub(crate) fn packet_source_constructed_type(source: &str) -> Option<String> {
     None
 }
 
-pub(crate) fn packet_display_owner(display: &str) -> Option<String> {
+pub fn packet_display_owner(display: &str) -> Option<String> {
     let owner = display
         .split(['.', ':', '#', '_'])
         .find(|part| {
@@ -134,7 +134,7 @@ pub(crate) fn packet_display_owner(display: &str) -> Option<String> {
     }
 }
 
-pub(crate) fn packet_sql_create_table_names(source: &str) -> Vec<String> {
+pub fn packet_sql_create_table_names(source: &str) -> Vec<String> {
     let mut names = Vec::new();
     for line in source.lines() {
         if let Some(name) = packet_sql_identifier_after(line, "create table")
@@ -149,7 +149,7 @@ pub(crate) fn packet_sql_create_table_names(source: &str) -> Vec<String> {
     names
 }
 
-pub(crate) fn packet_sql_foreign_key_claims(source: &str) -> Vec<String> {
+pub fn packet_sql_foreign_key_claims(source: &str) -> Vec<String> {
     let mut links = Vec::new();
     let mut current_table: Option<String> = None;
     for line in source.lines() {
@@ -228,7 +228,7 @@ fn packet_sql_identifier_between(line: &str, start: &str, end: &str) -> Option<S
     packet_first_sql_identifier(&line[start_at..end_at])
 }
 
-pub(crate) fn packet_sql_identifier_after(line: &str, needle: &str) -> Option<String> {
+pub fn packet_sql_identifier_after(line: &str, needle: &str) -> Option<String> {
     let lower = line.to_ascii_lowercase();
     let at = lower.find(needle)? + needle.len();
     if needle == "create table"
@@ -289,7 +289,7 @@ fn packet_first_sql_identifier(input: &str) -> Option<String> {
     }
 }
 
-pub(crate) fn packet_human_join(items: &[String]) -> String {
+pub fn packet_human_join(items: &[String]) -> String {
     match items {
         [] => String::new(),
         [one] => one.clone(),

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -562,16 +562,23 @@ fn agent_planning_crate_owns_planning_and_depends_on_contracts_only() {
     );
 
     for module in [
+        "citation.rs",
         "packet_citations.rs",
+        "packet_claim_profile_registry.rs",
         "packet_command_profiles.rs",
+        "packet_coverage.rs",
+        "packet_degradation.rs",
         "packet_evidence.rs",
         "packet_evidence_carriers.rs",
         "packet_evidence_roles.rs",
         "packet_flow_requirements.rs",
+        "packet_freshness.rs",
         "packet_obligations.rs",
         "packet_plan.rs",
+        "packet_profile_telemetry.rs",
         "packet_required_probes.rs",
         "packet_scoring.rs",
+        "packet_source_patterns.rs",
         "packet_terms.rs",
         "pinned_reader.rs",
         "planning.rs",
@@ -2069,7 +2076,7 @@ fn packet_claim_profile_contracts_are_enforced_at_runtime_not_only_in_debug_buil
     // run in the shipped build and skip the profile it rejects.
     let profiles = read("crates/codestory-runtime/src/agent/packet_claim_profiles.rs");
     let production = production_source_prefix(&profiles);
-    let registry = read("crates/codestory-runtime/src/agent/packet_claim_profile_registry.rs");
+    let registry = read("crates/codestory-agent/src/packet_claim_profile_registry.rs");
     let registry_production = production_source_prefix(&registry);
     for source in [&production, &registry_production] {
         assert!(
@@ -2102,7 +2109,7 @@ fn packet_claim_profile_contracts_are_enforced_at_runtime_not_only_in_debug_buil
         );
     }
 
-    let telemetry = read("crates/codestory-runtime/src/agent/packet_profile_telemetry.rs");
+    let telemetry = read("crates/codestory-agent/src/packet_profile_telemetry.rs");
     assert!(
         production_source_prefix(&telemetry).contains("PACKET_CLAIM_PROFILE_CONTRACT_VERSION"),
         "packet claim-profile telemetry must publish a contract version"
@@ -2115,7 +2122,7 @@ fn packet_profile_telemetry_travels_on_a_typed_field_not_the_evidence_annotation
     // confidence. Always-on telemetry published there was classified as a gap on every packet and
     // moved every answer from high/ready to medium/review. The counters must therefore be
     // structurally separated from evidence text, not merely reclassified as observations.
-    let telemetry = read("crates/codestory-runtime/src/agent/packet_profile_telemetry.rs");
+    let telemetry = read("crates/codestory-agent/src/packet_profile_telemetry.rs");
     let telemetry_production = production_source_prefix(&telemetry);
     assert!(
         telemetry_production.contains("-> PacketClaimProfileTelemetryDto"),

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -5,7 +5,10 @@ edition = "2024"
 
 [features]
 benchmark-support = []
-test-support = []
+# The runtime test hooks now partly live in codestory-agent (fresh_index_observation
+# moved with packet_freshness), so turning this on has to turn the agent crate's
+# hooks on too. Only dev/test edges enable it; no product build does.
+test-support = ["codestory-agent/test-support"]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/codestory-runtime/src/agent/mod.rs
+++ b/crates/codestory-runtime/src/agent/mod.rs
@@ -1,22 +1,15 @@
-pub(crate) mod citation;
 pub(crate) mod nucleo_policy;
 pub(crate) mod orchestrator;
 pub(crate) mod packet_batch;
 pub(crate) mod packet_budget;
 pub(crate) mod packet_capping;
-pub(crate) mod packet_claim_profile_registry;
 
 pub(crate) mod packet_claim_profiles;
 pub(crate) mod packet_claims;
-pub(crate) mod packet_coverage;
-pub(crate) mod packet_degradation;
-pub(crate) mod packet_freshness;
 #[cfg(test)]
 mod packet_obligations_runtime_tests;
 pub(crate) mod packet_probe;
-pub(crate) mod packet_profile_telemetry;
 pub(crate) mod packet_search;
-pub(crate) mod packet_source_patterns;
 pub(crate) mod packet_sufficiency;
 pub(crate) mod packet_trace;
 pub(crate) mod profiles;
@@ -31,9 +24,11 @@ pub(crate) mod trace_export;
 pub(crate) use codestory_agent::eval_probes;
 #[allow(unused_imports)]
 pub(crate) use codestory_agent::{
-    packet_citations, packet_command_profiles, packet_evidence, packet_evidence_roles,
-    packet_flow_requirements, packet_obligations, packet_plan, packet_required_probes,
-    packet_scoring, packet_terms, planning,
+    citation, packet_citations, packet_claim_profile_registry, packet_command_profiles,
+    packet_coverage, packet_degradation, packet_evidence, packet_evidence_roles,
+    packet_flow_requirements, packet_freshness, packet_obligations, packet_plan,
+    packet_profile_telemetry, packet_required_probes, packet_scoring, packet_source_patterns,
+    packet_terms, planning,
 };
 
 pub(crate) use orchestrator::{agent_ask, agent_packet};

--- a/scripts/retrieval-generalization-pending.json
+++ b/scripts/retrieval-generalization-pending.json
@@ -204,7 +204,7 @@
         "wsgiapp": 1
       }
     },
-    "crates/codestory-runtime/src/agent/packet_source_patterns.rs": {
+    "crates/codestory-agent/src/packet_source_patterns.rs": {
       "issue": "https://github.com/TheGreenCedar/CodeStory/issues/1573",
       "reason": "Source-pattern matching keeps holdout identifiers as example words. They are small enough to delete with the callers that supply them, not on their own.",
       "markers": {


### PR DESCRIPTION
Seven modules (~2.4k lines), 42 pure tests moved with census reconciling exactly, zero call-site changes via old-path aliases, six of seven byte-identical after mechanical rewrites (the seventh differs by two declared cfg re-gates), lint ratchet unchanged, contracts green locally and on the tree merged with the current tip. Two recorded fallback expansions: runtime's test-support feature forwards to the agent crate's; two telemetry accessors re-gated per the S4-10b precedent.

Closes #1882
Refs #1673
Refs #1179