### PR TITLE
Release CodeStory 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.17.0
+
 ### Fixed
 
 - Raising the source-file size limit no longer leaves newly admitted files

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-agent"
-version = "0.16.3"
+version = "0.17.0"
 dependencies = [
  "codestory-contracts",
  "serde",
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-bench"
-version = "0.16.3"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.16.3"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.16.3"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -603,7 +603,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.16.3"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-llama-sys"
-version = "0.16.3"
+version = "0.17.0"
 dependencies = [
  "codestory-contracts",
  "crossbeam-channel",
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.16.3"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -683,7 +683,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.16.3"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "codestory-agent",
@@ -709,7 +709,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.16.3"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.16.3"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/benchmarks/release-evidence/fixtures/candidate.json
+++ b/benchmarks/release-evidence/fixtures/candidate.json
@@ -62,9 +62,9 @@
   },
   "release_claims": {
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "a6411f2ab0fcb008dc35ebfb6c1951fd39abd2e9aa17dfd594fde5cfc0f88b0d",
-    "observed_at": "2026-08-08T19:19:24.395Z",
-    "expires_at": "2026-08-09T19:19:24.395Z",
+    "graph_sha256": "e838f43c6ce9ee8000fe1765df9e18eef2756b126769a98e10c750f0d103493b",
+    "observed_at": "2026-08-09T12:50:08.593Z",
+    "expires_at": "2026-08-10T12:50:08.593Z",
     "requested_claims": [
       {
         "id": "performance",
@@ -85,9 +85,9 @@
         "type": "performance",
         "tier": "live_behavior",
         "status": "measured",
-        "graph_sha256": "a6411f2ab0fcb008dc35ebfb6c1951fd39abd2e9aa17dfd594fde5cfc0f88b0d",
-        "observed_at": "2026-08-08T19:19:24.395Z",
-        "expires_at": "2026-08-09T19:19:24.395Z",
+        "graph_sha256": "e838f43c6ce9ee8000fe1765df9e18eef2756b126769a98e10c750f0d103493b",
+        "observed_at": "2026-08-09T12:50:08.593Z",
+        "expires_at": "2026-08-10T12:50:08.593Z",
         "identity": {
           "repository": "TheGreenCedar/CodeStory",
           "commit": "2222222222222222222222222222222222222222",
@@ -106,9 +106,9 @@
         "type": "answer_quality",
         "tier": "answer_quality",
         "status": "pass",
-        "graph_sha256": "a6411f2ab0fcb008dc35ebfb6c1951fd39abd2e9aa17dfd594fde5cfc0f88b0d",
-        "observed_at": "2026-08-08T19:19:24.395Z",
-        "expires_at": "2026-08-09T19:19:24.395Z",
+        "graph_sha256": "e838f43c6ce9ee8000fe1765df9e18eef2756b126769a98e10c750f0d103493b",
+        "observed_at": "2026-08-09T12:50:08.593Z",
+        "expires_at": "2026-08-10T12:50:08.593Z",
         "identity": {
           "repository": "TheGreenCedar/CodeStory",
           "commit": "2222222222222222222222222222222222222222",

--- a/benchmarks/release-evidence/fixtures/report.json
+++ b/benchmarks/release-evidence/fixtures/report.json
@@ -7,7 +7,7 @@
   "baseline_id": "ci-contract-v1@1111111111111111111111111111111111111111",
   "baseline_sha256": "0bbbe6dd8b4000151edf7b1270959d08e94e08db876e7f2372b25613e0f237c1",
   "candidate_path": "benchmarks/release-evidence/fixtures/candidate.json",
-  "candidate_sha256": "7a09121cc7a4e9d54b97c16f20c419920e985ff488d2231631936651c726e8df",
+  "candidate_sha256": "78e4f9457d9f06b0690ba5b68cbd8168204628700dbad14e0297b6997e00930f",
   "artifact_paths": [
     {
       "path": "candidate-stats.json",
@@ -26,9 +26,9 @@
       "type": "performance",
       "tier": "live_behavior",
       "status": "pass",
-      "graph_sha256": "a6411f2ab0fcb008dc35ebfb6c1951fd39abd2e9aa17dfd594fde5cfc0f88b0d",
-      "observed_at": "2026-08-08T19:19:24.395Z",
-      "expires_at": "2026-08-09T19:19:24.395Z",
+      "graph_sha256": "e838f43c6ce9ee8000fe1765df9e18eef2756b126769a98e10c750f0d103493b",
+      "observed_at": "2026-08-09T12:50:08.593Z",
+      "expires_at": "2026-08-10T12:50:08.593Z",
       "identity": {
         "repository": "TheGreenCedar/CodeStory",
         "commit": "2222222222222222222222222222222222222222",
@@ -47,9 +47,9 @@
       "type": "answer_quality",
       "tier": "answer_quality",
       "status": "pass",
-      "graph_sha256": "a6411f2ab0fcb008dc35ebfb6c1951fd39abd2e9aa17dfd594fde5cfc0f88b0d",
-      "observed_at": "2026-08-08T19:19:24.395Z",
-      "expires_at": "2026-08-09T19:19:24.395Z",
+      "graph_sha256": "e838f43c6ce9ee8000fe1765df9e18eef2756b126769a98e10c750f0d103493b",
+      "observed_at": "2026-08-09T12:50:08.593Z",
+      "expires_at": "2026-08-10T12:50:08.593Z",
       "identity": {
         "repository": "TheGreenCedar/CodeStory",
         "commit": "2222222222222222222222222222222222222222",
@@ -69,10 +69,10 @@
     "schema": "codestory.release-claim-evaluation/v1",
     "status": "pass",
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "a6411f2ab0fcb008dc35ebfb6c1951fd39abd2e9aa17dfd594fde5cfc0f88b0d",
+    "graph_sha256": "e838f43c6ce9ee8000fe1765df9e18eef2756b126769a98e10c750f0d103493b",
     "evidence_selection": "all_matching_rows_must_pass",
     "expected_commit": "2222222222222222222222222222222222222222",
-    "evaluated_at": "2026-08-08T19:19:24.395Z",
+    "evaluated_at": "2026-08-09T12:50:08.593Z",
     "claims": [
       {
         "id": "answer_quality",

--- a/crates/codestory-agent/Cargo.toml
+++ b/crates/codestory-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-agent"
-version = "0.16.3"
+version = "0.17.0"
 edition = "2024"
 
 [features]

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.16.3"
+version = "0.17.0"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.16.3"
+version = "0.17.0"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.16.3"
+version = "0.17.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.16.3"
+version = "0.17.0"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-llama-sys/Cargo.toml
+++ b/crates/codestory-llama-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-llama-sys"
-version = "0.16.3"
+version = "0.17.0"
 edition = "2024"
 build = "build.rs"
 

--- a/crates/codestory-llama-sys/model-contract.json
+++ b/crates/codestory-llama-sys/model-contract.json
@@ -37,7 +37,7 @@
   "producer": {
     "name": "codestory-llama-sys",
     "embedding_revision": "0.16.1",
-    "version": "0.16.3"
+    "version": "0.17.0"
   },
   "license": {
     "spdx_id": "MIT",

--- a/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
+++ b/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
@@ -43,22 +43,7 @@
     "query_queue_capacity": 64,
     "true_idle_observation_grace_ms": 2500
   },
-  "freeze_record": {
-    "calibration_bundle_sha256": "8e46bb349077ab8aa57c8641ead724b7550eae326dca5b2315a37b6131d65a92",
-    "calibration_freeze_digest": "9c84f7f2975edb0987c5e86b9e185f625293f9c0b97a2d60648150c5d11b6e32",
-    "input_constant_set_sha256": "ea58d298473ddf320469d15dc7c32176a1109d615a689c15ff76b67fb337e109",
-    "measurement_protocol_sha256": "d1bb9b2c7eb354fe98990aa32eedc0e165b0cf804212966e0a2ee362a2f5bf8e",
-    "protocol_sha256": "f4a3fa4afb4d5bcd8e707a5e21b687cdd023dc3398b28ff6891a2318e89c5ec7",
-    "run_artifact_sha256s": [
-      "1e163923abfa866471adf39cc8eaef76caf85f8e6b574e38c46f4d0521f784bc",
-      "5650984c5c20ae51dfd3d1d0a3991fcd8595cb56bb17c953363ed56a00455394",
-      "e7a17b60ac96684a952eeba8779bff6a2ac8614b8944d9e980120a6efc8dd0ee"
-    ],
-    "selected_at": "github-actions-run:30598888717:1",
-    "selection_rule": "constant_only_three_fresh_generations_one_sample_each+slow_host_floors_v2",
-    "selection_source_commit": "35efd4f08b6cc544dee11270fee3d61b28fd16a1",
-    "selection_source_tree": "9938542124d0b56578709efc13b30c077fa1eb1d"
-  },
+  "freeze_record": null,
   "qualification_thresholds": {
     "backend_observed_accelerator_residency": 1,
     "bulk_documents_per_second": 2,
@@ -75,5 +60,5 @@
   },
   "schema_version": 1,
   "selection_protocol": "codestory-per-user-embedding-server-v1",
-  "status": "frozen"
+  "status": "unfrozen"
 }

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.16.3"
+version = "0.17.0"
 edition = "2024"
 
 [features]

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.16.3"
+version = "0.17.0"
 edition = "2024"
 
 [features]

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.16.3"
+version = "0.17.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.16.3"
+version = "0.17.0"
 edition = "2024"
 
 [features]

--- a/plugins/codestory/.claude-plugin/plugin.json
+++ b/plugins/codestory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.16.3",
+  "version": "0.17.0",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.16.3",
+  "version": "0.17.0",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.github/plugin/plugin.json
+++ b/plugins/codestory/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codestory",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
-  "version": "0.16.3",
+  "version": "0.17.0",
   "author": {
     "name": "The Green Cedar",
     "url": "https://github.com/TheGreenCedar"

--- a/plugins/codestory/cli-version.json
+++ b/plugins/codestory/cli-version.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
-  "cli_version": "0.16.3",
-  "release_tag": "v0.16.3"
+  "cli_version": "0.17.0",
+  "release_tag": "v0.17.0"
 }

--- a/release-claims.json
+++ b/release-claims.json
@@ -15,7 +15,7 @@
     "answer_quality"
   ],
   "public_support": {
-    "release_line": "0.16",
+    "release_line": "0.17",
     "packages": [
       {
         "target": "macos-arm64",

--- a/scripts/tests/codestory-release-claims.test.mjs
+++ b/scripts/tests/codestory-release-claims.test.mjs
@@ -2001,6 +2001,12 @@ test("a version-only release bump leaves the native fingerprint unchanged", () =
   // pull requests run (#1673).
   const repository = versionSurfaceRepository("HEAD");
   try {
+    const currentVersion = JSON.parse(readFileSync(
+      path.join(repository, "plugins/codestory/cli-version.json"),
+      "utf8",
+    )).cli_version;
+    const [major, minor, patch] = currentVersion.split(".").map(Number);
+    const nextVersion = `${major}.${minor}.${patch + 1}`;
     const members = workspaceMemberManifests(
       readFileSync(path.join(repository, "Cargo.toml"), "utf8"),
     );
@@ -2013,16 +2019,16 @@ test("a version-only release bump leaves the native fingerprint unchanged", () =
     // cannot run against a manifest-only checkout. Cargo's own effect on the lock -- the recorded
     // version of each workspace crate -- is applied here in its place, and the owner's own
     // `--check` then certifies that the result is a complete release bump and nothing more.
-    runBump(repository, ["--version", "0.17.0"]);
+    runBump(repository, ["--version", nextVersion]);
     const lockPath = path.join(repository, "Cargo.lock");
     writeFileSync(
       lockPath,
       readFileSync(lockPath, "utf8").replace(
         /(name = "codestory-[a-z-]+"\nversion = ")[^"]+(")/gu,
-        "$10.17.0$2",
+        `$1${nextVersion}$2`,
       ),
     );
-    const certified = runBump(repository, ["--version", "0.17.0", "--check"]);
+    const certified = runBump(repository, ["--version", nextVersion, "--check"]);
     assert.equal(
       certified.status,
       0,

--- a/scripts/tests/fixtures/release-claims/positive.json
+++ b/scripts/tests/fixtures/release-claims/positive.json
@@ -17,7 +17,7 @@
       "type": "source_behavior",
       "tier": "source",
       "status": "pass",
-      "graph_sha256": "a6411f2ab0fcb008dc35ebfb6c1951fd39abd2e9aa17dfd594fde5cfc0f88b0d",
+      "graph_sha256": "e838f43c6ce9ee8000fe1765df9e18eef2756b126769a98e10c750f0d103493b",
       "observed_at": "2026-07-16T11:00:00.000Z",
       "expires_at": "2026-07-17T11:00:00.000Z",
       "identity": {


### PR DESCRIPTION
## Context

All v0.17 implementation packages are integrated on `dev/codestory-next`. This is the one release PR: it establishes calibration source `C`, receives the generated constant-only child `F`, and remains open through exact-candidate qualification. It cannot publish from dev and does not cross the protected `main` boundary.

## What changed

- synchronized 0.17.0 across the 10 workspace crates, Cargo.lock, the embedded-model producer, all three plugin manifests, and the managed CLI pin
- promoted the Unreleased changelog entries into 0.17.0
- advanced the declared public support line from 0.16 to 0.17
- regenerated the graph-bound release fixtures and made the native-fingerprint bump mutation version-relative
- cleared the prior v0.16 calibration freeze record so this exact source can collect three fresh Metal samples

## Review

The branch is a single direct child of integration head `da18b379c3d3e4f16d2d69674d42c041a0278577`.

Calibration source:
- commit: `424f2c01f8246cf409653a8ead928d42a3f4d941`
- tree: `efc9185ee63aff6380674daf5b6a2b643fe265f2`

After exact-head acceptance, the only permitted additional commit on this PR is the generated `crates/codestory-llama-sys/per-user-embedding-server-constant-set.json`. That direct child becomes frozen candidate `F`.

## Verification

- `node scripts/bump-version.mjs --version 0.17.0 --check`
- `python .github/scripts/check-codestory-release.py --version 0.17.0`
- `node .github/scripts/check-workflow-policy.mjs`
- release-claim/evidence contract suite — 119 passed, 0 failed
- plugin static suite — 130 passed, 1 platform skip, 0 failed
- `python .github/scripts/check-packaged-agent-proof.py --self-test`
- `git diff --check`

## Risk and boundary

No tag, release, or marketplace mutation occurs here. The PR remains draft through calibration-source acceptance, Metal calibration, the constant-only freeze commit, frozen-head acceptance, and exact-candidate qualification. Promotion to `main` still requires Albert's explicit combined approval.

Closes #1179
