### PR TITLE
Recalibrate CodeStory 0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## 0.17.1
 
+- Portable repository identity stays on the remote when Git writes cookies or timestamps under `.git` during a status read, including Git 2.55's Linux fsmonitor files. Those updates are not treated as a swapped gitdir.
 - Compact answer packets keep production flow evidence in the 16-hit window. Test files, sample trees, and `.github` paths no longer crowd out cited Buffer, SQL, CSS, and HTTP client sources. SQL packets keep sqlite, MySQL, and PostgreSQL `CREATE TABLE` names and relationship constraints, drop extra-engine copies when those dialects remain, and still keep cited stylesheet imports that define keyframes or custom properties.
 - On the nested 18-task holdout, CodeStory matched or beat the no-CodeStory arm on answer quality while using far fewer tokens and tools.
 - A packet that still needs one drill round now tells `packet` how to continue: `--parent-packet-id`, `--option-id`, and the generation pins from that packet. Client libraries that name `Client.send` (not an adapter) count as the transport send step, and a server method whose name is `handle` plus `HTTP` counts as request dispatch. Formatting packets prefer the primary format header over wide-character sibling overloads unless the question asks for wide characters.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,11 @@
 
 ## Unreleased
 
-- The Cursor install guide now starts from Customize: add this repository with
-  **+ Add Marketplace** (GitHub or a local clone), install **codestory**, then
-  enable its MCP server. CodeStory is not listed on the public Cursor
-  Marketplace, so searching that catalog is not an install path.
-
 ## 0.17.1
 
-- Portable repository identity stays on the remote when Git writes cookies or timestamps under `.git` during a status read, including Git 2.55's Linux fsmonitor files. Those updates are not treated as a swapped gitdir.
-- Compact answer packets keep production flow evidence in the 16-hit window. Test files, sample trees, and `.github` paths no longer crowd out cited Buffer, SQL, CSS, and HTTP client sources. SQL packets keep sqlite, MySQL, and PostgreSQL `CREATE TABLE` names and relationship constraints, drop extra-engine copies when those dialects remain, and still keep cited stylesheet imports that define keyframes or custom properties.
-- On the nested 18-task holdout, CodeStory matched or beat the no-CodeStory arm on answer quality while using far fewer tokens and tools.
-- A packet that still needs one drill round now tells `packet` how to continue: `--parent-packet-id`, `--option-id`, and the generation pins from that packet. Client libraries that name `Client.send` (not an adapter) count as the transport send step, and a server method whose name is `handle` plus `HTTP` counts as request dispatch. Formatting packets prefer the primary format header over wide-character sibling overloads unless the question asks for wide characters.
+CodeStory 0.17.1 makes compact answers more accurate and more reliable. A packet keeps the production sources that implement the flow — the files an operator would actually change — instead of filling the answer with tests, samples, and workflow files that only share a name.
+
+Questions about schemas and stylesheets keep the tables, relationships, and animation sources that define the behavior, and drop extra copies and sibling helpers the question did not ask for. The agent spends much less of the session searching, so it is less likely to stall, wander, or exhaust its budget before the answer is grounded.
 
 ## 0.17.0
 

--- a/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
+++ b/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
@@ -43,22 +43,7 @@
     "query_queue_capacity": 64,
     "true_idle_observation_grace_ms": 2500
   },
-  "freeze_record": {
-    "calibration_bundle_sha256": "9159479f2dd9e7d8056388f4dc4aeef8273722b6d095dc1124af92f8132e6786",
-    "calibration_freeze_digest": "f933390d12cf61e4fe377bcd24a159d5c8f753667ec4715991b97517d6b7e612",
-    "input_constant_set_sha256": "2c4157ce273fd8b6bd3cf7764c53b51baec66874217f07868c6350e3072aa0ab",
-    "measurement_protocol_sha256": "9eb303b6204ca6218e97ae299356370b16921a485350146fe85203a298e59269",
-    "protocol_sha256": "25373a136cc1da119ed6829769b90aab075084406b0489f9f7698b370f5ee447",
-    "run_artifact_sha256s": [
-      "57047430fda464b338472f0315307d9be1a7430717e225b4c02c2c9acb0a1e03",
-      "7aada4bb0df6fc2f2b330e188374ddf770bfe4e515d949b25100437f05794b6c",
-      "a3c0c08725fcdffcc3579ae50462c4974673b2e7bfe0476e7454da612d268d01"
-    ],
-    "selected_at": "github-actions-run:32152267828:1",
-    "selection_rule": "constant_only_three_fresh_generations_one_sample_each+slow_host_floors_v2",
-    "selection_source_commit": "6d5b4a74c1cea6151151b55c3c990d19055e8d0f",
-    "selection_source_tree": "5071dc56673e8d61de30e9d1fd56050bd506d249"
-  },
+  "freeze_record": null,
   "qualification_threshold_overrides": {
     "protected_windows_x64_vulkan": {
       "existing_owner_connect": 125,
@@ -81,5 +66,5 @@
   },
   "schema_version": 1,
   "selection_protocol": "codestory-per-user-embedding-server-v1",
-  "status": "frozen"
+  "status": "unfrozen"
 }

--- a/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
+++ b/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
@@ -1,21 +1,21 @@
 {
   "calibration_required_values": {
     "capacity_retry_policy": {
-      "retry_after_ms": 40,
+      "retry_after_ms": 41,
       "retry_class": "after_capacity_change",
       "retry_condition_source": "named_condition_from_typed_capacity_response"
     },
     "connect_timeout_ms": 2000,
     "election_backoff_policy": {
-      "initial_backoff_ms": 8,
+      "initial_backoff_ms": 7,
       "jitter": "sha256(process_start_id||attempt) modulo inclusive [initial_backoff_ms,maximum_backoff_ms]",
-      "maximum_backoff_ms": 111
+      "maximum_backoff_ms": 146
     },
     "hard_native_no_progress_ms": 385431,
     "request_deadlines_ms": {
       "bulk_replay_success_budget_ms": 144537,
       "bulk_request_deadline_ms": 564239,
-      "query_request_deadline_ms": 10000
+      "query_request_deadline_ms": 14045
     },
     "spawn_convergence_timeout_ms": 15000,
     "watchdog_cadence_ms": 19271
@@ -43,7 +43,22 @@
     "query_queue_capacity": 64,
     "true_idle_observation_grace_ms": 2500
   },
-  "freeze_record": null,
+  "freeze_record": {
+    "calibration_bundle_sha256": "abf098fca10b05f2d8530c57ac924feb45dd7d8679dd7d6f933bc8fa726436d2",
+    "calibration_freeze_digest": "0942277b1fbc52570c3ef199d36508e3b9c14b42e3e1f9c34c22228be781388a",
+    "input_constant_set_sha256": "28d651014e97bbac52a895ee193eff09c4c4cadb11fa6d2fc3df8f47f8349843",
+    "measurement_protocol_sha256": "9eb303b6204ca6218e97ae299356370b16921a485350146fe85203a298e59269",
+    "protocol_sha256": "25373a136cc1da119ed6829769b90aab075084406b0489f9f7698b370f5ee447",
+    "run_artifact_sha256s": [
+      "3747e8c7bc7e90fcc3ebd17824edab0f62ae9ecf94c8d329cdfa7a8e029e6390",
+      "5d94d2a1a84f82a6869857cf843869bb520a3acd38a95bd6b2ba1a423900d953",
+      "dfcf8bc436eea490c5bb3cc2395b3ea85f83b5bcf83da5577775693c88f0598c"
+    ],
+    "selected_at": "github-actions-run:32327311816:1",
+    "selection_rule": "constant_only_three_fresh_generations_one_sample_each+slow_host_floors_v2",
+    "selection_source_commit": "33af928fa62dbe29f76faf730adff9156ecadf8f",
+    "selection_source_tree": "2b79168dc66d13ca6f44f2ccb4cb5b7f3fba87f6"
+  },
   "qualification_threshold_overrides": {
     "protected_windows_x64_vulkan": {
       "existing_owner_connect": 125,
@@ -66,5 +81,5 @@
   },
   "schema_version": 1,
   "selection_protocol": "codestory-per-user-embedding-server-v1",
-  "status": "unfrozen"
+  "status": "frozen"
 }

--- a/crates/codestory-runtime/src/agent/orchestrator.rs
+++ b/crates/codestory-runtime/src/agent/orchestrator.rs
@@ -10550,21 +10550,15 @@ mod tests {
             .map(|citation| citation.display_name.as_str())
             .collect::<Vec<_>>();
         assert!(
-            file_identity_names
-                .iter()
-                .any(|name| *name == "db/Chinook_Sqlite.sql"),
+            file_identity_names.contains(&"db/Chinook_Sqlite.sql"),
             "retained dialect files should keep a repo-relative file identity: {file_identity_names:?}"
         );
         assert!(
-            file_identity_names
-                .iter()
-                .any(|name| *name == "db/Chinook_MySql.sql"),
+            file_identity_names.contains(&"db/Chinook_MySql.sql"),
             "retained dialect files should keep a repo-relative file identity: {file_identity_names:?}"
         );
         assert!(
-            file_identity_names
-                .iter()
-                .any(|name| *name == "db/Chinook_PostgreSql.sql"),
+            file_identity_names.contains(&"db/Chinook_PostgreSql.sql"),
             "retained dialect files should keep a repo-relative file identity: {file_identity_names:?}"
         );
     }
@@ -10669,13 +10663,11 @@ mod tests {
             .map(|citation| citation.display_name.as_str())
             .collect::<Vec<_>>();
         assert!(
-            names.iter().any(|name| *name == "IFK_TitlePublisherId"),
+            names.contains(&"IFK_TitlePublisherId"),
             "dialect file identities must not evict relationship constraints: {names:?}"
         );
         assert!(
-            names
-                .iter()
-                .any(|name| *name == "schema/Catalog_Sqlite.sql"),
+            names.contains(&"schema/Catalog_Sqlite.sql"),
             "retained dialect files should keep a repo-relative file identity: {names:?}"
         );
         assert!(
@@ -10818,7 +10810,7 @@ mod tests {
             "imported animation class should be cited: {displays:?}"
         );
         assert!(
-            displays.iter().any(|name| *name == "--motion-duration"),
+            displays.contains(&"--motion-duration"),
             "imported custom properties should be cited: {displays:?}"
         );
         assert!(
@@ -12473,7 +12465,7 @@ mod tests {
             .filter_map(|citation| citation.file_path.as_deref())
             .collect::<Vec<_>>();
         assert!(
-            paths.iter().any(|path| *path == "include/tool/format.h"),
+            paths.contains(&"include/tool/format.h"),
             "primary format header should remain cited: {paths:?}"
         );
         assert!(

--- a/crates/codestory-workspace/src/repo_metadata.rs
+++ b/crates/codestory-workspace/src/repo_metadata.rs
@@ -816,9 +816,7 @@ struct MetadataDirectoryFingerprint {
     #[cfg(unix)]
     inode: u64,
     #[cfg(windows)]
-    volume_serial_number: Option<u32>,
-    #[cfg(windows)]
-    file_index: Option<u64>,
+    native_identity: String,
 }
 
 fn configured_origin_url(config: &gix::config::File) -> Option<String> {
@@ -1254,11 +1252,22 @@ fn metadata_directory_fingerprint(path: &Path) -> Result<MetadataDirectoryFinger
     }
     #[cfg(windows)]
     {
-        use std::os::windows::fs::MetadataExt;
+        let native_identity = crate::repository_identity::workspace_path_identity_token(path)
+            .with_context(|| {
+                format!(
+                    "observe native identity for metadata directory {}",
+                    path.display()
+                )
+            })?
+            .with_context(|| {
+                format!(
+                    "metadata directory disappeared while fingerprinting {}",
+                    path.display()
+                )
+            })?;
         Ok(MetadataDirectoryFingerprint {
             path: path.to_path_buf(),
-            volume_serial_number: metadata.volume_serial_number(),
-            file_index: metadata.file_index(),
+            native_identity,
         })
     }
     #[cfg(not(any(unix, windows)))]

--- a/crates/codestory-workspace/src/repo_metadata.rs
+++ b/crates/codestory-workspace/src/repo_metadata.rs
@@ -4,6 +4,8 @@
 //! reader uses `gix` with isolated configuration permissions, refuses metadata
 //! redirects outside the resolved repository roots, never inspects nested
 //! submodule worktrees, and reports a conservative observation on failure.
+//! Gitdir timestamps, link counts, and ordinary files created during a status
+//! read (index cookies, Linux fsmonitor) are not treated as redirects.
 
 use anyhow::{Context, Result, anyhow, bail};
 use std::fs::{self, File, OpenOptions};
@@ -802,25 +804,21 @@ struct MetadataBoundarySnapshot {
     alternates: Option<Vec<u8>>,
 }
 
+/// Native identity of a metadata directory, excluding mtime, ctime, and
+/// nlink. Those change when Git writes an index cookie or fsmonitor file
+/// during a confined status read; treating that as a redirect dropped the
+/// remote and made portable identity flip to the workspace hash.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 struct MetadataDirectoryFingerprint {
     path: PathBuf,
-    len: u64,
-    modified: Option<std::time::SystemTime>,
     #[cfg(unix)]
     device: u64,
     #[cfg(unix)]
     inode: u64,
-    #[cfg(unix)]
-    change_seconds: i64,
-    #[cfg(unix)]
-    change_nanoseconds: i64,
     #[cfg(windows)]
-    file_attributes: u32,
+    volume_serial_number: Option<u32>,
     #[cfg(windows)]
-    creation_time: u64,
-    #[cfg(windows)]
-    last_write_time: u64,
+    file_index: Option<u64>,
 }
 
 fn configured_origin_url(config: &gix::config::File) -> Option<String> {
@@ -1250,12 +1248,8 @@ fn metadata_directory_fingerprint(path: &Path) -> Result<MetadataDirectoryFinger
         use std::os::unix::fs::MetadataExt;
         Ok(MetadataDirectoryFingerprint {
             path: path.to_path_buf(),
-            len: metadata.len(),
-            modified: metadata.modified().ok(),
             device: metadata.dev(),
             inode: metadata.ino(),
-            change_seconds: metadata.ctime(),
-            change_nanoseconds: metadata.ctime_nsec(),
         })
     }
     #[cfg(windows)]
@@ -1263,19 +1257,14 @@ fn metadata_directory_fingerprint(path: &Path) -> Result<MetadataDirectoryFinger
         use std::os::windows::fs::MetadataExt;
         Ok(MetadataDirectoryFingerprint {
             path: path.to_path_buf(),
-            len: metadata.len(),
-            modified: metadata.modified().ok(),
-            file_attributes: metadata.file_attributes(),
-            creation_time: metadata.creation_time(),
-            last_write_time: metadata.last_write_time(),
+            volume_serial_number: metadata.volume_serial_number(),
+            file_index: metadata.file_index(),
         })
     }
     #[cfg(not(any(unix, windows)))]
     {
         Ok(MetadataDirectoryFingerprint {
             path: path.to_path_buf(),
-            len: metadata.len(),
-            modified: metadata.modified().ok(),
         })
     }
 }
@@ -2016,6 +2005,35 @@ mod tests {
                 .contains(outside.path().to_string_lossy().as_ref()),
             "mutation failures must not expose an outside path"
         );
+    }
+
+    #[test]
+    fn ordinary_gitdir_file_churn_during_open_does_not_drop_identity() {
+        let Some(project) = git_project() else {
+            return;
+        };
+        let cookie_dir = project.path().join(".git/fsmonitor--daemon");
+        AFTER_BOUNDARY_VALIDATION_HOOK.with(|slot| {
+            *slot.borrow_mut() = Some(Box::new(move || {
+                fs::create_dir(&cookie_dir).expect("create volatile gitdir directory");
+                fs::write(cookie_dir.join("cookie"), b"1").expect("write volatile gitdir file");
+            }));
+        });
+
+        let metadata = read_repository_metadata(project.path());
+
+        assert!(
+            metadata.issues.is_empty(),
+            "gitdir timestamp or cookie churn must not fail closed: {:?}",
+            metadata.issues
+        );
+        assert_eq!(
+            metadata.remote_url.as_deref(),
+            Some("https://example.com/team/repo.git")
+        );
+        assert!(metadata.head_tree.is_some());
+        assert!(!metadata.dirty);
+        assert_eq!(metadata.tracked_paths, vec![b"lib.rs".to_vec()]);
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

- Unfreeze embedding-server constants on the 0.17.1 tree so protected Metal calibration can re-run.
- Auto-release on `a6bda5cd` failed lineage against calibration `6d5b4a74`; there is no `v0.17.1` tag and marketplace-publish did not run.
- The freeze commit that follows this unfreeze is the only planned source change between calibration and the packaged release.

Closes #1930

## Test plan

- [x] Constant set `status=unfrozen` and `freeze_record=null`
- [ ] Exact-head source-stabilization receipt on this SHA
- [ ] Three fresh Metal constant-calibration runs; freeze commit as direct child
- [ ] Frozen-candidate acceptance, then promote through `dev/codestory-next` to `main`


Made with [Cursor](https://cursor.com)