### PR TITLE
[v0.17 REL-CI S1-V2] Own the proof-workflow rules in the claim graph

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -833,13 +833,18 @@ function requireCalibrationProducerAuthentication(violations, file, job) {
   ]);
 }
 
+// The protected proof files' producer-authentication step fragments are rule
+// instances and live in release-claims.json under workflow_policy.step_fragments;
+// stepFragmentViolations evaluates them, so this boundary pins only the download
+// action and the condition and binding contract. Callers outside that migrated
+// family still pin authentication through
+// requireCalibrationProducerAuthentication.
 function requireCalibrationProducerBoundary(
   violations,
   file,
   job,
   expectedCondition,
 ) {
-  requireCalibrationProducerAuthentication(violations, file, job);
   requireStepUses(
     violations,
     file,
@@ -1086,20 +1091,29 @@ export function stepFragmentViolations(workflows, graph = loadReleaseClaimGraph(
 // release-claims.json under workflow_policy.structural_pins; scripts/
 // codestory-release-claims.mjs fails graph loading unless that block names exactly
 // the reviewed pin rows, so membership cannot drift by data edit. The checker keeps
-// only what stays code: the job-existence, needs-edge, and permission-scope
-// predicates each row's kind selects, whose violation text is byte-identical to the
-// retired inline calls.
+// only what stays code: the job-existence, needs-edge, and workflow- or job-scoped
+// permission predicates each row's kind selects, whose violation text is
+// byte-identical to the retired inline calls.
 // A missing workflow is reported by the structural validator that owns the file, so
 // each row evaluates only when its subject workflow parsed; a missing job, a
 // missing or widened needs edge, or an absent, weaker, or wider permission scope
 // fails the pin predicates exactly as the retired inline checks did.
 //
-// Some retired inline checks named the artifact a scope protects rather than the
-// scope itself; that reviewed violation text stays code, keyed by pin name, and the
-// derived scope wording remains the default for every other permission row.
+// Some retired inline checks named the artifact a scope protects or the role a job
+// plays rather than the scope or edge itself; that reviewed violation text stays
+// code, keyed by pin name, and the derived wording remains the default for every
+// other row.
 const structuralPinMessages = {
   post_publish_smoke_actions_read:
     row => `${row.file} must read the accepted pre-publish closeout`,
+  auto_release_release_needs_detect_version:
+    row => `${row.file} release must need version detection`,
+  auto_release_release_contents_write:
+    row => `${row.file} release caller must grant contents write`,
+  auto_release_release_actions_write:
+    row => `${row.file} release caller must grant actions write for superseded-run cancellation`,
+  auto_release_release_pull_requests_read:
+    row => `${row.file} release caller must pass pull-request metadata access to exact source proof`,
 };
 
 export function structuralPinViolations(workflows, graph = loadReleaseClaimGraph(repositoryRoot)) {
@@ -1115,10 +1129,22 @@ export function structuralPinViolations(workflows, graph = loadReleaseClaimGraph
         `${row.file} must contain job ${row.job}`,
       );
     } else if (row.kind === "needs") {
+      const message = structuralPinMessages[name];
       add(
         violations,
         sameMembers(needs(object(object(workflow.jobs)[row.job])), list(row.needs)),
-        `${row.file} ${String(row.job).replaceAll("-", " ")} must need ${list(row.needs).join(", ")}`,
+        message === undefined
+          ? `${row.file} ${String(row.job).replaceAll("-", " ")} must need ${list(row.needs).join(", ")}`
+          : message(row),
+      );
+    } else if (row.kind === "job_permission") {
+      const message = structuralPinMessages[name];
+      add(
+        violations,
+        object(object(object(workflow.jobs)[row.job]).permissions)[row.scope] === row.access,
+        message === undefined
+          ? `${row.file} ${String(row.job).replaceAll("-", " ")} must ${row.access} ${String(row.scope).replaceAll("-", " ")}`
+          : message(row),
       );
     } else {
       const message = structuralPinMessages[name];
@@ -4510,6 +4536,7 @@ function validatePackagedProof(workflows, violations, graph) {
       && namedStep(job, "Upload packaged agent proof artifacts") === undefined,
     `${file} package workflow must not add a second driver build, calibration, or hosted qualification`,
   );
+  requireCalibrationProducerAuthentication(violations, file, job);
   requireCalibrationProducerBoundary(
     violations,
     file,
@@ -6362,7 +6389,11 @@ function validateRemainingWorkflows(workflows, violations) {
       object(auto.jobs)["workflow-policy"] === undefined,
       `${autoFile} must delegate the release policy gate to release.yml exactly once`,
     );
-    const detectVersion = requireJob(violations, autoFile, auto, "detect-version");
+    // The version-detection and release jobs' structural pins - their existence,
+    // the release job's needs edge, and the release caller's permission grants -
+    // are rule instances and live in release-claims.json under
+    // workflow_policy.structural_pins; structuralPinViolations evaluates them.
+    const detectVersion = object(object(auto.jobs)["detect-version"]);
     add(
       violations,
       needs(detectVersion).length === 0,
@@ -6373,20 +6404,8 @@ function validateRemainingWorkflows(workflows, violations) {
       namedStep(detectVersion, "Validate synchronized release version") === undefined,
       `${autoFile} must delegate synchronized version validation to release.yml`,
     );
-    const release = requireJob(violations, autoFile, auto, "release");
+    const release = object(object(auto.jobs).release);
     add(violations, release.uses === "./.github/workflows/release.yml", `${autoFile} must call the release workflow`);
-    add(violations, sameMembers(needs(release), ["detect-version"]), `${autoFile} release must need version detection`);
-    add(violations, object(release.permissions).contents === "write", `${autoFile} release caller must grant contents write`);
-    add(
-      violations,
-      object(release.permissions).actions === "write",
-      `${autoFile} release caller must grant actions write for superseded-run cancellation`,
-    );
-    add(
-      violations,
-      object(release.permissions)["pull-requests"] === "read",
-      `${autoFile} release caller must pass pull-request metadata access to exact source proof`,
-    );
     add(violations, object(release.with).publish_release === true, `${autoFile} trusted main caller must explicitly authorize publication`);
     add(
       violations,
@@ -6465,7 +6484,15 @@ function validateRemainingWorkflows(workflows, violations) {
         && serverBehaviorInput.default === false,
       `${metalFile} server-behavior-only claim scope must be an explicit opt-in`,
     );
-    const job = requireJob(violations, metalFile, metal, "packaged-metal");
+    // The packaged-metal job's structural pin (job existence) is a rule instance
+    // and lives in release-claims.json under workflow_policy.structural_pins;
+    // structuralPinViolations evaluates it. The lane's step fragments - mode
+    // validation, model preparation, host evidence, candidate authentication and
+    // cache handling, calibration-producer authentication, the calibration
+    // collector, the protected and candidate-installed proofs, and the release
+    // cells - are rule instances and live in release-claims.json under
+    // workflow_policy.step_fragments; stepFragmentViolations evaluates them.
+    const job = object(object(metal.jobs)["packaged-metal"]);
     add(violations, JSON.stringify(job["runs-on"]) === JSON.stringify(["self-hosted", "macOS", "ARM64", "codestory-metal"]), `${metalFile} must use the protected Apple Silicon runner`);
     add(violations, job.environment === "macos-metal-release", `${metalFile} must use the protected Metal environment`);
     const validateCandidate = namedStep(job, "Validate candidate-installed mode");
@@ -6475,19 +6502,10 @@ function validateRemainingWorkflows(workflows, violations) {
         && validateCandidate?.shell === "bash",
       `${metalFile} candidate-installed validation must be an explicit Bash boundary`,
     );
-    requireStepRun(violations, metalFile, job, "Validate candidate-installed mode", [
-      'test "$SERVER_BEHAVIOR_ONLY" = true',
-      'test "$CALIBRATION_MODE" = false',
-    ]);
     requireStepEnv(violations, metalFile, job, "Validate candidate-installed mode", {
       SERVER_BEHAVIOR_ONLY: "${{ inputs.server_behavior_only }}",
       CALIBRATION_MODE: "${{ inputs.calibration_mode }}",
     });
-    requireStepRun(violations, metalFile, job, "Prepare checksum-pinned embedded model", [
-      "node scripts/prepare-embedded-model.mjs",
-      '--cache-root "$RUNNER_TOOL_CACHE/codestory/model-material"',
-    ]);
-    requireStepRun(violations, metalFile, job, "Capture host evidence", ["python3 --version", 'test "$macos_major" -ge 15']);
     const calibrationClock = namedStep(
       job,
       "Start Metal constant calibration clock",
@@ -6631,27 +6649,6 @@ function validateRemainingWorkflows(workflows, violations) {
           === "${{ inputs.server_behavior_only }}",
       `${metalFile} packaged candidate authentication must bind all exact artifacts before cache lookup`,
     );
-    requireStepRun(violations, metalFile, job, "Authenticate exact candidate artifacts", [
-      "actions/runs/$GITHUB_RUN_ID/artifacts?per_page=100",
-      ".github/workflows/auto-release.yml",
-      ".github/workflows/release.yml",
-      ".github/workflows/packaged-platform-pr.yml",
-      'if [ "$SERVER_BEHAVIOR_ONLY" != true ]; then',
-      'test "$CANDIDATE_PRODUCER_WORKFLOW_PATH" =',
-      ".head_repository.full_name",
-      '.path\' <<<"$producer_run")" = "$CANDIDATE_PRODUCER_WORKFLOW_PATH"',
-      '.head_sha\' <<<"$producer_run")" = "$(git rev-parse HEAD)"',
-      '.run_attempt\' <<<"$producer_run")" = "$GITHUB_RUN_ATTEMPT"',
-      ".workflow_run.id == $run_id",
-      ".workflow_run.head_sha == $sha",
-      "expected one exact candidate artifact",
-      'artifact="$(select_artifact "$ARTIFACT_NAME")"',
-      'record_artifact="$(select_artifact "$CANDIDATE_RECORD_ARTIFACT")"',
-      'select_artifact "$QUALIFICATION_ARTIFACT"',
-      "package-id=$artifact_id",
-      "package-bytes=$expected_size",
-      "package-sha256=${expected_digest#sha256:}",
-    ]);
     add(
       violations,
       recordDownload?.if === "inputs.use_packaged_cli_artifact"
@@ -6666,23 +6663,6 @@ function validateRemainingWorkflows(workflows, violations) {
         && cacheRestore?.shell === "bash"
         && cacheRestore?.["continue-on-error"] === undefined,
       `${metalFile} protected cache lookup must consume only the exact small candidate record`,
-    );
-    requireStepRun(
-      violations,
-      metalFile,
-      job,
-      "Restore exact candidate archive from protected host",
-      [
-        "--arg repository \"$GITHUB_REPOSITORY\"",
-        "--arg source_sha \"$(git rev-parse HEAD)\"",
-        "--arg source_tree \"$(git rev-parse 'HEAD^{tree}')\"",
-        "--arg target macos-arm64",
-        "$RUNNER_TOOL_CACHE/codestory/candidate-archives",
-        "candidate-archive-store.mjs restore",
-        "--record \"$record\"",
-        "--output-dir target/release-dist",
-        "echo \"hit=$hit\" >> \"$GITHUB_OUTPUT\"",
-      ],
     );
     add(
       violations,
@@ -6704,23 +6684,6 @@ function validateRemainingWorkflows(workflows, violations) {
           === "${{ steps.candidate-artifacts.outputs.package-sha256 }}"
         && object(cacheMiss?.env).GH_TOKEN === "${{ github.token }}",
       `${metalFile} large Actions artifact transfer must be a cache-miss-only authenticated boundary`,
-    );
-    requireStepRun(
-      violations,
-      metalFile,
-      job,
-      "Download, authenticate, and admit candidate archive on miss",
-      [
-        "actions/artifacts/$ARTIFACT_ID/zip",
-      "--continue-at -",
-      "--max-time 120",
-        'test "$actual_size" = "$EXPECTED_SIZE"',
-        'test "$actual_digest" = "$EXPECTED_SHA256"',
-        "extract-candidate-actions-artifact.py",
-        "candidate-archive-store.mjs admit",
-        "--store-root \"$RUNNER_TOOL_CACHE/codestory/candidate-archives\"",
-        "--output-dir target/release-dist",
-      ],
     );
     add(
       violations,
@@ -6813,16 +6776,6 @@ function validateRemainingWorkflows(workflows, violations) {
       `${metalFile} must reject a frozen or stale calibration source immediately after checkout and before setup or compilation`,
     );
     const calibrationStepName = "Collect three independent Metal constant calibration runs";
-    requireStepRun(violations, metalFile, job, calibrationStepName, [
-      "--proof-tier calibration",
-      "--engine-policy accelerated",
-      "--expected-backend Metal",
-      "--qualification-matrix-cell protected_macos_arm64_metal",
-      "--collect-constant-calibration",
-      "--constant-calibration-output-dir target/calibration-runs/macos",
-      "--qualification-driver target/release/codestory_embedding_constant_calibration",
-      "--out-dir target/calibration-proof/macos",
-    ]);
     const calibrationRun = shellLiteralNormalizedText(
       stepRun(job, calibrationStepName),
     );
@@ -6894,16 +6847,6 @@ function validateRemainingWorkflows(workflows, violations) {
       `${metalFile} calibration must publish shared build/package and five-phase collector timing, including model preparation and an under-ten-minute total`,
     );
     const engine = namedStep(job, "Prove protected Metal runtime");
-    requireStepRun(violations, metalFile, job, "Prove protected Metal runtime", [
-      "--engine-policy accelerated",
-      "--expected-backend Metal",
-      "--offline",
-      "--proof-tier protected_hardware",
-      "--qualification-matrix-cell protected_macos_arm64_metal",
-      "--calibration-producer-run-id",
-      "--calibration-producer-artifact",
-      "--server-behavior-only",
-    ]);
     add(violations, object(engine?.env).CODESTORY_EMBED_ALLOW_CPU === "0", `${metalFile} engine proof must reject CPU fallback`);
     const engineRun = stepRun(
       job,
@@ -6947,40 +6890,12 @@ function validateRemainingWorkflows(workflows, violations) {
       candidateStage?.if === "${{ inputs.candidate_installed_proof && !inputs.calibration_mode }}",
       `${metalFile} candidate-managed staging must require candidate mode outside calibration`,
     );
-    requireStepRun(violations, metalFile, job, "Stage isolated candidate-managed macOS install", [
-      "--prepare-candidate-installed-proof",
-      "--candidate-plugin-root-output",
-      "--candidate-plugin-data-output",
-      "--installed-plugin-attestation-output",
-      "--candidate-producer-workflow-path",
-      "gh api",
-      ".head_repository.full_name",
-      ".path",
-      ".head_sha",
-      ".run_attempt",
-      "$CANDIDATE_PRODUCER_WORKFLOW_PATH",
-      "$RUNNER_TEMP/codestory-candidate-installed-macos.",
-      'candidate_root="$(cd "$candidate_root" && pwd -P)"',
-      '"$GITHUB_WORKSPACE/"*',
-      "CODESTORY_CANDIDATE_MACOS_ROOT=",
-    ]);
     const candidateProof = namedStep(job, "Prove candidate-installed macOS Metal runtime");
     add(
       violations,
       candidateProof?.if === "${{ inputs.candidate_installed_proof && !inputs.calibration_mode }}",
       `${metalFile} candidate-installed Metal proof must require candidate mode outside calibration`,
     );
-    requireStepRun(violations, metalFile, job, "Prove candidate-installed macOS Metal runtime", [
-      "--engine-policy accelerated",
-      "--expected-backend Metal",
-      "--proof-tier installed_runtime",
-      "--installed-plugin-attestation",
-      "--installed-plugin-data",
-      "$CANDIDATE_PRODUCER_WORKFLOW_PATH",
-      "--server-behavior-only",
-      "$CODESTORY_CANDIDATE_MACOS_ROOT/plugin",
-      "$CODESTORY_CANDIDATE_MACOS_ROOT/data",
-    ]);
     const candidateProofRun = stepRun(
       job,
       "Prove candidate-installed macOS Metal runtime",
@@ -6997,17 +6912,6 @@ function validateRemainingWorkflows(workflows, violations) {
       object(candidateProof?.env).CODESTORY_EMBED_ALLOW_CPU === "0",
       `${metalFile} candidate-installed proof must reject CPU fallback`,
     );
-    requireStepRun(violations, metalFile, job, "Emit authenticated Metal release cell", [
-      "codestory-release-cell-manifest.mjs produce",
-      "accelerator_execution:macos-arm64-metal",
-      "--producer-job packaged-metal",
-      '--expected-sha "$INPUT_REF"',
-    ]);
-    requireStepRun(violations, metalFile, job, "Emit authenticated macOS retrieval-readiness release cell", [
-      "retrieval_readiness:macos-arm64",
-      "--producer-job packaged-metal",
-      '--expected-sha "$INPUT_REF"',
-    ]);
     for (const cell of [
       "Emit authenticated Metal release cell",
       "Emit authenticated macOS retrieval-readiness release cell",
@@ -7022,26 +6926,6 @@ function validateRemainingWorkflows(workflows, violations) {
         && String(metalCellUpload?.if ?? "").includes("success()")
         && String(metalCellUpload?.if ?? "").includes("inputs.emit_release_cells"),
       `${metalFile} Metal release cell must be a success-only retained artifact`,
-    );
-    requireStepRun(violations, metalFile, job, "Emit authenticated candidate-installed macOS release cell", [
-      "candidate_installed_behavior:macos-arm64",
-      "--producer-job packaged-metal",
-      "candidate_managed_plugin",
-      '--expected-sha "$INPUT_REF"',
-    ]);
-    forbidStepRun(
-      violations,
-      metalFile,
-      job,
-      "Emit authenticated Metal release cell",
-      ["calibration"],
-    );
-    forbidStepRun(
-      violations,
-      metalFile,
-      job,
-      "Emit authenticated candidate-installed macOS release cell",
-      ["calibration"],
     );
     requireStepUses(
       violations,
@@ -7122,7 +7006,15 @@ function validateRemainingWorkflows(workflows, violations) {
         && serverBehaviorInput.default === false,
       `${vulkanFile} server-behavior-only claim scope must be an explicit opt-in`,
     );
-    const job = requireJob(violations, vulkanFile, vulkan, "packaged-vulkan");
+    // The packaged-vulkan job's structural pin (job existence) is a rule instance
+    // and lives in release-claims.json under workflow_policy.structural_pins;
+    // structuralPinViolations evaluates it. The lane's step fragments - mode
+    // validation, build-tool evidence, model preparation, candidate cache
+    // handling, calibration-producer authentication, the protected and
+    // candidate-installed proofs, and the release cells - are rule instances and
+    // live in release-claims.json under workflow_policy.step_fragments;
+    // stepFragmentViolations evaluates them.
+    const job = object(object(vulkan.jobs)["packaged-vulkan"]);
     add(violations, JSON.stringify(job["runs-on"]) === JSON.stringify(["self-hosted", "Windows", "X64", "codestory-vulkan"]), `${vulkanFile} must use the protected Windows Vulkan runner`);
     add(violations, job.environment === "windows-vulkan-proof", `${vulkanFile} must use the protected Vulkan environment`);
     const pythonSetup = namedStep(job, "Install pinned Python");
@@ -7175,10 +7067,6 @@ function validateRemainingWorkflows(workflows, violations) {
       validateCandidate?.if === "inputs.candidate_installed_proof",
       `${vulkanFile} candidate-installed validation must require explicit candidate mode`,
     );
-    requireStepRun(violations, vulkanFile, job, "Validate candidate-installed mode", [
-      'if ($env:SERVER_BEHAVIOR_ONLY -ne "true")',
-      "candidate_installed_proof requires server_behavior_only",
-    ]);
     requireStepEnv(violations, vulkanFile, job, "Validate candidate-installed mode", {
       SERVER_BEHAVIOR_ONLY: "${{ inputs.server_behavior_only }}",
     });
@@ -7190,15 +7078,6 @@ function validateRemainingWorkflows(workflows, violations) {
         && sourceBuildTools?.shell === windowsPowerShellShell,
       `${vulkanFile} source build tool evidence must remain source-only and fail closed`,
     );
-    requireStepRun(violations, vulkanFile, job, "Capture source build tool evidence", [
-      "CMAKE_GENERATOR=Ninja",
-      "cmake --version",
-      "ninja --version",
-    ]);
-    requireStepRun(violations, vulkanFile, job, "Prepare checksum-pinned embedded model", [
-      "node scripts/prepare-embedded-model.mjs",
-      '--cache-root "$env:RUNNER_TOOL_CACHE/codestory/model-material"',
-    ]);
     const nativeBuild = namedStep(job, "Build and package native CLI");
     const nativeBuildRun = shellLiteralNormalizedText(String(nativeBuild?.run ?? ""));
     add(
@@ -7360,23 +7239,6 @@ function validateRemainingWorkflows(workflows, violations) {
         && windowsCacheRestore?.["continue-on-error"] === undefined,
       `${vulkanFile} protected cache lookup must consume only the exact small Windows candidate record`,
     );
-    requireStepRun(
-      violations,
-      vulkanFile,
-      job,
-      "Restore exact candidate archive from protected host",
-      [
-        "$record.source.commit -ne $sourceSha",
-        "$record.source.tree -ne $sourceTree",
-        "$record.target -ne \"windows-x64\"",
-        "codestory/candidate-archives",
-        "candidate-archive-store.mjs restore",
-        "--record $recordPath",
-        "--output-dir target/release-dist",
-        "\"hit=$hit\"",
-        "$env:GITHUB_OUTPUT",
-      ],
-    );
     add(
       violations,
       windowsCacheMiss?.if
@@ -7397,23 +7259,6 @@ function validateRemainingWorkflows(workflows, violations) {
           === "${{ steps.candidate-artifacts.outputs.package-sha256 }}"
         && object(windowsCacheMiss?.env).GH_TOKEN === "${{ github.token }}",
       `${vulkanFile} large Windows Actions artifact transfer must be cache-miss-only and outer-digest authenticated`,
-    );
-    requireStepRun(
-      violations,
-      vulkanFile,
-      job,
-      "Download, authenticate, and admit candidate archive on miss",
-      [
-        "actions/artifacts/$env:ARTIFACT_ID/zip",
-        "--continue-at -",
-        "--max-time 120",
-        "$actualSize -ne [long]$env:EXPECTED_SIZE",
-        "$actualDigest -ne $env:EXPECTED_SHA256",
-        "extract-candidate-actions-artifact.py",
-        "candidate-archive-store.mjs admit",
-        "--store-root $store",
-        "--output-dir target/release-dist",
-      ],
     );
     add(
       violations,
@@ -7490,16 +7335,6 @@ function validateRemainingWorkflows(workflows, violations) {
       "${{ !inputs.server_behavior_only }}",
     );
     const engine = namedStep(job, "Prove protected Windows Vulkan runtime");
-    requireStepRun(violations, vulkanFile, job, "Prove protected Windows Vulkan runtime", [
-      "--engine-policy accelerated",
-      "--expected-backend Vulkan",
-      "--offline",
-      "--proof-tier protected_hardware",
-      "--qualification-matrix-cell protected_windows_x64_vulkan",
-      "--calibration-producer-run-id",
-      "--calibration-producer-artifact",
-      "--server-behavior-only",
-    ]);
     add(violations, object(engine?.env).CODESTORY_EMBED_ALLOW_CPU === "0", `${vulkanFile} engine proof must reject CPU fallback`);
     const engineRun = stepRun(job, "Prove protected Windows Vulkan runtime");
     add(
@@ -7548,47 +7383,12 @@ function validateRemainingWorkflows(workflows, violations) {
       candidateStage?.if === "inputs.candidate_installed_proof",
       `${vulkanFile} candidate-managed staging must require explicit candidate mode`,
     );
-    requireStepRun(violations, vulkanFile, job, "Stage isolated candidate-managed Windows install", [
-      "--prepare-candidate-installed-proof",
-      "--candidate-plugin-root-output",
-      "--candidate-plugin-data-output",
-      "--installed-plugin-attestation-output",
-      "--candidate-producer-workflow-path",
-      "gh api",
-      "$run.head_repository.full_name",
-      "$run.path",
-      "$run.head_sha",
-      "$run.run_attempt",
-      "$env:CANDIDATE_PRODUCER_WORKFLOW_PATH",
-      "[IO.Path]::GetPathRoot($env:GITHUB_WORKSPACE)",
-      "cs-ci-",
-      "Substring(0, 12)",
-      "[IO.Path]::GetFullPath",
-      "$env:GITHUB_WORKSPACE",
-      "CODESTORY_CANDIDATE_WINDOWS_ROOT=",
-    ]);
     const candidateProof = namedStep(job, "Prove candidate-installed Windows Vulkan runtime");
     add(
       violations,
       candidateProof?.if === "inputs.candidate_installed_proof",
       `${vulkanFile} candidate-installed Vulkan proof must require explicit candidate mode`,
     );
-    requireStepRun(violations, vulkanFile, job, "Prove candidate-installed Windows Vulkan runtime", [
-      "--proof-tier installed_runtime",
-      "--engine-policy accelerated",
-      "--expected-backend Vulkan",
-      "--installed-plugin-attestation",
-      "--installed-plugin-data",
-      "--candidate-producer-workflow-path",
-      "$env:CANDIDATE_PRODUCER_WORKFLOW_PATH",
-      "--server-behavior-only",
-      "--expected-source-sha",
-      "--expected-source-tree",
-      "$env:CODESTORY_CANDIDATE_WINDOWS_ROOT",
-      "$env:TEMP = $proofTemp",
-      "$env:TMP = $proofTemp",
-      "$env:TMPDIR = $proofTemp",
-    ]);
     const candidateProofRun = stepRun(
       job,
       "Prove candidate-installed Windows Vulkan runtime",
@@ -7617,12 +7417,6 @@ function validateRemainingWorkflows(workflows, violations) {
         && object(candidateUpload?.with)["if-no-files-found"] === "error",
       `${vulkanFile} candidate-installed proof must retain one attempt-scoped artifact`,
     );
-    requireStepRun(violations, vulkanFile, job, "Emit authenticated Vulkan release cell", [
-      "codestory-release-cell-manifest.mjs produce",
-      "accelerator_execution:windows-x64-vulkan",
-      "--producer-job packaged-vulkan",
-      '--expected-sha "$INPUT_REF"',
-    ]);
     for (const cell of [
       "Emit authenticated Vulkan release cell",
       "Emit authenticated Windows retrieval-readiness release cell",
@@ -7644,31 +7438,6 @@ function validateRemainingWorkflows(workflows, violations) {
         && String(vulkanCellUpload?.if ?? "").includes("inputs.emit_release_cells")
         && !String(vulkanCellUpload?.if ?? "").includes("!inputs.server_behavior_only"),
       `${vulkanFile} Vulkan release cell must be a success-only retained artifact`,
-    );
-    requireStepRun(violations, vulkanFile, job, "Emit authenticated candidate-installed Windows release cell", [
-      "candidate_installed_behavior:windows-x64",
-      "--producer-job packaged-vulkan",
-      "candidate_managed_plugin",
-      '--expected-sha "$INPUT_REF"',
-    ]);
-    requireStepRun(violations, vulkanFile, job, "Emit authenticated Windows retrieval-readiness release cell", [
-      "retrieval_readiness:windows-x64",
-      "--producer-job packaged-vulkan",
-      '--expected-sha "$INPUT_REF"',
-    ]);
-    forbidStepRun(
-      violations,
-      vulkanFile,
-      job,
-      "Emit authenticated Vulkan release cell",
-      ["calibration"],
-    );
-    forbidStepRun(
-      violations,
-      vulkanFile,
-      job,
-      "Emit authenticated candidate-installed Windows release cell",
-      ["calibration"],
     );
     requireStepUses(
       violations,
@@ -7740,22 +7509,21 @@ function validateRemainingWorkflows(workflows, violations) {
       trigger(linuxVulkan, "workflow_dispatch") === undefined,
       `${linuxVulkanFile} standalone proof must not bypass the coordinator`,
     );
-    const route = requireJob(violations, linuxVulkanFile, linuxVulkan, "route");
+    // The route, packaged-vulkan, and optional-constant-calibration jobs'
+    // structural pins (job existence) are rule instances and live in
+    // release-claims.json under workflow_policy.structural_pins;
+    // structuralPinViolations evaluates them. The lanes' step fragments - the
+    // route gate, host evidence, mode validation, candidate cache handling,
+    // calibration-producer authentication, the protected and candidate-installed
+    // proofs, the release cells, and the optional calibration collector - are
+    // rule instances and live in release-claims.json under
+    // workflow_policy.step_fragments; stepFragmentViolations evaluates them.
+    const route = object(object(linuxVulkan.jobs).route);
     add(
       violations,
       JSON.stringify(route["runs-on"]) === JSON.stringify("ubuntu-latest")
         && route["timeout-minutes"] === 5,
       `${linuxVulkanFile} standalone dispatch validation must stay on a bounded hosted route job`,
-    );
-    requireStepRun(
-      violations,
-      linuxVulkanFile,
-      route,
-      "Require an upstream package for standalone protected proof",
-      [
-        'if [ "$EVENT_NAME" = workflow_dispatch ] && [ "$CONSTANT_CALIBRATION_MODE" != true ]; then',
-        'test -n "$PACKAGE_RUN_ID"',
-      ],
     );
     requireStepEnv(
       violations,
@@ -7768,7 +7536,7 @@ function validateRemainingWorkflows(workflows, violations) {
         PACKAGE_RUN_ID: "${{ inputs.package_run_id }}",
       },
     );
-    const job = requireJob(violations, linuxVulkanFile, linuxVulkan, "packaged-vulkan");
+    const job = object(object(linuxVulkan.jobs)["packaged-vulkan"]);
     add(
       violations,
       job.if === "${{ !inputs.constant_calibration_mode }}"
@@ -7782,11 +7550,6 @@ function validateRemainingWorkflows(workflows, violations) {
       "Install pinned Python",
       "actions/setup-python@v7.0.0",
     );
-    requireStepRun(violations, linuxVulkanFile, job, "Capture Linux Vulkan host evidence", [
-      "uname -m",
-      "vulkaninfo --summary",
-      "test \"$(uname -m)\" = x86_64",
-    ]);
     const validateCandidate = namedStep(job, "Validate candidate-installed mode");
     add(
       violations,
@@ -7794,9 +7557,6 @@ function validateRemainingWorkflows(workflows, violations) {
         && validateCandidate?.shell === "bash",
       `${linuxVulkanFile} candidate-installed validation must require explicit candidate mode`,
     );
-    requireStepRun(violations, linuxVulkanFile, job, "Validate candidate-installed mode", [
-      'test "$SERVER_BEHAVIOR_ONLY" = true',
-    ]);
     requireStepEnv(violations, linuxVulkanFile, job, "Validate candidate-installed mode", {
       SERVER_BEHAVIOR_ONLY: "${{ inputs.server_behavior_only }}",
     });
@@ -7922,23 +7682,6 @@ function validateRemainingWorkflows(workflows, violations) {
         && linuxCacheRestore?.["continue-on-error"] === undefined,
       `${linuxVulkanFile} protected cache lookup must consume only the exact small Linux candidate record`,
     );
-    requireStepRun(
-      violations,
-      linuxVulkanFile,
-      job,
-      "Restore exact candidate archive from protected host",
-      [
-        "--arg repository \"$GITHUB_REPOSITORY\"",
-        "--arg source_sha \"$(git rev-parse HEAD)\"",
-        "--arg source_tree \"$(git rev-parse 'HEAD^{tree}')\"",
-        "--arg target linux-x64",
-        "$RUNNER_TOOL_CACHE/codestory/candidate-archives",
-        "candidate-archive-store.mjs restore",
-        "--record \"$record\"",
-        "--output-dir target/release-dist",
-        "echo \"hit=$hit\" >> \"$GITHUB_OUTPUT\"",
-      ],
-    );
     add(
       violations,
       linuxCacheMiss?.if === "steps.candidate-cache.outputs.hit != 'true'"
@@ -7958,23 +7701,6 @@ function validateRemainingWorkflows(workflows, violations) {
           === "${{ steps.candidate-artifacts.outputs.package-sha256 }}"
         && object(linuxCacheMiss?.env).GH_TOKEN === "${{ github.token }}",
       `${linuxVulkanFile} large Linux Actions artifact transfer must be cache-miss-only and outer-digest authenticated`,
-    );
-    requireStepRun(
-      violations,
-      linuxVulkanFile,
-      job,
-      "Download, authenticate, and admit candidate archive on miss",
-      [
-        "actions/artifacts/$ARTIFACT_ID/zip",
-        "--continue-at -",
-        "--max-time 120",
-        'test "$actual_size" = "$EXPECTED_SIZE"',
-        'test "$actual_digest" = "$EXPECTED_SHA256"',
-        "extract-candidate-actions-artifact.py",
-        "candidate-archive-store.mjs admit",
-        "--store-root \"$RUNNER_TOOL_CACHE/codestory/candidate-archives\"",
-        "--output-dir target/release-dist",
-      ],
     );
     add(
       violations,
@@ -8071,16 +7797,6 @@ function validateRemainingWorkflows(workflows, violations) {
       `${linuxVulkanFile} must not replace the verified qualification driver before execution`,
     );
     const engine = namedStep(job, "Prove offline Linux Vulkan retrieval");
-    requireStepRun(violations, linuxVulkanFile, job, "Prove offline Linux Vulkan retrieval", [
-      "--engine-policy accelerated",
-      "--expected-backend Vulkan",
-      "--offline",
-      "--proof-tier protected_hardware",
-      "--qualification-matrix-cell protected_linux_x64_vulkan",
-      "--calibration-producer-run-id",
-      "--calibration-producer-artifact",
-      "--server-behavior-only",
-    ]);
     add(
       violations,
       object(engine?.env).CODESTORY_EMBED_ALLOW_CPU === "0",
@@ -8120,16 +7836,6 @@ function validateRemainingWorkflows(workflows, violations) {
         && occurrenceCount(engineRun, "check-packaged-agent-proof.py") === 1,
       `${linuxVulkanFile} server-behavior proof must omit calibration while standalone qualification runs one lifecycle proof without optional quality`,
     );
-    requireStepRun(violations, linuxVulkanFile, job, "Stage isolated candidate-managed Linux install", [
-      "--prepare-candidate-installed-proof",
-      "--candidate-plugin-root-output",
-      "--candidate-plugin-data-output",
-      "--installed-plugin-attestation-output",
-      "--candidate-producer-workflow-path",
-      "gh api",
-      "$RUNNER_TEMP/codestory-candidate-installed-linux.",
-      "CODESTORY_CANDIDATE_LINUX_ROOT=",
-    ]);
     add(
       violations,
       namedStep(job, "Stage isolated candidate-managed Linux install")?.if
@@ -8137,14 +7843,6 @@ function validateRemainingWorkflows(workflows, violations) {
       `${linuxVulkanFile} candidate-managed staging must require explicit candidate mode`,
     );
     const candidate = namedStep(job, "Prove candidate-installed Linux Vulkan runtime");
-    requireStepRun(violations, linuxVulkanFile, job, "Prove candidate-installed Linux Vulkan runtime", [
-      "--engine-policy accelerated",
-      "--expected-backend Vulkan",
-      "--proof-tier installed_runtime",
-      "--installed-plugin-attestation",
-      "--installed-plugin-data",
-      "--server-behavior-only",
-    ]);
     add(
       violations,
       candidate?.if === "inputs.candidate_installed_proof",
@@ -8155,35 +7853,11 @@ function validateRemainingWorkflows(workflows, violations) {
       object(candidate?.env).CODESTORY_EMBED_ALLOW_CPU === "0",
       `${linuxVulkanFile} candidate-installed proof must reject CPU fallback`,
     );
-    forbidStepRun(
-      violations,
-      linuxVulkanFile,
-      job,
-      "Prove candidate-installed Linux Vulkan runtime",
-      ["calibration", "--ground-only", "--engine-policy cpu_explicit"],
-    );
-    requireStepRun(violations, linuxVulkanFile, job, "Emit authenticated Linux Vulkan release cells", [
-      "accelerator_execution:linux-x64-vulkan",
-      "retrieval_readiness:linux-x64",
-      "candidate_installed_behavior:linux-x64",
-      "--producer-job packaged-vulkan",
-      '--expected-sha "$INPUT_REF"',
-    ]);
     requireStepEnv(violations, linuxVulkanFile, job, "Emit authenticated Linux Vulkan release cells", {
       INPUT_REF: "${{ inputs.ref }}",
     });
-    forbidStepRun(
-      violations,
-      linuxVulkanFile,
-      job,
-      "Emit authenticated Linux Vulkan release cells",
-      ["calibration"],
-    );
-    const optionalCalibration = requireJob(
-      violations,
-      linuxVulkanFile,
-      linuxVulkan,
-      "optional-constant-calibration",
+    const optionalCalibration = object(
+      object(linuxVulkan.jobs)["optional-constant-calibration"],
     );
     add(
       violations,
@@ -8194,28 +7868,7 @@ function validateRemainingWorkflows(workflows, violations) {
         && optionalCalibration.environment === "linux-vulkan-proof",
       `${linuxVulkanFile} optional calibration must be a standalone protected coordinator-only Vulkan job`,
     );
-    requireStepRun(
-      violations,
-      linuxVulkanFile,
-      optionalCalibration,
-      "Prepare checksum-pinned embedded model",
-      [
-        "node scripts/prepare-embedded-model.mjs",
-        '--cache-root "$RUNNER_TOOL_CACHE/codestory/model-material"',
-      ],
-    );
     const optionalCollectorName = "Collect optional Linux Vulkan constant calibration";
-    requireStepRun(violations, linuxVulkanFile, optionalCalibration, optionalCollectorName, [
-      'test "$CONSTANT_CALIBRATION_MODE" = true',
-      "--engine-policy accelerated",
-      "--expected-backend Vulkan",
-      "--proof-tier calibration",
-      "--qualification-matrix-cell protected_linux_x64_vulkan",
-      "--collect-constant-calibration",
-      "--constant-calibration-output-dir target/calibration-runs/linux-vulkan",
-      "--qualification-driver target/release/codestory_embedding_constant_calibration",
-      "--out-dir target/calibration-proof/linux-vulkan",
-    ]);
     const optionalCollector = namedStep(optionalCalibration, optionalCollectorName);
     const optionalCollectorRun = shellLiteralNormalizedText(
       stepRun(optionalCalibration, optionalCollectorName),
@@ -8322,7 +7975,10 @@ function validateRemainingWorkflows(workflows, violations) {
     violations.push(`${guardFile} must exist`);
   } else {
     add(violations, includesAll(at(guard, "on", "pull_request", "branches"), ["main"]), `${guardFile} must guard main`);
-    const job = requireJob(violations, guardFile, guard, "enforce-source-branch");
+    // The enforce-source-branch job's structural pin (job existence) is a rule
+    // instance and lives in release-claims.json under
+    // workflow_policy.structural_pins; structuralPinViolations evaluates it.
+    const job = object(object(guard.jobs)["enforce-source-branch"]);
     const step = namedStep(job, "Require dev/codestory-next source branch");
     add(violations, object(step?.env).HEAD_REPO !== undefined && object(step?.env).BASE_REPO !== undefined, `${guardFile} must compare source and base repository identity`);
     add(violations, String(step?.run ?? "").includes("dev/codestory-next"), `${guardFile} must require the dev source branch`);

--- a/benchmarks/release-evidence/fixtures/candidate.json
+++ b/benchmarks/release-evidence/fixtures/candidate.json
@@ -62,7 +62,7 @@
   },
   "release_claims": {
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "74556a0ce3f810108f4ccb83c81d94060e77e807ec965a1987e1f405325d1257",
+    "graph_sha256": "08c48aadee5be419653a2d9aae2d90a7c9680273be84fa97013291e5daee23db",
     "observed_at": "2026-08-08T19:19:24.395Z",
     "expires_at": "2026-08-09T19:19:24.395Z",
     "requested_claims": [
@@ -85,7 +85,7 @@
         "type": "performance",
         "tier": "live_behavior",
         "status": "measured",
-        "graph_sha256": "74556a0ce3f810108f4ccb83c81d94060e77e807ec965a1987e1f405325d1257",
+        "graph_sha256": "08c48aadee5be419653a2d9aae2d90a7c9680273be84fa97013291e5daee23db",
         "observed_at": "2026-08-08T19:19:24.395Z",
         "expires_at": "2026-08-09T19:19:24.395Z",
         "identity": {
@@ -106,7 +106,7 @@
         "type": "answer_quality",
         "tier": "answer_quality",
         "status": "pass",
-        "graph_sha256": "74556a0ce3f810108f4ccb83c81d94060e77e807ec965a1987e1f405325d1257",
+        "graph_sha256": "08c48aadee5be419653a2d9aae2d90a7c9680273be84fa97013291e5daee23db",
         "observed_at": "2026-08-08T19:19:24.395Z",
         "expires_at": "2026-08-09T19:19:24.395Z",
         "identity": {

--- a/benchmarks/release-evidence/fixtures/report.json
+++ b/benchmarks/release-evidence/fixtures/report.json
@@ -7,7 +7,7 @@
   "baseline_id": "ci-contract-v1@1111111111111111111111111111111111111111",
   "baseline_sha256": "0bbbe6dd8b4000151edf7b1270959d08e94e08db876e7f2372b25613e0f237c1",
   "candidate_path": "benchmarks/release-evidence/fixtures/candidate.json",
-  "candidate_sha256": "a59e5fbaaad14b44bcccb5b56cf5d7d77e0a3fbe4e2f08ceff2eec620042287c",
+  "candidate_sha256": "53005aa53ea2fe4ca003eed69337249157279f28c2ffc94c21921596fd583a6c",
   "artifact_paths": [
     {
       "path": "candidate-stats.json",
@@ -26,7 +26,7 @@
       "type": "performance",
       "tier": "live_behavior",
       "status": "pass",
-      "graph_sha256": "74556a0ce3f810108f4ccb83c81d94060e77e807ec965a1987e1f405325d1257",
+      "graph_sha256": "08c48aadee5be419653a2d9aae2d90a7c9680273be84fa97013291e5daee23db",
       "observed_at": "2026-08-08T19:19:24.395Z",
       "expires_at": "2026-08-09T19:19:24.395Z",
       "identity": {
@@ -47,7 +47,7 @@
       "type": "answer_quality",
       "tier": "answer_quality",
       "status": "pass",
-      "graph_sha256": "74556a0ce3f810108f4ccb83c81d94060e77e807ec965a1987e1f405325d1257",
+      "graph_sha256": "08c48aadee5be419653a2d9aae2d90a7c9680273be84fa97013291e5daee23db",
       "observed_at": "2026-08-08T19:19:24.395Z",
       "expires_at": "2026-08-09T19:19:24.395Z",
       "identity": {
@@ -69,7 +69,7 @@
     "schema": "codestory.release-claim-evaluation/v1",
     "status": "pass",
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "74556a0ce3f810108f4ccb83c81d94060e77e807ec965a1987e1f405325d1257",
+    "graph_sha256": "08c48aadee5be419653a2d9aae2d90a7c9680273be84fa97013291e5daee23db",
     "evidence_selection": "all_matching_rows_must_pass",
     "expected_commit": "2222222222222222222222222222222222222222",
     "evaluated_at": "2026-08-08T19:19:24.395Z",

--- a/release-claims.json
+++ b/release-claims.json
@@ -2275,6 +2275,662 @@
           "--expected-sha \"$RESOLVED_REF\""
         ],
         "reason": "The source release cell is the proof the release chain later consumes, so it must be produced by the manifest tool, name the source_behavior cell and this producer job, and bind the resolved SHA. Each fragment pins one of those identity conjuncts."
+      },
+      "macos_metal_validate_candidate_installed_mode": {
+        "kind": "require",
+        "file": "macos-metal-proof.yml",
+        "job": "packaged-metal",
+        "step": "Validate candidate-installed mode",
+        "fragments": [
+          "test \"$SERVER_BEHAVIOR_ONLY\" = true",
+          "test \"$CALIBRATION_MODE\" = false"
+        ],
+        "reason": "Candidate-installed mode on the Metal host is only sound as a server-behavior claim outside calibration; the fragments pin both mode tests so the validation cannot silently accept a wider claim scope."
+      },
+      "macos_metal_embedded_model": {
+        "kind": "require",
+        "file": "macos-metal-proof.yml",
+        "job": "packaged-metal",
+        "step": "Prepare checksum-pinned embedded model",
+        "fragments": [
+          "node scripts/prepare-embedded-model.mjs",
+          "--cache-root \"$RUNNER_TOOL_CACHE/codestory/model-material\""
+        ],
+        "reason": "Model material reaches the protected Metal host only through the checksum-pinned preparation script and the runner tool cache root; the fragments pin that invocation and its cache root."
+      },
+      "macos_metal_host_evidence": {
+        "kind": "require",
+        "file": "macos-metal-proof.yml",
+        "job": "packaged-metal",
+        "step": "Capture host evidence",
+        "fragments": [
+          "python3 --version",
+          "test \"$macos_major\" -ge 15"
+        ],
+        "reason": "Host evidence must record the interpreter the proof depends on and refuse a macOS older than the qualified floor; the fragments pin the version capture and the major-version gate."
+      },
+      "macos_metal_candidate_authentication": {
+        "kind": "require",
+        "file": "macos-metal-proof.yml",
+        "job": "packaged-metal",
+        "step": "Authenticate exact candidate artifacts",
+        "fragments": [
+          "actions/runs/$GITHUB_RUN_ID/artifacts?per_page=100",
+          ".github/workflows/auto-release.yml",
+          ".github/workflows/release.yml",
+          ".github/workflows/packaged-platform-pr.yml",
+          "if [ \"$SERVER_BEHAVIOR_ONLY\" != true ]; then",
+          "test \"$CANDIDATE_PRODUCER_WORKFLOW_PATH\" =",
+          ".head_repository.full_name",
+          ".path' <<<\"$producer_run\")\" = \"$CANDIDATE_PRODUCER_WORKFLOW_PATH\"",
+          ".head_sha' <<<\"$producer_run\")\" = \"$(git rev-parse HEAD)\"",
+          ".run_attempt' <<<\"$producer_run\")\" = \"$GITHUB_RUN_ATTEMPT\"",
+          ".workflow_run.id == $run_id",
+          ".workflow_run.head_sha == $sha",
+          "expected one exact candidate artifact",
+          "artifact=\"$(select_artifact \"$ARTIFACT_NAME\")\"",
+          "record_artifact=\"$(select_artifact \"$CANDIDATE_RECORD_ARTIFACT\")\"",
+          "select_artifact \"$QUALIFICATION_ARTIFACT\"",
+          "package-id=$artifact_id",
+          "package-bytes=$expected_size",
+          "package-sha256=${expected_digest#sha256:}"
+        ],
+        "reason": "The packaged proof consumes exactly the artifacts its own run produced from an allowlisted producer at this head and attempt. Each fragment pins one authentication conjunct - the run-scoped artifact listing, the producer allowlist, the same-repository, path, head-SHA, and attempt tests, the run-bound artifact filters, the one-artifact expectation, the three exact artifact selections, and the recorded package identity outputs."
+      },
+      "macos_metal_candidate_cache_restore": {
+        "kind": "require",
+        "file": "macos-metal-proof.yml",
+        "job": "packaged-metal",
+        "step": "Restore exact candidate archive from protected host",
+        "fragments": [
+          "--arg repository \"$GITHUB_REPOSITORY\"",
+          "--arg source_sha \"$(git rev-parse HEAD)\"",
+          "--arg source_tree \"$(git rev-parse 'HEAD^{tree}')\"",
+          "--arg target macos-arm64",
+          "$RUNNER_TOOL_CACHE/codestory/candidate-archives",
+          "candidate-archive-store.mjs restore",
+          "--record \"$record\"",
+          "--output-dir target/release-dist",
+          "echo \"hit=$hit\" >> \"$GITHUB_OUTPUT\""
+        ],
+        "reason": "A protected-host cache hit is only the reviewed archive when the record binds this repository, source commit and tree, and the macOS target, and the restore goes through the archive store into the exact output directory; the fragments pin those bindings and the recorded hit output."
+      },
+      "macos_metal_candidate_cache_miss": {
+        "kind": "require",
+        "file": "macos-metal-proof.yml",
+        "job": "packaged-metal",
+        "step": "Download, authenticate, and admit candidate archive on miss",
+        "fragments": [
+          "actions/artifacts/$ARTIFACT_ID/zip",
+          "--continue-at -",
+          "--max-time 120",
+          "test \"$actual_size\" = \"$EXPECTED_SIZE\"",
+          "test \"$actual_digest\" = \"$EXPECTED_SHA256\"",
+          "extract-candidate-actions-artifact.py",
+          "candidate-archive-store.mjs admit",
+          "--store-root \"$RUNNER_TOOL_CACHE/codestory/candidate-archives\"",
+          "--output-dir target/release-dist"
+        ],
+        "reason": "A cache miss may transfer the large Actions artifact only through the resumable bounded download, must prove the outer size and digest before extraction, and must admit the archive through the store into the exact output directory; the fragments pin that authenticated admission chain."
+      },
+      "macos_metal_calibration_producer_authentication": {
+        "kind": "require",
+        "file": "macos-metal-proof.yml",
+        "job": "packaged-metal",
+        "step": "Authenticate calibration bundle producer",
+        "fragments": [
+          "actions/runs/",
+          ".github/workflows/packaged-platform-pr.yml",
+          "workflow_dispatch",
+          "success",
+          "embedding-calibration-bundle-",
+          "artifacts?per_page=100",
+          "expired"
+        ],
+        "reason": "A calibration bundle is trusted only when its producer run is the frozen-candidate coordinator's dispatched, successful run and the bundle artifact is the unexpired one it named; the fragments pin the producer-run lookup, the coordinator path, the dispatch event, the success conclusion, the bundle name prefix, the artifact listing, and the expiry check."
+      },
+      "macos_metal_constant_calibration_runs": {
+        "kind": "require",
+        "file": "macos-metal-proof.yml",
+        "job": "packaged-metal",
+        "step": "Collect three independent Metal constant calibration runs",
+        "fragments": [
+          "--proof-tier calibration",
+          "--engine-policy accelerated",
+          "--expected-backend Metal",
+          "--qualification-matrix-cell protected_macos_arm64_metal",
+          "--collect-constant-calibration",
+          "--constant-calibration-output-dir target/calibration-runs/macos",
+          "--qualification-driver target/release/codestory_embedding_constant_calibration",
+          "--out-dir target/calibration-proof/macos"
+        ],
+        "reason": "Calibration collects constants through the dedicated collector with the accelerated Metal engine on the protected matrix cell and writes runs and proof to the reviewed directories; each fragment pins one flag of that single collector invocation."
+      },
+      "macos_metal_protected_runtime_proof": {
+        "kind": "require",
+        "file": "macos-metal-proof.yml",
+        "job": "packaged-metal",
+        "step": "Prove protected Metal runtime",
+        "fragments": [
+          "--engine-policy accelerated",
+          "--expected-backend Metal",
+          "--offline",
+          "--proof-tier protected_hardware",
+          "--qualification-matrix-cell protected_macos_arm64_metal",
+          "--calibration-producer-run-id",
+          "--calibration-producer-artifact",
+          "--server-behavior-only"
+        ],
+        "reason": "The protected Metal proof must run the accelerated offline harness against the protected matrix cell with the calibration producer bound and the server-behavior scope explicit; each fragment pins one flag of that invocation."
+      },
+      "macos_metal_candidate_staging": {
+        "kind": "require",
+        "file": "macos-metal-proof.yml",
+        "job": "packaged-metal",
+        "step": "Stage isolated candidate-managed macOS install",
+        "fragments": [
+          "--prepare-candidate-installed-proof",
+          "--candidate-plugin-root-output",
+          "--candidate-plugin-data-output",
+          "--installed-plugin-attestation-output",
+          "--candidate-producer-workflow-path",
+          "gh api",
+          ".head_repository.full_name",
+          ".path",
+          ".head_sha",
+          ".run_attempt",
+          "$CANDIDATE_PRODUCER_WORKFLOW_PATH",
+          "$RUNNER_TEMP/codestory-candidate-installed-macos.",
+          "candidate_root=\"$(cd \"$candidate_root\" && pwd -P)\"",
+          "\"$GITHUB_WORKSPACE/\"*",
+          "CODESTORY_CANDIDATE_MACOS_ROOT="
+        ],
+        "reason": "Candidate-managed staging must go through the harness staging flags, authenticate the producer run by repository, path, head SHA, and attempt, and land in an isolated runner-temp root outside the workspace; the fragments pin that staging chain and the exported root."
+      },
+      "macos_metal_candidate_installed_proof": {
+        "kind": "require",
+        "file": "macos-metal-proof.yml",
+        "job": "packaged-metal",
+        "step": "Prove candidate-installed macOS Metal runtime",
+        "fragments": [
+          "--engine-policy accelerated",
+          "--expected-backend Metal",
+          "--proof-tier installed_runtime",
+          "--installed-plugin-attestation",
+          "--installed-plugin-data",
+          "$CANDIDATE_PRODUCER_WORKFLOW_PATH",
+          "--server-behavior-only",
+          "$CODESTORY_CANDIDATE_MACOS_ROOT/plugin",
+          "$CODESTORY_CANDIDATE_MACOS_ROOT/data"
+        ],
+        "reason": "The candidate-installed proof must run the accelerated Metal harness at the installed-runtime tier against the staged plugin root and data with the producer path and server-behavior scope bound; each fragment pins one of those conjuncts."
+      },
+      "macos_metal_release_cell": {
+        "kind": "require",
+        "file": "macos-metal-proof.yml",
+        "job": "packaged-metal",
+        "step": "Emit authenticated Metal release cell",
+        "fragments": [
+          "codestory-release-cell-manifest.mjs produce",
+          "accelerator_execution:macos-arm64-metal",
+          "--producer-job packaged-metal",
+          "--expected-sha \"$INPUT_REF\""
+        ],
+        "reason": "The Metal release cell must be produced by the manifest tool, name the accelerator-execution macOS cell and this producer job, and bind the caller's expected SHA; each fragment pins one identity conjunct."
+      },
+      "macos_metal_retrieval_readiness_cell": {
+        "kind": "require",
+        "file": "macos-metal-proof.yml",
+        "job": "packaged-metal",
+        "step": "Emit authenticated macOS retrieval-readiness release cell",
+        "fragments": [
+          "retrieval_readiness:macos-arm64",
+          "--producer-job packaged-metal",
+          "--expected-sha \"$INPUT_REF\""
+        ],
+        "reason": "The macOS retrieval-readiness cell must name its cell, this producer job, and the caller's expected SHA; each fragment pins one identity conjunct."
+      },
+      "macos_metal_candidate_installed_cell": {
+        "kind": "require",
+        "file": "macos-metal-proof.yml",
+        "job": "packaged-metal",
+        "step": "Emit authenticated candidate-installed macOS release cell",
+        "fragments": [
+          "candidate_installed_behavior:macos-arm64",
+          "--producer-job packaged-metal",
+          "candidate_managed_plugin",
+          "--expected-sha \"$INPUT_REF\""
+        ],
+        "reason": "The candidate-installed macOS cell must name its cell, this producer job, the candidate-managed plugin claim, and the caller's expected SHA; each fragment pins one identity conjunct."
+      },
+      "macos_metal_release_cell_no_calibration": {
+        "kind": "forbid",
+        "file": "macos-metal-proof.yml",
+        "job": "packaged-metal",
+        "step": "Emit authenticated Metal release cell",
+        "fragments": [
+          "calibration"
+        ],
+        "reason": "The Metal release cell is a qualification artifact; a calibration reference inside it would let calibration evidence leak into the release chain, so the fragment forbids the word outright."
+      },
+      "macos_metal_candidate_installed_cell_no_calibration": {
+        "kind": "forbid",
+        "file": "macos-metal-proof.yml",
+        "job": "packaged-metal",
+        "step": "Emit authenticated candidate-installed macOS release cell",
+        "fragments": [
+          "calibration"
+        ],
+        "reason": "The candidate-installed macOS cell must stay a runtime-behavior artifact; the fragment forbids any calibration reference so the candidate lane cannot smuggle calibration claims."
+      },
+      "windows_vulkan_validate_candidate_installed_mode": {
+        "kind": "require",
+        "file": "windows-vulkan-proof.yml",
+        "job": "packaged-vulkan",
+        "step": "Validate candidate-installed mode",
+        "fragments": [
+          "if ($env:SERVER_BEHAVIOR_ONLY -ne \"true\")",
+          "candidate_installed_proof requires server_behavior_only"
+        ],
+        "reason": "Candidate-installed mode on the Windows host is only sound as a server-behavior claim; the fragments pin the PowerShell mode test and its failure message so the validation cannot widen the claim scope."
+      },
+      "windows_vulkan_source_build_tools": {
+        "kind": "require",
+        "file": "windows-vulkan-proof.yml",
+        "job": "packaged-vulkan",
+        "step": "Capture source build tool evidence",
+        "fragments": [
+          "CMAKE_GENERATOR=Ninja",
+          "cmake --version",
+          "ninja --version"
+        ],
+        "reason": "The source fallback builds native code with the Ninja generator, so the evidence step must export that generator and record the exact cmake and ninja versions; the fragments pin all three."
+      },
+      "windows_vulkan_embedded_model": {
+        "kind": "require",
+        "file": "windows-vulkan-proof.yml",
+        "job": "packaged-vulkan",
+        "step": "Prepare checksum-pinned embedded model",
+        "fragments": [
+          "node scripts/prepare-embedded-model.mjs",
+          "--cache-root \"$env:RUNNER_TOOL_CACHE/codestory/model-material\""
+        ],
+        "reason": "Model material reaches the protected Windows host only through the checksum-pinned preparation script and the runner tool cache root; the fragments pin that invocation and its cache root."
+      },
+      "windows_vulkan_candidate_cache_restore": {
+        "kind": "require",
+        "file": "windows-vulkan-proof.yml",
+        "job": "packaged-vulkan",
+        "step": "Restore exact candidate archive from protected host",
+        "fragments": [
+          "$record.source.commit -ne $sourceSha",
+          "$record.source.tree -ne $sourceTree",
+          "$record.target -ne \"windows-x64\"",
+          "codestory/candidate-archives",
+          "candidate-archive-store.mjs restore",
+          "--record $recordPath",
+          "--output-dir target/release-dist",
+          "\"hit=$hit\"",
+          "$env:GITHUB_OUTPUT"
+        ],
+        "reason": "A protected-host cache hit is only the reviewed archive when the record matches this source commit and tree and the Windows target, and the restore goes through the archive store into the exact output directory; the fragments pin those checks and the recorded hit output."
+      },
+      "windows_vulkan_candidate_cache_miss": {
+        "kind": "require",
+        "file": "windows-vulkan-proof.yml",
+        "job": "packaged-vulkan",
+        "step": "Download, authenticate, and admit candidate archive on miss",
+        "fragments": [
+          "actions/artifacts/$env:ARTIFACT_ID/zip",
+          "--continue-at -",
+          "--max-time 120",
+          "$actualSize -ne [long]$env:EXPECTED_SIZE",
+          "$actualDigest -ne $env:EXPECTED_SHA256",
+          "extract-candidate-actions-artifact.py",
+          "candidate-archive-store.mjs admit",
+          "--store-root $store",
+          "--output-dir target/release-dist"
+        ],
+        "reason": "A cache miss may transfer the large Actions artifact only through the resumable bounded download, must prove the outer size and digest before extraction, and must admit the archive through the store into the exact output directory; the fragments pin that authenticated admission chain."
+      },
+      "windows_vulkan_calibration_producer_authentication": {
+        "kind": "require",
+        "file": "windows-vulkan-proof.yml",
+        "job": "packaged-vulkan",
+        "step": "Authenticate calibration bundle producer",
+        "fragments": [
+          "actions/runs/",
+          ".github/workflows/packaged-platform-pr.yml",
+          "workflow_dispatch",
+          "success",
+          "embedding-calibration-bundle-",
+          "artifacts?per_page=100",
+          "expired"
+        ],
+        "reason": "A calibration bundle is trusted only when its producer run is the frozen-candidate coordinator's dispatched, successful run and the bundle artifact is the unexpired one it named; the fragments pin the producer-run lookup, the coordinator path, the dispatch event, the success conclusion, the bundle name prefix, the artifact listing, and the expiry check."
+      },
+      "windows_vulkan_protected_runtime_proof": {
+        "kind": "require",
+        "file": "windows-vulkan-proof.yml",
+        "job": "packaged-vulkan",
+        "step": "Prove protected Windows Vulkan runtime",
+        "fragments": [
+          "--engine-policy accelerated",
+          "--expected-backend Vulkan",
+          "--offline",
+          "--proof-tier protected_hardware",
+          "--qualification-matrix-cell protected_windows_x64_vulkan",
+          "--calibration-producer-run-id",
+          "--calibration-producer-artifact",
+          "--server-behavior-only"
+        ],
+        "reason": "The protected Windows Vulkan proof must run the accelerated offline harness against the protected matrix cell with the calibration producer bound and the server-behavior scope explicit; each fragment pins one flag of that invocation."
+      },
+      "windows_vulkan_candidate_staging": {
+        "kind": "require",
+        "file": "windows-vulkan-proof.yml",
+        "job": "packaged-vulkan",
+        "step": "Stage isolated candidate-managed Windows install",
+        "fragments": [
+          "--prepare-candidate-installed-proof",
+          "--candidate-plugin-root-output",
+          "--candidate-plugin-data-output",
+          "--installed-plugin-attestation-output",
+          "--candidate-producer-workflow-path",
+          "gh api",
+          "$run.head_repository.full_name",
+          "$run.path",
+          "$run.head_sha",
+          "$run.run_attempt",
+          "$env:CANDIDATE_PRODUCER_WORKFLOW_PATH",
+          "[IO.Path]::GetPathRoot($env:GITHUB_WORKSPACE)",
+          "cs-ci-",
+          "Substring(0, 12)",
+          "[IO.Path]::GetFullPath",
+          "$env:GITHUB_WORKSPACE",
+          "CODESTORY_CANDIDATE_WINDOWS_ROOT="
+        ],
+        "reason": "Candidate-managed staging must go through the harness staging flags, authenticate the producer run by repository, path, head SHA, and attempt, and land in a short isolated root on the workspace drive outside the workspace tree; the fragments pin that staging chain and the exported root."
+      },
+      "windows_vulkan_candidate_installed_proof": {
+        "kind": "require",
+        "file": "windows-vulkan-proof.yml",
+        "job": "packaged-vulkan",
+        "step": "Prove candidate-installed Windows Vulkan runtime",
+        "fragments": [
+          "--proof-tier installed_runtime",
+          "--engine-policy accelerated",
+          "--expected-backend Vulkan",
+          "--installed-plugin-attestation",
+          "--installed-plugin-data",
+          "--candidate-producer-workflow-path",
+          "$env:CANDIDATE_PRODUCER_WORKFLOW_PATH",
+          "--server-behavior-only",
+          "--expected-source-sha",
+          "--expected-source-tree",
+          "$env:CODESTORY_CANDIDATE_WINDOWS_ROOT",
+          "$env:TEMP = $proofTemp",
+          "$env:TMP = $proofTemp",
+          "$env:TMPDIR = $proofTemp"
+        ],
+        "reason": "The candidate-installed proof must run the accelerated Vulkan harness at the installed-runtime tier against the staged install with the producer path, server-behavior scope, and expected source identity bound, and must redirect every temp root into the proof's own directory; each fragment pins one of those conjuncts."
+      },
+      "windows_vulkan_release_cell": {
+        "kind": "require",
+        "file": "windows-vulkan-proof.yml",
+        "job": "packaged-vulkan",
+        "step": "Emit authenticated Vulkan release cell",
+        "fragments": [
+          "codestory-release-cell-manifest.mjs produce",
+          "accelerator_execution:windows-x64-vulkan",
+          "--producer-job packaged-vulkan",
+          "--expected-sha \"$INPUT_REF\""
+        ],
+        "reason": "The Vulkan release cell must be produced by the manifest tool, name the accelerator-execution Windows cell and this producer job, and bind the caller's expected SHA; each fragment pins one identity conjunct."
+      },
+      "windows_vulkan_candidate_installed_cell": {
+        "kind": "require",
+        "file": "windows-vulkan-proof.yml",
+        "job": "packaged-vulkan",
+        "step": "Emit authenticated candidate-installed Windows release cell",
+        "fragments": [
+          "candidate_installed_behavior:windows-x64",
+          "--producer-job packaged-vulkan",
+          "candidate_managed_plugin",
+          "--expected-sha \"$INPUT_REF\""
+        ],
+        "reason": "The candidate-installed Windows cell must name its cell, this producer job, the candidate-managed plugin claim, and the caller's expected SHA; each fragment pins one identity conjunct."
+      },
+      "windows_vulkan_retrieval_readiness_cell": {
+        "kind": "require",
+        "file": "windows-vulkan-proof.yml",
+        "job": "packaged-vulkan",
+        "step": "Emit authenticated Windows retrieval-readiness release cell",
+        "fragments": [
+          "retrieval_readiness:windows-x64",
+          "--producer-job packaged-vulkan",
+          "--expected-sha \"$INPUT_REF\""
+        ],
+        "reason": "The Windows retrieval-readiness cell must name its cell, this producer job, and the caller's expected SHA; each fragment pins one identity conjunct."
+      },
+      "windows_vulkan_release_cell_no_calibration": {
+        "kind": "forbid",
+        "file": "windows-vulkan-proof.yml",
+        "job": "packaged-vulkan",
+        "step": "Emit authenticated Vulkan release cell",
+        "fragments": [
+          "calibration"
+        ],
+        "reason": "The Vulkan release cell is a qualification artifact; the fragment forbids any calibration reference so calibration evidence cannot leak into the release chain."
+      },
+      "windows_vulkan_candidate_installed_cell_no_calibration": {
+        "kind": "forbid",
+        "file": "windows-vulkan-proof.yml",
+        "job": "packaged-vulkan",
+        "step": "Emit authenticated candidate-installed Windows release cell",
+        "fragments": [
+          "calibration"
+        ],
+        "reason": "The candidate-installed Windows cell must stay a runtime-behavior artifact; the fragment forbids any calibration reference so the candidate lane cannot smuggle calibration claims."
+      },
+      "linux_vulkan_route_upstream_package": {
+        "kind": "require",
+        "file": "linux-vulkan-proof.yml",
+        "job": "route",
+        "step": "Require an upstream package for standalone protected proof",
+        "fragments": [
+          "if [ \"$EVENT_NAME\" = workflow_dispatch ] && [ \"$CONSTANT_CALIBRATION_MODE\" != true ]; then",
+          "test -n \"$PACKAGE_RUN_ID\""
+        ],
+        "reason": "A standalone dispatch without an upstream package would rebuild the candidate on the protected host; the fragments pin the dispatch-mode test and the package-run requirement so standalone proofs always consume a prior package."
+      },
+      "linux_vulkan_host_evidence": {
+        "kind": "require",
+        "file": "linux-vulkan-proof.yml",
+        "job": "packaged-vulkan",
+        "step": "Capture Linux Vulkan host evidence",
+        "fragments": [
+          "uname -m",
+          "vulkaninfo --summary",
+          "test \"$(uname -m)\" = x86_64"
+        ],
+        "reason": "Host evidence must prove the machine is the x86_64 Vulkan host the claim names; the fragments pin the architecture capture, the Vulkan summary, and the architecture test."
+      },
+      "linux_vulkan_validate_candidate_installed_mode": {
+        "kind": "require",
+        "file": "linux-vulkan-proof.yml",
+        "job": "packaged-vulkan",
+        "step": "Validate candidate-installed mode",
+        "fragments": [
+          "test \"$SERVER_BEHAVIOR_ONLY\" = true"
+        ],
+        "reason": "Candidate-installed mode on the Linux host is only sound as a server-behavior claim; the fragment pins the mode test so the validation cannot widen the claim scope."
+      },
+      "linux_vulkan_candidate_cache_restore": {
+        "kind": "require",
+        "file": "linux-vulkan-proof.yml",
+        "job": "packaged-vulkan",
+        "step": "Restore exact candidate archive from protected host",
+        "fragments": [
+          "--arg repository \"$GITHUB_REPOSITORY\"",
+          "--arg source_sha \"$(git rev-parse HEAD)\"",
+          "--arg source_tree \"$(git rev-parse 'HEAD^{tree}')\"",
+          "--arg target linux-x64",
+          "$RUNNER_TOOL_CACHE/codestory/candidate-archives",
+          "candidate-archive-store.mjs restore",
+          "--record \"$record\"",
+          "--output-dir target/release-dist",
+          "echo \"hit=$hit\" >> \"$GITHUB_OUTPUT\""
+        ],
+        "reason": "A protected-host cache hit is only the reviewed archive when the record binds this repository, source commit and tree, and the Linux target, and the restore goes through the archive store into the exact output directory; the fragments pin those bindings and the recorded hit output."
+      },
+      "linux_vulkan_candidate_cache_miss": {
+        "kind": "require",
+        "file": "linux-vulkan-proof.yml",
+        "job": "packaged-vulkan",
+        "step": "Download, authenticate, and admit candidate archive on miss",
+        "fragments": [
+          "actions/artifacts/$ARTIFACT_ID/zip",
+          "--continue-at -",
+          "--max-time 120",
+          "test \"$actual_size\" = \"$EXPECTED_SIZE\"",
+          "test \"$actual_digest\" = \"$EXPECTED_SHA256\"",
+          "extract-candidate-actions-artifact.py",
+          "candidate-archive-store.mjs admit",
+          "--store-root \"$RUNNER_TOOL_CACHE/codestory/candidate-archives\"",
+          "--output-dir target/release-dist"
+        ],
+        "reason": "A cache miss may transfer the large Actions artifact only through the resumable bounded download, must prove the outer size and digest before extraction, and must admit the archive through the store into the exact output directory; the fragments pin that authenticated admission chain."
+      },
+      "linux_vulkan_calibration_producer_authentication": {
+        "kind": "require",
+        "file": "linux-vulkan-proof.yml",
+        "job": "packaged-vulkan",
+        "step": "Authenticate calibration bundle producer",
+        "fragments": [
+          "actions/runs/",
+          ".github/workflows/packaged-platform-pr.yml",
+          "workflow_dispatch",
+          "success",
+          "embedding-calibration-bundle-",
+          "artifacts?per_page=100",
+          "expired"
+        ],
+        "reason": "A calibration bundle is trusted only when its producer run is the frozen-candidate coordinator's dispatched, successful run and the bundle artifact is the unexpired one it named; the fragments pin the producer-run lookup, the coordinator path, the dispatch event, the success conclusion, the bundle name prefix, the artifact listing, and the expiry check."
+      },
+      "linux_vulkan_offline_retrieval_proof": {
+        "kind": "require",
+        "file": "linux-vulkan-proof.yml",
+        "job": "packaged-vulkan",
+        "step": "Prove offline Linux Vulkan retrieval",
+        "fragments": [
+          "--engine-policy accelerated",
+          "--expected-backend Vulkan",
+          "--offline",
+          "--proof-tier protected_hardware",
+          "--qualification-matrix-cell protected_linux_x64_vulkan",
+          "--calibration-producer-run-id",
+          "--calibration-producer-artifact",
+          "--server-behavior-only"
+        ],
+        "reason": "The offline Linux Vulkan proof must run the accelerated offline harness against the protected matrix cell with the calibration producer bound and the server-behavior scope explicit; each fragment pins one flag of that invocation."
+      },
+      "linux_vulkan_candidate_staging": {
+        "kind": "require",
+        "file": "linux-vulkan-proof.yml",
+        "job": "packaged-vulkan",
+        "step": "Stage isolated candidate-managed Linux install",
+        "fragments": [
+          "--prepare-candidate-installed-proof",
+          "--candidate-plugin-root-output",
+          "--candidate-plugin-data-output",
+          "--installed-plugin-attestation-output",
+          "--candidate-producer-workflow-path",
+          "gh api",
+          "$RUNNER_TEMP/codestory-candidate-installed-linux.",
+          "CODESTORY_CANDIDATE_LINUX_ROOT="
+        ],
+        "reason": "Candidate-managed staging must go through the harness staging flags, authenticate the producer run, and land in an isolated runner-temp root; the fragments pin that staging chain and the exported root."
+      },
+      "linux_vulkan_candidate_installed_proof": {
+        "kind": "require",
+        "file": "linux-vulkan-proof.yml",
+        "job": "packaged-vulkan",
+        "step": "Prove candidate-installed Linux Vulkan runtime",
+        "fragments": [
+          "--engine-policy accelerated",
+          "--expected-backend Vulkan",
+          "--proof-tier installed_runtime",
+          "--installed-plugin-attestation",
+          "--installed-plugin-data",
+          "--server-behavior-only"
+        ],
+        "reason": "The candidate-installed proof must run the accelerated Vulkan harness at the installed-runtime tier against the staged plugin attestation and data with the server-behavior scope explicit; each fragment pins one of those conjuncts."
+      },
+      "linux_vulkan_candidate_installed_proof_scope": {
+        "kind": "forbid",
+        "file": "linux-vulkan-proof.yml",
+        "job": "packaged-vulkan",
+        "step": "Prove candidate-installed Linux Vulkan runtime",
+        "fragments": [
+          "calibration",
+          "--ground-only",
+          "--engine-policy cpu_explicit"
+        ],
+        "reason": "The candidate-installed lane is a bounded accelerated runtime proof; the fragments forbid calibration, ground-only retrieval, and the explicit CPU engine so the lane cannot quietly become a weaker or different claim."
+      },
+      "linux_vulkan_release_cells": {
+        "kind": "require",
+        "file": "linux-vulkan-proof.yml",
+        "job": "packaged-vulkan",
+        "step": "Emit authenticated Linux Vulkan release cells",
+        "fragments": [
+          "accelerator_execution:linux-x64-vulkan",
+          "retrieval_readiness:linux-x64",
+          "candidate_installed_behavior:linux-x64",
+          "--producer-job packaged-vulkan",
+          "--expected-sha \"$INPUT_REF\""
+        ],
+        "reason": "The single Linux cell step must name all three Linux cells and this producer job and bind the caller's expected SHA; each fragment pins one identity conjunct."
+      },
+      "linux_vulkan_release_cells_no_calibration": {
+        "kind": "forbid",
+        "file": "linux-vulkan-proof.yml",
+        "job": "packaged-vulkan",
+        "step": "Emit authenticated Linux Vulkan release cells",
+        "fragments": [
+          "calibration"
+        ],
+        "reason": "The Linux release cells are qualification artifacts; the fragment forbids any calibration reference so calibration evidence cannot leak into the release chain."
+      },
+      "linux_vulkan_optional_calibration_embedded_model": {
+        "kind": "require",
+        "file": "linux-vulkan-proof.yml",
+        "job": "optional-constant-calibration",
+        "step": "Prepare checksum-pinned embedded model",
+        "fragments": [
+          "node scripts/prepare-embedded-model.mjs",
+          "--cache-root \"$RUNNER_TOOL_CACHE/codestory/model-material\""
+        ],
+        "reason": "Model material reaches the optional calibration job only through the checksum-pinned preparation script and the runner tool cache root; the fragments pin that invocation and its cache root."
+      },
+      "linux_vulkan_optional_calibration_collector": {
+        "kind": "require",
+        "file": "linux-vulkan-proof.yml",
+        "job": "optional-constant-calibration",
+        "step": "Collect optional Linux Vulkan constant calibration",
+        "fragments": [
+          "test \"$CONSTANT_CALIBRATION_MODE\" = true",
+          "--engine-policy accelerated",
+          "--expected-backend Vulkan",
+          "--proof-tier calibration",
+          "--qualification-matrix-cell protected_linux_x64_vulkan",
+          "--collect-constant-calibration",
+          "--constant-calibration-output-dir target/calibration-runs/linux-vulkan",
+          "--qualification-driver target/release/codestory_embedding_constant_calibration",
+          "--out-dir target/calibration-proof/linux-vulkan"
+        ],
+        "reason": "Optional calibration must gate on its explicit mode and collect constants through the dedicated collector with the accelerated Vulkan engine on the protected matrix cell, writing runs and proof to the reviewed directories; each fragment pins one flag of that single collector invocation."
       }
     },
     "structural_pins": {
@@ -2368,6 +3024,87 @@
         "file": "source-proof.yml",
         "job": "windows-native-contracts",
         "reason": "The Windows-native contracts job is the only place the path-identity and native-staging tests run on a real Windows toolchain before merge. Its existence is pinned here so the job cannot be renamed or deleted by a workflow edit alone; the graph-owned step fragments and the checker's shape rules then constrain what the surviving job must run."
+      },
+      "auto_release_detect_version_job": {
+        "kind": "job",
+        "file": "auto-release.yml",
+        "job": "detect-version",
+        "reason": "Version detection is the job that decides whether a main push is a release at all. Its existence is pinned here so the job cannot be renamed or deleted by a workflow edit alone; the checker's shape rules then constrain what the surviving job must not do."
+      },
+      "auto_release_release_job": {
+        "kind": "job",
+        "file": "auto-release.yml",
+        "job": "release",
+        "reason": "The release job is the one trusted caller of the reusable release workflow on main. Its existence is pinned here so the job cannot be renamed or deleted by a workflow edit alone; the graph-owned needs edge and permission grants then constrain how the surviving job calls it."
+      },
+      "auto_release_release_needs_detect_version": {
+        "kind": "needs",
+        "file": "auto-release.yml",
+        "job": "release",
+        "needs": [
+          "detect-version"
+        ],
+        "reason": "The trusted main caller may invoke the release workflow only after version detection has decided a release is due, and nothing else may gate it - an added dependency would let another job influence publication and a dropped one would release undetected versions. The edge is pinned here so it cannot change by a workflow edit alone."
+      },
+      "auto_release_release_contents_write": {
+        "kind": "job_permission",
+        "file": "auto-release.yml",
+        "job": "release",
+        "scope": "contents",
+        "access": "write",
+        "reason": "The release caller publishes tags and release assets, which requires exactly contents write on the caller side; the grant is pinned here so it cannot silently widen or drop by a workflow edit alone."
+      },
+      "auto_release_release_actions_write": {
+        "kind": "job_permission",
+        "file": "auto-release.yml",
+        "job": "release",
+        "scope": "actions",
+        "access": "write",
+        "reason": "Superseded-run cancellation is an Actions-surface write, so the caller must grant actions write; the grant is pinned here so it cannot silently widen or drop by a workflow edit alone."
+      },
+      "auto_release_release_pull_requests_read": {
+        "kind": "job_permission",
+        "file": "auto-release.yml",
+        "job": "release",
+        "scope": "pull-requests",
+        "access": "read",
+        "reason": "The exact source proof reads pull-request metadata to authenticate the head it releases, which requires exactly pull-requests read from the caller; the grant is pinned here so it cannot silently widen or drop by a workflow edit alone."
+      },
+      "macos_metal_packaged_metal_job": {
+        "kind": "job",
+        "file": "macos-metal-proof.yml",
+        "job": "packaged-metal",
+        "reason": "The packaged-metal job is the only lane that proves accelerated execution on protected Apple Silicon. Its existence is pinned here so the job cannot be renamed or deleted by a workflow edit alone; the graph-owned step fragments and the checker's shape rules then constrain what the surviving job must run."
+      },
+      "windows_vulkan_packaged_vulkan_job": {
+        "kind": "job",
+        "file": "windows-vulkan-proof.yml",
+        "job": "packaged-vulkan",
+        "reason": "The packaged-vulkan job is the only lane that proves accelerated execution on the protected Windows Vulkan host. Its existence is pinned here so the job cannot be renamed or deleted by a workflow edit alone; the graph-owned step fragments and the checker's shape rules then constrain what the surviving job must run."
+      },
+      "linux_vulkan_route_job": {
+        "kind": "job",
+        "file": "linux-vulkan-proof.yml",
+        "job": "route",
+        "reason": "The route job is the bounded hosted gate that validates a standalone dispatch before anything reaches the protected Linux host. Its existence is pinned here so the job cannot be renamed or deleted by a workflow edit alone; the graph-owned step fragments then constrain what the surviving job must run."
+      },
+      "linux_vulkan_packaged_vulkan_job": {
+        "kind": "job",
+        "file": "linux-vulkan-proof.yml",
+        "job": "packaged-vulkan",
+        "reason": "The packaged-vulkan job is the only lane that proves accelerated execution on the protected Linux Vulkan host. Its existence is pinned here so the job cannot be renamed or deleted by a workflow edit alone; the graph-owned step fragments and the checker's shape rules then constrain what the surviving job must run."
+      },
+      "linux_vulkan_optional_constant_calibration_job": {
+        "kind": "job",
+        "file": "linux-vulkan-proof.yml",
+        "job": "optional-constant-calibration",
+        "reason": "Optional Linux constant calibration runs as its own coordinator-gated job so calibration can never share a lane with release proof. Its existence is pinned here so the job cannot be renamed or deleted by a workflow edit alone; the graph-owned step fragments and the checker's shape rules then constrain what the surviving job must run."
+      },
+      "main_branch_source_guard_enforce_source_branch_job": {
+        "kind": "job",
+        "file": "main-branch-source-guard.yml",
+        "job": "enforce-source-branch",
+        "reason": "The source-branch guard is the only check standing between an arbitrary branch and a main merge. Its existence is pinned here so the job cannot be renamed or deleted by a workflow edit alone; the checker's identity and branch rules then constrain what the surviving job must compare."
       }
     },
     "constant_mirrors": {

--- a/scripts/codestory-release-claims.mjs
+++ b/scripts/codestory-release-claims.mjs
@@ -146,11 +146,55 @@ const STEP_FRAGMENT_CONTRACTS = new Map([
   ["source_proof_full_gate_workspace_tests", { kind: "require" }],
   ["source_proof_full_gate_clippy", { kind: "require" }],
   ["source_proof_full_gate_release_cell", { kind: "require" }],
+  ["macos_metal_validate_candidate_installed_mode", { kind: "require" }],
+  ["macos_metal_embedded_model", { kind: "require" }],
+  ["macos_metal_host_evidence", { kind: "require" }],
+  ["macos_metal_candidate_authentication", { kind: "require" }],
+  ["macos_metal_candidate_cache_restore", { kind: "require" }],
+  ["macos_metal_candidate_cache_miss", { kind: "require" }],
+  ["macos_metal_calibration_producer_authentication", { kind: "require" }],
+  ["macos_metal_constant_calibration_runs", { kind: "require" }],
+  ["macos_metal_protected_runtime_proof", { kind: "require" }],
+  ["macos_metal_candidate_staging", { kind: "require" }],
+  ["macos_metal_candidate_installed_proof", { kind: "require" }],
+  ["macos_metal_release_cell", { kind: "require" }],
+  ["macos_metal_retrieval_readiness_cell", { kind: "require" }],
+  ["macos_metal_candidate_installed_cell", { kind: "require" }],
+  ["macos_metal_release_cell_no_calibration", { kind: "forbid" }],
+  ["macos_metal_candidate_installed_cell_no_calibration", { kind: "forbid" }],
+  ["windows_vulkan_validate_candidate_installed_mode", { kind: "require" }],
+  ["windows_vulkan_source_build_tools", { kind: "require" }],
+  ["windows_vulkan_embedded_model", { kind: "require" }],
+  ["windows_vulkan_candidate_cache_restore", { kind: "require" }],
+  ["windows_vulkan_candidate_cache_miss", { kind: "require" }],
+  ["windows_vulkan_calibration_producer_authentication", { kind: "require" }],
+  ["windows_vulkan_protected_runtime_proof", { kind: "require" }],
+  ["windows_vulkan_candidate_staging", { kind: "require" }],
+  ["windows_vulkan_candidate_installed_proof", { kind: "require" }],
+  ["windows_vulkan_release_cell", { kind: "require" }],
+  ["windows_vulkan_candidate_installed_cell", { kind: "require" }],
+  ["windows_vulkan_retrieval_readiness_cell", { kind: "require" }],
+  ["windows_vulkan_release_cell_no_calibration", { kind: "forbid" }],
+  ["windows_vulkan_candidate_installed_cell_no_calibration", { kind: "forbid" }],
+  ["linux_vulkan_route_upstream_package", { kind: "require" }],
+  ["linux_vulkan_host_evidence", { kind: "require" }],
+  ["linux_vulkan_validate_candidate_installed_mode", { kind: "require" }],
+  ["linux_vulkan_candidate_cache_restore", { kind: "require" }],
+  ["linux_vulkan_candidate_cache_miss", { kind: "require" }],
+  ["linux_vulkan_calibration_producer_authentication", { kind: "require" }],
+  ["linux_vulkan_offline_retrieval_proof", { kind: "require" }],
+  ["linux_vulkan_candidate_staging", { kind: "require" }],
+  ["linux_vulkan_candidate_installed_proof", { kind: "require" }],
+  ["linux_vulkan_candidate_installed_proof_scope", { kind: "forbid" }],
+  ["linux_vulkan_release_cells", { kind: "require" }],
+  ["linux_vulkan_release_cells_no_calibration", { kind: "forbid" }],
+  ["linux_vulkan_optional_calibration_embedded_model", { kind: "require" }],
+  ["linux_vulkan_optional_calibration_collector", { kind: "require" }],
 ]);
 // The graph owns every structural-pin rule instance (job existence, needs edges,
-// and permission scopes) for workflow families migrated off inline requireJob,
-// needs, and permission checks; the checker owns only those three predicates and
-// their message shapes.
+// and workflow- or job-scoped permission grants) for workflow families migrated
+// off inline requireJob, needs, and permission checks; the checker owns only those
+// predicates and their message shapes.
 // Membership is exact and fail-closed: a graph that drops, renames, or invents a
 // structural pin must not load, so a rule instance cannot disappear by data edit.
 // Kind names the predicate a row binds.
@@ -169,6 +213,18 @@ const STRUCTURAL_PIN_CONTRACTS = new Map([
   ["source_proof_full_source_gate_needs_resolve", { kind: "needs" }],
   ["source_proof_retrieval_generalization_job", { kind: "job" }],
   ["source_proof_windows_native_contracts_job", { kind: "job" }],
+  ["auto_release_detect_version_job", { kind: "job" }],
+  ["auto_release_release_job", { kind: "job" }],
+  ["auto_release_release_needs_detect_version", { kind: "needs" }],
+  ["auto_release_release_contents_write", { kind: "job_permission" }],
+  ["auto_release_release_actions_write", { kind: "job_permission" }],
+  ["auto_release_release_pull_requests_read", { kind: "job_permission" }],
+  ["macos_metal_packaged_metal_job", { kind: "job" }],
+  ["windows_vulkan_packaged_vulkan_job", { kind: "job" }],
+  ["linux_vulkan_route_job", { kind: "job" }],
+  ["linux_vulkan_packaged_vulkan_job", { kind: "job" }],
+  ["linux_vulkan_optional_constant_calibration_job", { kind: "job" }],
+  ["main_branch_source_guard_enforce_source_branch_job", { kind: "job" }],
 ]);
 // The graph owns every cross-file constant-mirror rule instance (a repository file
 // that must repeat a reviewed constant verbatim) for families migrated off inline
@@ -988,7 +1044,9 @@ function validateStructuralPins(policy) {
       ? ["kind", "file", "job", "reason"]
       : contract.kind === "needs"
         ? ["kind", "file", "job", "needs", "reason"]
-        : ["kind", "file", "scope", "access", "reason"];
+        : contract.kind === "job_permission"
+          ? ["kind", "file", "job", "scope", "access", "reason"]
+          : ["kind", "file", "scope", "access", "reason"];
     if (
       JSON.stringify([...Object.keys(row)].sort())
         !== JSON.stringify([...expectedKeys].sort())
@@ -1005,6 +1063,9 @@ function validateStructuralPins(policy) {
       nonEmptyText(row.job, `${label}.job`);
       stringArray(row.needs, `${label}.needs`, { nonEmpty: true });
     } else {
+      if (contract.kind === "job_permission") {
+        nonEmptyText(row.job, `${label}.job`);
+      }
       nonEmptyText(row.scope, `${label}.scope`);
       if (row.access !== "read" && row.access !== "write") {
         fail(`${label}.access must be read or write`);

--- a/scripts/tests/codestory-release-claims.test.mjs
+++ b/scripts/tests/codestory-release-claims.test.mjs
@@ -715,7 +715,7 @@ test("pinned programs are an exact fail-closed membership with graph-owned diges
 
 test("step fragments are an exact fail-closed membership with graph-owned rule data", () => {
   const rules = graph.workflow_policy.step_fragments;
-  assert.equal(Object.keys(rules).length, 35);
+  assert.equal(Object.keys(rules).length, 79);
   for (const row of Object.values(rules)) {
     assert.ok(row.kind === "require" || row.kind === "forbid");
     assert.ok(row.fragments.length > 0);
@@ -756,6 +756,16 @@ test("step fragments are an exact fail-closed membership with graph-owned rule d
     [draft => {
       draft.workflow_policy.step_fragments.source_proof_full_gate_workspace_tests.fragments = [];
     }, /source_proof_full_gate_workspace_tests\.fragments must be a non-empty array/u],
+    [draft => {
+      delete draft.workflow_policy.step_fragments.macos_metal_protected_runtime_proof;
+    }, /step_fragments must declare macos_metal_protected_runtime_proof/u],
+    [draft => {
+      draft.workflow_policy.step_fragments.linux_vulkan_release_cells_no_calibration.kind =
+        "require";
+    }, /linux_vulkan_release_cells_no_calibration\.kind must be forbid/u],
+    [draft => {
+      draft.workflow_policy.step_fragments.windows_vulkan_candidate_installed_proof.fragments = [];
+    }, /windows_vulkan_candidate_installed_proof\.fragments must be a non-empty array/u],
   ];
   for (const [mutate, expected] of mutations) {
     const draft = structuredClone(graph);
@@ -766,17 +776,25 @@ test("step fragments are an exact fail-closed membership with graph-owned rule d
 
 test("structural pins are an exact fail-closed membership with graph-owned rule data", () => {
   const pins = graph.workflow_policy.structural_pins;
-  assert.equal(Object.keys(pins).length, 14);
+  assert.equal(Object.keys(pins).length, 26);
   for (const row of Object.values(pins)) {
-    assert.ok(row.kind === "job" || row.kind === "permission" || row.kind === "needs");
-    if (row.kind === "permission") {
+    assert.ok(
+      row.kind === "job" || row.kind === "permission" || row.kind === "needs"
+      || row.kind === "job_permission",
+    );
+    if (row.kind === "permission" || row.kind === "job_permission") {
       assert.ok(row.access === "read" || row.access === "write");
+    }
+    if (row.kind === "job_permission") {
+      assert.ok(typeof row.job === "string" && row.job.length > 0);
     }
     if (row.kind === "needs") {
       assert.ok(row.needs.length > 0);
     }
   }
   assert.equal(pins.source_proof_full_source_gate_needs_resolve.kind, "needs");
+  assert.equal(pins.auto_release_release_needs_detect_version.kind, "needs");
+  assert.equal(pins.auto_release_release_contents_write.kind, "job_permission");
   const mutations = [
     [draft => {
       delete draft.workflow_policy.structural_pins.close_dev_issues_job;
@@ -827,6 +845,19 @@ test("structural pins are an exact fail-closed membership with graph-owned rule 
     [draft => {
       draft.workflow_policy.structural_pins.source_proof_full_source_gate_needs_resolve.needs = [];
     }, /source_proof_full_source_gate_needs_resolve\.needs must be a non-empty array/u],
+    [draft => {
+      delete draft.workflow_policy.structural_pins.macos_metal_packaged_metal_job;
+    }, /structural_pins must declare macos_metal_packaged_metal_job/u],
+    [draft => {
+      draft.workflow_policy.structural_pins.auto_release_release_contents_write.kind =
+        "permission";
+    }, /auto_release_release_contents_write\.kind must be job_permission/u],
+    [draft => {
+      delete draft.workflow_policy.structural_pins.auto_release_release_contents_write.job;
+    }, /auto_release_release_contents_write must carry exactly kind, file, job, scope, access, reason/u],
+    [draft => {
+      draft.workflow_policy.structural_pins.auto_release_release_actions_write.access = "admin";
+    }, /auto_release_release_actions_write\.access must be read or write/u],
   ];
   for (const [mutate, expected] of mutations) {
     const draft = structuredClone(graph);

--- a/scripts/tests/fixtures/release-claims/positive.json
+++ b/scripts/tests/fixtures/release-claims/positive.json
@@ -17,7 +17,7 @@
       "type": "source_behavior",
       "tier": "source",
       "status": "pass",
-      "graph_sha256": "74556a0ce3f810108f4ccb83c81d94060e77e807ec965a1987e1f405325d1257",
+      "graph_sha256": "08c48aadee5be419653a2d9aae2d90a7c9680273be84fa97013291e5daee23db",
       "observed_at": "2026-07-16T11:00:00.000Z",
       "expires_at": "2026-07-17T11:00:00.000Z",
       "identity": {


### PR DESCRIPTION
validateRemainingWorkflows wholly migrated where convertible: 44 fragment rows + 12 structural pins (first job_permission kind); the shared calibration-authentication helper seam handled with behavior unchanged; bespoke/computational dispositions documented. Oracle 8,206/0. Policy 1367/0, claims 48/0, evidence-gate 23/0.

Closes #1907
Refs #1670
Refs #1179