### PR TITLE
[v0.17 REL-CI S1d-1] Own the locked-setup constant mirrors in the claim graph

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -197,6 +197,7 @@ export function retrievalGeneralizationSuitePolicyViolations(
     "root",
     "rustRoot",
     "retrievalRoot",
+    "agentRoot",
     "extraRustRoot",
     "nonRustRoot",
     "taskRoot",
@@ -1109,6 +1110,28 @@ export function structuralPinViolations(workflows, graph = loadReleaseClaimGraph
         object(workflow.permissions)[row.scope] === row.access,
         `${row.file} must ${row.access} ${String(row.scope).replaceAll("-", " ")}`,
       );
+    }
+  }
+  return violations;
+}
+
+// Every cross-file constant-mirror rule INSTANCE (a repository file that must repeat
+// a reviewed constant verbatim) lives in release-claims.json under
+// workflow_policy.constant_mirrors; scripts/codestory-release-claims.mjs fails graph
+// loading unless that block names exactly the reviewed mirror rows, so membership
+// cannot drift by data edit. The checker keeps only what stays code: the one
+// source-inclusion predicate every row binds and its reviewed violation message,
+// byte-identical to the retired inline file/fragment table. Each mirror file is read
+// exactly as the retired table read it - relative to the process working directory -
+// so a missing mirror file still throws out of the validator instead of degrading
+// into a softer violation.
+export function constantMirrorViolations(graph = loadReleaseClaimGraph(repositoryRoot)) {
+  const violations = [];
+  for (const value of Object.values(object(object(graph.workflow_policy).constant_mirrors))) {
+    const row = object(value);
+    const source = fs.readFileSync(String(row.file), "utf8");
+    for (const fragment of list(row.fragments)) {
+      add(violations, source.includes(fragment), `${row.file} must preserve locked Cargo contract ${fragment}`);
     }
   }
   return violations;
@@ -2239,48 +2262,6 @@ export function notaryStepViolations(step) {
     .some(line => /^\s*--wait(?:\s|\\|$)/u.test(line) || /notarytool\s+submit.*\s--wait(?:\s|$)/u.test(line))
     ? ["notarization must poll explicitly instead of using notarytool --wait"]
     : [];
-}
-
-function validateLockedSetupSurfaces(violations) {
-  const contracts = new Map([
-    [
-      path.join(".cargo", "config.toml"),
-      [
-        'retrieval-setup = "run --locked -p codestory-cli',
-        'retrieval-status = "run --locked -p codestory-cli',
-      ],
-    ],
-    [
-      path.join("scripts", "codex-worktree-setup.mjs"),
-      [
-        '["build", "--release", "--locked", "-p", "codestory-cli"]',
-        "prepare-embedded-model.mjs",
-        "CODESTORY_EMBED_MODEL_SOURCE",
-      ],
-    ],
-    [
-      path.join("plugins", "codestory", "skills", "codestory-grounding", "scripts", "setup.sh"),
-      [
-        "cargo build --release --locked -p codestory-cli",
-        "prepare-embedded-model.mjs",
-        "CODESTORY_EMBED_MODEL_SOURCE",
-      ],
-    ],
-    [
-      path.join("plugins", "codestory", "skills", "codestory-grounding", "scripts", "setup.ps1"),
-      [
-        '@("build", "--release", "--locked", "-p", "codestory-cli"',
-        "prepare-embedded-model.mjs",
-        "CODESTORY_EMBED_MODEL_SOURCE",
-      ],
-    ],
-  ]);
-  for (const [file, fragments] of contracts) {
-    const source = fs.readFileSync(file, "utf8");
-    for (const fragment of fragments) {
-      add(violations, source.includes(fragment), `${file} must preserve locked Cargo contract ${fragment}`);
-    }
-  }
 }
 
 function validateIssueWorkflows(workflows, violations) {
@@ -11199,7 +11180,9 @@ export function validateWorkflows(workflows, graph = loadReleaseClaimGraph(repos
   validateCargoTestFilters(workflows, violations);
   validatePluginRelease(workflows, violations, graph);
   validateMarketplaceSync(workflows, violations, graph);
-  validateLockedSetupSurfaces(violations);
+  // The locked-setup constant mirrors are rule instances and live in
+  // release-claims.json under workflow_policy.constant_mirrors;
+  // constantMirrorViolations evaluates them.
   validateIssueWorkflows(workflows, violations);
   validatePluginAndDraftWorkflows(workflows, violations, graph);
   validateReleaseCoordinator(workflows, violations, graph);
@@ -11220,6 +11203,7 @@ export function validateWorkflows(workflows, graph = loadReleaseClaimGraph(repos
   violations.push(...pinnedProgramViolations(workflows, graph));
   violations.push(...stepFragmentViolations(workflows, graph));
   violations.push(...structuralPinViolations(workflows, graph));
+  violations.push(...constantMirrorViolations(graph));
   return violations;
 }
 

--- a/benchmarks/release-evidence/fixtures/candidate.json
+++ b/benchmarks/release-evidence/fixtures/candidate.json
@@ -62,7 +62,7 @@
   },
   "release_claims": {
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "bd3f772980b4ddccbbfca8a1cbcd209d2540ddcd8457b1059077f23180987ab5",
+    "graph_sha256": "11357a29406c0217c8e3ede04ec858b1be1469f5685cc3fb0078ea4f1501ca45",
     "observed_at": "2026-08-08T19:19:24.395Z",
     "expires_at": "2026-08-09T19:19:24.395Z",
     "requested_claims": [
@@ -85,7 +85,7 @@
         "type": "performance",
         "tier": "live_behavior",
         "status": "measured",
-        "graph_sha256": "bd3f772980b4ddccbbfca8a1cbcd209d2540ddcd8457b1059077f23180987ab5",
+        "graph_sha256": "11357a29406c0217c8e3ede04ec858b1be1469f5685cc3fb0078ea4f1501ca45",
         "observed_at": "2026-08-08T19:19:24.395Z",
         "expires_at": "2026-08-09T19:19:24.395Z",
         "identity": {
@@ -106,7 +106,7 @@
         "type": "answer_quality",
         "tier": "answer_quality",
         "status": "pass",
-        "graph_sha256": "bd3f772980b4ddccbbfca8a1cbcd209d2540ddcd8457b1059077f23180987ab5",
+        "graph_sha256": "11357a29406c0217c8e3ede04ec858b1be1469f5685cc3fb0078ea4f1501ca45",
         "observed_at": "2026-08-08T19:19:24.395Z",
         "expires_at": "2026-08-09T19:19:24.395Z",
         "identity": {

--- a/benchmarks/release-evidence/fixtures/report.json
+++ b/benchmarks/release-evidence/fixtures/report.json
@@ -7,7 +7,7 @@
   "baseline_id": "ci-contract-v1@1111111111111111111111111111111111111111",
   "baseline_sha256": "0bbbe6dd8b4000151edf7b1270959d08e94e08db876e7f2372b25613e0f237c1",
   "candidate_path": "benchmarks/release-evidence/fixtures/candidate.json",
-  "candidate_sha256": "5b228e3f5eece50ef61edf0ee848ec5f3f66d18709e7ba418828c59abe6559ba",
+  "candidate_sha256": "ee239bf615a750e4350b12045a0e190655a549297bb8a0e803bf1192da99eb0d",
   "artifact_paths": [
     {
       "path": "candidate-stats.json",
@@ -26,7 +26,7 @@
       "type": "performance",
       "tier": "live_behavior",
       "status": "pass",
-      "graph_sha256": "bd3f772980b4ddccbbfca8a1cbcd209d2540ddcd8457b1059077f23180987ab5",
+      "graph_sha256": "11357a29406c0217c8e3ede04ec858b1be1469f5685cc3fb0078ea4f1501ca45",
       "observed_at": "2026-08-08T19:19:24.395Z",
       "expires_at": "2026-08-09T19:19:24.395Z",
       "identity": {
@@ -47,7 +47,7 @@
       "type": "answer_quality",
       "tier": "answer_quality",
       "status": "pass",
-      "graph_sha256": "bd3f772980b4ddccbbfca8a1cbcd209d2540ddcd8457b1059077f23180987ab5",
+      "graph_sha256": "11357a29406c0217c8e3ede04ec858b1be1469f5685cc3fb0078ea4f1501ca45",
       "observed_at": "2026-08-08T19:19:24.395Z",
       "expires_at": "2026-08-09T19:19:24.395Z",
       "identity": {
@@ -69,7 +69,7 @@
     "schema": "codestory.release-claim-evaluation/v1",
     "status": "pass",
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "bd3f772980b4ddccbbfca8a1cbcd209d2540ddcd8457b1059077f23180987ab5",
+    "graph_sha256": "11357a29406c0217c8e3ede04ec858b1be1469f5685cc3fb0078ea4f1501ca45",
     "evidence_selection": "all_matching_rows_must_pass",
     "expected_commit": "2222222222222222222222222222222222222222",
     "evaluated_at": "2026-08-08T19:19:24.395Z",

--- a/release-claims.json
+++ b/release-claims.json
@@ -1922,6 +1922,43 @@
         "access": "read",
         "reason": "The automation authenticates a close request by reading the merged pull request - merge commit, base branch, and stack metadata - before it touches any issue. That verification needs only pull-requests: read, pinned here so the read-side scope cannot widen into write access on the automation's token."
       }
+    },
+    "constant_mirrors": {
+      "cargo_config_retrieval_aliases": {
+        "file": ".cargo/config.toml",
+        "fragments": [
+          "retrieval-setup = \"run --locked -p codestory-cli",
+          "retrieval-status = \"run --locked -p codestory-cli"
+        ],
+        "reason": "The cargo aliases are the human entry points into retrieval setup and status. Each alias must keep running the codestory-cli binary with --locked so a hand-typed `cargo retrieval-setup` resolves the exact dependency set the lockfile reviewed, mirroring the same locked invocation the setup scripts pin - one surface cannot drift to an unlocked build while the others stay locked."
+      },
+      "codex_worktree_setup": {
+        "file": "scripts/codex-worktree-setup.mjs",
+        "fragments": [
+          "[\"build\", \"--release\", \"--locked\", \"-p\", \"codestory-cli\"]",
+          "prepare-embedded-model.mjs",
+          "CODESTORY_EMBED_MODEL_SOURCE"
+        ],
+        "reason": "The worktree bootstrap is the agent-facing setup surface. It must keep the exact locked release build of codestory-cli and the embedded-model staging pair - the prepare script and its source override variable - so a fresh worktree reproduces the reviewed toolchain instead of resolving new dependency versions or skipping model provisioning."
+      },
+      "grounding_setup_sh": {
+        "file": "plugins/codestory/skills/codestory-grounding/scripts/setup.sh",
+        "fragments": [
+          "cargo build --release --locked -p codestory-cli",
+          "prepare-embedded-model.mjs",
+          "CODESTORY_EMBED_MODEL_SOURCE"
+        ],
+        "reason": "The POSIX skill setup is the shipped plugin's own bootstrap. It must mirror the same locked release build of codestory-cli and the embedded-model staging pair the worktree setup pins, so an installed skill and a development worktree provision identical binaries from identical dependency sets."
+      },
+      "grounding_setup_ps1": {
+        "file": "plugins/codestory/skills/codestory-grounding/scripts/setup.ps1",
+        "fragments": [
+          "@(\"build\", \"--release\", \"--locked\", \"-p\", \"codestory-cli\"",
+          "prepare-embedded-model.mjs",
+          "CODESTORY_EMBED_MODEL_SOURCE"
+        ],
+        "reason": "The Windows skill setup is the same bootstrap spelled for PowerShell. It must mirror the locked release build argument vector and the embedded-model staging pair verbatim, so the Windows install path cannot quietly diverge from the POSIX and worktree surfaces it mirrors."
+      }
     }
   }
 }

--- a/scripts/codestory-release-claims.mjs
+++ b/scripts/codestory-release-claims.mjs
@@ -127,6 +127,19 @@ const STRUCTURAL_PIN_CONTRACTS = new Map([
   ["close_dev_issues_issues_write", { kind: "permission" }],
   ["close_dev_issues_pull_requests_read", { kind: "permission" }],
 ]);
+// The graph owns every cross-file constant-mirror rule instance (a repository file
+// that must repeat a reviewed constant verbatim) for families migrated off inline
+// file/fragment tables; the checker owns only the source-inclusion predicate and its
+// message shape. All rows bind that one predicate, so membership carries names
+// alone. Membership is exact and fail-closed: a graph that drops, renames, or
+// invents a mirror row must not load, so a rule instance cannot disappear by data
+// edit.
+const CONSTANT_MIRROR_ROWS = new Set([
+  "cargo_config_retrieval_aliases",
+  "codex_worktree_setup",
+  "grounding_setup_sh",
+  "grounding_setup_ps1",
+]);
 const FAILURE_ORDER = new Map([
   ["unsupported_claim", 0],
   ["missing", 1],
@@ -941,6 +954,33 @@ function validateStructuralPins(policy) {
     nonEmptyText(row.reason, `${label}.reason`);
   }
   return pins;
+}
+
+function validateConstantMirrors(policy) {
+  const mirrors = object(policy.constant_mirrors, "workflow_policy.constant_mirrors");
+  for (const name of Object.keys(mirrors)) {
+    if (!CONSTANT_MIRROR_ROWS.has(name)) {
+      fail(`workflow_policy.constant_mirrors names unknown constant mirror ${name}`);
+    }
+  }
+  for (const name of CONSTANT_MIRROR_ROWS) {
+    if (mirrors[name] === undefined) {
+      fail(`workflow_policy.constant_mirrors must declare ${name}`);
+    }
+    const label = `workflow_policy.constant_mirrors.${name}`;
+    const row = object(mirrors[name], label);
+    const expectedKeys = ["file", "fragments", "reason"];
+    if (
+      JSON.stringify([...Object.keys(row)].sort())
+        !== JSON.stringify([...expectedKeys].sort())
+    ) {
+      fail(`${label} must carry exactly ${expectedKeys.join(", ")}`);
+    }
+    nonEmptyText(row.file, `${label}.file`);
+    stringArray(row.fragments, `${label}.fragments`, { nonEmpty: true });
+    nonEmptyText(row.reason, `${label}.reason`);
+  }
+  return mirrors;
 }
 
 function validateQualificationPolicy(value, pinnedPrograms) {
@@ -1910,6 +1950,7 @@ export function validateReleaseClaimGraph(graph) {
   const pinnedPrograms = validatePinnedPrograms(policy);
   validateStepFragments(policy);
   validateStructuralPins(policy);
+  validateConstantMirrors(policy);
   validateProofFloor(policy.proof_floor);
   if (!Array.isArray(policy.package_matrix) || policy.package_matrix.length !== 3) {
     fail("workflow_policy.package_matrix must define three release package rows");
@@ -2218,6 +2259,11 @@ export function loadReleaseClaimGraph(repoRoot = path.resolve(path.dirname(fileU
     const relative = path.join(".github", "workflows", row.file);
     if (!existsSync(path.join(repoRoot, relative))) {
       fail(`workflow_policy.structural_pins.${name} binds missing file ${relative}`);
+    }
+  }
+  for (const [name, row] of Object.entries(validated.workflow_policy.constant_mirrors)) {
+    if (!existsSync(path.join(repoRoot, row.file))) {
+      fail(`workflow_policy.constant_mirrors.${name} binds missing file ${row.file}`);
     }
   }
   return validated;

--- a/scripts/tests/codestory-release-claims.test.mjs
+++ b/scripts/tests/codestory-release-claims.test.mjs
@@ -797,6 +797,51 @@ test("structural pins are an exact fail-closed membership with graph-owned rule 
   }
 });
 
+test("constant mirrors are an exact fail-closed membership with graph-owned rule data", () => {
+  const mirrors = graph.workflow_policy.constant_mirrors;
+  assert.equal(Object.keys(mirrors).length, 4);
+  for (const row of Object.values(mirrors)) {
+    assert.ok(typeof row.file === "string" && row.file.length > 0);
+    assert.ok(Array.isArray(row.fragments) && row.fragments.length > 0);
+  }
+  const mutations = [
+    [draft => {
+      delete draft.workflow_policy.constant_mirrors.codex_worktree_setup;
+    }, /constant_mirrors must declare codex_worktree_setup/u],
+    [draft => {
+      draft.workflow_policy.constant_mirrors.unowned_extra = structuredClone(
+        draft.workflow_policy.constant_mirrors.codex_worktree_setup,
+      );
+    }, /names unknown constant mirror unowned_extra/u],
+    [draft => {
+      delete draft.workflow_policy.constant_mirrors.cargo_config_retrieval_aliases.fragments;
+    }, /cargo_config_retrieval_aliases must carry exactly file, fragments, reason/u],
+    [draft => {
+      draft.workflow_policy.constant_mirrors.grounding_setup_sh.job = "setup";
+    }, /grounding_setup_sh must carry exactly file, fragments, reason/u],
+    [draft => {
+      draft.workflow_policy.constant_mirrors.grounding_setup_sh.fragments = [];
+    }, /grounding_setup_sh\.fragments must be a non-empty array/u],
+    [draft => {
+      draft.workflow_policy.constant_mirrors.grounding_setup_ps1.fragments = [
+        "prepare-embedded-model.mjs",
+        "prepare-embedded-model.mjs",
+      ];
+    }, /grounding_setup_ps1\.fragments must not contain duplicates/u],
+    [draft => {
+      draft.workflow_policy.constant_mirrors.cargo_config_retrieval_aliases.file = "";
+    }, /cargo_config_retrieval_aliases\.file must be a non-empty string/u],
+    [draft => {
+      draft.workflow_policy.constant_mirrors.grounding_setup_ps1.reason = "";
+    }, /grounding_setup_ps1\.reason must be a non-empty string/u],
+  ];
+  for (const [mutate, expected] of mutations) {
+    const draft = structuredClone(graph);
+    mutate(draft);
+    assert.throws(() => validateReleaseClaimGraph(draft), expected);
+  }
+});
+
 test("benchmark leakage names only the one-process Node contract", () => {
   const benchmarkLeakage = graph.failure_controls
     .find(({ id }) => id === "benchmark_leakage");

--- a/scripts/tests/fixtures/release-claims/positive.json
+++ b/scripts/tests/fixtures/release-claims/positive.json
@@ -17,7 +17,7 @@
       "type": "source_behavior",
       "tier": "source",
       "status": "pass",
-      "graph_sha256": "bd3f772980b4ddccbbfca8a1cbcd209d2540ddcd8457b1059077f23180987ab5",
+      "graph_sha256": "11357a29406c0217c8e3ede04ec858b1be1469f5685cc3fb0078ea4f1501ca45",
       "observed_at": "2026-07-16T11:00:00.000Z",
       "expires_at": "2026-07-17T11:00:00.000Z",
       "identity": {


### PR DESCRIPTION
The locked-setup file/fragment table (4 files × 11 fragments) graph-owned behind one generic predicate, messages byte-identical, fail-closed membership with a load-time missing-file check, 8-mutation loader test. Also carries a one-line repair for a tip-red this PR's author found: the S4-7 hostile-matrix seeding fix left agentRoot unregistered in the checker's write roots (invisible to CI's path filters — the policy checker and 43 policy tests fail at the current tip locally). Oracle run with that repair withdrawn so the migration was the only delta: 8,206 mutants, zero mismatches. Policy 1367/0, claims 47/0, lint ok.

Closes #1893
Refs #1670
Refs #1179