### PR TITLE
[v0.17 REL-CI W8.2] Refresh graph-derived release fixtures

### DIFF
--- a/benchmarks/release-evidence/fixtures/candidate.json
+++ b/benchmarks/release-evidence/fixtures/candidate.json
@@ -62,7 +62,7 @@
   },
   "release_claims": {
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "4a96bbdefe50672b5ceb4ee982377150dae58550d69d01b451fb4c33b0ce9d4e",
+    "graph_sha256": "a6411f2ab0fcb008dc35ebfb6c1951fd39abd2e9aa17dfd594fde5cfc0f88b0d",
     "observed_at": "2026-08-08T19:19:24.395Z",
     "expires_at": "2026-08-09T19:19:24.395Z",
     "requested_claims": [
@@ -85,7 +85,7 @@
         "type": "performance",
         "tier": "live_behavior",
         "status": "measured",
-        "graph_sha256": "4a96bbdefe50672b5ceb4ee982377150dae58550d69d01b451fb4c33b0ce9d4e",
+        "graph_sha256": "a6411f2ab0fcb008dc35ebfb6c1951fd39abd2e9aa17dfd594fde5cfc0f88b0d",
         "observed_at": "2026-08-08T19:19:24.395Z",
         "expires_at": "2026-08-09T19:19:24.395Z",
         "identity": {
@@ -106,7 +106,7 @@
         "type": "answer_quality",
         "tier": "answer_quality",
         "status": "pass",
-        "graph_sha256": "4a96bbdefe50672b5ceb4ee982377150dae58550d69d01b451fb4c33b0ce9d4e",
+        "graph_sha256": "a6411f2ab0fcb008dc35ebfb6c1951fd39abd2e9aa17dfd594fde5cfc0f88b0d",
         "observed_at": "2026-08-08T19:19:24.395Z",
         "expires_at": "2026-08-09T19:19:24.395Z",
         "identity": {

--- a/benchmarks/release-evidence/fixtures/report.json
+++ b/benchmarks/release-evidence/fixtures/report.json
@@ -7,7 +7,7 @@
   "baseline_id": "ci-contract-v1@1111111111111111111111111111111111111111",
   "baseline_sha256": "0bbbe6dd8b4000151edf7b1270959d08e94e08db876e7f2372b25613e0f237c1",
   "candidate_path": "benchmarks/release-evidence/fixtures/candidate.json",
-  "candidate_sha256": "76838924eb88948998e4015cefa7cc7ec88d9898990b7bf7f5dcfb06311105ff",
+  "candidate_sha256": "7a09121cc7a4e9d54b97c16f20c419920e985ff488d2231631936651c726e8df",
   "artifact_paths": [
     {
       "path": "candidate-stats.json",
@@ -26,7 +26,7 @@
       "type": "performance",
       "tier": "live_behavior",
       "status": "pass",
-      "graph_sha256": "4a96bbdefe50672b5ceb4ee982377150dae58550d69d01b451fb4c33b0ce9d4e",
+      "graph_sha256": "a6411f2ab0fcb008dc35ebfb6c1951fd39abd2e9aa17dfd594fde5cfc0f88b0d",
       "observed_at": "2026-08-08T19:19:24.395Z",
       "expires_at": "2026-08-09T19:19:24.395Z",
       "identity": {
@@ -47,7 +47,7 @@
       "type": "answer_quality",
       "tier": "answer_quality",
       "status": "pass",
-      "graph_sha256": "4a96bbdefe50672b5ceb4ee982377150dae58550d69d01b451fb4c33b0ce9d4e",
+      "graph_sha256": "a6411f2ab0fcb008dc35ebfb6c1951fd39abd2e9aa17dfd594fde5cfc0f88b0d",
       "observed_at": "2026-08-08T19:19:24.395Z",
       "expires_at": "2026-08-09T19:19:24.395Z",
       "identity": {
@@ -69,7 +69,7 @@
     "schema": "codestory.release-claim-evaluation/v1",
     "status": "pass",
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "4a96bbdefe50672b5ceb4ee982377150dae58550d69d01b451fb4c33b0ce9d4e",
+    "graph_sha256": "a6411f2ab0fcb008dc35ebfb6c1951fd39abd2e9aa17dfd594fde5cfc0f88b0d",
     "evidence_selection": "all_matching_rows_must_pass",
     "expected_commit": "2222222222222222222222222222222222222222",
     "evaluated_at": "2026-08-08T19:19:24.395Z",

--- a/scripts/tests/fixtures/release-claims/positive.json
+++ b/scripts/tests/fixtures/release-claims/positive.json
@@ -17,7 +17,7 @@
       "type": "source_behavior",
       "tier": "source",
       "status": "pass",
-      "graph_sha256": "4a96bbdefe50672b5ceb4ee982377150dae58550d69d01b451fb4c33b0ce9d4e",
+      "graph_sha256": "a6411f2ab0fcb008dc35ebfb6c1951fd39abd2e9aa17dfd594fde5cfc0f88b0d",
       "observed_at": "2026-07-16T11:00:00.000Z",
       "expires_at": "2026-07-17T11:00:00.000Z",
       "identity": {


### PR DESCRIPTION
Closes #1670

PR #1918 correctly changed the graph-owned stable-version guard, but its hosted plugin-static run exposed the omitted derived graph digest fixtures after merge. This commit refreshes exactly those fixtures and the candidate digest that binds them.

Verification on `19dafad4`:

- exact failed hosted command from PR #1918: 119 passed, 0 failed
- `node scripts/codestory-release-claims.mjs validate --repo .` — passed (`a6411f2a…`)
- `node .github/scripts/check-workflow-policy.mjs` — passed
- `git diff --check` — passed

No release, version, workflow, or product behavior changes here.