### PR TITLE
align mcp agent-guide and next-calls with the matching-tool loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+MCP now tells agents to call the tool that matches the task and retry that same tool while CodeStory prepares. It no longer starts with `ground`, invents an `affected` path, or treats `status` as a required next step.
+
 ## 0.17.1
 
 CodeStory 0.17.1 makes compact answers more accurate and more reliable. A packet keeps the production sources that implement the flow — the files an operator would actually change — instead of filling the answer with tests, samples, and workflow files that only share a name.

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -1726,23 +1726,6 @@ fn handle_stdio_message(
                                     .unwrap_or(250),
                             }));
                         }
-                        if retained_local {
-                            recommended_next_calls.push(serde_json::json!({
-                                "method": "tools/call",
-                                "tool": "affected",
-                                "arguments": {
-                                    "project": crate::display::clean_path_string(
-                                        &runtime.project_root.to_string_lossy()
-                                    ),
-                                    "paths": ["<changed-project-path>"]
-                                },
-                                "evidence_scope": "retained_core_publication",
-                            }));
-                        }
-                        recommended_next_calls.push(serde_json::json!({
-                            "method": "resources/read",
-                            "uri": diagnostics_uri.clone(),
-                        }));
                         let error = serde_json::json!({
                             "code": if error.code == "cancelled" {
                                 "cancelled"
@@ -6218,22 +6201,15 @@ fn stdio_status_recommended_next_calls(
                 }
             ]);
         }
-        return serde_json::json!([
-            stdio_recommended_next_call(
-                non_ready
-                    .full_repair
-                    .first()
-                    .or_else(|| non_ready.minimum_next.first())
-                    .map(String::as_str)
-                    .unwrap_or("Retry the requested CodeStory tool."),
-                project
-            ),
-            {
-                "method": "tools/call",
-                "tool": "status",
-                "arguments": {"project": project}
-            }
-        ]);
+        return serde_json::json!([stdio_recommended_next_call(
+            non_ready
+                .full_repair
+                .first()
+                .or_else(|| non_ready.minimum_next.first())
+                .map(String::as_str)
+                .unwrap_or("Retry the requested CodeStory tool."),
+            project
+        )]);
     }
 
     serde_json::json!([
@@ -6278,7 +6254,7 @@ fn stdio_status_recommended_next_calls(
     ])
 }
 
-fn stdio_recommended_next_call(command: &str, project: &serde_json::Value) -> serde_json::Value {
+fn stdio_recommended_next_call(command: &str, _project: &serde_json::Value) -> serde_json::Value {
     if command.starts_with("Restart/reload the Codex host/app") {
         return serde_json::json!({
             "method": "host/restart",
@@ -6287,10 +6263,8 @@ fn stdio_recommended_next_call(command: &str, project: &serde_json::Value) -> se
     }
     if command.contains("ready --goal local") || command.contains("codestory-cli doctor") {
         return serde_json::json!({
-            "method": "tools/call",
-            "tool": "status",
-            "arguments": {"project": project},
-            "instruction": "Read status again after the MCP-managed local freshness check. Use the debug_command only for maintainer transcripts.",
+            "method": "host/instruction",
+            "instruction": "Retry the matching CodeStory tool. Status is an optional diagnostic, not a product prerequisite. Use the debug_command only for maintainer transcripts.",
             "debug_command": command
         });
     }
@@ -6500,9 +6474,27 @@ fn read_stdio_agent_guide_resource() -> serde_json::Value {
         "purpose": "Direct CodeStory tools for repository orientation, navigation, and broad search.",
         "recommended_call_sequence": [
             {
-                "method": "tools/call",
-                "tool": "ground",
-                "arguments": {"project": project, "budget": "balanced"}
+                "step": 1,
+                "action": "resolve_project_root",
+                "note": "Pass the exact absolute repository root as project on every CodeStory call."
+            },
+            {
+                "step": 2,
+                "action": "call_matching_tool",
+                "arguments": {"project": project},
+                "note": "Call the tool that matches the task. Do not call status first. Orientation may use ground; it is not the first required call."
+            },
+            {
+                "step": 3,
+                "action": "retry_same_tool",
+                "when": ["preparing", "updating"],
+                "after_field": "retry_after_ms",
+                "note": "Wait retry_after_ms and retry the same tool with the same arguments. Do not poll status."
+            },
+            {
+                "step": 4,
+                "action": "read_focused_source_for_remaining_gaps",
+                "note": "Preserve cited anchors. Read focused source only for remaining evidence gaps."
             }
         ],
         "readiness_lanes": [
@@ -6588,7 +6580,7 @@ fn read_stdio_agent_guide_resource() -> serde_json::Value {
                         "arguments": {
                             "project": project,
                             "question": "<broad-task-question>",
-                            "budget": "compact"
+                            "budget": "standard"
                         }
                     },
                     {
@@ -6615,7 +6607,7 @@ fn read_stdio_agent_guide_resource() -> serde_json::Value {
             {
                 "surface": "ground",
                 "kind": "tool and codestory://grounding resource",
-                "when": "Use first for compact repository orientation."
+                "when": "Use for repository orientation. It is not a required first call."
             },
             {
                 "surface": "packet",
@@ -6646,7 +6638,7 @@ fn read_stdio_agent_guide_resource() -> serde_json::Value {
         "safety_notes": [
             "CodeStory tools never edit repository source. Product calls refresh local managed state and initialize the packaged retrieval engine automatically; all are non-destructive, idempotent, and require no confirmation.",
             "Pass the same absolute project path to every tool call.",
-            "Use ground first for compact repository orientation.",
+            "Call the matching tool first. Orientation may use ground; it is not required first.",
             "Use packet for broad task questions and context after selecting a concrete target.",
             "When a tool reports preparing, wait retry_after_ms and retry that same tool. Do not ask the user to repair CodeStory.",
             "Treat Supported, NotEstablished, and Unavailable packets as terminal. DrillOnce means repeat the exact original question and execute the listed option_ids once against the pinned generation, then answer. Do not search to close English flow families.",
@@ -8085,9 +8077,103 @@ mod tests {
 
         assert_eq!(calls[0]["method"], json!("host/restart"));
         assert_eq!(calls[0]["instruction"], json!(restart));
+        assert_eq!(calls[1]["method"], json!("tools/call"));
+        assert_eq!(calls[1]["tool"], json!("status"));
         assert!(
             calls[0].get("command").is_none(),
             "restart boundary should not be exposed as a CLI command: {calls}"
+        );
+    }
+
+    #[test]
+    fn stdio_status_next_calls_keep_ground_for_local_repair_and_empty_packet_lane() {
+        let project = json!("/absolute/project");
+        let local_repair = stdio_status_recommended_next_calls(
+            &[ReadinessVerdictDto {
+                goal: ReadinessGoalDto::LocalNavigation,
+                status: ReadinessStatusDto::RepairIndex,
+                summary: "Local map needs a product refresh.".to_string(),
+                minimum_next: vec![
+                    "codestory-cli ready --goal local --project /absolute/project".to_string(),
+                ],
+                full_repair: vec![],
+                setup: None,
+                index: None,
+                sidecar: None,
+            }],
+            &project,
+        );
+        assert_eq!(local_repair[0]["tool"], json!("ground"));
+        assert_eq!(local_repair[0]["activation_required"], json!(true));
+        assert!(
+            local_repair
+                .as_array()
+                .is_some_and(|calls| calls.iter().all(|call| call["tool"] != json!("status"))),
+            "local map repair should activate with ground, not status: {local_repair}"
+        );
+
+        let packet_blocked = stdio_status_recommended_next_calls(
+            &[ReadinessVerdictDto {
+                goal: ReadinessGoalDto::AgentPacketSearch,
+                status: ReadinessStatusDto::Blocked,
+                summary: "Packet waits on full retrieval.".to_string(),
+                minimum_next: vec!["Retry the requested CodeStory tool.".to_string()],
+                full_repair: vec![],
+                setup: None,
+                index: None,
+                sidecar: None,
+            }],
+            &project,
+        );
+        assert_eq!(packet_blocked, json!([]));
+
+        let other_repair = stdio_status_recommended_next_calls(
+            &[ReadinessVerdictDto {
+                goal: ReadinessGoalDto::LocalNavigation,
+                status: ReadinessStatusDto::Blocked,
+                summary: "Local navigation is blocked.".to_string(),
+                minimum_next: vec!["codestory-cli doctor --project /absolute/project".to_string()],
+                full_repair: vec![],
+                setup: None,
+                index: None,
+                sidecar: None,
+            }],
+            &project,
+        );
+        assert!(
+            other_repair
+                .as_array()
+                .is_some_and(|calls| calls.iter().all(|call| call["tool"] != json!("status"))),
+            "status is not a product next call outside host-reload: {other_repair}"
+        );
+    }
+
+    #[test]
+    fn agent_guide_sequence_matches_skill_matching_tool_loop() {
+        let guide = read_stdio_agent_guide_resource();
+        let sequence = guide["recommended_call_sequence"]
+            .as_array()
+            .expect("agent guide publishes a call sequence");
+        assert_eq!(sequence[0]["action"], json!("resolve_project_root"));
+        assert_eq!(sequence[1]["action"], json!("call_matching_tool"));
+        assert_eq!(sequence[2]["action"], json!("retry_same_tool"));
+        assert_ne!(sequence[0].get("tool"), Some(&json!("ground")));
+        assert_ne!(sequence[1].get("tool"), Some(&json!("ground")));
+        let packet = guide["readiness_lanes"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .find(|lane| lane["readiness_goal"] == json!("agent_packet_search"))
+            .and_then(|lane| lane["calls"].as_array().cloned())
+            .into_iter()
+            .flatten()
+            .find(|call| call["tool"] == json!("packet"))
+            .expect("packet example");
+        assert_eq!(packet["arguments"]["budget"], json!("standard"));
+        let guide_text = guide.to_string();
+        assert!(
+            !guide_text.contains("Use ground first"),
+            "agent guide must not teach ground as the first required call: {guide}"
         );
     }
 

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -1698,6 +1698,22 @@ fn multi_project_packet_repairs_keep_operation_identity_project_scoped() {
         assert_eq!(error["cause_code"], json!("cache_busy"));
         assert_eq!(error["retry_tool"], json!("packet"));
         assert!(error["retry_after_ms"].as_u64().is_some());
+        assert!(
+            error["recommended_next_calls"]
+                .as_array()
+                .is_some_and(|calls| {
+                    calls.iter().any(|call| {
+                        call["method"] == "tools/call"
+                            && call["tool"] == "packet"
+                            && call["arguments"]["project"] == json!(project.path())
+                    }) && !calls.iter().any(|call| {
+                        call["tool"] == "affected"
+                            || call["tool"] == "status"
+                            || call["method"] == "resources/read"
+                    })
+                }),
+            "preparing packet must retry the same tool without status or placeholder affected: {error}"
+        );
         operation_ids.push(
             error["operation"]["operation_id"]
                 .as_str()
@@ -5382,22 +5398,27 @@ fn resources_read_agent_guide_describes_default_browser_loop_and_safety() {
 
     let result = assert_success_envelope(&response, json!("agent-guide-resource"));
     let guide = json_resource_content(result, "codestory://agent-guide");
+    let sequence = guide
+        .get("recommended_call_sequence")
+        .and_then(Value::as_array)
+        .unwrap_or_else(|| panic!("agent guide should include recommended_call_sequence: {guide}"));
     assert!(
-        guide
-            .get("default_browser_loop")
-            .or_else(|| guide.get("recommended_call_sequence"))
-            .or_else(|| guide.get("recommended_next_calls"))
-            .and_then(Value::as_array)
-            .is_some_and(|calls| {
-                calls.iter().any(|call| {
-                    call["tool"] == json!("ground") && call.pointer("/arguments/project").is_some()
-                })
+        sequence
+            .iter()
+            .any(|step| step["action"] == json!("call_matching_tool")
+                && step.pointer("/arguments/project").is_some())
+            && sequence
+                .iter()
+                .any(|step| step["action"] == json!("retry_same_tool"))
+            && sequence.first().is_some_and(|step| {
+                step["action"] == json!("resolve_project_root")
+                    && step.get("tool") != Some(&json!("ground"))
             })
             && guide
                 .get("readiness_lanes")
                 .and_then(Value::as_array)
                 .is_some_and(|lanes| lanes.len() >= 2),
-        "agent guide should include a concise default browser loop or call sequence: {guide}"
+        "agent guide should publish the matching-tool loop, not ground-first: {guide}"
     );
     let local_lane = guide["readiness_lanes"]
         .as_array()
@@ -5454,6 +5475,17 @@ fn resources_read_agent_guide_describes_default_browser_loop_and_safety() {
             "agent lane should include {expected}: {guide}"
         );
     }
+    let packet_example = agent_lane["calls"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .find(|call| call["tool"] == json!("packet"))
+        .unwrap_or_else(|| panic!("agent lane should include a packet example: {guide}"));
+    assert_eq!(
+        packet_example["arguments"]["budget"],
+        json!("standard"),
+        "packet example budget must be standard, not compact: {guide}"
+    );
     let mut strings = Vec::new();
     string_values_recursive(&guide, &mut strings);
     for expected in [
@@ -5479,6 +5511,10 @@ fn resources_read_agent_guide_describes_default_browser_loop_and_safety() {
         !unconditional_sequence_text.contains("\"tool\":\"packet\"")
             && !unconditional_sequence_text.contains("\"tool\":\"search\""),
         "packet/search should not be unconditional normal next steps: {guide}"
+    );
+    assert!(
+        guide_text.contains("matching tool") && !guide_text.contains("use ground first"),
+        "agent guide should follow the matching-tool loop instead of requiring ground first: {guide}"
     );
     assert!(
         guide_text.contains("preparing")
@@ -5830,18 +5866,23 @@ fn failed_replacement_retries_keep_identity_and_offer_retained_local_analysis() 
         first_error["recommended_next_calls"]
             .as_array()
             .is_some_and(|calls| {
-                calls.iter().any(|call| {
-                    call["method"] == "tools/call"
-                        && call["tool"] == "affected"
+                !calls.iter().any(|call| {
+                    call["tool"] == "affected"
                         && call["arguments"]["paths"] == json!(["<changed-project-path>"])
-                }) && calls.iter().any(|call| {
+                }) && !calls.iter().any(|call| {
                     call["method"] == "resources/read"
                         && call["uri"]
                             .as_str()
-                            .is_some_and(|uri| uri.starts_with("codestory://status?project="))
-                })
+                            .is_some_and(|uri| uri.starts_with("codestory://status"))
+                }) && !calls.iter().any(|call| call["tool"] == "status")
             }),
-        "terminal MCP response must provide useful native follow-ups: {first_error}"
+        "terminal MCP response must not invent affected paths or require status: {first_error}"
+    );
+    assert!(
+        first_error["diagnostics_uri"]
+            .as_str()
+            .is_some_and(|uri| uri.starts_with("codestory://status?project=")),
+        "diagnostics remain available without becoming a next-call prerequisite: {first_error}"
     );
 
     let first_operation = first_error["operation"].clone();

--- a/plugins/codestory/skills/codestory-grounding/references/packet.md
+++ b/plugins/codestory/skills/codestory-grounding/references/packet.md
@@ -28,8 +28,7 @@ CLI flags. Every call requires `project` (absolute repository root).
 - `probes` uses tagged objects with `kind` equal to `exact_path`, `symbol_id`,
   `file_symbol`, `free_query`, or `continuation`. For example,
   `{"kind":"exact_path","path":"assets/desk.svg"}` selects that exact
-  project-relative file without fuzzy substitution. CLI accepts the same
-  object through repeatable `--probe '<json>'`. Typed and legacy probes share
+  project-relative file without fuzzy substitution. Typed and legacy probes share
   one combined 16-item limit; every string field is limited to 240 characters.
 - Exact path, symbol-ID, file-symbol, and symbol-bound continuation probes add
   exact citations keyed by path or stable node ID. They are not converted back
@@ -38,9 +37,9 @@ CLI flags. Every call requires `project` (absolute repository root).
   `core_generation_id`, optional `retrieval_generation`, optional exact
   `symbol_id`, and `query`; reuse fails closed when the selected evidence
   generation changes. Search and definition links emit this bound form.
-- `extra_probes` and CLI `--extra-probe` remain legacy compatibility inputs.
-  They enter the same runtime resolver. Neither typed nor legacy probes replace
-  the compiled disposition.
+- `extra_probes` remains a legacy compatibility input. It enters the same
+  runtime resolver. Neither typed nor legacy probes replace the compiled
+  disposition.
 - Judge the answer from compiled support units (symbol locations, source
   ranges, typed CALL/INHERITANCE/import edges, and complete-query negatives).
   `disposition.kind=supported` means that evidence is present. It does not mean

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -1146,6 +1146,7 @@ test("skill teaches MCP catalog arguments, not Clap flags", async () => {
     assert.match(text, /generated-mcp-syntax\.md/u, name);
     assert.doesNotMatch(text, /See \[generated CLI syntax\]/u, name);
     assert.doesNotMatch(text, /<codestory-cli>/u, name);
+    assert.doesNotMatch(text, /--probe\b/u, name);
     assert.doesNotMatch(text, / --(?:why|mode|file|refresh|plan-details)\b/u, name);
   }
 });


### PR DESCRIPTION
Closes #1937

## Summary

- MCP `agent-guide` now publishes the matching-tool loop from the grounding skill: call the intended tool first, retry it while `preparing`, and treat `ground` as orientation rather than a required first call. Packet examples use the `standard` budget.
- Blocked packet/search next-calls retry the same tool when preparing. They no longer invent `affected` paths or tell the agent to read status as a prerequisite. LocalNavigation repair may still recommend `ground`; AgentPacketSearch stays empty; `status` remains only for host-reload.
- Skill `packet.md` drops leftover CLI `--probe` / `--extra-probe` wording. Plugin-static MCP-linked pages fail on `<codestory-cli>` and `--probe`.

## Test plan

- [x] `cargo test --locked -p codestory-cli --lib -- agent_guide_sequence_matches_skill`
- [x] `cargo test --locked -p codestory-cli --lib -- next_calls`
- [x] `cargo test --locked -p codestory-cli --lib -- published_guidance_calls`
- [x] `cargo test --locked -p codestory-cli --test stdio_protocol_contracts`
- [x] `node --test plugins/codestory/tests/plugin-static.test.mjs`
- [x] `git diff --check`

Base: `origin/dev/codestory-next` (`f5b42b7b`). Head after this commit: see PR SHA.

## Risk

Wave 5 still owns preparing-as-success. Hosts that stop on `isError` for preparing will still not honor retry. This PR only changes the recommended next-call shapes.


Made with [Cursor](https://cursor.com)