### PR TITLE
[v0.17 EV-7b] Add the protected-host real-notifier parity lane

### DIFF
--- a/.github/workflows/notifier-parity.yml
+++ b/.github/workflows/notifier-parity.yml
@@ -1,0 +1,108 @@
+name: EV-7b real-notifier parity
+
+# The final closure proof for issue #1651: the freshness-observer matrices run
+# against each platform's REAL notifier (FSEvents / ReadDirectoryChangesW /
+# WSL inotify) on the protected hosts, proving watcher-driven freshness without
+# per-operation full scans. The push trigger is the bootstrap: dev-only
+# workflows are not dispatchable until they have run once.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Exact source SHA to prove. Defaults to the dispatched branch head.
+        required: false
+        default: ""
+        type: string
+  push:
+    branches:
+      - dev/codestory-next
+    paths:
+      - .github/workflows/notifier-parity.yml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: notifier-parity-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  parity-macos-fsevents:
+    name: Parity macOS FSEvents
+    runs-on: [self-hosted, macOS, ARM64, codestory-metal]
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+      - name: Install pinned Rust
+        shell: bash
+        run: |
+          rustup toolchain install 1.95.0 --profile minimal
+          rustup default 1.95.0
+      - name: Prove real-notifier parity
+        shell: bash
+        run: |
+          set -euo pipefail
+          sw_vers
+          uname -a
+          cargo test --locked -p codestory-workspace --lib filesystem_observer
+          cargo test --locked -p codestory-runtime --lib freshness_observer
+          cargo test --locked -p codestory-runtime --lib affected
+
+  parity-windows-rdcw:
+    name: Parity Windows ReadDirectoryChangesW
+    runs-on: [self-hosted, Windows, X64, codestory-vulkan]
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+      # The self-hosted Windows service account runs under the default Restricted
+      # execution policy, so every run step carries the bypass shell.
+      - name: Install pinned Rust
+        shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
+        run: |
+          rustup toolchain install 1.95.0 --profile minimal
+          rustup default 1.95.0
+      - name: Prove real-notifier parity
+        shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
+        env:
+          CMAKE_GENERATOR: Ninja
+        run: |
+          $ErrorActionPreference = "Stop"
+          cmd /c ver
+          cargo test --locked -p codestory-workspace --lib filesystem_observer
+          if ($LASTEXITCODE -ne 0) { throw "workspace observer parity failed" }
+          cargo test --locked -p codestory-runtime --lib freshness_observer
+          if ($LASTEXITCODE -ne 0) { throw "runtime freshness parity failed" }
+          cargo test --locked -p codestory-runtime --lib affected
+          if ($LASTEXITCODE -ne 0) { throw "runtime affected parity failed" }
+
+  parity-linux-wsl-inotify:
+    name: Parity Linux WSL inotify
+    runs-on: [self-hosted, Linux, X64, codestory-linux-vulkan]
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+      - name: Install pinned Rust
+        shell: bash
+        run: |
+          rustup toolchain install 1.95.0 --profile minimal
+          rustup default 1.95.0
+      - name: Prove real-notifier parity over WSL inotify
+        shell: bash
+        run: |
+          set -euo pipefail
+          uname -a
+          # The WSL claim is load-bearing: prove the Microsoft kernel, and show the
+          # observed roots live on the Linux filesystem, where the observer treats
+          # inotify as the real notifier (only /mnt/<drive> interop mounts refuse).
+          grep -qiE 'microsoft|wsl' /proc/sys/kernel/osrelease
+          df -T /tmp "$PWD"
+          cargo test --locked -p codestory-workspace --lib filesystem_observer
+          cargo test --locked -p codestory-runtime --lib freshness_observer
+          cargo test --locked -p codestory-runtime --lib affected


### PR DESCRIPTION
Adds the dispatchable notifier-parity proof lane for EV-7b: three jobs pinned to the protected hosts (codestory-metal / codestory-vulkan / codestory-linux-vulkan), each capturing host identity and running the three focused suites at the exact head — workspace `filesystem_observer` lib tests (25), runtime `freshness_observer` filter (18), and the `affected` suite (38).

The lane is `workflow_dispatch` with a `ref` input for exact-SHA proofs, plus a push trigger scoped to the workflow file itself: the merge push is the bootstrap run that indexes the workflow so later exact-head dispatches work (dev-only workflows 404 on dispatch until they have run once).

Filters stay focused on `filesystem_observer` / `freshness_observer` / `affected` — deliberately NOT the full runtime `--lib` run, which carries known macOS flake #1853.

Gates run locally: check-workflow-policy.mjs, run-actionlint.mjs, and the literal-ratchet test all pass on this branch.

Closes #1651
Refs #1179

🤖 Generated with [Claude Code](https://claude.com/claude-code)