### PR TITLE
[v0.17 REL-CI S1e-1] Own the draft command lists in the claim graph

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -1137,57 +1137,22 @@ export function constantMirrorViolations(graph = loadReleaseClaimGraph(repositor
   return violations;
 }
 
-const draftProofCommands = [
-  "cargo test --locked -p codestory-llama-sys --test native_staging",
-  "cargo test --locked -p codestory-llama-sys --test model_staging",
-  "cargo test --locked -p codestory-cli --test native_launcher_contracts",
-  "cargo test --locked -p codestory-cli --test stdio_protocol_contracts two_stdio_processes_observe_only_complete_generations_during_real_refresh -- --nocapture",
-  "cargo test --locked -p codestory-runtime publication_transitions_fail_or_cancel_atomically -- --nocapture",
-  "cargo test --locked -p codestory-store staged_promotion_abort_recovers_old_or_complete_new_and_cleans_artifacts -- --nocapture",
-];
-const draftSeedCommands = [
-  "cargo test --locked -p codestory-llama-sys --test native_staging --no-run",
-  "cargo test --locked -p codestory-llama-sys --test model_staging --no-run",
-  "cargo test --locked -p codestory-cli --test stdio_protocol_contracts --no-run two_stdio_processes_observe_only_complete_generations_during_real_refresh -- --nocapture",
-  "cargo test --locked -p codestory-runtime --no-run publication_transitions_fail_or_cancel_atomically -- --nocapture",
-  "cargo test --locked -p codestory-store --no-run staged_promotion_abort_recovers_old_or_complete_new_and_cleans_artifacts -- --nocapture",
-];
-const draftProofTopologyDigest = createHash("sha256")
-  .update(draftSeedCommands.join("\n"))
-  .digest("hex");
-const draftProofTopology = `proof5-v1-${draftProofTopologyDigest}`;
+// Every draft command-list rule INSTANCE (the exact serial proof commands the
+// draft lane must run and the exact seed commands the retrieval producer must
+// build) lives in release-claims.json under workflow_policy.command_lists;
+// scripts/codestory-release-claims.mjs fails graph loading unless that block names
+// exactly the reviewed list rows, so membership cannot drift by data edit. The
+// checker keeps only what stays code: the one sequence-equality predicate every
+// row binds, its reviewed violation messages, and the cache-key composition that
+// digests the graph-declared seed commands into the shared proof topology.
+function commandListRow(graph, name) {
+  return object(object(object(graph.workflow_policy).command_lists)[name]);
+}
 const cacheRunner = "${{ runner.os }}";
 const cacheRustVersion = "${{ steps.rust-cache-key.outputs.version }}";
 const cacheTarget = "${{ steps.rust-cache-key.outputs.target }}";
 const cacheManifests = "${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml', 'vendor/**/Cargo.toml') }}";
 const cacheLock = "${{ hashFiles('Cargo.lock') }}";
-const draftCachePrefix = [
-  cacheRunner,
-  "draft-v2",
-  cacheRustVersion,
-  cacheTarget,
-  "workspace",
-  draftProofTopology,
-  "default-features",
-  cacheManifests,
-].join("-");
-const retrievalCachePrefix = [
-  cacheRunner,
-  "cargo-stable",
-  cacheRustVersion,
-  cacheTarget,
-  "retrieval-contracts",
-  draftProofTopology,
-  "default-features",
-  cacheManifests,
-].join("-");
-const draftCachePrimary = `${draftCachePrefix}-${cacheLock}`;
-const retrievalCachePrimary = `${retrievalCachePrefix}-${cacheLock}`;
-const draftCacheRestoreKeys = [
-  retrievalCachePrimary,
-  `${draftCachePrefix}-`,
-  `${retrievalCachePrefix}-`,
-];
 const cacheSaveCondition = "success() && steps.cargo-cache-restore.outputs.cache-hit != 'true' && steps.cargo-cache-restore.outputs.cache-primary-key != ''";
 const draftCompilerCachePath = "${{ runner.temp }}/codestory-draft-sccache";
 const draftCompilerCachePrefix =
@@ -1356,7 +1321,6 @@ const draftRunCommands = new Map([
   ["Lint workspace libraries", [
     "cargo clippy --workspace --lib --locked -- -D warnings",
   ]],
-  ["Prove focused publication contracts", draftProofCommands],
 ]);
 
 function nonCommentLines(value) {
@@ -1921,11 +1885,49 @@ export function windowsManifestProofPolicyViolations(workflowValue) {
   return violations;
 }
 
-export function draftSourcePolicyViolations(jobValue, retrievalJobValue) {
+export function draftSourcePolicyViolations(
+  jobValue,
+  retrievalJobValue,
+  graph = loadReleaseClaimGraph(repositoryRoot),
+) {
   const violations = [];
   const job = object(jobValue);
   const retrievalJob = object(retrievalJobValue);
   const steps = list(job.steps).map(object);
+  const proofRow = commandListRow(graph, "draft_proof_commands");
+  const seedRow = commandListRow(graph, "draft_seed_commands");
+  const proofCommands = list(proofRow.commands).map(String);
+  const seedCommands = list(seedRow.commands).map(String);
+  const draftProofTopology = `proof5-v1-${createHash("sha256")
+    .update(seedCommands.join("\n"))
+    .digest("hex")}`;
+  const draftCachePrefix = [
+    cacheRunner,
+    "draft-v2",
+    cacheRustVersion,
+    cacheTarget,
+    "workspace",
+    draftProofTopology,
+    "default-features",
+    cacheManifests,
+  ].join("-");
+  const retrievalCachePrefix = [
+    cacheRunner,
+    "cargo-stable",
+    cacheRustVersion,
+    cacheTarget,
+    "retrieval-contracts",
+    draftProofTopology,
+    "default-features",
+    cacheManifests,
+  ].join("-");
+  const draftCachePrimary = `${draftCachePrefix}-${cacheLock}`;
+  const retrievalCachePrimary = `${retrievalCachePrefix}-${cacheLock}`;
+  const draftCacheRestoreKeys = [
+    retrievalCachePrimary,
+    `${draftCachePrefix}-`,
+    `${retrievalCachePrefix}-`,
+  ];
 
   add(
     violations,
@@ -1960,7 +1962,10 @@ export function draftSourcePolicyViolations(jobValue, retrievalJobValue) {
     );
   }
 
-  for (const [name, commands] of draftRunCommands) {
+  for (const [name, commands] of [
+    ...draftRunCommands,
+    [String(proofRow.step), proofCommands],
+  ]) {
     const step = namedStep(job, name);
     add(violations, step !== undefined, `draft source job must contain one ${name} step`);
     add(violations, sameStrings(nonCommentLines(step?.run), commands), `draft source step ${name} must keep its exact serial command sequence`);
@@ -2028,7 +2033,7 @@ export function draftSourcePolicyViolations(jobValue, retrievalJobValue) {
   add(violations, sameStrings(nonCommentLines(retrievalRestoreWith.path), draftCachePaths), "retrieval cache producer must retain the proof-compatible path set");
   add(violations, retrievalRestoreWith.key === retrievalCachePrimary, "retrieval cache producer key must match the draft exact-lock, manifest, feature, and proof-topology fallback");
 
-  const retrievalSeed = namedStep(retrievalJob, "Seed draft proof test-profile artifacts");
+  const retrievalSeed = namedStep(retrievalJob, String(seedRow.step));
   add(
     violations,
     hasExactKeys(retrievalSeed, ["name", "run"]),
@@ -2036,7 +2041,7 @@ export function draftSourcePolicyViolations(jobValue, retrievalJobValue) {
   );
   add(
     violations,
-    sameStrings(nonCommentLines(retrievalSeed?.run), draftSeedCommands),
+    sameStrings(nonCommentLines(retrievalSeed?.run), seedCommands),
     "retrieval cache producer must seed the exact five test-profile targets in serial order",
   );
 
@@ -2428,7 +2433,7 @@ function validatePluginAndDraftWorkflows(workflows, violations, graph) {
       "jobs",
       "linux-contracts",
     ));
-    for (const violation of draftSourcePolicyViolations(job, retrievalJob)) {
+    for (const violation of draftSourcePolicyViolations(job, retrievalJob, graph)) {
       violations.push(`${rustFile} ${violation}`);
     }
   }

--- a/benchmarks/release-evidence/fixtures/candidate.json
+++ b/benchmarks/release-evidence/fixtures/candidate.json
@@ -62,7 +62,7 @@
   },
   "release_claims": {
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "11357a29406c0217c8e3ede04ec858b1be1469f5685cc3fb0078ea4f1501ca45",
+    "graph_sha256": "9a9c81bc142e7c472ceb6db25fa28fa7181a19ec5fd21963d0357b1624c4ad82",
     "observed_at": "2026-08-08T19:19:24.395Z",
     "expires_at": "2026-08-09T19:19:24.395Z",
     "requested_claims": [
@@ -85,7 +85,7 @@
         "type": "performance",
         "tier": "live_behavior",
         "status": "measured",
-        "graph_sha256": "11357a29406c0217c8e3ede04ec858b1be1469f5685cc3fb0078ea4f1501ca45",
+        "graph_sha256": "9a9c81bc142e7c472ceb6db25fa28fa7181a19ec5fd21963d0357b1624c4ad82",
         "observed_at": "2026-08-08T19:19:24.395Z",
         "expires_at": "2026-08-09T19:19:24.395Z",
         "identity": {
@@ -106,7 +106,7 @@
         "type": "answer_quality",
         "tier": "answer_quality",
         "status": "pass",
-        "graph_sha256": "11357a29406c0217c8e3ede04ec858b1be1469f5685cc3fb0078ea4f1501ca45",
+        "graph_sha256": "9a9c81bc142e7c472ceb6db25fa28fa7181a19ec5fd21963d0357b1624c4ad82",
         "observed_at": "2026-08-08T19:19:24.395Z",
         "expires_at": "2026-08-09T19:19:24.395Z",
         "identity": {

--- a/benchmarks/release-evidence/fixtures/report.json
+++ b/benchmarks/release-evidence/fixtures/report.json
@@ -7,7 +7,7 @@
   "baseline_id": "ci-contract-v1@1111111111111111111111111111111111111111",
   "baseline_sha256": "0bbbe6dd8b4000151edf7b1270959d08e94e08db876e7f2372b25613e0f237c1",
   "candidate_path": "benchmarks/release-evidence/fixtures/candidate.json",
-  "candidate_sha256": "ee239bf615a750e4350b12045a0e190655a549297bb8a0e803bf1192da99eb0d",
+  "candidate_sha256": "a0b6c86a6c9db22ab7b4eaf8fe3cfc552d4506dff9a6bbda425463edb860feac",
   "artifact_paths": [
     {
       "path": "candidate-stats.json",
@@ -26,7 +26,7 @@
       "type": "performance",
       "tier": "live_behavior",
       "status": "pass",
-      "graph_sha256": "11357a29406c0217c8e3ede04ec858b1be1469f5685cc3fb0078ea4f1501ca45",
+      "graph_sha256": "9a9c81bc142e7c472ceb6db25fa28fa7181a19ec5fd21963d0357b1624c4ad82",
       "observed_at": "2026-08-08T19:19:24.395Z",
       "expires_at": "2026-08-09T19:19:24.395Z",
       "identity": {
@@ -47,7 +47,7 @@
       "type": "answer_quality",
       "tier": "answer_quality",
       "status": "pass",
-      "graph_sha256": "11357a29406c0217c8e3ede04ec858b1be1469f5685cc3fb0078ea4f1501ca45",
+      "graph_sha256": "9a9c81bc142e7c472ceb6db25fa28fa7181a19ec5fd21963d0357b1624c4ad82",
       "observed_at": "2026-08-08T19:19:24.395Z",
       "expires_at": "2026-08-09T19:19:24.395Z",
       "identity": {
@@ -69,7 +69,7 @@
     "schema": "codestory.release-claim-evaluation/v1",
     "status": "pass",
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "11357a29406c0217c8e3ede04ec858b1be1469f5685cc3fb0078ea4f1501ca45",
+    "graph_sha256": "9a9c81bc142e7c472ceb6db25fa28fa7181a19ec5fd21963d0357b1624c4ad82",
     "evidence_selection": "all_matching_rows_must_pass",
     "expected_commit": "2222222222222222222222222222222222222222",
     "evaluated_at": "2026-08-08T19:19:24.395Z",

--- a/release-claims.json
+++ b/release-claims.json
@@ -1959,6 +1959,35 @@
         ],
         "reason": "The Windows skill setup is the same bootstrap spelled for PowerShell. It must mirror the locked release build argument vector and the embedded-model staging pair verbatim, so the Windows install path cannot quietly diverge from the POSIX and worktree surfaces it mirrors."
       }
+    },
+    "command_lists": {
+      "draft_proof_commands": {
+        "file": "rust-ci.yml",
+        "job": "linux-draft",
+        "step": "Prove focused publication contracts",
+        "commands": [
+          "cargo test --locked -p codestory-llama-sys --test native_staging",
+          "cargo test --locked -p codestory-llama-sys --test model_staging",
+          "cargo test --locked -p codestory-cli --test native_launcher_contracts",
+          "cargo test --locked -p codestory-cli --test stdio_protocol_contracts two_stdio_processes_observe_only_complete_generations_during_real_refresh -- --nocapture",
+          "cargo test --locked -p codestory-runtime publication_transitions_fail_or_cancel_atomically -- --nocapture",
+          "cargo test --locked -p codestory-store staged_promotion_abort_recovers_old_or_complete_new_and_cleans_artifacts -- --nocapture"
+        ],
+        "reason": "The draft lane's publication proof is this exact serial command sequence: the two locked llama-sys staging harnesses, the CLI native-launcher and stdio-protocol contracts, and the runtime and store publication-atomicity proofs. The sequence is owned here so a workflow edit alone cannot drop, reorder, or dilute a proof target; the checker keeps only the sequence-equality predicate and its reviewed messages."
+      },
+      "draft_seed_commands": {
+        "file": "retrieval-engine-smoke.yml",
+        "job": "linux-contracts",
+        "step": "Seed draft proof test-profile artifacts",
+        "commands": [
+          "cargo test --locked -p codestory-llama-sys --test native_staging --no-run",
+          "cargo test --locked -p codestory-llama-sys --test model_staging --no-run",
+          "cargo test --locked -p codestory-cli --test stdio_protocol_contracts --no-run two_stdio_processes_observe_only_complete_generations_during_real_refresh -- --nocapture",
+          "cargo test --locked -p codestory-runtime --no-run publication_transitions_fail_or_cancel_atomically -- --nocapture",
+          "cargo test --locked -p codestory-store --no-run staged_promotion_abort_recovers_old_or_complete_new_and_cleans_artifacts -- --nocapture"
+        ],
+        "reason": "The retrieval producer seeds the draft proof's test-profile artifacts with the --no-run counterparts of the focused targets, and this list is also the digest input for the shared proof5 cache topology: the checker derives the draft and retrieval cache keys from these graph-declared seed commands, so cache identity and seeded content cannot drift apart through a checker edit alone."
+      }
     }
   }
 }

--- a/scripts/codestory-release-claims.mjs
+++ b/scripts/codestory-release-claims.mjs
@@ -140,6 +140,17 @@ const CONSTANT_MIRROR_ROWS = new Set([
   "grounding_setup_sh",
   "grounding_setup_ps1",
 ]);
+// The graph owns every command-list rule instance (an exact serial command sequence
+// a reviewed workflow step must run) for families migrated off inline checker
+// constants; the checker owns only the sequence-equality predicate, its message
+// shapes, and the cache-key composition digested from the declared seed commands.
+// All rows bind that one predicate, so membership carries names alone. Membership
+// is exact and fail-closed: a graph that drops, renames, or invents a command-list
+// row must not load, so a rule instance cannot disappear by data edit.
+const COMMAND_LIST_ROWS = new Set([
+  "draft_proof_commands",
+  "draft_seed_commands",
+]);
 const FAILURE_ORDER = new Map([
   ["unsupported_claim", 0],
   ["missing", 1],
@@ -981,6 +992,35 @@ function validateConstantMirrors(policy) {
     nonEmptyText(row.reason, `${label}.reason`);
   }
   return mirrors;
+}
+
+function validateCommandLists(policy) {
+  const lists = object(policy.command_lists, "workflow_policy.command_lists");
+  for (const name of Object.keys(lists)) {
+    if (!COMMAND_LIST_ROWS.has(name)) {
+      fail(`workflow_policy.command_lists names unknown command list ${name}`);
+    }
+  }
+  for (const name of COMMAND_LIST_ROWS) {
+    if (lists[name] === undefined) {
+      fail(`workflow_policy.command_lists must declare ${name}`);
+    }
+    const label = `workflow_policy.command_lists.${name}`;
+    const row = object(lists[name], label);
+    const expectedKeys = ["file", "job", "step", "commands", "reason"];
+    if (
+      JSON.stringify([...Object.keys(row)].sort())
+        !== JSON.stringify([...expectedKeys].sort())
+    ) {
+      fail(`${label} must carry exactly ${expectedKeys.join(", ")}`);
+    }
+    nonEmptyText(row.file, `${label}.file`);
+    nonEmptyText(row.job, `${label}.job`);
+    nonEmptyText(row.step, `${label}.step`);
+    stringArray(row.commands, `${label}.commands`, { nonEmpty: true });
+    nonEmptyText(row.reason, `${label}.reason`);
+  }
+  return lists;
 }
 
 function validateQualificationPolicy(value, pinnedPrograms) {
@@ -1951,6 +1991,7 @@ export function validateReleaseClaimGraph(graph) {
   validateStepFragments(policy);
   validateStructuralPins(policy);
   validateConstantMirrors(policy);
+  validateCommandLists(policy);
   validateProofFloor(policy.proof_floor);
   if (!Array.isArray(policy.package_matrix) || policy.package_matrix.length !== 3) {
     fail("workflow_policy.package_matrix must define three release package rows");
@@ -2264,6 +2305,12 @@ export function loadReleaseClaimGraph(repoRoot = path.resolve(path.dirname(fileU
   for (const [name, row] of Object.entries(validated.workflow_policy.constant_mirrors)) {
     if (!existsSync(path.join(repoRoot, row.file))) {
       fail(`workflow_policy.constant_mirrors.${name} binds missing file ${row.file}`);
+    }
+  }
+  for (const [name, row] of Object.entries(validated.workflow_policy.command_lists)) {
+    const relative = path.join(".github", "workflows", row.file);
+    if (!existsSync(path.join(repoRoot, relative))) {
+      fail(`workflow_policy.command_lists.${name} binds missing file ${relative}`);
     }
   }
   return validated;

--- a/scripts/tests/codestory-release-claims.test.mjs
+++ b/scripts/tests/codestory-release-claims.test.mjs
@@ -842,6 +842,58 @@ test("constant mirrors are an exact fail-closed membership with graph-owned rule
   }
 });
 
+test("command lists are an exact fail-closed membership with graph-owned rule data", () => {
+  const lists = graph.workflow_policy.command_lists;
+  assert.equal(Object.keys(lists).length, 2);
+  for (const row of Object.values(lists)) {
+    assert.ok(typeof row.file === "string" && row.file.length > 0);
+    assert.ok(typeof row.job === "string" && row.job.length > 0);
+    assert.ok(typeof row.step === "string" && row.step.length > 0);
+    assert.ok(Array.isArray(row.commands) && row.commands.length > 0);
+  }
+  assert.equal(lists.draft_proof_commands.commands.length, 6);
+  assert.equal(lists.draft_seed_commands.commands.length, 5);
+  const mutations = [
+    [draft => {
+      delete draft.workflow_policy.command_lists.draft_seed_commands;
+    }, /command_lists must declare draft_seed_commands/u],
+    [draft => {
+      draft.workflow_policy.command_lists.unowned_extra = structuredClone(
+        draft.workflow_policy.command_lists.draft_proof_commands,
+      );
+    }, /names unknown command list unowned_extra/u],
+    [draft => {
+      delete draft.workflow_policy.command_lists.draft_proof_commands.commands;
+    }, /draft_proof_commands must carry exactly file, job, step, commands, reason/u],
+    [draft => {
+      draft.workflow_policy.command_lists.draft_seed_commands.kind = "require";
+    }, /draft_seed_commands must carry exactly file, job, step, commands, reason/u],
+    [draft => {
+      draft.workflow_policy.command_lists.draft_seed_commands.commands = [];
+    }, /draft_seed_commands\.commands must be a non-empty array/u],
+    [draft => {
+      draft.workflow_policy.command_lists.draft_proof_commands.commands = [
+        "cargo test --locked -p codestory-llama-sys --test native_staging",
+        "cargo test --locked -p codestory-llama-sys --test native_staging",
+      ];
+    }, /draft_proof_commands\.commands must not contain duplicates/u],
+    [draft => {
+      draft.workflow_policy.command_lists.draft_proof_commands.file = "";
+    }, /draft_proof_commands\.file must be a non-empty string/u],
+    [draft => {
+      draft.workflow_policy.command_lists.draft_seed_commands.step = "";
+    }, /draft_seed_commands\.step must be a non-empty string/u],
+    [draft => {
+      draft.workflow_policy.command_lists.draft_seed_commands.reason = "";
+    }, /draft_seed_commands\.reason must be a non-empty string/u],
+  ];
+  for (const [mutate, expected] of mutations) {
+    const draft = structuredClone(graph);
+    mutate(draft);
+    assert.throws(() => validateReleaseClaimGraph(draft), expected);
+  }
+});
+
 test("benchmark leakage names only the one-process Node contract", () => {
   const benchmarkLeakage = graph.failure_controls
     .find(({ id }) => id === "benchmark_leakage");

--- a/scripts/tests/fixtures/release-claims/positive.json
+++ b/scripts/tests/fixtures/release-claims/positive.json
@@ -17,7 +17,7 @@
       "type": "source_behavior",
       "tier": "source",
       "status": "pass",
-      "graph_sha256": "11357a29406c0217c8e3ede04ec858b1be1469f5685cc3fb0078ea4f1501ca45",
+      "graph_sha256": "9a9c81bc142e7c472ceb6db25fa28fa7181a19ec5fd21963d0357b1624c4ad82",
       "observed_at": "2026-07-16T11:00:00.000Z",
       "expires_at": "2026-07-17T11:00:00.000Z",
       "identity": {


### PR DESCRIPTION
Draft proof/seed command lists graph-owned; the engine composes the cache keys from graph-declared seeds; six messages verbatim; fail-closed membership. Oracle 8,206/0. Policy 1367/0, claims 48/0, evidence-gate 23/0.

Closes #1896
Refs #1670
Refs #1179