### PR TITLE
[v0.17 S4-Z] Close out the agent extraction: guards, count assertion, residual docs

### DIFF
--- a/crates/codestory-agent/src/lib.rs
+++ b/crates/codestory-agent/src/lib.rs
@@ -41,6 +41,7 @@ pub mod packet_sufficiency;
 pub mod packet_terms;
 pub mod pinned_reader;
 pub mod planning;
+pub mod profiles;
 pub mod text;
 pub mod trail;
 pub mod workspace_path_identity;

--- a/crates/codestory-agent/src/packet_scoring.rs
+++ b/crates/codestory-agent/src/packet_scoring.rs
@@ -22,6 +22,12 @@ use codestory_contracts::api::{
 };
 use std::cmp::Ordering;
 
+// `normalize_identifier` was hoisted to the leaf `text` module to dissolve the
+// packet_terms <-> packet_scoring release-code import cycle
+// (`agent_planning_import_graph_stays_acyclic`); the re-export keeps every
+// existing `packet_scoring::normalize_identifier` call site valid.
+pub use crate::text::normalize_identifier;
+
 /// Sort descending on a rank that is evaluated exactly once per element.
 ///
 /// `packet_citation_rank` and `packet_claim_carry_rank` allocate and rescan every
@@ -1212,14 +1218,6 @@ pub fn packet_terms_contain(terms: &[String], needle: &str) -> bool {
     terms
         .iter()
         .any(|term| term.eq_ignore_ascii_case(needle) || normalize_identifier(term) == needle)
-}
-
-pub fn normalize_identifier(value: &str) -> String {
-    value
-        .chars()
-        .filter(|ch| ch.is_ascii_alphanumeric())
-        .flat_map(|ch| ch.to_lowercase())
-        .collect()
 }
 
 pub fn packet_file_stem_matches_query(query: &str, path: Option<&str>) -> bool {

--- a/crates/codestory-agent/src/packet_terms.rs
+++ b/crates/codestory-agent/src/packet_terms.rs
@@ -1,5 +1,6 @@
-use crate::packet_scoring::normalize_identifier;
-use crate::text::{is_non_primary_source_term, query_mentions_non_primary_source};
+use crate::text::{
+    is_non_primary_source_term, normalize_identifier, query_mentions_non_primary_source,
+};
 use std::collections::HashSet;
 
 pub fn prompt_search_terms(prompt: &str) -> Vec<String> {

--- a/crates/codestory-agent/src/profiles.rs
+++ b/crates/codestory-agent/src/profiles.rs
@@ -7,7 +7,7 @@ use codestory_contracts::api::{
 const CUSTOM_ASK_TRAIL_MAX_NODES: u32 = 2_000;
 
 #[derive(Debug, Clone)]
-pub(crate) struct TrailPlan {
+pub struct TrailPlan {
     pub mode: TrailMode,
     pub depth: u32,
     pub direction: TrailDirection,
@@ -18,7 +18,7 @@ pub(crate) struct TrailPlan {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct ResolvedProfile {
+pub struct ResolvedProfile {
     pub preset: AgentRetrievalPresetDto,
     pub policy_mode: AgentRetrievalPolicyModeDto,
     pub trail_plans: Vec<TrailPlan>,
@@ -28,7 +28,7 @@ pub(crate) struct ResolvedProfile {
     pub max_source_bytes: usize,
 }
 
-pub(crate) fn resolve_profile(
+pub fn resolve_profile(
     prompt: &str,
     selection: &AgentRetrievalProfileSelectionDto,
 ) -> ResolvedProfile {
@@ -42,7 +42,7 @@ pub(crate) fn resolve_profile(
     }
 }
 
-pub(crate) fn route_auto_preset(prompt: &str) -> AgentRetrievalPresetDto {
+pub fn route_auto_preset(prompt: &str) -> AgentRetrievalPresetDto {
     let normalized = prompt.to_ascii_lowercase();
 
     if contains_any(&normalized, &["inherit", "override", "base class", "trait"]) {

--- a/crates/codestory-agent/src/text.rs
+++ b/crates/codestory-agent/src/text.rs
@@ -26,6 +26,14 @@ pub fn normalize_symbol_query(value: &str) -> String {
     value.trim().to_ascii_lowercase()
 }
 
+pub fn normalize_identifier(value: &str) -> String {
+    value
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .flat_map(|ch| ch.to_lowercase())
+        .collect()
+}
+
 pub fn exact_symbol_query_terms(query: &str) -> Vec<String> {
     let trimmed = trim_symbol_candidate(query);
     if looks_like_standalone_symbol_query(trimmed) {

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -532,6 +532,59 @@ fn indexer_crate_stays_decoupled_from_runtime_and_cli() {
     );
 }
 
+/// The moved planning modules `codestory-agent` owns: the allowlist the
+/// location, count, and import-DAG contracts below all read.
+///
+/// Everything under `crates/codestory-agent/src` must appear here except the
+/// named exclusions in [`AGENT_MODULE_ALLOWLIST_EXCLUSIONS`];
+/// `agent_module_allowlist_stays_in_sync_with_the_agent_source_tree` enforces
+/// that, so adding a module to the crate without extending this list fails
+/// loudly instead of silently escaping every contract built on it.
+const AGENT_PLANNING_MODULES: [&str; 30] = [
+    "citation.rs",
+    "packet_citations.rs",
+    "packet_claim_profile_registry.rs",
+    "packet_claim_profiles.rs",
+    "packet_claims.rs",
+    "packet_command.rs",
+    "packet_command_profiles.rs",
+    "packet_coverage.rs",
+    "packet_degradation.rs",
+    "packet_evidence.rs",
+    "packet_evidence_carriers.rs",
+    "packet_evidence_roles.rs",
+    "packet_execution_graphs.rs",
+    "packet_flow_requirements.rs",
+    "packet_freshness.rs",
+    "packet_obligations.rs",
+    "packet_plan.rs",
+    "packet_probes.rs",
+    "packet_profile_telemetry.rs",
+    "packet_required_probes.rs",
+    "packet_scoring.rs",
+    "packet_source_patterns.rs",
+    "packet_sufficiency.rs",
+    "packet_terms.rs",
+    "pinned_reader.rs",
+    "planning.rs",
+    "profiles.rs",
+    "text.rs",
+    "trail.rs",
+    "workspace_path_identity.rs",
+];
+
+/// Agent-crate source files that are deliberately not planning modules.
+///
+/// - `lib.rs` is the crate root: module wiring and re-exports, not a planning
+///   surface of its own.
+/// - `eval_probes.rs` is the eval-only production file: `lib.rs` gates it
+///   behind `cfg(any(test, feature = "test-support"))`, the generalization
+///   lint classifies it as eval-only, and
+///   `agent_eval_hooks_stay_on_for_runtime_tests_and_off_for_product_builds`
+///   pins how it compiles. Listing it as a planning module would hand the
+///   import-DAG guard a file no product build links.
+const AGENT_MODULE_ALLOWLIST_EXCLUSIONS: [&str; 2] = ["lib.rs", "eval_probes.rs"];
+
 /// Packet planning lives in `codestory-agent`, and the crate DAG is what keeps
 /// it from growing the powers it was extracted away from.
 ///
@@ -561,33 +614,7 @@ fn agent_planning_crate_owns_planning_and_depends_on_contracts_only() {
          runtime state through PinnedReader, never through a producer crate"
     );
 
-    for module in [
-        "citation.rs",
-        "packet_citations.rs",
-        "packet_claim_profile_registry.rs",
-        "packet_claim_profiles.rs",
-        "packet_claims.rs",
-        "packet_command_profiles.rs",
-        "packet_coverage.rs",
-        "packet_degradation.rs",
-        "packet_evidence.rs",
-        "packet_evidence_carriers.rs",
-        "packet_evidence_roles.rs",
-        "packet_flow_requirements.rs",
-        "packet_freshness.rs",
-        "packet_obligations.rs",
-        "packet_plan.rs",
-        "packet_profile_telemetry.rs",
-        "packet_required_probes.rs",
-        "packet_scoring.rs",
-        "packet_source_patterns.rs",
-        "packet_sufficiency.rs",
-        "packet_terms.rs",
-        "pinned_reader.rs",
-        "planning.rs",
-        "text.rs",
-        "workspace_path_identity.rs",
-    ] {
+    for module in AGENT_PLANNING_MODULES {
         assert!(
             repo_root()
                 .join("crates/codestory-agent/src")
@@ -620,6 +647,194 @@ fn agent_planning_crate_owns_planning_and_depends_on_contracts_only() {
         assert!(
             !agent_source.contains(forbidden),
             "codestory-agent must not spell {forbidden}: planning owns no persisted state"
+        );
+    }
+}
+
+/// A list that must stay in sync with a directory cannot be trusted to drift
+/// silently: this pins `AGENT_PLANNING_MODULES` to the actual contents of
+/// `crates/codestory-agent/src`, so a module added to the crate without a
+/// matching allowlist entry — and therefore invisible to the location and
+/// import-DAG contracts — fails here by name.
+#[test]
+fn agent_module_allowlist_stays_in_sync_with_the_agent_source_tree() {
+    let mut files = Vec::new();
+    collect_rs_files(&repo_root().join("crates/codestory-agent/src"), &mut files);
+    let source_root = repo_root().join("crates/codestory-agent/src");
+    let found = files
+        .iter()
+        .map(|path| {
+            path.strip_prefix(&source_root)
+                .expect("agent source file lives below the agent src root")
+                .to_string_lossy()
+                .replace('\\', "/")
+        })
+        .collect::<BTreeSet<_>>();
+
+    let allowlist = AGENT_PLANNING_MODULES
+        .iter()
+        .map(|module| (*module).to_string())
+        .collect::<BTreeSet<_>>();
+    let exclusions = AGENT_MODULE_ALLOWLIST_EXCLUSIONS
+        .iter()
+        .map(|module| (*module).to_string())
+        .collect::<BTreeSet<_>>();
+    assert!(
+        allowlist.is_disjoint(&exclusions),
+        "a module cannot be both an allowlisted planning module and a named exclusion"
+    );
+    for exclusion in &exclusions {
+        assert!(
+            found.contains(exclusion),
+            "stale exclusion: {exclusion} is named but no longer exists under \
+             crates/codestory-agent/src"
+        );
+    }
+
+    let expected = allowlist
+        .union(&exclusions)
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let unlisted = found.difference(&expected).cloned().collect::<Vec<_>>();
+    let missing = allowlist.difference(&found).cloned().collect::<Vec<_>>();
+    assert!(
+        unlisted.is_empty(),
+        "agent-crate source files missing from AGENT_PLANNING_MODULES (add each one, or name it \
+         in AGENT_MODULE_ALLOWLIST_EXCLUSIONS with a reason): {unlisted:?}"
+    );
+    assert!(
+        missing.is_empty(),
+        "AGENT_PLANNING_MODULES entries with no file under crates/codestory-agent/src: {missing:?}"
+    );
+    assert_eq!(
+        AGENT_PLANNING_MODULES.len(),
+        found.len() - exclusions.len(),
+        "the agent module allowlist length must equal the .rs file count under \
+         crates/codestory-agent/src minus the named exclusions"
+    );
+}
+
+/// Scan one line of release-compiled planning source for sibling-module
+/// references (`crate::<module>` / `super::<module>`), recording each hit as an
+/// import edge for the DAG guard below.
+fn record_planning_import_edges<'a>(
+    code: &str,
+    module_names: &BTreeSet<&'a str>,
+    edges: &mut BTreeSet<&'a str>,
+) {
+    for prefix in ["crate::", "super::"] {
+        let mut rest = code;
+        while let Some(position) = rest.find(prefix) {
+            rest = &rest[position + prefix.len()..];
+            let end = rest
+                .find(|character: char| !(character.is_ascii_alphanumeric() || character == '_'))
+                .unwrap_or(rest.len());
+            if let Some(name) = module_names.get(&rest[..end]) {
+                edges.insert(name);
+            }
+        }
+    }
+}
+
+/// Walk the planning import graph depth-first; returns the module path of the
+/// first release-code import cycle found, if any.
+fn find_planning_import_cycle<'a>(
+    graph: &BTreeMap<&'a str, BTreeSet<&'a str>>,
+) -> Option<Vec<&'a str>> {
+    fn visit<'a>(
+        module: &'a str,
+        graph: &BTreeMap<&'a str, BTreeSet<&'a str>>,
+        finished: &mut BTreeSet<&'a str>,
+        stack: &mut Vec<&'a str>,
+    ) -> Option<Vec<&'a str>> {
+        if let Some(position) = stack.iter().position(|entry| *entry == module) {
+            let mut cycle = stack[position..].to_vec();
+            cycle.push(module);
+            return Some(cycle);
+        }
+        if finished.contains(module) {
+            return None;
+        }
+        stack.push(module);
+        if let Some(imports) = graph.get(module) {
+            for import in imports {
+                if let Some(cycle) = visit(import, graph, finished, stack) {
+                    return Some(cycle);
+                }
+            }
+        }
+        stack.pop();
+        finished.insert(module);
+        None
+    }
+
+    let mut finished = BTreeSet::new();
+    for module in graph.keys() {
+        let mut stack = Vec::new();
+        if let Some(cycle) = visit(module, graph, &mut finished, &mut stack) {
+            return Some(cycle);
+        }
+    }
+    None
+}
+
+/// S4-10a dissolved the planning strongly-connected component: in release code
+/// the moved planning modules import each other along a DAG
+/// (obligations ≺ plan ≺ claims ≺ sufficiency ≺ budget was the dissolving
+/// order). Until now that order was conventional — the M2 mutation recorded on
+/// #1865 reintroduced a release-code back-edge (obligations importing
+/// sufficiency) and nothing failed, because rustc is perfectly happy to compile
+/// a module cycle inside one crate.
+///
+/// This is the assertion that mutation must fail by name: the release-compiled
+/// source of every allowlisted planning module (top-level `#[cfg(test)]` items
+/// stripped by the same helper the other source contracts use; line comments
+/// dropped so prose mentioning a module path is not an edge) is scanned for
+/// `crate::`/`super::` sibling references, and the resulting import graph must
+/// stay acyclic.
+#[test]
+fn agent_planning_import_graph_stays_acyclic() {
+    let module_names = AGENT_PLANNING_MODULES
+        .iter()
+        .map(|module| {
+            module
+                .strip_suffix(".rs")
+                .expect("allowlist entries are .rs file names")
+        })
+        .collect::<BTreeSet<_>>();
+
+    let mut graph: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
+    for module in &module_names {
+        let source = read(&format!("crates/codestory-agent/src/{module}.rs"));
+        let production = production_source(&source);
+        let mut imports = BTreeSet::new();
+        for line in production.lines() {
+            // Cut line comments (`//`, `///`, `//!`) so rustdoc links and
+            // prose naming a module path do not become edges.
+            let code = line.split("//").next().unwrap_or_default();
+            record_planning_import_edges(code, &module_names, &mut imports);
+        }
+        imports.remove(*module);
+        graph.insert(module, imports);
+    }
+
+    // Scanner self-check: packet_sufficiency imports packet_claims in release
+    // code today. If the reference extraction regresses to matching nothing,
+    // the acyclicity assertion below would pass vacuously; fail here instead.
+    assert!(
+        graph
+            .get("packet_sufficiency")
+            .is_some_and(|imports| imports.contains("packet_claims")),
+        "planning import scan lost the known packet_sufficiency -> packet_claims edge; \
+         the DAG guard is no longer reading real imports"
+    );
+
+    if let Some(cycle) = find_planning_import_cycle(&graph) {
+        panic!(
+            "agent planning modules must import each other along a DAG; a release-code \
+             import cycle was reintroduced: {}. Break the cycle instead of extending it — \
+             this is the boundary S4-10a's seam breaks established (#1673, M2 on #1865).",
+            cycle.join(" -> ")
         );
     }
 }

--- a/crates/codestory-runtime/src/agent/mod.rs
+++ b/crates/codestory-runtime/src/agent/mod.rs
@@ -1,3 +1,43 @@
+// Deliberate residuals of the S4 agent-planning extraction (#1673). Planning
+// moved to `codestory-agent`, which depends on `codestory-contracts` and
+// nothing else in this workspace. Everything still declared below stays in the
+// runtime on purpose, because each module needs a power the contracts-only
+// planning crate must never have. The six execution residuals the epic
+// ratchets:
+//
+// - `orchestrator`: takes `&AppController` and runs the ask/packet loop —
+//   resolves targets, executes trails and searches, reads sources, and
+//   assembles the answer from live retrieval results.
+// - `retrieval_primary`: executes pinned-publication retrieval; reaches
+//   `codestory_store::Store`, `codestory_retrieval`, and the controller's
+//   active publication state.
+// - `packet_batch`: batch search execution over `&AppController`, including
+//   wall-clock step recording into the retrieval trace.
+// - `packet_probe`: resolves probe requests against `&AppController`,
+//   `target_resolution`, and `codestory_workspace` path checks.
+// - `packet_search`: `impl AppController` — the batch-search entry points the
+//   packet path calls on the controller itself.
+// - `nucleo_policy`: thread-local execution policy read by
+//   `crate::search::engine` to suppress the Nucleo full-table scan while
+//   sidecar-primary retrieval runs.
+//
+// Runtime-owned for reasons beside `AppController` reach:
+//
+// - `packet_budget`: composition site that closes the workspace path-identity
+//   seam (`RuntimeWorkspacePathIdentity`) and folds the runtime's step-trace
+//   summary into the budget verdict.
+// - `packet_capping`: leans on `packet_batch` matching and the runtime's
+//   retrieval file-role classification; a confidence-pin contract names its
+//   runtime path as a gap-marker producer.
+// - `trace`, `trace_export`, `packet_trace` (the trace surfaces): they record
+//   and export what retrieval *executed* — wall-clock steps, shadow output,
+//   and the `CODESTORY_PACKET_STEP_TRACE_OUT` file write, which the planning
+//   crate is forbidden to spell (`fs::write` is contract-banned there).
+// - `path_identity`: the runtime half of the `WorkspacePathIdentity` seam,
+//   closing it over `codestory_workspace::same_workspace_path`.
+// - `packet_obligations_runtime_tests`, `packet_sufficiency_runtime_tests`:
+//   `cfg(test)` suites that exercise moved planning composed with runtime
+//   state the planning crate cannot construct.
 pub(crate) mod nucleo_policy;
 pub(crate) mod orchestrator;
 pub(crate) mod packet_batch;
@@ -12,7 +52,6 @@ pub(crate) mod packet_search;
 mod packet_sufficiency_runtime_tests;
 pub(crate) mod packet_trace;
 pub(crate) mod path_identity;
-pub(crate) mod profiles;
 pub(crate) mod retrieval_primary;
 pub(crate) mod trace;
 pub(crate) mod trace_export;
@@ -28,7 +67,7 @@ pub(crate) use codestory_agent::{
     packet_claims, packet_command_profiles, packet_coverage, packet_degradation, packet_evidence,
     packet_evidence_roles, packet_flow_requirements, packet_freshness, packet_obligations,
     packet_plan, packet_profile_telemetry, packet_required_probes, packet_scoring,
-    packet_source_patterns, packet_sufficiency, packet_terms, planning,
+    packet_source_patterns, packet_sufficiency, packet_terms, planning, profiles,
 };
 
 pub(crate) use orchestrator::{agent_ask, agent_packet};

--- a/crates/codestory-runtime/src/agent/orchestrator.rs
+++ b/crates/codestory-runtime/src/agent/orchestrator.rs
@@ -8670,6 +8670,75 @@ mod tests {
         }
     }
 
+    /// M1 coverage recorded on #1865: every pair-shaped claim call site is
+    /// generic over the telemetry half, so an orchestrator that degrades to the
+    /// telemetry-free `packet_supported_claims` plus a defaulted
+    /// `PacketClaimTelemetry` still compiles — and ships an all-zero
+    /// claim-source breakdown that looks exactly like a packet whose fitted
+    /// layers never fired. Both `append_packet_evidence_sections` branches (the
+    /// obligations branch threads the pair through
+    /// `packet_claims_with_obligation_receipts_and_telemetry`, which must pass
+    /// the telemetry through untouched) have to publish the telemetry that was
+    /// computed WITH the claims: the full DTO, not a default.
+    #[test]
+    fn packet_evidence_sections_publish_the_claim_telemetry_computed_with_the_claims() {
+        let question = "Explain the packet evidence roles.";
+        let citations = vec![
+            test_packet_citation("CliCommand", "crates/tool-cli/src/main.rs", 0.8),
+            test_packet_citation("RuntimeCoordinator", "crates/core/src/runtime.rs", 0.8),
+            test_packet_citation("WorkspacePlan", "crates/core/src/workspace/plan.rs", 0.8),
+            test_packet_citation("GraphIndexer", "crates/indexer/src/lib.rs", 0.8),
+            test_packet_citation("ProjectionStore", "crates/store/src/projection.rs", 0.8),
+        ];
+        let limits = packet_budget_limits(PacketBudgetModeDto::Compact);
+        let answer = packet_answer_fixture(question, citations);
+
+        let (expected_claims, expected_telemetry) = packet_supported_claims_with_telemetry(&answer);
+        assert!(
+            !expected_claims.is_empty(),
+            "fixture citations must produce claims, or a telemetry-free mutant is invisible"
+        );
+        let expected = expected_telemetry.to_dto(packet_claim_profile_registry_summary());
+        let counted_claims: u32 = expected
+            .claim_sources
+            .iter()
+            .map(|entry| entry.claims)
+            .sum();
+        assert!(
+            counted_claims > 0,
+            "the expected claim-source breakdown must be non-zero, or it cannot be told \
+             apart from the defaulted telemetry of a telemetry-free claims pair"
+        );
+
+        let obligations = build_packet_obligation_plan(
+            question,
+            PacketTaskClassDto::ArchitectureExplanation,
+            &[],
+        );
+        for (label, obligations) in [
+            ("without obligations", None),
+            ("with obligations", Some(&obligations)),
+        ] {
+            let mut published_answer = answer.clone();
+            append_packet_evidence_sections(
+                &mut published_answer,
+                PacketTaskClassDto::ArchitectureExplanation,
+                &limits,
+                obligations,
+            );
+            let published = published_answer
+                .retrieval_trace
+                .packet_claim_profile_telemetry
+                .expect("packet evidence sections must publish typed claim telemetry");
+            assert_eq!(
+                published, expected,
+                "the {label} branch must publish the telemetry computed with the claims; \
+                 a call site passing a telemetry-free claims pair (packet_supported_claims \
+                 plus a defaulted telemetry) ships this all-zero breakdown instead (#1865 M1)"
+            );
+        }
+    }
+
     #[test]
     fn packet_claim_profile_telemetry_stays_out_of_the_evidence_annotation_channel() {
         // Regression: the fire-rate counters were appended to `retrieval_trace.annotations`,


### PR DESCRIPTION
The #1673 close-out: profiles.rs moved (the last trivially-movable module — every remaining file has cited runtime reach); the module allowlist gains a set-equality + count assertion (which caught four pre-existing unlisted modules); a production-import DAG guard lands (and immediately caught a real pre-existing packet_terms↔packet_scoring release cycle, dissolved via a leaf hoist with zero call-site churn); the M1 telemetry-coverage test kills the recorded mutation at both call sites; the runtime agent/mod.rs documents every deliberate residual with reasons. All three guards demonstrated live and reverted. Agent 310/0, runtime 856/0, contracts 44/0, lint, clippy x3, fmt.

Closes #1899
Closes #1673
Refs #1179