### PR TITLE
[v0.17 REL-CI W8.2] Refuse prerelease versions at release entrypoints

### DIFF
--- a/.github/scripts/check-codestory-release.py
+++ b/.github/scripts/check-codestory-release.py
@@ -14,6 +14,7 @@ SEMVER_RE = re.compile(
     r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
     r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
 )
+STABLE_RELEASE_RE = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
 
 PLUGIN_MANIFESTS = (
     Path("plugins/codestory/.codex-plugin/plugin.json"),
@@ -107,6 +108,15 @@ def validate_model_producer(root: Path, expected: str) -> None:
 def fail(message: str) -> None:
     print(f"error: {message}", file=sys.stderr)
     raise SystemExit(1)
+
+
+def stable_release_version(value: str) -> str:
+    expected = value.removeprefix("v")
+    if not STABLE_RELEASE_RE.fullmatch(expected):
+        raise ValueError(
+            f"version must be a stable release version like 0.17.0, got {value!r}"
+        )
+    return expected
 
 
 def compare_semver_core(left: str, right: str) -> int:
@@ -221,15 +231,21 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    expected = args.version.removeprefix("v")
-    if not SEMVER_RE.fullmatch(expected):
-        fail(f"version must be strict semver like 0.7.0, got {args.version!r}")
+    try:
+        expected = stable_release_version(args.version)
+    except ValueError as exc:
+        fail(str(exc))
 
     root = Path(args.project_root).resolve()
     cli_manifest = root / "crates" / "codestory-cli" / "Cargo.toml"
     cli_name, cli_version = package_info(cli_manifest)
     if cli_name != "codestory-cli":
         fail(f"{cli_manifest} package.name is {cli_name!r}, expected 'codestory-cli'")
+    if not STABLE_RELEASE_RE.fullmatch(cli_version):
+        fail(
+            f"codestory-cli version surface must be a stable release version like 0.17.0, "
+            f"got {cli_version!r}"
+        )
 
     if args.lane == "plugin":
         try:

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -6602,14 +6602,17 @@ test("marketplace sync keeps dispatch inputs out of script text", async (t) => {
     }, /must run commit_shape='\^\[0-9a-fA-F\]\{7,40\}\$'/u],
     ["the version shape check disappears", workflow => {
       const step = draftStep(workflow.jobs.sync, guard);
-      step.run = step.run.replace("^[0-9]+\\.[0-9]+\\.[0-9]+", "^.+");
+      step.run = step.run.replace(
+        "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)",
+        "^.+",
+      );
     }, /must run version_shape=/u],
     // A prefix fragment cannot see a dropped closing anchor, and an unanchored version regex admits
     // `0.16.3; id`. The pinned fragment carries the anchor, so the truncation is a violation.
     ["the version regex loses its closing anchor", workflow => {
       const step = draftStep(workflow.jobs.sync, guard);
-      step.run = step.run.replace("(-[0-9A-Za-z.]+)?$'", "'");
-    }, /must run version_shape='\^\[0-9\]\+\\\.\[0-9\]\+\\\.\[0-9\]\+\(-\[0-9A-Za-z\.\]\+\)\?\$'/u],
+      step.run = step.run.replace("(0|[1-9][0-9]*)$'", "(0|[1-9][0-9]*)'");
+    }, /must run version_shape=/u],
     // Substring assertions prove a string is present, not that it is consulted. This body satisfies
     // every fragment above -- both anchored regexes, both comparisons, no grep -- and refuses
     // nothing, so only a pin over the whole script can see it.
@@ -7429,6 +7432,9 @@ test("the marketplace dispatch guard refuses whole values, not first lines", asy
     ["an empty commit", { INPUT_COMMIT: "", INPUT_VERSION: version }],
     ["an empty version", { INPUT_COMMIT: commit, INPUT_VERSION: "" }],
     ["a v-prefixed version", { INPUT_COMMIT: commit, INPUT_VERSION: "v0.16.3" }],
+    ["a prerelease version", { INPUT_COMMIT: commit, INPUT_VERSION: "0.16.3-rc.1" }],
+    ["a build version", { INPUT_COMMIT: commit, INPUT_VERSION: "0.16.3+build.1" }],
+    ["a version with a leading zero", { INPUT_COMMIT: commit, INPUT_VERSION: "00.16.3" }],
   ];
   for (const [name, environment] of refused) {
     await t.test(`refuses ${name}`, () => {
@@ -7440,7 +7446,6 @@ test("the marketplace dispatch guard refuses whole values, not first lines", asy
   const admitted = [
     ["an abbreviated sha", { INPUT_COMMIT: "abc1234", INPUT_VERSION: version }],
     ["a full sha", { INPUT_COMMIT: commit, INPUT_VERSION: "1.0.0" }],
-    ["a prerelease version", { INPUT_COMMIT: commit, INPUT_VERSION: "0.16.3-rc.1" }],
     ["an uppercase sha", { INPUT_COMMIT: "ABC1234DEF", INPUT_VERSION: version }],
   ];
   for (const [name, environment] of admitted) {

--- a/.github/scripts/detect-codestory-release.py
+++ b/.github/scripts/detect-codestory-release.py
@@ -12,11 +12,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 
-SEMVER_RE = re.compile(
-    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
-    r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
-    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
-)
+STABLE_RELEASE_RE = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
 SEMVER_PARTS_RE = re.compile(
     r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
     r"(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?"
@@ -133,8 +129,11 @@ def decide_release(
     tag_exists: bool,
     release_exists: bool,
 ) -> ReleaseDecision:
-    if not SEMVER_RE.fullmatch(new_version):
-        raise ValueError(f"codestory-cli version must be strict semver, got {new_version!r}.")
+    if not STABLE_RELEASE_RE.fullmatch(new_version):
+        raise ValueError(
+            "codestory-cli version must be a stable release version like X.Y.Z, "
+            f"got {new_version!r}."
+        )
 
     if tag_exists != release_exists:
         raise ValueError(
@@ -195,6 +194,11 @@ def classify_release_lane(*, cli_version: str, plugin_version: str) -> str:
     the plugin fast lane: the plugin ships alone and runs the already-published CLI named by
     its pin. A plugin behind the CLI is always a synchronization error.
     """
+    for name, version in (("codestory-cli", cli_version), ("plugin", plugin_version)):
+        if not STABLE_RELEASE_RE.fullmatch(version):
+            raise ValueError(
+                f"{name} version must be a stable release version like X.Y.Z, got {version!r}."
+            )
     if plugin_version == cli_version:
         return "native"
     if compare_semver(plugin_version, cli_version) > 0:

--- a/.github/scripts/test-detect-codestory-release.py
+++ b/.github/scripts/test-detect-codestory-release.py
@@ -85,6 +85,17 @@ class AutoReleaseDecisionTest(unittest.TestCase):
                 release_exists=False,
             )
 
+    def test_refuses_prerelease_and_build_versions(self) -> None:
+        for version in ("0.17.0-rc.1", "0.17.0+build.1", "00.17.0"):
+            with self.subTest(version=version):
+                with self.assertRaisesRegex(ValueError, "stable release version"):
+                    detector.decide_release(
+                        old_version="0.16.3",
+                        new_version=version,
+                        tag_exists=False,
+                        release_exists=False,
+                    )
+
 
 class ReleaseLaneTest(unittest.TestCase):
     def test_equal_versions_are_the_native_lane(self) -> None:
@@ -104,8 +115,27 @@ class ReleaseLaneTest(unittest.TestCase):
             detector.classify_release_lane(cli_version="0.16.2", plugin_version="0.16.1")
         self.assertIn("bump-version.mjs", str(caught.exception))
 
+    def test_release_lanes_require_stable_versions(self) -> None:
+        for cli_version, plugin_version in (
+            ("0.17.0-rc.1", "0.17.0-rc.1"),
+            ("0.17.0", "0.17.1-rc.1"),
+        ):
+            with self.subTest(cli_version=cli_version, plugin_version=plugin_version):
+                with self.assertRaisesRegex(ValueError, "stable release version"):
+                    detector.classify_release_lane(
+                        cli_version=cli_version,
+                        plugin_version=plugin_version,
+                    )
+
 
 class ReleaseSynchronizationTest(unittest.TestCase):
+    def test_release_validator_requires_a_stable_version(self) -> None:
+        self.assertEqual(checker.stable_release_version("v0.17.0"), "0.17.0")
+        for version in ("0.17.0-rc.1", "0.17.0+build.1", "00.17.0"):
+            with self.subTest(version=version):
+                with self.assertRaisesRegex(ValueError, "stable release version"):
+                    checker.stable_release_version(version)
+
     def test_refuses_embedded_model_producer_drift(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             contract = Path(directory) / checker.MODEL_CONTRACT

--- a/.github/workflows/marketplace-sync.yml
+++ b/.github/workflows/marketplace-sync.yml
@@ -51,13 +51,13 @@ jobs:
           # per-line test on its first line and carries the rest through untouched. Bash regex has
           # no notion of a line: here ^ and $ are the ends of the value itself.
           commit_shape='^[0-9a-fA-F]{7,40}$'
-          version_shape='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'
+          version_shape='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
           if [[ ! "$INPUT_COMMIT" =~ $commit_shape ]]; then
             echo "::error::commit must be a 7-40 character hexadecimal commit id."
             exit 1
           fi
           if [[ ! "$INPUT_VERSION" =~ $version_shape ]]; then
-            echo "::error::version must be a semantic version without a v prefix."
+            echo "::error::version must be a stable semantic version like 0.17.0 without a v prefix."
             exit 1
           fi
 

--- a/release-claims.json
+++ b/release-claims.json
@@ -1752,7 +1752,7 @@
         "file": "marketplace-sync.yml",
         "job": "sync",
         "step": "Validate the dispatched release coordinates",
-        "sha256": "6380c916a1b3566b4b9d6545b63fbc9c7db12b54fb328b5c89316daae0162d84",
+        "sha256": "3935d34bb0922b6d8489699693f504369068f7590fa2cf4372b6e7945ef6f00f",
         "reason": "check-workflow-policy.test.mjs runs this exact script against hostile dispatch values and proves it exits non-zero, so the digest stands for a rejection that was measured, not merely read."
       },
       "packaged_platform_pr_closeout": {
@@ -1894,7 +1894,7 @@
         "step": "Validate the dispatched release coordinates",
         "fragments": [
           "commit_shape='^[0-9a-fA-F]{7,40}$'",
-          "version_shape='^[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9A-Za-z.]+)?$'",
+          "version_shape='^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$'",
           "if [[ ! \"$INPUT_COMMIT\" =~ $commit_shape ]]; then",
           "if [[ ! \"$INPUT_VERSION\" =~ $version_shape ]]; then"
         ],

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -19,7 +19,7 @@ import { parsePublishedArchiveDigests } from "./lib/pinned-archive-digests.mjs";
 import { workspaceMemberNames } from "./lib/workspace-members.mjs";
 
 const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const SEMVER = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/u;
+const STABLE_RELEASE_VERSION = /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/u;
 
 /// Every codestory-* crate, in workspace order, read from the workspace itself.
 ///
@@ -69,8 +69,8 @@ function parseArguments(argv) {
   }
   if (!values.version) fail("--version is required");
   values.version = values.version.replace(/^v/u, "");
-  if (!SEMVER.test(values.version)) {
-    fail(`--version must be strict semver like 0.17.0, got ${values.version}`);
+  if (!STABLE_RELEASE_VERSION.test(values.version)) {
+    fail(`--version must be a stable release version like 0.17.0, got ${values.version}`);
   }
   if (!new Set(["native", "plugin"]).has(values.lane)) {
     fail(`--lane must be native or plugin, got ${values.lane}`);
@@ -169,7 +169,7 @@ async function publishedArchiveDigests(pin, checksumSource) {
   if (
     !pin ||
     typeof pin.cli_version !== "string" ||
-    !SEMVER.test(pin.cli_version) ||
+    !STABLE_RELEASE_VERSION.test(pin.cli_version) ||
     pin.release_tag !== `v${pin.cli_version}`
   ) {
     fail(`${CLI_VERSION_PIN} does not name a valid published CLI release`);

--- a/scripts/tests/bump-version.test.mjs
+++ b/scripts/tests/bump-version.test.mjs
@@ -244,11 +244,16 @@ test("--check rejects a stale Cargo.lock when every source manifest is current",
   }
 });
 
-test("a bad version is rejected before anything is written", () => {
+test("non-stable versions are rejected before anything is written", () => {
   const root = fixtureRoot("0.16.1");
   try {
-    assert.throws(() => bump(root, ["--version", "0.17"]), /strict semver/u);
-    assert.throws(() => bump(root, ["--version", "not-a-version"]), /strict semver/u);
+    for (const version of ["0.17", "not-a-version", "0.17.0-rc.1", "0.17.0+build.1", "00.17.0"]) {
+      assert.throws(
+        () => bump(root, ["--version", version]),
+        /stable release version/u,
+        `admitted ${version}`,
+      );
+    }
     assert.throws(
       () => bump(root, ["--version", "0.16.2", "--lane", "plugin", "--archive-checksums"]),
       /--archive-checksums requires a value/u,


### PR DESCRIPTION
Closes #1670

## Result

Release tooling now accepts only stable `major.minor.patch` versions. Prerelease, build-metadata, and leading-zero forms fail before version writes, automatic lane selection, release validation, or marketplace recovery checkout/token work. Both native and plugin-only lanes use the same stable boundary.

The marketplace guard remains graph-owned: its required fragment and comment-stripped executable digest move together in `release-claims.json`.

## Verification

- `node --test scripts/tests/bump-version.test.mjs` — 7 passed
- `python .github/scripts/test-detect-codestory-release.py` — 13 passed
- `node scripts/codestory-release-claims.mjs validate --repo .` — passed
- `node .github/scripts/check-workflow-policy.mjs` — passed
- focused marketplace workflow-policy mutations — 48 passed
- `node .github/scripts/run-actionlint.mjs` — passed
- `python .github/scripts/check-codestory-release.py --version 0.16.3` — passed
- `git diff --check origin/dev/codestory-next...HEAD` — passed

The full workflow-policy suite was stopped after the user requested a two-minute terminal bound. Its preceding run completed 1,366/1,369; the only failures were the two stale regex mutation fixtures corrected here, and their focused 48-test lane passes on this exact head.

## Risk

This intentionally removes prerelease/build release inputs. No version surface, release tag, publication, or protected proof was changed or dispatched.