### PR TITLE
document how Cursor users load CodeStory into Customize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,10 @@
 
 ## Unreleased
 
-- The Cursor install guide now starts from how CodeStory becomes visible in
-  Customize: the local plugin installer, or a team marketplace that imported
-  this repository. It states that CodeStory is not listed on the public Cursor
-  Marketplace, so searching Customize's official catalog is not an install
-  path.
+- The Cursor install guide now starts from Customize: add this repository with
+  **+ Add Marketplace** (GitHub or a local clone), install **codestory**, then
+  enable its MCP server. CodeStory is not listed on the public Cursor
+  Marketplace, so searching that catalog is not an install path.
 
 ## 0.17.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- The Cursor install guide now starts from how CodeStory becomes visible in
+  Customize: the local plugin installer, or a team marketplace that imported
+  this repository. It states that CodeStory is not listed on the public Cursor
+  Marketplace, so searching Customize's official catalog is not an install
+  path.
+
 ## 0.17.1
 
 - Compact answer packets keep production flow evidence in the 16-hit window. Test files, sample trees, and `.github` paths no longer crowd out cited Buffer, SQL, CSS, and HTTP client sources. SQL packets keep sqlite, MySQL, and PostgreSQL `CREATE TABLE` names and relationship constraints, drop extra-engine copies when those dialects remain, and still keep cited stylesheet imports that define keyframes or custom properties.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ queries stay local by default.
 | Host | Start here |
 | --- | --- |
 | Codex | [Codex guide](docs/users/codex.md) — the recommended first install |
-| Cursor | [Cursor guide](docs/users/cursor.md) — local plugin or team marketplace |
+| Cursor | [Cursor guide](docs/users/cursor.md) — add the marketplace in Customize |
 | Claude Code | [Claude Code guide](docs/users/claude-code.md) |
 | GitHub Copilot | [Copilot guide](docs/users/copilot.md) |
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ queries stay local by default.
 | Host | Start here |
 | --- | --- |
 | Codex | [Codex guide](docs/users/codex.md) — the recommended first install |
-| Cursor | [Cursor guide](docs/users/cursor.md) — install from Customize |
+| Cursor | [Cursor guide](docs/users/cursor.md) — local plugin or team marketplace |
 | Claude Code | [Claude Code guide](docs/users/claude-code.md) |
 | GitHub Copilot | [Copilot guide](docs/users/copilot.md) |
 

--- a/docs/users/README.md
+++ b/docs/users/README.md
@@ -15,7 +15,7 @@ reports progress while it runs, and resumes if it is interrupted. See
 | Host | Setup | What is automatic |
 | --- | --- | --- |
 | [Codex](codex.md) | Install from `/plugins` | MCP, hooks, skill, matching CLI |
-| [Cursor](cursor.md) | Load the local plugin or a team marketplace, then enable MCP once | Rule, hook, skill, and launcher; matching CLI fetched after the first MCP call |
+| [Cursor](cursor.md) | Add the marketplace in Customize, then enable MCP once | Rule, hook, skill, and launcher; matching CLI fetched after the first MCP call |
 | [Claude Code](claude-code.md) | Install the plugin and configure MCP | Hooks; preparation after MCP connects |
 | [Copilot CLI](copilot.md#copilot-cli) | Install hooks and configure MCP | Session instructions; preparation after MCP connects |
 | [Copilot editor](copilot.md#copilot-editor) | Add repository instructions and optionally MCP | CodeStory evidence only when MCP is connected |

--- a/docs/users/README.md
+++ b/docs/users/README.md
@@ -15,7 +15,7 @@ reports progress while it runs, and resumes if it is interrupted. See
 | Host | Setup | What is automatic |
 | --- | --- | --- |
 | [Codex](codex.md) | Install from `/plugins` | MCP, hooks, skill, matching CLI |
-| [Cursor](cursor.md) | Install from Customize, then enable MCP once | Rule, hook, skill, and launcher; matching CLI fetched after the first MCP call |
+| [Cursor](cursor.md) | Load the local plugin or a team marketplace, then enable MCP once | Rule, hook, skill, and launcher; matching CLI fetched after the first MCP call |
 | [Claude Code](claude-code.md) | Install the plugin and configure MCP | Hooks; preparation after MCP connects |
 | [Copilot CLI](copilot.md#copilot-cli) | Install hooks and configure MCP | Session instructions; preparation after MCP connects |
 | [Copilot editor](copilot.md#copilot-editor) | Add repository instructions and optionally MCP | CodeStory evidence only when MCP is connected |

--- a/docs/users/cursor.md
+++ b/docs/users/cursor.md
@@ -1,51 +1,131 @@
 # Cursor
 
-CodeStory ships as a Cursor plugin. It installs the grounding rule, skill,
-session-start context, and managed runtime launcher together.
+CodeStory is a Cursor plugin: grounding rule, skill, session-start hook, and
+managed runtime launcher. Cursor shows it in **Customize** only after you load
+that package onto the machine or your team imports this repository as a
+marketplace. It is not listed on the public [Cursor
+Marketplace](https://cursor.com/marketplace). Searching Customize's official
+catalog for **codestory** will not find it.
 
-## Install
+## Requirements
 
-1. Open **Customize → Plugins** in Cursor and install **codestory** for your
-   user or project.
-2. Open the installed plugin in Customize and enable its **codestory** MCP
-   server. Cursor requires this one-time toggle; plugins cannot enable MCP on
-   your behalf.
-3. Reload the Cursor window and open the repository root as the workspace.
+- One of the supported platform and accelerator combinations below;
+- Node.js on `PATH` for the plugin adapter; and
+- a Cursor reload after installing or replacing the plugin package.
 
-Ask:
+<!-- codestory-public-support:start -->
+| Platform | Release support |
+| --- | --- |
+| macOS 15+ on Apple Silicon | Supported with Metal |
+| Windows x64 | Supported with Vulkan |
+| Linux x64 | Supported with Vulkan |
+| CPU-only Windows and Linux | Unsupported |
+| Intel Mac | Unsupported |
+| Windows ARM | Unsupported |
+<!-- codestory-public-support:end -->
 
-```text
-Where is request validation implemented, who calls it, and which tests cover it?
-```
+The packaged CLI contains its model and embedding engine, so normal use needs
+no Docker, external embedding endpoint, model download, or Xcode toolchain.
+Building CodeStory from source has separate [contributor
+prerequisites](../contributors/getting-started.md#prerequisites).
+
+## Make CodeStory visible in Customize
+
+Pick the path that matches how you get software.
+
+### Personal install
+
+This is the path for an individual machine. It links the shipped plugin into
+Cursor's local plugin directory so **Customize** can list it.
+
+1. Clone [TheGreenCedar/CodeStory](https://github.com/TheGreenCedar/CodeStory)
+   and check out the release you want, or use a clone whose `plugins/codestory`
+   tree is clean and committed.
+2. From that repository root, run:
+
+   ```sh
+   node scripts/install-codestory-cursor-plugin.mjs
+   ```
+
+   The installer links `plugins/codestory` to
+   `~/.cursor/plugins/local/codestory` (on Windows,
+   `%USERPROFILE%\.cursor\plugins\local\codestory`) and uses
+   `~/.cursor/plugins/data/codestory` for plugin state. It refuses a dirty or
+   incomplete plugin tree.
+3. Reload the Cursor window (**Developer: Reload Window**).
+4. Open **Customize** in the sidebar. **codestory** should appear as a local
+   plugin.
+
+Without `--cli`, the first MCP call downloads the version-matched signed
+runtime. Use `--cli` only when dogfooding a local `codestory-cli` build; see
+[Local plugin development](#local-plugin-development).
+
+### Team marketplace
+
+This is the path that makes CodeStory **browsable** in Customize for everyone
+on a Teams or Enterprise workspace.
+
+An administrator opens **Dashboard → Plugins → Team Marketplaces → Add
+Marketplace → Import from Repo** and selects this repository. Cursor's
+repository access settings must grant the workspace access to the repository;
+private repositories also need the corresponding organization or repository
+permission. The import reads
+[`.cursor-plugin/marketplace.json`](../../.cursor-plugin/marketplace.json),
+which points at `plugins/codestory`.
+
+Enable **Auto Refresh** for automatic catalog updates, or use **Refresh** from
+the Team Marketplaces dashboard after a repository update. That refresh updates
+the catalog only.
+
+After the import, each developer:
+
+1. Opens **Customize → Plugins**.
+2. Finds **codestory** from the team marketplace.
+3. Selects **Install** and chooses a user or project scope.
+
+Publication on cursor.com/marketplace is a separate maintainer step and is not
+an install path today.
+
+## Enable MCP and verify
+
+Cursor will not start CodeStory tools until you enable the plugin's MCP server.
+Plugins cannot flip that toggle for you.
+
+1. In **Customize**, open the installed **codestory** plugin and enable its
+   **codestory** MCP server.
+2. Reload the Cursor window if the server does not connect.
+3. Open the repository you want to ground. The plugin is not limited to the
+   CodeStory checkout; every CodeStory tool call still names that repository's
+   absolute `project` root.
+4. Start a fresh agent chat. Cursor asks before running MCP tools by default;
+   approve the CodeStory calls.
+5. Ask:
+
+   ```text
+   Where is request validation implemented, who calls it, and which tests cover it?
+   ```
 
 On the first call, the launcher fetches the matching CodeStory runtime if it is
-not already installed, then prepares the repository. Cursor should retry the
-same tool after its reported delay. A healthy answer cites real files and
-symbols; if MCP is unavailable, the agent
-uses ordinary source inspection and says that CodeStory evidence was not
-available.
+not already installed, then prepares the repository. The agent should retry the
+same tool after the reported delay. A healthy answer cites real files and
+symbols. If MCP is unavailable, the agent uses ordinary source inspection and
+says that CodeStory evidence was not available.
+
+Shared first-use behavior: [User guide](README.md#first-use).
 
 ## Update
 
-Refresh **codestory** in Customize, reload the Cursor window, and start a fresh
-agent session. The plugin refresh replaces the rule, skill, hook, and launcher;
-the launcher then selects the matching managed runtime.
+How you refresh depends on how the plugin was loaded:
 
-## Team distribution
+- **Personal install:** update the clone, keep `plugins/codestory` clean and
+  committed, re-run the installer if the local link is missing, then reload
+  Cursor.
+- **Team marketplace:** an administrator refreshes the team catalog, then each
+  user refreshes **codestory** in Customize and reloads Cursor.
 
-For a Teams or Enterprise workspace, an administrator opens **Dashboard →
-Plugins → Team Marketplaces → Add Marketplace → Import from Repo**, then selects
-this repository. Cursor's repository access settings must grant the workspace
-access to the repository; private repositories also need the corresponding
-organization or repository permission. The marketplace manifest at
-[`.cursor-plugin/marketplace.json`](../../.cursor-plugin/marketplace.json)
-points Cursor at the package under `plugins/codestory`.
-
-Enable **Auto Refresh** for automatic marketplace updates, or use **Refresh**
-from the Team Marketplaces dashboard after a repository update. This refreshes
-the team marketplace catalog. Individual users still refresh the installed
-plugin from Customize and reload Cursor. Publication in the public Cursor
-Marketplace is a separate maintainer step.
+Start a fresh agent session after reload. The replacement covers the rule,
+skill, hook, and launcher; the launcher then selects the matching managed
+runtime.
 
 ## Advanced: repository-managed setup
 
@@ -64,23 +144,33 @@ and are not the primary CodeStory install path.
 
 ## Local plugin development
 
-From a clean committed CodeStory checkout, run:
+From a clean committed CodeStory checkout, pass a local CLI only when you need
+that exact binary instead of the managed download:
 
 ```sh
 node scripts/install-codestory-cursor-plugin.mjs \
   --cli "$(pwd)/target/release/codestory-cli"
 ```
 
-Without `--cli`, the plugin uses the version-matched managed runtime.
+Without `--cli`, the plugin uses the version-matched managed runtime. Reload
+Cursor, enable **codestory** MCP in Customize, and start a fresh agent session.
 
 ## Troubleshooting
 
 | Symptom | Action |
 | --- | --- |
-| Plugin is installed but tools are missing | Enable **codestory** MCP in Customize and reload the window |
-| MCP fails to start | Confirm `node` is on `PATH`, then refresh the plugin |
-| Runtime is stale after an update | Refresh the plugin, reload Cursor, and start a fresh session |
+| **codestory** is missing from Customize | It is not on the public marketplace. Run the [personal installer](#personal-install) or ask an admin to [import this repository](#team-marketplace) |
+| Plugin is listed but tools are missing | Enable **codestory** MCP in Customize, approve the tool prompt, and reload the window |
+| MCP fails to start | Confirm `node` is on `PATH`, then reload. Inspect **MCP Logs** in the Output panel (**Cmd+Shift+U** / **Ctrl+Shift+U**) |
+| Runtime is stale after an update | Refresh the plugin the same way you installed it, reload Cursor, and start a fresh session |
 | A tool remains preparing | Retry that same tool after its returned delay |
 
-Shared first-use behavior: [User guide](README.md#first-use). Readiness and
-cache recovery: [Troubleshooting](troubleshooting.md).
+Readiness and cache recovery: [Troubleshooting](troubleshooting.md).
+
+## Differences from Codex
+
+Codex installs from `/plugins` against the public **TheGreenCedar** catalog.
+Cursor has no equivalent public listing today: load the plugin locally, or
+install it from a team marketplace that imported this repository. Once MCP is
+connected, repository preparation and the per-user retrieval server behave the
+same as in Codex.

--- a/docs/users/cursor.md
+++ b/docs/users/cursor.md
@@ -1,11 +1,12 @@
 # Cursor
 
 CodeStory is a Cursor plugin: grounding rule, skill, session-start hook, and
-managed runtime launcher. Cursor shows it in **Customize** only after you load
-that package onto the machine or your team imports this repository as a
-marketplace. It is not listed on the public [Cursor
-Marketplace](https://cursor.com/marketplace). Searching Customize's official
-catalog for **codestory** will not find it.
+managed runtime launcher. It is not listed on the public [Cursor
+Marketplace](https://cursor.com/marketplace). Searching that catalog for
+**codestory** will not find it.
+
+Add this repository as a marketplace in Customize, then install **codestory**
+from it.
 
 ## Requirements
 
@@ -29,81 +30,35 @@ no Docker, external embedding endpoint, model download, or Xcode toolchain.
 Building CodeStory from source has separate [contributor
 prerequisites](../contributors/getting-started.md#prerequisites).
 
-## Make CodeStory visible in Customize
+## Install
 
-Pick the path that matches how you get software.
+1. Open **Customize** in the Cursor sidebar.
+2. Select **+ Add Marketplace**.
+3. Import this repository:
+   - **Import from Github** —
+     [TheGreenCedar/CodeStory](https://github.com/TheGreenCedar/CodeStory); or
+   - **Import from Disk** — a local clone of the same repository.
+4. Install **codestory** from that marketplace, for your user or the current
+   project.
+5. Open the installed plugin and enable its **codestory** MCP server. Cursor
+   requires this one-time toggle; the plugin cannot enable MCP on your behalf.
+6. Reload the Cursor window if the server does not connect.
 
-### Personal install
-
-This is the path for an individual machine. It links the shipped plugin into
-Cursor's local plugin directory so **Customize** can list it.
-
-1. Clone [TheGreenCedar/CodeStory](https://github.com/TheGreenCedar/CodeStory)
-   and check out the release you want, or use a clone whose `plugins/codestory`
-   tree is clean and committed.
-2. From that repository root, run:
-
-   ```sh
-   node scripts/install-codestory-cursor-plugin.mjs
-   ```
-
-   The installer links `plugins/codestory` to
-   `~/.cursor/plugins/local/codestory` (on Windows,
-   `%USERPROFILE%\.cursor\plugins\local\codestory`) and uses
-   `~/.cursor/plugins/data/codestory` for plugin state. It refuses a dirty or
-   incomplete plugin tree.
-3. Reload the Cursor window (**Developer: Reload Window**).
-4. Open **Customize** in the sidebar. **codestory** should appear as a local
-   plugin.
-
-Without `--cli`, the first MCP call downloads the version-matched signed
-runtime. Use `--cli` only when dogfooding a local `codestory-cli` build; see
-[Local plugin development](#local-plugin-development).
-
-### Team marketplace
-
-This is the path that makes CodeStory **browsable** in Customize for everyone
-on a Teams or Enterprise workspace.
-
-An administrator opens **Dashboard → Plugins → Team Marketplaces → Add
-Marketplace → Import from Repo** and selects this repository. Cursor's
-repository access settings must grant the workspace access to the repository;
-private repositories also need the corresponding organization or repository
-permission. The import reads
+The import reads
 [`.cursor-plugin/marketplace.json`](../../.cursor-plugin/marketplace.json),
-which points at `plugins/codestory`.
+which points Cursor at `plugins/codestory`. Do not use **Create New**; that
+starts an empty marketplace instead of loading CodeStory.
 
-Enable **Auto Refresh** for automatic catalog updates, or use **Refresh** from
-the Team Marketplaces dashboard after a repository update. That refresh updates
-the catalog only.
+Open the repository you want to ground. The plugin is not limited to the
+CodeStory checkout; every CodeStory tool call still names that repository's
+absolute `project` root.
 
-After the import, each developer:
+Start a fresh agent chat. Cursor asks before running MCP tools by default;
+approve the CodeStory calls, then ask:
 
-1. Opens **Customize → Plugins**.
-2. Finds **codestory** from the team marketplace.
-3. Selects **Install** and chooses a user or project scope.
-
-Publication on cursor.com/marketplace is a separate maintainer step and is not
-an install path today.
-
-## Enable MCP and verify
-
-Cursor will not start CodeStory tools until you enable the plugin's MCP server.
-Plugins cannot flip that toggle for you.
-
-1. In **Customize**, open the installed **codestory** plugin and enable its
-   **codestory** MCP server.
-2. Reload the Cursor window if the server does not connect.
-3. Open the repository you want to ground. The plugin is not limited to the
-   CodeStory checkout; every CodeStory tool call still names that repository's
-   absolute `project` root.
-4. Start a fresh agent chat. Cursor asks before running MCP tools by default;
-   approve the CodeStory calls.
-5. Ask:
-
-   ```text
-   Where is request validation implemented, who calls it, and which tests cover it?
-   ```
+```text
+Where is request validation implemented, who calls it, and which tests cover it?
+```
 
 On the first call, the launcher fetches the matching CodeStory runtime if it is
 not already installed, then prepares the repository. The agent should retry the
@@ -115,17 +70,10 @@ Shared first-use behavior: [User guide](README.md#first-use).
 
 ## Update
 
-How you refresh depends on how the plugin was loaded:
-
-- **Personal install:** update the clone, keep `plugins/codestory` clean and
-  committed, re-run the installer if the local link is missing, then reload
-  Cursor.
-- **Team marketplace:** an administrator refreshes the team catalog, then each
-  user refreshes **codestory** in Customize and reloads Cursor.
-
-Start a fresh agent session after reload. The replacement covers the rule,
-skill, hook, and launcher; the launcher then selects the matching managed
-runtime.
+Refresh the CodeStory marketplace in Customize, then refresh or reinstall
+**codestory** from it and reload the Cursor window. Start a fresh agent
+session. The replacement covers the rule, skill, hook, and launcher; the
+launcher then selects the matching managed runtime.
 
 ## Advanced: repository-managed setup
 
@@ -144,25 +92,29 @@ and are not the primary CodeStory install path.
 
 ## Local plugin development
 
-From a clean committed CodeStory checkout, pass a local CLI only when you need
-that exact binary instead of the managed download:
+The installer below is only for dogfooding a checkout with an optional local
+CLI. Normal installs use [Add Marketplace](#install).
+
+From a clean committed CodeStory checkout:
 
 ```sh
-node scripts/install-codestory-cursor-plugin.mjs \
-  --cli "$(pwd)/target/release/codestory-cli"
+node scripts/install-codestory-cursor-plugin.mjs
 ```
 
-Without `--cli`, the plugin uses the version-matched managed runtime. Reload
-Cursor, enable **codestory** MCP in Customize, and start a fresh agent session.
+Pass `--cli "$(pwd)/target/release/codestory-cli"` to use that exact binary
+instead of the managed download. The installer links `plugins/codestory` into
+`~/.cursor/plugins/local/codestory` and writes any CLI override only into
+Cursor's private CodeStory data directory. Reload Cursor, enable **codestory**
+MCP in Customize, and start a fresh agent session.
 
 ## Troubleshooting
 
 | Symptom | Action |
 | --- | --- |
-| **codestory** is missing from Customize | It is not on the public marketplace. Run the [personal installer](#personal-install) or ask an admin to [import this repository](#team-marketplace) |
+| **codestory** is missing from Customize | It is not on the public marketplace. [Add this repository as a marketplace](#install), then install **codestory** from it |
 | Plugin is listed but tools are missing | Enable **codestory** MCP in Customize, approve the tool prompt, and reload the window |
 | MCP fails to start | Confirm `node` is on `PATH`, then reload. Inspect **MCP Logs** in the Output panel (**Cmd+Shift+U** / **Ctrl+Shift+U**) |
-| Runtime is stale after an update | Refresh the plugin the same way you installed it, reload Cursor, and start a fresh session |
+| Runtime is stale after an update | Refresh the marketplace and the plugin in Customize, reload Cursor, and start a fresh session |
 | A tool remains preparing | Retry that same tool after its returned delay |
 
 Readiness and cache recovery: [Troubleshooting](troubleshooting.md).
@@ -170,7 +122,6 @@ Readiness and cache recovery: [Troubleshooting](troubleshooting.md).
 ## Differences from Codex
 
 Codex installs from `/plugins` against the public **TheGreenCedar** catalog.
-Cursor has no equivalent public listing today: load the plugin locally, or
-install it from a team marketplace that imported this repository. Once MCP is
-connected, repository preparation and the per-user retrieval server behave the
-same as in Codex.
+Cursor has no equivalent public listing: add this repository with **+ Add
+Marketplace**, then install **codestory**. Once MCP is connected, repository
+preparation and the per-user retrieval server behave the same as in Codex.

--- a/docs/users/troubleshooting.md
+++ b/docs/users/troubleshooting.md
@@ -34,7 +34,7 @@ Trust boundaries: [Trust and readiness](trust-and-readiness.md).
 | Host | Check |
 | --- | --- |
 | Codex | Confirm **TheGreenCedar -> codestory** is installed, then start a fresh host session |
-| Cursor | Confirm the **codestory** plugin is installed, enable its MCP server in Customize, then reload Cursor; inspect `.cursor/mcp.json` only for the advanced repository-managed setup |
+| Cursor | Confirm **codestory** is loaded via the local installer or a team marketplace (it is not on the public Cursor Marketplace), enable its MCP server in Customize, then reload Cursor; inspect `.cursor/mcp.json` only for the advanced repository-managed setup |
 | Claude Code | Confirm the plugin hook and the separately configured MCP server |
 | Copilot | Hooks or instructions do not start MCP; configure it explicitly |
 

--- a/docs/users/troubleshooting.md
+++ b/docs/users/troubleshooting.md
@@ -34,7 +34,7 @@ Trust boundaries: [Trust and readiness](trust-and-readiness.md).
 | Host | Check |
 | --- | --- |
 | Codex | Confirm **TheGreenCedar -> codestory** is installed, then start a fresh host session |
-| Cursor | Confirm **codestory** is loaded via the local installer or a team marketplace (it is not on the public Cursor Marketplace), enable its MCP server in Customize, then reload Cursor; inspect `.cursor/mcp.json` only for the advanced repository-managed setup |
+| Cursor | Confirm this repository is added as a marketplace in Customize, **codestory** is installed from it, and its MCP server is enabled, then reload Cursor; inspect `.cursor/mcp.json` only for the advanced repository-managed setup |
 | Claude Code | Confirm the plugin hook and the separately configured MCP server |
 | Copilot | Hooks or instructions do not start MCP; configure it explicitly |
 

--- a/plugins/codestory/README.md
+++ b/plugins/codestory/README.md
@@ -88,12 +88,18 @@ installed plugin, and a fresh host session loads that replacement. See the
 
 ## Cursor install
 
-Open **Customize → Plugins**, install **codestory**, enable its MCP server once,
-and reload the Cursor window. The package supplies the rule, grounding skill,
-session-start context, and managed CLI launcher. On the first MCP call, the
-launcher fetches the matching managed runtime if it is not already installed.
-The MCP toggle is a Cursor platform setting, so installing the plugin cannot
-enable it on your behalf.
+CodeStory is not listed on the public Cursor Marketplace. A machine gets the
+plugin by running `node scripts/install-codestory-cursor-plugin.mjs` from a
+clean committed checkout, or by installing **codestory** from a team marketplace
+that imported this repository. The [Cursor guide](../../docs/users/cursor.md)
+owns those paths.
+
+After the plugin is visible in **Customize**, enable its **codestory** MCP
+server once and reload the Cursor window. The package supplies the rule,
+grounding skill, session-start context, and managed CLI launcher. On the first
+MCP call, the launcher fetches the matching managed runtime if it is not
+already installed. The MCP toggle is a Cursor platform setting, so installing
+the plugin cannot enable it on your behalf.
 
 For Teams or Enterprise distribution, an administrator uses **Dashboard →
 Plugins → Team Marketplaces → Add Marketplace → Import from Repo** and selects
@@ -102,8 +108,8 @@ the repository, including the required organization or repository permission
 for a private repository. The import reads
 [`.cursor-plugin/marketplace.json`](../../.cursor-plugin/marketplace.json).
 Enable **Auto Refresh** or use **Refresh** from the Team Marketplaces dashboard
-after an update. That refresh updates the team catalog; each user still refreshes
-the installed plugin from Customize and reloads Cursor.
+after an update. That refresh updates the team catalog; each user still
+installs or refreshes the plugin from Customize and reloads Cursor.
 
 ## CodeStoryDev / Cursor refresh
 

--- a/plugins/codestory/README.md
+++ b/plugins/codestory/README.md
@@ -88,28 +88,19 @@ installed plugin, and a fresh host session loads that replacement. See the
 
 ## Cursor install
 
-CodeStory is not listed on the public Cursor Marketplace. A machine gets the
-plugin by running `node scripts/install-codestory-cursor-plugin.mjs` from a
-clean committed checkout, or by installing **codestory** from a team marketplace
-that imported this repository. The [Cursor guide](../../docs/users/cursor.md)
-owns those paths.
+CodeStory is not listed on the public Cursor Marketplace. In **Customize**,
+select **+ Add Marketplace**, then **Import from Github**
+([TheGreenCedar/CodeStory](https://github.com/TheGreenCedar/CodeStory)) or
+**Import from Disk** (a local clone). Install **codestory** from that
+marketplace, enable its MCP server once, and reload the Cursor window. The
+[Cursor guide](../../docs/users/cursor.md) owns that path.
 
-After the plugin is visible in **Customize**, enable its **codestory** MCP
-server once and reload the Cursor window. The package supplies the rule,
-grounding skill, session-start context, and managed CLI launcher. On the first
-MCP call, the launcher fetches the matching managed runtime if it is not
-already installed. The MCP toggle is a Cursor platform setting, so installing
-the plugin cannot enable it on your behalf.
-
-For Teams or Enterprise distribution, an administrator uses **Dashboard →
-Plugins → Team Marketplaces → Add Marketplace → Import from Repo** and selects
-this repository. Cursor's access settings must grant the workspace access to
-the repository, including the required organization or repository permission
-for a private repository. The import reads
+The import reads
 [`.cursor-plugin/marketplace.json`](../../.cursor-plugin/marketplace.json).
-Enable **Auto Refresh** or use **Refresh** from the Team Marketplaces dashboard
-after an update. That refresh updates the team catalog; each user still
-installs or refreshes the plugin from Customize and reloads Cursor.
+The package supplies the rule, grounding skill, session-start context, and
+managed CLI launcher. On the first MCP call, the launcher fetches the matching
+managed runtime if it is not already installed. The MCP toggle is a Cursor
+platform setting, so installing the plugin cannot enable it on your behalf.
 
 ## CodeStoryDev / Cursor refresh
 


### PR DESCRIPTION
Closes #1932
Refs #1922

## Summary

- The Cursor guide starts from Customize **+ Add Marketplace**: **Import from Github** (`TheGreenCedar/CodeStory`) or **Import from Disk** (a local clone), then install **codestory** and enable its MCP server.
- It no longer splits personal vs team. Adding the marketplace is the one user path; the local installer stays under dogfood only.
- Hub pages and the plugin README match that UI.

## Test plan

- [x] Read the changed pages
- [x] `git diff --check`
- [x] `node .github/scripts/check-doc-links.mjs`