### PR TITLE
[v0.17] Bound the remaining node-name lookups to candidate ids

### DIFF
--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -1224,6 +1224,7 @@ pub(crate) fn sidecar_rejection_diagnostic(
 ) -> String {
     let project_root = controller.require_project_root().ok();
     let storage = controller.open_storage_read_only().ok();
+    // Deliberate full-map copy: resolution discovers node ids mid-walk from storage, so an upfront candidate bound would change diagnostic labels.
     let node_names = controller.state.lock().node_names.clone();
     let candidate_summaries: Vec<String> = query_result
         .hits
@@ -1292,6 +1293,7 @@ fn sidecar_candidate_resolution_labels(
 ) -> Vec<String> {
     let project_root = controller.require_project_root().ok();
     let storage = controller.open_storage_read_only().ok();
+    // Deliberate full-map copy: resolution discovers node ids mid-walk from storage, so an upfront candidate bound would change diagnostic labels.
     let node_names = controller.state.lock().node_names.clone();
     candidates
         .iter()
@@ -1329,6 +1331,7 @@ fn sidecar_candidate_admission_labels(
 ) -> Vec<SidecarCandidateAdmissionLabel> {
     let project_root = controller.require_project_root().ok();
     let storage = controller.open_storage_read_only().ok();
+    // Deliberate full-map copy: resolution discovers node ids mid-walk from storage, so an upfront candidate bound would change diagnostic labels.
     let node_names = controller.state.lock().node_names.clone();
     let search_nodes = ranked_hit_nodes(search_hits);
     let search_paths = project_root

--- a/crates/codestory-runtime/src/search_scoring.rs
+++ b/crates/codestory-runtime/src/search_scoring.rs
@@ -15,6 +15,7 @@ use super::{
 use crate::agent::packet_evidence::decorate_lexical_search_hit_evidence;
 #[cfg(test)]
 use crate::agent::packet_evidence::decorate_search_hit_evidence;
+use crate::controller_symbols::node_names_for_ids;
 #[cfg(test)]
 use crate::search_publication::{
     retrieval_state_from_engine, retrieval_state_from_engine_with_storage_contract,
@@ -449,10 +450,9 @@ impl AppController {
             }
         }
 
-        Ok(Some((
-            aggregate_symbol_matches(direct_matches, expanded),
-            s.node_names.clone(),
-        )))
+        let matches = aggregate_symbol_matches(direct_matches, expanded);
+        let node_names = node_names_for_ids(&s.node_names, matches.iter().map(|(id, _)| *id));
+        Ok(Some((matches, node_names)))
     }
 
     fn search_hybrid_results(
@@ -650,7 +650,8 @@ impl AppController {
                 "hybrid_search_instrumentation"
             );
 
-            (hits, s.node_names.clone(), retrieval)
+            let node_names = node_names_for_ids(&s.node_names, hits.iter().map(|hit| hit.node_id));
+            (hits, node_names, retrieval)
         };
 
         let mut out = Vec::with_capacity(hybrid.len());

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -73,7 +73,8 @@ const EDGE_SELECT_BASE: &str = "SELECT e.id, e.source_node_id, e.target_node_id,
 /// an unpinned planner reads `resolved_source_node_id IS NULL` as the more
 /// selective term and seeks every unresolved CALL edge in the repository.
 /// `raw_call_edges_by_effective_source_plan_seeks_both_branches` holds the shape.
-/// Every pinned index is created for any live store (schema.rs:396,415).
+/// `INDEXED BY` makes both indexes hard `prepare()` dependencies; storage_impl/schema.rs
+/// guarantees them with `CREATE INDEX IF NOT EXISTS` for every live store.
 const RAW_CALL_EDGES_BY_EFFECTIVE_SOURCE_SQL: &str = "SELECT e.id, e.source_node_id, e.target_node_id, e.kind, e.file_node_id, e.line, e.resolved_source_node_id, e.resolved_target_node_id, e.confidence, e.callsite_identity, e.certainty, e.candidate_target_node_ids
      FROM edge e INDEXED BY idx_edge_resolved_source
      WHERE e.resolved_source_node_id = ?1


### PR DESCRIPTION
Both hot-path full-map clones now use the existing node_names_for_ids bound (hit sets/order byte-identical); the three diagnostics clones are justified in place with comments (mid-resolution ID discovery precludes an upfront bound); the INDEXED BY hard dependency is documented against its schema.rs guarantee. Runtime lib green modulo the tracked #1853 flake; clippy/fmt clean.

Closes #1847
Refs #1661
Refs #1179