### PR TITLE
[v0.17 S4-3] Inject workspace path identity into sufficiency behind a required seam

### DIFF
--- a/crates/codestory-agent/src/lib.rs
+++ b/crates/codestory-agent/src/lib.rs
@@ -41,5 +41,7 @@ pub mod pinned_reader;
 pub mod planning;
 pub mod text;
 pub mod trail;
+pub mod workspace_path_identity;
 
 pub use pinned_reader::{ContinuationRefusal, PinnedReader, admit_continuation_probe};
+pub use workspace_path_identity::WorkspacePathIdentity;

--- a/crates/codestory-agent/src/workspace_path_identity.rs
+++ b/crates/codestory-agent/src/workspace_path_identity.rs
@@ -1,0 +1,24 @@
+//! The path-identity seam between packet sufficiency and the workspace crate.
+//!
+//! Sufficiency needs exactly one question answered — do two spellings name the
+//! same workspace file? — and answering it takes the filesystem identity
+//! machinery in `codestory_workspace::same_workspace_path`, which this crate
+//! must never link. The trait is the whole seam: the runtime implements it
+//! over the real filesystem probe and threads it into sufficiency wherever a
+//! packet is assembled.
+//!
+//! The implementation arrives as a REQUIRED argument at every consumer. The
+//! seam must never grow a `Default`, and no consumer may accept an `Option` of
+//! it: a defaulted seam is how the LanguageExtraction defect happened — a
+//! sibling construction site compiled against the default and silently ran
+//! without the real dependency. With no fallback, every new construction site
+//! is a compile error until it threads the seam explicitly.
+
+use std::path::Path;
+
+/// Decides whether two paths name the same workspace file.
+pub trait WorkspacePathIdentity {
+    /// `true` exactly when `left` and `right` resolve to the same workspace
+    /// file identity, however differently they are spelled.
+    fn same_workspace_path(&self, left: &Path, right: &Path) -> bool;
+}

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -584,6 +584,7 @@ fn agent_planning_crate_owns_planning_and_depends_on_contracts_only() {
         "pinned_reader.rs",
         "planning.rs",
         "text.rs",
+        "workspace_path_identity.rs",
     ] {
         assert!(
             repo_root()
@@ -618,6 +619,51 @@ fn agent_planning_crate_owns_planning_and_depends_on_contracts_only() {
             !agent_source.contains(forbidden),
             "codestory-agent must not spell {forbidden}: planning owns no persisted state"
         );
+    }
+}
+
+/// The `WorkspacePathIdentity` seam is threaded into packet sufficiency as a
+/// REQUIRED argument, and the requirement only holds while nothing can stand
+/// in for it. A defaulted seam is exactly the LanguageExtraction defect: a
+/// sibling construction site compiles against the default and silently runs
+/// without the real dependency. Neither the trait's home in `codestory-agent`
+/// nor the runtime adapter that closes it over
+/// `codestory_workspace::same_workspace_path` may ever spell a `Default`, so
+/// every new construction site stays a compile error until it threads the
+/// seam explicitly.
+#[test]
+fn workspace_path_identity_seam_never_grows_a_default() {
+    let seam = read("crates/codestory-agent/src/workspace_path_identity.rs");
+    assert!(
+        seam.contains("pub trait WorkspacePathIdentity"),
+        "the WorkspacePathIdentity seam trait must live in codestory-agent"
+    );
+    let adapter = read("crates/codestory-runtime/src/agent/path_identity.rs");
+    assert!(
+        adapter.contains("impl WorkspacePathIdentity for RuntimeWorkspacePathIdentity"),
+        "the runtime must close the WorkspacePathIdentity seam over same_workspace_path"
+    );
+
+    for (path, source) in [
+        (
+            "crates/codestory-agent/src/workspace_path_identity.rs",
+            &seam,
+        ),
+        (
+            "crates/codestory-runtime/src/agent/path_identity.rs",
+            &adapter,
+        ),
+    ] {
+        for line in source.lines() {
+            let spells_default = line.contains("impl Default")
+                || (line.contains("derive") && line.contains("Default"));
+            assert!(
+                !spells_default,
+                "{path} must not give the path identity seam a Default; keep it a required \
+                 argument so sibling construction sites fail to compile without it \
+                 (offending line: {line:?})"
+            );
+        }
     }
 }
 

--- a/crates/codestory-runtime/src/agent/mod.rs
+++ b/crates/codestory-runtime/src/agent/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod packet_probe;
 pub(crate) mod packet_search;
 pub(crate) mod packet_sufficiency;
 pub(crate) mod packet_trace;
+pub(crate) mod path_identity;
 pub(crate) mod profiles;
 pub(crate) mod retrieval_primary;
 pub(crate) mod trace;

--- a/crates/codestory-runtime/src/agent/orchestrator.rs
+++ b/crates/codestory-runtime/src/agent/orchestrator.rs
@@ -89,6 +89,7 @@ use crate::agent::packet_terms::{
     packet_terms_indicate_stylesheet_animation_flow,
     packet_terms_indicate_url_session_request_flow, prompt_search_terms,
 };
+use crate::agent::path_identity::RuntimeWorkspacePathIdentity;
 use crate::agent::profiles::{ResolvedProfile, TrailPlan, resolve_profile};
 use crate::agent::retrieval_primary::{
     RETRIEVAL_VERSION_SIDECAR, SidecarPrimarySearchOutcome, maybe_run_retrieval_shadow,
@@ -566,6 +567,7 @@ pub(crate) fn agent_packet(
     append_packet_non_trace_phase(&mut answer, "evidence_sections", phase_started);
     let phase_started = Instant::now();
     let sufficiency = build_packet_sufficiency_with_obligation_context(
+        &RuntimeWorkspacePathIdentity,
         &project_root,
         &question,
         plan.task_class,
@@ -5437,6 +5439,7 @@ mod tests {
         finalize_packet_obligation_plan(question, task_class, &mut obligations, &answer, &budget);
         append_packet_evidence_sections(&mut answer, task_class, &limits, Some(&obligations));
         let sufficiency = build_packet_sufficiency_with_obligation_context(
+            &RuntimeWorkspacePathIdentity,
             packet_fixture_project_root(),
             question,
             task_class,
@@ -10632,6 +10635,7 @@ mod tests {
             &budget,
         );
         let sufficiency = build_packet_sufficiency_with_obligation_context(
+            &RuntimeWorkspacePathIdentity,
             packet_fixture_project_root(),
             question,
             PacketTaskClassDto::ArchitectureExplanation,
@@ -10870,6 +10874,7 @@ mod tests {
             &budget,
         );
         let sufficiency = build_packet_sufficiency_with_obligation_context(
+            &RuntimeWorkspacePathIdentity,
             packet_fixture_project_root(),
             question,
             PacketTaskClassDto::ArchitectureExplanation,
@@ -10941,6 +10946,7 @@ mod tests {
             &budget,
         );
         let sufficiency = build_packet_sufficiency_with_obligation_context(
+            &RuntimeWorkspacePathIdentity,
             packet_fixture_project_root(),
             question,
             PacketTaskClassDto::ArchitectureExplanation,

--- a/crates/codestory-runtime/src/agent/packet_budget.rs
+++ b/crates/codestory-runtime/src/agent/packet_budget.rs
@@ -13,6 +13,7 @@ use crate::agent::packet_required_probes::packet_sufficiency_required_probe_quer
 use crate::agent::packet_sufficiency::{
     PACKET_MARKDOWN_TRUNCATION_SUFFIX, build_packet_sufficiency_with_obligation_context,
 };
+use crate::agent::path_identity::RuntimeWorkspacePathIdentity;
 use crate::agent::trace_export::packet_retrieval_trace_summary;
 use codestory_contracts::api::{
     AgentAnswerDto, AgentPacketDto, AgentResponseBlockDto, AgentRetrievalStepKindDto,
@@ -260,6 +261,7 @@ fn rebuild_packet_budget_dependents(
     );
     refresh_packet_claim_markdown(packet);
     packet.sufficiency = build_packet_sufficiency_with_obligation_context(
+        &RuntimeWorkspacePathIdentity,
         project_root,
         &packet.question,
         task_class,

--- a/crates/codestory-runtime/src/agent/packet_obligations_runtime_tests.rs
+++ b/crates/codestory-runtime/src/agent/packet_obligations_runtime_tests.rs
@@ -4,6 +4,7 @@ use crate::agent::packet_claims::packet_supported_claims;
 use crate::agent::packet_freshness::fresh_index_observation;
 use crate::agent::packet_obligations::*;
 use crate::agent::packet_sufficiency::build_packet_sufficiency_with_obligation_context;
+use crate::agent::path_identity::RuntimeWorkspacePathIdentity;
 use codestory_contracts::api::*;
 use std::path::Path;
 
@@ -251,6 +252,7 @@ fn cancelled_diagnostic_query_does_not_block_a_complete_material_ledger() {
     }));
     assert!(material_packet_obligations_are_proven(&plan), "{plan:#?}");
     let sufficiency = build_packet_sufficiency_with_obligation_context(
+        &RuntimeWorkspacePathIdentity,
         Path::new("/workspace/example"),
         question,
         PacketTaskClassDto::ArchitectureExplanation,
@@ -334,6 +336,7 @@ fn a_required_query_whose_semantic_stage_timed_out_demotes_through_its_obligatio
     );
 
     let sufficiency = build_packet_sufficiency_with_obligation_context(
+        &RuntimeWorkspacePathIdentity,
         Path::new("/workspace/example"),
         question,
         PacketTaskClassDto::ArchitectureExplanation,
@@ -692,6 +695,7 @@ fn sufficient_profile_closes_incidental_nonmaterial_guard_path() {
         "the raw unproven guard receipt must exercise the terminal open-next gate"
     );
     let sufficiency = build_packet_sufficiency_with_obligation_context(
+        &RuntimeWorkspacePathIdentity,
         Path::new("/workspace/example"),
         question,
         PacketTaskClassDto::SymbolOwnership,
@@ -779,6 +783,7 @@ fn case_distinct_exact_symbols_need_separate_carriers() {
     assert!(!material_packet_obligations_are_proven(&plan));
 
     let sufficiency = build_packet_sufficiency_with_obligation_context(
+        &RuntimeWorkspacePathIdentity,
         Path::new("/workspace/example"),
         question,
         PacketTaskClassDto::SymbolOwnership,
@@ -841,6 +846,7 @@ fn case_distinct_slash_qualified_symbols_need_separate_carriers() {
     assert!(lower.carrier_node_ids.is_empty());
 
     let sufficiency = build_packet_sufficiency_with_obligation_context(
+        &RuntimeWorkspacePathIdentity,
         Path::new("/workspace/example"),
         question,
         PacketTaskClassDto::SymbolOwnership,
@@ -908,6 +914,7 @@ fn one_proven_claim_cannot_hide_an_unproven_claim_in_the_same_file() {
     }));
 
     let sufficiency = build_packet_sufficiency_with_obligation_context(
+        &RuntimeWorkspacePathIdentity,
         Path::new("/workspace/example"),
         question,
         PacketTaskClassDto::SymbolOwnership,
@@ -992,6 +999,7 @@ fn missing_requested_claim_gets_a_material_unsupported_obligation() {
     assert!(!material_packet_obligations_are_proven(&plan));
 
     let sufficiency = build_packet_sufficiency_with_obligation_context(
+        &RuntimeWorkspacePathIdentity,
         Path::new("/workspace/example"),
         question,
         PacketTaskClassDto::SymbolOwnership,
@@ -1037,6 +1045,7 @@ fn false_shape_carrier_stays_reported_partial_and_open_next() {
         Some("carrier_does_not_satisfy_role_contract")
     );
     let sufficiency = build_packet_sufficiency_with_obligation_context(
+        &RuntimeWorkspacePathIdentity,
         Path::new("/workspace/example"),
         INDEXING_QUESTION,
         PacketTaskClassDto::ArchitectureExplanation,
@@ -1081,6 +1090,7 @@ fn known_false_carriers_publish_no_proven_claims_and_stay_open_next() {
     );
 
     let sufficiency = build_packet_sufficiency_with_obligation_context(
+        &RuntimeWorkspacePathIdentity,
         Path::new("/workspace/example"),
         question,
         PacketTaskClassDto::SymbolOwnership,
@@ -1135,6 +1145,7 @@ fn missing_carrier_keeps_requested_path_as_open_next_candidate() {
         &budget,
     );
     let sufficiency = build_packet_sufficiency_with_obligation_context(
+        &RuntimeWorkspacePathIdentity,
         Path::new("/workspace/example"),
         INDEXING_QUESTION,
         PacketTaskClassDto::ArchitectureExplanation,

--- a/crates/codestory-runtime/src/agent/packet_sufficiency.rs
+++ b/crates/codestory-runtime/src/agent/packet_sufficiency.rs
@@ -24,6 +24,8 @@ use crate::agent::packet_scoring::{
     packet_display_path,
 };
 use crate::agent::packet_terms::packet_probe_terms;
+#[cfg(test)]
+use crate::agent::path_identity::RuntimeWorkspacePathIdentity;
 use codestory_agent::packet_command::next_deeper_packet_argv;
 #[allow(unused_imports)]
 pub(crate) use codestory_agent::packet_command::quote_packet_command_value;
@@ -31,6 +33,7 @@ pub(crate) use codestory_agent::packet_command::{
     packet_argv, packet_display_project_arg, packet_follow_up_invocation, render_packet_command,
 };
 pub(crate) use codestory_agent::packet_execution_graphs::packet_execution_graphs;
+use codestory_agent::workspace_path_identity::WorkspacePathIdentity;
 use codestory_contracts::api::{
     AgentAnswerDto, AgentCitationDto, AgentRetrievalStepStatusDto, EdgeKind, GraphResponse,
     NodeKind, PacketBudgetDto, PacketBudgetModeDto, PacketClaimDto, PacketClaimObligationDto,
@@ -98,6 +101,7 @@ pub(crate) fn build_packet_sufficiency_with_probe_context(
     exact_probe_paths: &[String],
 ) -> PacketSufficiencyDto {
     build_packet_sufficiency_with_optional_obligation_context(
+        &RuntimeWorkspacePathIdentity,
         project_root,
         question,
         task_class,
@@ -111,6 +115,7 @@ pub(crate) fn build_packet_sufficiency_with_probe_context(
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn build_packet_sufficiency_with_obligation_context(
+    path_identity: &dyn WorkspacePathIdentity,
     project_root: &Path,
     question: &str,
     task_class: PacketTaskClassDto,
@@ -121,6 +126,7 @@ pub(crate) fn build_packet_sufficiency_with_obligation_context(
     obligations: &PacketObligationPlanDto,
 ) -> PacketSufficiencyDto {
     build_packet_sufficiency_with_optional_obligation_context(
+        path_identity,
         project_root,
         question,
         task_class,
@@ -134,6 +140,7 @@ pub(crate) fn build_packet_sufficiency_with_obligation_context(
 
 #[allow(clippy::too_many_arguments)]
 fn build_packet_sufficiency_with_optional_obligation_context(
+    path_identity: &dyn WorkspacePathIdentity,
     project_root: &Path,
     question: &str,
     task_class: PacketTaskClassDto,
@@ -157,6 +164,7 @@ fn build_packet_sufficiency_with_optional_obligation_context(
         extra_probes,
     );
     assemble_packet_sufficiency_with_probe_context(
+        path_identity,
         PacketSufficiencyInput {
             project_root,
             question,
@@ -175,7 +183,13 @@ fn build_packet_sufficiency_with_optional_obligation_context(
 
 #[cfg(test)]
 fn assemble_packet_sufficiency(input: PacketSufficiencyInput<'_>) -> PacketSufficiencyDto {
-    assemble_packet_sufficiency_with_probe_context(input, &[], &[], None)
+    assemble_packet_sufficiency_with_probe_context(
+        &RuntimeWorkspacePathIdentity,
+        input,
+        &[],
+        &[],
+        None,
+    )
 }
 
 #[cfg(test)]
@@ -183,7 +197,13 @@ fn assemble_packet_sufficiency_with_route_probes(
     input: PacketSufficiencyInput<'_>,
     selected_probes: &[String],
 ) -> PacketSufficiencyDto {
-    assemble_packet_sufficiency_with_probe_context(input, selected_probes, &[], None)
+    assemble_packet_sufficiency_with_probe_context(
+        &RuntimeWorkspacePathIdentity,
+        input,
+        selected_probes,
+        &[],
+        None,
+    )
 }
 
 #[cfg(test)]
@@ -191,10 +211,17 @@ fn assemble_packet_sufficiency_with_exact_paths(
     input: PacketSufficiencyInput<'_>,
     exact_probe_paths: &[String],
 ) -> PacketSufficiencyDto {
-    assemble_packet_sufficiency_with_probe_context(input, &[], exact_probe_paths, None)
+    assemble_packet_sufficiency_with_probe_context(
+        &RuntimeWorkspacePathIdentity,
+        input,
+        &[],
+        exact_probe_paths,
+        None,
+    )
 }
 
 fn assemble_packet_sufficiency_with_probe_context(
+    path_identity: &dyn WorkspacePathIdentity,
     input: PacketSufficiencyInput<'_>,
     selected_probes: &[String],
     exact_probe_paths: &[String],
@@ -253,8 +280,12 @@ fn assemble_packet_sufficiency_with_probe_context(
     let has_minimum_claims = sufficiency_claims.len() >= min_claims;
     let claim_family_count = packet_supported_claim_family_count(&sufficiency_claims);
     let has_minimum_claim_families = claim_family_count >= min_claim_families;
-    let missing_exact_path_claims =
-        packet_missing_exact_path_claims(project_root, exact_probe_paths, &sufficiency_claims);
+    let missing_exact_path_claims = packet_missing_exact_path_claims(
+        path_identity,
+        project_root,
+        exact_probe_paths,
+        &sufficiency_claims,
+    );
     // Legacy/unit callers without an obligation ledger retain the pre-EV-5 route-probe contract.
     // Production claims must survive typed binding; route stages may additionally use the exact
     // Proven carrier rows from that same plan below.
@@ -482,7 +513,7 @@ fn assemble_packet_sufficiency_with_probe_context(
                 .iter()
                 .any(|unprovable| unprovable == &display)
                 && !unprovable_paths.iter().any(|unprovable| {
-                    packet_paths_match_exact_probe(project_root, unprovable, path)
+                    packet_paths_match_exact_probe(path_identity, project_root, unprovable, path)
                 })
         });
     }
@@ -2024,6 +2055,7 @@ fn packet_claim_is_generic_navigation_or_source_evidence(claim: &PacketClaimDto)
 /// Every resolved in-project path the caller named must be carried by its own proof-bearing claim,
 /// whatever the task class: a packet that answers around a requested path has not answered about it.
 fn packet_missing_exact_path_claims(
+    path_identity: &dyn WorkspacePathIdentity,
     project_root: &Path,
     exact_probe_paths: &[String],
     sufficiency_claims: &[PacketClaimDto],
@@ -2033,7 +2065,12 @@ fn packet_missing_exact_path_claims(
             .iter()
             .fold(Vec::<&String>::new(), |mut unique_paths, path| {
                 if !unique_paths.iter().any(|existing| {
-                    packet_paths_match_exact_probe(project_root, existing.as_str(), path)
+                    packet_paths_match_exact_probe(
+                        path_identity,
+                        project_root,
+                        existing.as_str(),
+                        path,
+                    )
                 }) {
                     unique_paths.push(path);
                 }
@@ -2053,6 +2090,7 @@ fn packet_missing_exact_path_claims(
                             citation_sufficiency_eligible(citation)
                                 && citation.file_path.as_deref().is_some_and(|citation_path| {
                                     packet_paths_match_exact_probe(
+                                        path_identity,
                                         project_root,
                                         citation_path,
                                         path.as_str(),
@@ -2116,6 +2154,7 @@ fn packet_assign_exact_path_claim(
 }
 
 fn packet_paths_match_exact_probe(
+    path_identity: &dyn WorkspacePathIdentity,
     project_root: &Path,
     citation_path: &str,
     exact_probe_path: &str,
@@ -2128,7 +2167,7 @@ fn packet_paths_match_exact_probe(
             project_root.join(path)
         }
     };
-    codestory_workspace::same_workspace_path(
+    path_identity.same_workspace_path(
         absolute(citation_path).as_path(),
         absolute(exact_probe_path).as_path(),
     )
@@ -3069,6 +3108,7 @@ mod tests {
             supported_claims_with_telemetry,
         );
         let sufficiency = build_packet_sufficiency_with_obligation_context(
+            &RuntimeWorkspacePathIdentity,
             Path::new("C:/workspace/project"),
             question,
             PacketTaskClassDto::RouteTracing,
@@ -4361,8 +4401,13 @@ mod tests {
             stdio_path.to_string(),
             runtime_path.to_string(),
         ];
-        let sufficiency =
-            assemble_packet_sufficiency_with_probe_context(input(), &[], &exact_paths, None);
+        let sufficiency = assemble_packet_sufficiency_with_probe_context(
+            &RuntimeWorkspacePathIdentity,
+            input(),
+            &[],
+            &exact_paths,
+            None,
+        );
 
         assert_eq!(sufficiency.status, PacketSufficiencyStatusDto::Partial);
         assert!(
@@ -4401,12 +4446,18 @@ mod tests {
         let project_root = Path::new("C:/workspace/project");
 
         assert!(packet_paths_match_exact_probe(
+            &RuntimeWorkspacePathIdentity,
             project_root,
             "crates/foo/src/lib.rs",
             "crates/foo/src/lib.rs"
         ));
         assert!(
-            !packet_paths_match_exact_probe(project_root, "src/lib.rs", "crates/foo/src/lib.rs"),
+            !packet_paths_match_exact_probe(
+                &RuntimeWorkspacePathIdentity,
+                project_root,
+                "src/lib.rs",
+                "crates/foo/src/lib.rs"
+            ),
             "a shorter same-suffix citation must not satisfy a different exact path"
         );
     }
@@ -4436,6 +4487,7 @@ mod tests {
         );
 
         let missing = packet_missing_exact_path_claims(
+            &RuntimeWorkspacePathIdentity,
             project_root,
             &paths.map(str::to_string),
             &[overlapping_claim, launcher_claim],
@@ -4467,6 +4519,7 @@ mod tests {
         broad_claim.citations = citations.to_vec();
 
         let missing = packet_missing_exact_path_claims(
+            &RuntimeWorkspacePathIdentity,
             project_root,
             &paths.map(str::to_string),
             &[broad_claim],
@@ -4533,6 +4586,7 @@ mod tests {
         let exact_paths = paths.map(str::to_string);
 
         let sufficiency = assemble_packet_sufficiency_with_probe_context(
+            &RuntimeWorkspacePathIdentity,
             PacketSufficiencyInput {
                 project_root: Path::new("C:/workspace/project"),
                 question,
@@ -7725,6 +7779,7 @@ mod tests {
             answer.citations = vec![covered.clone()];
 
             let sufficiency = assemble_packet_sufficiency_with_probe_context(
+                &RuntimeWorkspacePathIdentity,
                 PacketSufficiencyInput {
                     project_root: Path::new("C:/workspace/project"),
                     question,
@@ -7781,6 +7836,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         let sufficiency = assemble_packet_sufficiency_with_probe_context(
+            &RuntimeWorkspacePathIdentity,
             PacketSufficiencyInput {
                 project_root: Path::new("C:/workspace/project"),
                 question,
@@ -8069,6 +8125,7 @@ mod tests {
         ];
 
         let sufficiency = assemble_packet_sufficiency_with_probe_context(
+            &RuntimeWorkspacePathIdentity,
             PacketSufficiencyInput {
                 project_root: Path::new("C:/workspace/project"),
                 question,

--- a/crates/codestory-runtime/src/agent/path_identity.rs
+++ b/crates/codestory-runtime/src/agent/path_identity.rs
@@ -1,0 +1,119 @@
+//! Runtime side of the workspace path identity seam.
+//!
+//! `codestory-agent` owns the [`WorkspacePathIdentity`] trait and can never
+//! link `codestory-workspace`; this module is where the runtime closes the
+//! seam over the real filesystem probe. Every packet-sufficiency construction
+//! site threads [`RuntimeWorkspacePathIdentity`] explicitly — the seam has no
+//! `Default` and no `Option` fallback, so a construction site that forgets it
+//! is a compile error rather than a packet that silently compares paths with
+//! the wrong oracle.
+
+use codestory_agent::workspace_path_identity::WorkspacePathIdentity;
+use std::path::Path;
+
+/// The runtime's [`WorkspacePathIdentity`]: two paths name the same workspace
+/// file exactly when [`codestory_workspace::same_workspace_path`] says so.
+pub(crate) struct RuntimeWorkspacePathIdentity;
+
+impl WorkspacePathIdentity for RuntimeWorkspacePathIdentity {
+    fn same_workspace_path(&self, left: &Path, right: &Path) -> bool {
+        codestory_workspace::same_workspace_path(left, right)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+
+    /// The seam is only honest if the injected adapter and the direct call are
+    /// the same oracle. Run both over a tempdir matrix of path spellings —
+    /// identical, dot-segment relative forms, trailing separators, case
+    /// differences, a symlink, genuinely different files, and a missing file —
+    /// and require equal verdicts on every row, plus the absolute verdict on
+    /// the rows whose answer is platform-independent.
+    #[test]
+    fn runtime_adapter_matches_direct_same_workspace_path_over_spelling_matrix() {
+        let workspace = tempfile::tempdir().expect("create workspace tempdir");
+        let root = workspace.path();
+        fs::create_dir(root.join("sub")).expect("create subdirectory");
+        fs::write(root.join("Alpha.rs"), "alpha").expect("write Alpha.rs");
+        fs::write(root.join("beta.rs"), "beta").expect("write beta.rs");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(root.join("Alpha.rs"), root.join("link.rs"))
+            .expect("create symlink to Alpha.rs");
+
+        let trailing_separator_spelling = {
+            let mut spelling = root.join("Alpha.rs").into_os_string();
+            spelling.push(std::path::MAIN_SEPARATOR.to_string());
+            PathBuf::from(spelling)
+        };
+
+        // (label, left spelling, right spelling, verdict when platform-independent)
+        let mut matrix: Vec<(&str, PathBuf, PathBuf, Option<bool>)> = vec![
+            (
+                "identical absolute spellings",
+                root.join("Alpha.rs"),
+                root.join("Alpha.rs"),
+                Some(true),
+            ),
+            (
+                "dot-segment relative form of the same file",
+                root.join("sub").join("..").join("Alpha.rs"),
+                root.join("Alpha.rs"),
+                Some(true),
+            ),
+            (
+                "trailing separator on one spelling",
+                trailing_separator_spelling,
+                root.join("Alpha.rs"),
+                None,
+            ),
+            (
+                "case-differing spelling of the same name",
+                root.join("alpha.rs"),
+                root.join("Alpha.rs"),
+                None,
+            ),
+            (
+                "genuinely different files",
+                root.join("Alpha.rs"),
+                root.join("beta.rs"),
+                Some(false),
+            ),
+            (
+                "missing file compared through normalized spelling",
+                root.join("missing.rs"),
+                root.join("missing.rs"),
+                Some(true),
+            ),
+            (
+                "missing file never matches an existing one",
+                root.join("missing.rs"),
+                root.join("Alpha.rs"),
+                Some(false),
+            ),
+        ];
+        #[cfg(unix)]
+        matrix.push((
+            "symlink spelling of the same file",
+            root.join("link.rs"),
+            root.join("Alpha.rs"),
+            Some(true),
+        ));
+
+        for (label, left, right, expected) in matrix {
+            let direct = codestory_workspace::same_workspace_path(&left, &right);
+            let injected = RuntimeWorkspacePathIdentity.same_workspace_path(&left, &right);
+            assert_eq!(
+                injected, direct,
+                "adapter and direct same_workspace_path must agree for {label}: \
+                 {left:?} vs {right:?}"
+            );
+            if let Some(expected) = expected {
+                assert_eq!(direct, expected, "direct verdict for {label}");
+            }
+        }
+    }
+}

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -120,6 +120,7 @@ pub mod agent_test_support {
         obligations: &PacketObligationPlanDto,
     ) -> PacketSufficiencyDto {
         crate::agent::packet_sufficiency::build_packet_sufficiency_with_obligation_context(
+            &crate::agent::path_identity::RuntimeWorkspacePathIdentity,
             project_root,
             question,
             task_class,


### PR DESCRIPTION
WorkspacePathIdentity trait (agent, contracts-only) + runtime adapter over same_workspace_path, threaded as a REQUIRED argument (no Default, contract-asserted); sufficiency no longer names codestory_workspace. Differential spelling-matrix proves adapter == direct per row. Agent 190/0, runtime 975/0, contracts 42/0, lint, clippy x3, fmt.

Closes #1892
Refs #1673
Refs #1179