### PR TITLE
run http_transport_contracts on draft CLI CI

### DIFF
--- a/.github/workflows/retrieval-engine-smoke.yml
+++ b/.github/workflows/retrieval-engine-smoke.yml
@@ -177,6 +177,9 @@ jobs:
       - name: Stdio protocol contract tests
         run: cargo test --locked -p codestory-cli --test stdio_protocol_contracts
 
+      - name: HTTP transport fail-closed contract tests
+        run: cargo test --locked -p codestory-cli --test http_transport_contracts
+
       - name: CLI search JSON fail-closed contract tests
         run: cargo test --locked -p codestory-cli --test search_json_output
 

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -461,6 +461,8 @@ cells supply the other platform evidence when those adapters change.
 
 Docs-only scope is `README.md`, `docs/**`, `plugins/codestory/README.md`,
 `plugins/codestory/docs/**`, and `plugins/codestory/skills/**`.
+`docs/contributors/testing-matrix.md` is not in this lane; it remains a
+crate-durability path pin.
 
 ```sh
 node .github/scripts/check-doc-links.mjs


### PR DESCRIPTION
Closes #1939

## Summary

- `retrieval-engine-smoke.yml` `linux-contracts` now runs `cargo test --locked -p codestory-cli --test http_transport_contracts` next to the other named CLI contract binaries.
- The docs-only fast path in `docs/contributors/testing-matrix.md` states that this file is not docs-only and remains a crate-durability path pin.

No product runtime change. No changelog entry.

## How to review

- Workflow: one new blocking step on `linux-contracts`, before seed/save. Same `--test` named-filter shape as `stdio_protocol_contracts` / `search_json_output`.
- Docs: one sentence under Docs-only fast path. Crate-durability path list is unchanged.

## Verification

- Base: `origin/dev/codestory-next` `f5b42b7b`
- Head: `7b8347b7`
- `npm ci --ignore-scripts`
- `node .github/scripts/check-workflow-policy.mjs` passed
- `git diff --check` passed
- Did not add `cli_golden_path` to every PR
- Did not run `http_transport_contracts` locally (CI job owns that binary)

## Risk

- `linux-contracts` already compiles CLI integration tests; this adds one more binary and wall time. HTTP tests spawn loopback servers, so a hang or flake would fail draft PRs that already trigger this workflow (`crates/**` and the existing path set).
- Editing `testing-matrix.md` still fires `crate-durability.yml` by design.

## Follow-up

None in this slice. Wave 2 `cli_golden_path` stays on its own lane.


Made with [Cursor](https://cursor.com)