### PR TITLE
[v0.17 REL-CI S1b-1] Own the smallest step-fragment family in the claim graph

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -1058,6 +1058,29 @@ export function pinnedProgramViolations(workflows, graph = loadReleaseClaimGraph
   return violations;
 }
 
+// Every step-fragment rule INSTANCE for a migrated workflow family lives in
+// release-claims.json under workflow_policy.step_fragments; scripts/
+// codestory-release-claims.mjs fails graph loading unless that block names exactly
+// the reviewed rule rows, so membership cannot drift by data edit. The checker keeps
+// only what stays code: the requireStepRun/forbidStepRun predicates each row's kind
+// selects, whose violation text is byte-identical to the retired inline calls.
+// A missing workflow is reported by the structural validator that owns the file, so
+// each row evaluates only when its subject workflow parsed; every other absence
+// (missing job, missing step, empty script) fails the fragment predicates exactly as
+// the retired inline checks did.
+export function stepFragmentViolations(workflows, graph = loadReleaseClaimGraph(repositoryRoot)) {
+  const violations = [];
+  for (const value of Object.values(object(object(graph.workflow_policy).step_fragments))) {
+    const row = object(value);
+    const workflow = workflows.get(row.file);
+    if (!workflow) continue;
+    const job = object(object(workflow.jobs)[row.job]);
+    const evaluate = row.kind === "forbid" ? forbidStepRun : requireStepRun;
+    evaluate(violations, row.file, job, row.step, list(row.fragments));
+  }
+  return violations;
+}
+
 const draftProofCommands = [
   "cargo test --locked -p codestory-llama-sys --test native_staging",
   "cargo test --locked -p codestory-llama-sys --test model_staging",
@@ -2239,10 +2262,8 @@ function validateIssueWorkflows(workflows, violations) {
     for (const fragment of ["codex/", "review/codestory-saga-", "[codex]", "saga:codestory-intelligence"]) {
       add(violations, String(job.if ?? "").includes(fragment), `${sagaFile} guarded condition must include ${fragment}`);
     }
-    requireStepRun(violations, sagaFile, job, "Check PR issue relationship", [
-      "close[sd]?|fix(?:e[sd])?|resolve[sd]?",
-      "#\\d+|https://github\\.com/TheGreenCedar/CodeStory/issues/\\d+",
-    ]);
+    // The guard's step fragments are rule instances and live in release-claims.json
+    // under workflow_policy.step_fragments; stepFragmentViolations evaluates them.
   }
 
   const closeFile = "close-dev-issues.yml";
@@ -2253,30 +2274,10 @@ function validateIssueWorkflows(workflows, violations) {
     add(violations, includesAll(at(close, "on", "push", "branches"), ["dev/codestory-next"]), `${closeFile} must run on dev/codestory-next pushes`);
     add(violations, object(close.permissions).issues === "write", `${closeFile} must write issues`);
     add(violations, object(close.permissions)["pull-requests"] === "read", `${closeFile} must read pull requests`);
-    const job = requireJob(violations, closeFile, close, "close-linked-issues");
-    requireStepRun(violations, closeFile, job, "Close issues referenced by the merged PR", [
-      'commit = event["after"]',
-      'pull_request.get("merged_at")',
-      'pull_request.get("merge_commit_sha") == commit',
-      'pull_request.get("base", {}).get("ref") == "dev/codestory-next"',
-      'pullRequest(number: $number)',
-      'entries(first: 100, after: $cursor)',
-      'if stack_response.get("errors")',
-      'if "stack" not in pull_request_node',
-      'stack.get("baseRefName") != "dev/codestory-next"',
-      'metadata != expected_stack',
-      'expected_stack[2] != len(entries)',
-      'if next_cursor == cursor or next_cursor in seen_cursors',
-      'if stack_repository != repository',
-      'existing = merged_pull_requests_by_number.get(number)',
-      'stacked_pull_request.get("merged")',
-      'stacked_pull_request.get("mergedAt")',
-      'merge_commit.get("oid") == commit',
-      'anchor.get("body") != pull_request.get("body")',
-      'if "pull_request" in issue:',
-      '"state_reason=completed"',
-      "https://github\\.com/TheGreenCedar/CodeStory/issues/(\\d+)",
-    ]);
+    requireJob(violations, closeFile, close, "close-linked-issues");
+    // The close automation's step fragments are rule instances and live in
+    // release-claims.json under workflow_policy.step_fragments;
+    // stepFragmentViolations evaluates them.
   }
 }
 
@@ -11182,6 +11183,7 @@ export function validateWorkflows(workflows, graph = loadReleaseClaimGraph(repos
   violations.push(...protectedRunnerReservationViolations(workflows, graph));
   violations.push(...releaseWorkflowContractViolations(workflows, graph));
   violations.push(...pinnedProgramViolations(workflows, graph));
+  violations.push(...stepFragmentViolations(workflows, graph));
   return violations;
 }
 

--- a/benchmarks/release-evidence/fixtures/candidate.json
+++ b/benchmarks/release-evidence/fixtures/candidate.json
@@ -62,7 +62,7 @@
   },
   "release_claims": {
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "5094baf04b547df9d18b55dd5acdd83a026bfcc4ad8e79a252ec3454fbb9d24c",
+    "graph_sha256": "b7e72a3c17bd126f55eb4f7903083f9eb6ffda8c877e6e065f89d4a9bd254f83",
     "observed_at": "2026-08-08T19:19:24.395Z",
     "expires_at": "2026-08-09T19:19:24.395Z",
     "requested_claims": [
@@ -85,7 +85,7 @@
         "type": "performance",
         "tier": "live_behavior",
         "status": "measured",
-        "graph_sha256": "5094baf04b547df9d18b55dd5acdd83a026bfcc4ad8e79a252ec3454fbb9d24c",
+        "graph_sha256": "b7e72a3c17bd126f55eb4f7903083f9eb6ffda8c877e6e065f89d4a9bd254f83",
         "observed_at": "2026-08-08T19:19:24.395Z",
         "expires_at": "2026-08-09T19:19:24.395Z",
         "identity": {
@@ -106,7 +106,7 @@
         "type": "answer_quality",
         "tier": "answer_quality",
         "status": "pass",
-        "graph_sha256": "5094baf04b547df9d18b55dd5acdd83a026bfcc4ad8e79a252ec3454fbb9d24c",
+        "graph_sha256": "b7e72a3c17bd126f55eb4f7903083f9eb6ffda8c877e6e065f89d4a9bd254f83",
         "observed_at": "2026-08-08T19:19:24.395Z",
         "expires_at": "2026-08-09T19:19:24.395Z",
         "identity": {

--- a/benchmarks/release-evidence/fixtures/report.json
+++ b/benchmarks/release-evidence/fixtures/report.json
@@ -7,7 +7,7 @@
   "baseline_id": "ci-contract-v1@1111111111111111111111111111111111111111",
   "baseline_sha256": "0bbbe6dd8b4000151edf7b1270959d08e94e08db876e7f2372b25613e0f237c1",
   "candidate_path": "benchmarks/release-evidence/fixtures/candidate.json",
-  "candidate_sha256": "3a63fafb6b80761ecd4abff7a2b3778ae32ebcd95cde52790e6898561d6572f4",
+  "candidate_sha256": "d18363a9993be04202ce4965e486583c1b02abdc1a4ee7eee7a7dc04a45802b3",
   "artifact_paths": [
     {
       "path": "candidate-stats.json",
@@ -26,7 +26,7 @@
       "type": "performance",
       "tier": "live_behavior",
       "status": "pass",
-      "graph_sha256": "5094baf04b547df9d18b55dd5acdd83a026bfcc4ad8e79a252ec3454fbb9d24c",
+      "graph_sha256": "b7e72a3c17bd126f55eb4f7903083f9eb6ffda8c877e6e065f89d4a9bd254f83",
       "observed_at": "2026-08-08T19:19:24.395Z",
       "expires_at": "2026-08-09T19:19:24.395Z",
       "identity": {
@@ -47,7 +47,7 @@
       "type": "answer_quality",
       "tier": "answer_quality",
       "status": "pass",
-      "graph_sha256": "5094baf04b547df9d18b55dd5acdd83a026bfcc4ad8e79a252ec3454fbb9d24c",
+      "graph_sha256": "b7e72a3c17bd126f55eb4f7903083f9eb6ffda8c877e6e065f89d4a9bd254f83",
       "observed_at": "2026-08-08T19:19:24.395Z",
       "expires_at": "2026-08-09T19:19:24.395Z",
       "identity": {
@@ -69,7 +69,7 @@
     "schema": "codestory.release-claim-evaluation/v1",
     "status": "pass",
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "5094baf04b547df9d18b55dd5acdd83a026bfcc4ad8e79a252ec3454fbb9d24c",
+    "graph_sha256": "b7e72a3c17bd126f55eb4f7903083f9eb6ffda8c877e6e065f89d4a9bd254f83",
     "evidence_selection": "all_matching_rows_must_pass",
     "expected_commit": "2222222222222222222222222222222222222222",
     "evaluated_at": "2026-08-08T19:19:24.395Z",

--- a/release-claims.json
+++ b/release-claims.json
@@ -1844,6 +1844,49 @@
         "sha256": "efc5126e24162d52f9da8bac38c3414b3a7492fb17eed5ff19867fadad69623e",
         "reason": "The companion qualification driver is intentionally retained only inside the private Actions package artifact. This digest pins both sides of that contract: the producer may read Cargo's trusted hard-linked build output but retains only a new singly linked copy bound to the exact candidate archive, and the consumer rejects symlinks, retained hardlinks, extra files, identity drift, and byte drift before restoring execute permission. Any helper edit therefore requires policy and mutation-test review in the same PR."
       }
+    },
+    "step_fragments": {
+      "saga_issue_link_guard": {
+        "kind": "require",
+        "file": "saga-issue-link-guard.yml",
+        "job": "require-closing-issue-link",
+        "step": "Check PR issue relationship",
+        "fragments": [
+          "close[sd]?|fix(?:e[sd])?|resolve[sd]?",
+          "#\\d+|https://github\\.com/TheGreenCedar/CodeStory/issues/\\d+"
+        ],
+        "reason": "Every codex pull request must name the issue it closes before review. The guard's matcher must keep recognizing both the closing keywords and both issue-reference spellings; each fragment is one reviewed half of that grep, owned here so it cannot be weakened by a checker edit alone."
+      },
+      "close_dev_issues": {
+        "kind": "require",
+        "file": "close-dev-issues.yml",
+        "job": "close-linked-issues",
+        "step": "Close issues referenced by the merged PR",
+        "fragments": [
+          "commit = event[\"after\"]",
+          "pull_request.get(\"merged_at\")",
+          "pull_request.get(\"merge_commit_sha\") == commit",
+          "pull_request.get(\"base\", {}).get(\"ref\") == \"dev/codestory-next\"",
+          "pullRequest(number: $number)",
+          "entries(first: 100, after: $cursor)",
+          "if stack_response.get(\"errors\")",
+          "if \"stack\" not in pull_request_node",
+          "stack.get(\"baseRefName\") != \"dev/codestory-next\"",
+          "metadata != expected_stack",
+          "expected_stack[2] != len(entries)",
+          "if next_cursor == cursor or next_cursor in seen_cursors",
+          "if stack_repository != repository",
+          "existing = merged_pull_requests_by_number.get(number)",
+          "stacked_pull_request.get(\"merged\")",
+          "stacked_pull_request.get(\"mergedAt\")",
+          "merge_commit.get(\"oid\") == commit",
+          "anchor.get(\"body\") != pull_request.get(\"body\")",
+          "if \"pull_request\" in issue:",
+          "\"state_reason=completed\"",
+          "https://github\\.com/TheGreenCedar/CodeStory/issues/(\\d+)"
+        ],
+        "reason": "The close automation decides which issues a push to dev/codestory-next may close as completed. Each fragment pins one authentication, stack-integrity, or pagination check inside the inline Python program - merge-commit identity, base-branch and stack verification, cursor-loop and repository guards, and the completed state_reason - so none of those checks can be deleted without a reviewed graph edit."
+      }
     }
   }
 }

--- a/scripts/codestory-release-claims.mjs
+++ b/scripts/codestory-release-claims.mjs
@@ -105,6 +105,15 @@ const PINNED_PROGRAM_CONTRACTS = new Map([
   ["packaged_host_compiler_finalizer", { subject: "step_script_raw_text", job: true, step: true }],
   ["qualification_driver_artifact", { subject: "helper_file_text", job: false, step: false }],
 ]);
+// The graph owns every step-fragment rule instance for workflow families migrated
+// off inline requireStepRun/forbidStepRun calls; the checker owns only those two
+// predicates and their message shapes. Membership is exact and fail-closed: a graph
+// that drops, renames, or invents a step-fragment rule must not load, so a rule
+// instance cannot disappear by data edit. Kind names the predicate a row binds.
+const STEP_FRAGMENT_CONTRACTS = new Map([
+  ["saga_issue_link_guard", { kind: "require" }],
+  ["close_dev_issues", { kind: "require" }],
+]);
 const FAILURE_ORDER = new Map([
   ["unsupported_claim", 0],
   ["missing", 1],
@@ -848,6 +857,38 @@ function validatePinnedPrograms(policy) {
     nonEmptyText(row.reason, `${label}.reason`);
   }
   return programs;
+}
+
+function validateStepFragments(policy) {
+  const rules = object(policy.step_fragments, "workflow_policy.step_fragments");
+  for (const name of Object.keys(rules)) {
+    if (!STEP_FRAGMENT_CONTRACTS.has(name)) {
+      fail(`workflow_policy.step_fragments names unknown step fragment rule ${name}`);
+    }
+  }
+  for (const [name, contract] of STEP_FRAGMENT_CONTRACTS) {
+    if (rules[name] === undefined) {
+      fail(`workflow_policy.step_fragments must declare ${name}`);
+    }
+    const label = `workflow_policy.step_fragments.${name}`;
+    const row = object(rules[name], label);
+    const expectedKeys = ["kind", "file", "job", "step", "fragments", "reason"];
+    if (
+      JSON.stringify([...Object.keys(row)].sort())
+        !== JSON.stringify([...expectedKeys].sort())
+    ) {
+      fail(`${label} must carry exactly ${expectedKeys.join(", ")}`);
+    }
+    if (row.kind !== contract.kind) {
+      fail(`${label}.kind must be ${contract.kind}`);
+    }
+    nonEmptyText(row.file, `${label}.file`);
+    nonEmptyText(row.job, `${label}.job`);
+    nonEmptyText(row.step, `${label}.step`);
+    stringArray(row.fragments, `${label}.fragments`, { nonEmpty: true });
+    nonEmptyText(row.reason, `${label}.reason`);
+  }
+  return rules;
 }
 
 function validateQualificationPolicy(value, pinnedPrograms) {
@@ -1815,6 +1856,7 @@ export function validateReleaseClaimGraph(graph) {
     fail("workflow_policy.artifact_retention_days must be a positive integer");
   }
   const pinnedPrograms = validatePinnedPrograms(policy);
+  validateStepFragments(policy);
   validateProofFloor(policy.proof_floor);
   if (!Array.isArray(policy.package_matrix) || policy.package_matrix.length !== 3) {
     fail("workflow_policy.package_matrix must define three release package rows");
@@ -2111,6 +2153,12 @@ export function loadReleaseClaimGraph(repoRoot = path.resolve(path.dirname(fileU
       : path.join(".github", "workflows", row.file);
     if (!existsSync(path.join(repoRoot, relative))) {
       fail(`workflow_policy.pinned_programs.${name} pins missing file ${relative}`);
+    }
+  }
+  for (const [name, row] of Object.entries(validated.workflow_policy.step_fragments)) {
+    const relative = path.join(".github", "workflows", row.file);
+    if (!existsSync(path.join(repoRoot, relative))) {
+      fail(`workflow_policy.step_fragments.${name} binds missing file ${relative}`);
     }
   }
   return validated;

--- a/scripts/tests/codestory-release-claims.test.mjs
+++ b/scripts/tests/codestory-release-claims.test.mjs
@@ -713,6 +713,46 @@ test("pinned programs are an exact fail-closed membership with graph-owned diges
   }
 });
 
+test("step fragments are an exact fail-closed membership with graph-owned rule data", () => {
+  const rules = graph.workflow_policy.step_fragments;
+  assert.equal(Object.keys(rules).length, 2);
+  for (const row of Object.values(rules)) {
+    assert.equal(row.kind, "require");
+    assert.ok(row.fragments.length > 0);
+  }
+  const mutations = [
+    [draft => {
+      delete draft.workflow_policy.step_fragments.close_dev_issues;
+    }, /step_fragments must declare close_dev_issues/u],
+    [draft => {
+      draft.workflow_policy.step_fragments.unowned_extra = structuredClone(
+        draft.workflow_policy.step_fragments.close_dev_issues,
+      );
+    }, /names unknown step fragment rule unowned_extra/u],
+    [draft => {
+      draft.workflow_policy.step_fragments.saga_issue_link_guard.kind = "forbid";
+    }, /saga_issue_link_guard\.kind must be require/u],
+    [draft => {
+      delete draft.workflow_policy.step_fragments.saga_issue_link_guard.step;
+    }, /saga_issue_link_guard must carry exactly kind, file, job, step, fragments, reason/u],
+    [draft => {
+      draft.workflow_policy.step_fragments.close_dev_issues.fragments = [];
+    }, /close_dev_issues\.fragments must be a non-empty array/u],
+    [draft => {
+      const fragments = draft.workflow_policy.step_fragments.close_dev_issues.fragments;
+      fragments.push(fragments[0]);
+    }, /close_dev_issues\.fragments must not contain duplicates/u],
+    [draft => {
+      draft.workflow_policy.step_fragments.saga_issue_link_guard.reason = "";
+    }, /saga_issue_link_guard\.reason must be a non-empty string/u],
+  ];
+  for (const [mutate, expected] of mutations) {
+    const draft = structuredClone(graph);
+    mutate(draft);
+    assert.throws(() => validateReleaseClaimGraph(draft), expected);
+  }
+});
+
 test("benchmark leakage names only the one-process Node contract", () => {
   const benchmarkLeakage = graph.failure_controls
     .find(({ id }) => id === "benchmark_leakage");

--- a/scripts/tests/fixtures/release-claims/positive.json
+++ b/scripts/tests/fixtures/release-claims/positive.json
@@ -17,7 +17,7 @@
       "type": "source_behavior",
       "tier": "source",
       "status": "pass",
-      "graph_sha256": "5094baf04b547df9d18b55dd5acdd83a026bfcc4ad8e79a252ec3454fbb9d24c",
+      "graph_sha256": "b7e72a3c17bd126f55eb4f7903083f9eb6ffda8c877e6e065f89d4a9bd254f83",
       "observed_at": "2026-07-16T11:00:00.000Z",
       "expires_at": "2026-07-17T11:00:00.000Z",
       "identity": {


### PR DESCRIPTION
First fragment-category migration on the S1a template: graph rows + generic evaluator reusing requireStepRun, messages verbatim, exact-membership fail-closed, pins regenerated. Oracle: 8,206 mutants, zero mismatches, pristine identical (clean-captured, exit 0). Policy 1367/0, claims 45/0, lint ok.

Closes #1883
Refs #1670
Refs #1179