### PR TITLE
[codex] restore calibration lineage after integration rewrite

### DIFF
--- a/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
+++ b/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
@@ -43,22 +43,7 @@
     "query_queue_capacity": 64,
     "true_idle_observation_grace_ms": 2500
   },
-  "freeze_record": {
-    "calibration_bundle_sha256": "e31ea79dc8ec8b7acaeacfe0873e1c0c0e2e973100d8ba6fdb648977521c019c",
-    "calibration_freeze_digest": "43b9a097e7c7b48f8c6fe879eb87712177dadf5b41a56456af098191cdb539bb",
-    "input_constant_set_sha256": "4c3b926d87e7be6acd95f1ba8bb7eb47d7d129a6469f6831e13ecd8dcf47cdca",
-    "measurement_protocol_sha256": "9eb303b6204ca6218e97ae299356370b16921a485350146fe85203a298e59269",
-    "protocol_sha256": "25373a136cc1da119ed6829769b90aab075084406b0489f9f7698b370f5ee447",
-    "run_artifact_sha256s": [
-      "1737bc3a48c2dc462dd0e66429cfe3ede7d11f1c9621b09982548b98daa570dd",
-      "531167ad81370e3efe35053ba9c547af94aa98ce9f1249c3736ec59e6f73e1b6",
-      "f7b75783a7fc6f5bbc7f69ec709c82519581fdc3b8c515ce4aa29eea8eace3d7"
-    ],
-    "selected_at": "github-actions-run:32384586972:1",
-    "selection_rule": "constant_only_three_fresh_generations_one_sample_each+slow_host_floors_v2",
-    "selection_source_commit": "ab5293ffc6ac351876804fac82f0a30a5d5b1efe",
-    "selection_source_tree": "02258311c5aec3428918a7c612ab46bfbcc19270"
-  },
+  "freeze_record": null,
   "qualification_threshold_overrides": {
     "protected_windows_x64_vulkan": {
       "existing_owner_connect": 125,
@@ -81,5 +66,5 @@
   },
   "schema_version": 1,
   "selection_protocol": "codestory-per-user-embedding-server-v1",
-  "status": "frozen"
+  "status": "unfrozen"
 }

--- a/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
+++ b/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
@@ -1,7 +1,7 @@
 {
   "calibration_required_values": {
     "capacity_retry_policy": {
-      "retry_after_ms": 43,
+      "retry_after_ms": 40,
       "retry_class": "after_capacity_change",
       "retry_condition_source": "named_condition_from_typed_capacity_response"
     },
@@ -9,7 +9,7 @@
     "election_backoff_policy": {
       "initial_backoff_ms": 7,
       "jitter": "sha256(process_start_id||attempt) modulo inclusive [initial_backoff_ms,maximum_backoff_ms]",
-      "maximum_backoff_ms": 111
+      "maximum_backoff_ms": 110
     },
     "hard_native_no_progress_ms": 385431,
     "request_deadlines_ms": {
@@ -43,7 +43,22 @@
     "query_queue_capacity": 64,
     "true_idle_observation_grace_ms": 2500
   },
-  "freeze_record": null,
+  "freeze_record": {
+    "calibration_bundle_sha256": "bbd058a1c4410002e0554f8059f5a215442615d1dbe3a5e7c2024d2ab6078ecb",
+    "calibration_freeze_digest": "6379ab52916fac118883243752475e87028f470088911af6c37c3226c75ebb7e",
+    "input_constant_set_sha256": "a913f3971db333f2d97c26e8bd7c5f3cb30c1b6a996608049c0a8cc88d7cdc6e",
+    "measurement_protocol_sha256": "9eb303b6204ca6218e97ae299356370b16921a485350146fe85203a298e59269",
+    "protocol_sha256": "25373a136cc1da119ed6829769b90aab075084406b0489f9f7698b370f5ee447",
+    "run_artifact_sha256s": [
+      "7c747b0e24a9df121fcc1f3317211e82a392389e68c9c271a29cfa1da6bbb659",
+      "b4e015ee27a521818264d110e0e95092b570cd4904d8994c2dd49d09ab15db0c",
+      "d638a189c881b6dced364cc21fb883542df5052b81fe2441187f7b67b9a140cb"
+    ],
+    "selected_at": "github-actions-run:32389005238:1",
+    "selection_rule": "constant_only_three_fresh_generations_one_sample_each+slow_host_floors_v2",
+    "selection_source_commit": "e1a4162a68c879e09be25d8ab387840135677e40",
+    "selection_source_tree": "0feebc3c8224515048383687c70f95513c845653"
+  },
   "qualification_threshold_overrides": {
     "protected_windows_x64_vulkan": {
       "existing_owner_connect": 125,
@@ -66,5 +81,5 @@
   },
   "schema_version": 1,
   "selection_protocol": "codestory-per-user-embedding-server-v1",
-  "status": "unfrozen"
+  "status": "frozen"
 }


### PR DESCRIPTION
Closes #1956

## Context

PR #1957 merged the release publication fix into `dev/codestory-next`, but GitHub's rebase merge rewrote the already-calibrated source and freeze commits. The resulting tree is byte-identical to the accepted frozen tree, but the release lineage contract correctly rejects rebased calibration ancestry.

## What changed

- unfreeze the generated embedding-server constant set on the actual integrated dev head;
- retain the calibrated numeric values unchanged;
- re-establish the required source stabilization → calibration → constant-only freeze → frozen-candidate acceptance chain from this exact integration lineage.

No workflow or product source is changed by this follow-up PR.

## Review

Verify that this commit is the direct child of `5c610c026d32aa29640afc89d4ac22da3de6573f`, changes only the constant-set JSON, replaces the freeze record with `null`, changes status to `unfrozen`, and preserves every normalized constant value.

## Risk

This PR exists to prevent publication from bypassing the calibration-lineage guard. Promotion remains blocked until a fresh generated constant-only freeze and frozen-candidate acceptance are attached to this exact ancestry.
