### PR TITLE
Promote calibrated CodeStory 0.17.1

### DIFF
--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -1434,7 +1434,7 @@ fn multi_project_stdio_allows_nested_repo_under_home() {
     let nested = home.path().join("nested-repo");
     fs::create_dir(&nested).expect("create nested repo");
     write_tiny_rust_workspace(&nested);
-    fs::write(&nested.join("secrets"), "not a project root\n").expect("file named secrets");
+    fs::write(nested.join("secrets"), "not a project root\n").expect("file named secrets");
     let cache_root = tempfile::tempdir().expect("nested-home cache");
     let mut server =
         spawn_multi_project_stdio_server_with_home(cache_root.path(), Some(home.path()), false);

--- a/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
+++ b/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
@@ -43,22 +43,7 @@
     "query_queue_capacity": 64,
     "true_idle_observation_grace_ms": 2500
   },
-  "freeze_record": {
-    "calibration_bundle_sha256": "abf098fca10b05f2d8530c57ac924feb45dd7d8679dd7d6f933bc8fa726436d2",
-    "calibration_freeze_digest": "0942277b1fbc52570c3ef199d36508e3b9c14b42e3e1f9c34c22228be781388a",
-    "input_constant_set_sha256": "28d651014e97bbac52a895ee193eff09c4c4cadb11fa6d2fc3df8f47f8349843",
-    "measurement_protocol_sha256": "9eb303b6204ca6218e97ae299356370b16921a485350146fe85203a298e59269",
-    "protocol_sha256": "25373a136cc1da119ed6829769b90aab075084406b0489f9f7698b370f5ee447",
-    "run_artifact_sha256s": [
-      "3747e8c7bc7e90fcc3ebd17824edab0f62ae9ecf94c8d329cdfa7a8e029e6390",
-      "5d94d2a1a84f82a6869857cf843869bb520a3acd38a95bd6b2ba1a423900d953",
-      "dfcf8bc436eea490c5bb3cc2395b3ea85f83b5bcf83da5577775693c88f0598c"
-    ],
-    "selected_at": "github-actions-run:32327311816:1",
-    "selection_rule": "constant_only_three_fresh_generations_one_sample_each+slow_host_floors_v2",
-    "selection_source_commit": "33af928fa62dbe29f76faf730adff9156ecadf8f",
-    "selection_source_tree": "2b79168dc66d13ca6f44f2ccb4cb5b7f3fba87f6"
-  },
+  "freeze_record": null,
   "qualification_threshold_overrides": {
     "protected_windows_x64_vulkan": {
       "existing_owner_connect": 125,
@@ -81,5 +66,5 @@
   },
   "schema_version": 1,
   "selection_protocol": "codestory-per-user-embedding-server-v1",
-  "status": "frozen"
+  "status": "unfrozen"
 }

--- a/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
+++ b/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
@@ -1,21 +1,21 @@
 {
   "calibration_required_values": {
     "capacity_retry_policy": {
-      "retry_after_ms": 41,
+      "retry_after_ms": 40,
       "retry_class": "after_capacity_change",
       "retry_condition_source": "named_condition_from_typed_capacity_response"
     },
     "connect_timeout_ms": 2000,
     "election_backoff_policy": {
-      "initial_backoff_ms": 7,
+      "initial_backoff_ms": 9,
       "jitter": "sha256(process_start_id||attempt) modulo inclusive [initial_backoff_ms,maximum_backoff_ms]",
-      "maximum_backoff_ms": 146
+      "maximum_backoff_ms": 112
     },
     "hard_native_no_progress_ms": 385431,
     "request_deadlines_ms": {
       "bulk_replay_success_budget_ms": 144537,
       "bulk_request_deadline_ms": 564239,
-      "query_request_deadline_ms": 14045
+      "query_request_deadline_ms": 10000
     },
     "spawn_convergence_timeout_ms": 15000,
     "watchdog_cadence_ms": 19271
@@ -43,7 +43,22 @@
     "query_queue_capacity": 64,
     "true_idle_observation_grace_ms": 2500
   },
-  "freeze_record": null,
+  "freeze_record": {
+    "calibration_bundle_sha256": "1a5ef37823c919fb5d689b19e1cb1d929fbe7f88d363fa56f485c5a601486a69",
+    "calibration_freeze_digest": "6f85edf2ff8c25c57bed590ade555584d2fd53ba8b9909af240abf2c68ebfb28",
+    "input_constant_set_sha256": "e55cd293dbc9b6ab321c17f0827cfc6f6785ade262fb03b61b0a6b2818e547a5",
+    "measurement_protocol_sha256": "9eb303b6204ca6218e97ae299356370b16921a485350146fe85203a298e59269",
+    "protocol_sha256": "25373a136cc1da119ed6829769b90aab075084406b0489f9f7698b370f5ee447",
+    "run_artifact_sha256s": [
+      "533256a40fe1f6de5838cc2652afd172a7b30f1c80da3aa842de2afc9d32e605",
+      "b67b523f29c135863a63cd93bab0412707adb987bd3034b9e9b84a4b03c901b9",
+      "bd45844642ebc16cc5d5feebe7dbff7c51063970cfb52e653cb987f2e6f40688"
+    ],
+    "selected_at": "github-actions-run:32369286084:1",
+    "selection_rule": "constant_only_three_fresh_generations_one_sample_each+slow_host_floors_v2",
+    "selection_source_commit": "e97578e510498b0fb03587de8e33c3fd0890feae",
+    "selection_source_tree": "96e247b1e93fecd2f84202097d71f23d3d2be18c"
+  },
   "qualification_threshold_overrides": {
     "protected_windows_x64_vulkan": {
       "existing_owner_connect": 125,
@@ -66,5 +81,5 @@
   },
   "schema_version": 1,
   "selection_protocol": "codestory-per-user-embedding-server-v1",
-  "status": "unfrozen"
+  "status": "frozen"
 }


### PR DESCRIPTION
## Summary

Promotes `dev/codestory-next` at frozen candidate `ef869254` into `main` and ships **0.17.1** through automatic release.

- Dest-complete 0.17.1 source (MCP preparing envelopes, explicit `affected` paths, sensitive project-root refusal, agent-guide alignment) plus the Metal constant-set freeze.
- Calibration source `C` is `e97578e5`. Freeze `F` is `ef869254`, the direct constant-set-only child.
- Simulated merge of `main` and this head produces freeze tree `b5b0d076a68479d20c9f174ee9c6249bebb65b80`. Merge with a merge commit (do not squash or rebase).

Closes #1953 if still open.

## Test plan

- [x] #1954 fast-forwarded dest to `ef869254`
- [x] `git merge-tree --write-tree origin/main origin/dev/codestory-next` equals freeze tree
- [ ] After merge: `origin/main^{tree}` equals `b5b0d076`
- [ ] Freeze `ef869254` is a direct parent of `origin/main`
- [ ] Auto Release creates `v0.17.1`