### PR TITLE
Strip Unreleased changelog notes before dest-to-main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,22 +2,6 @@
 
 ## Unreleased
 
-MCP now tells agents to call the tool that matches the task and retry that same tool while CodeStory prepares. It no longer starts with `ground`, invents an `affected` path, or treats `status` as a required next step.
-
-### Changed
-
-- CLI `affected` requires explicit paths or stdin, matching MCP. It no longer invents a git diff when those are omitted.
-- Repo-text matches are leads only. They no longer count as packet proof.
-- MCP `project` and CLI `--project` refuse the user home directory, `~/.ssh`,
-  `~/.gnupg`, and a `secrets/` directory used as the repository root. Set
-  `CODESTORY_ALLOW_SENSITIVE_PROJECT_ROOT=1` at process start to override. Nested
-  repositories under home are unchanged.
-- First-run MCP tool calls that are still preparing now return a successful
-  structured result with `retry_after_ms` instead of `isError: true`, so hosts
-  that stop on errors still retry. Compact and MCP status report `degraded_reason`
-  and `live_ready` beside `retrieval_mode`, so `full` is not readable as "packet
-  may run now."
-
 ## 0.17.1
 
 CodeStory 0.17.1 makes compact answers more accurate and more reliable. A packet keeps the production sources that implement the flow — the files an operator would actually change — instead of filling the answer with tests, samples, and workflow files that only share a name.


### PR DESCRIPTION
## Summary

- Removes the Unreleased MCP/CLI notes that landed with dest merges after 0.17.1 was already versioned.
- Leaves an empty `## Unreleased` heading. The 0.17.1 section is unchanged.
- Closes #1950

## Test plan

- [x] Read `CHANGELOG.md`
- [x] `git diff --check`
- [x] `node .github/scripts/check-doc-links.mjs`