### PR TITLE
[codex] preserve exact release calibration lineage

### DIFF
--- a/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
+++ b/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
@@ -7,7 +7,7 @@
     },
     "connect_timeout_ms": 2000,
     "election_backoff_policy": {
-      "initial_backoff_ms": 7,
+      "initial_backoff_ms": 8,
       "jitter": "sha256(process_start_id||attempt) modulo inclusive [initial_backoff_ms,maximum_backoff_ms]",
       "maximum_backoff_ms": 110
     },
@@ -43,7 +43,22 @@
     "query_queue_capacity": 64,
     "true_idle_observation_grace_ms": 2500
   },
-  "freeze_record": null,
+  "freeze_record": {
+    "calibration_bundle_sha256": "9978183c27431c88d049bcad1cc7846e5e62e39b1344cb22f17c686f21b2ad8a",
+    "calibration_freeze_digest": "02678ee032d901f409eaba41b6f4dafd01ca2443c2ace7f42b9ef9b9780fe174",
+    "input_constant_set_sha256": "d345146e0fbc62a35b930d9c009724e4d2482e4d4c9a69c3bd7ec0c5f442a106",
+    "measurement_protocol_sha256": "9eb303b6204ca6218e97ae299356370b16921a485350146fe85203a298e59269",
+    "protocol_sha256": "25373a136cc1da119ed6829769b90aab075084406b0489f9f7698b370f5ee447",
+    "run_artifact_sha256s": [
+      "10731b4a8d980cc5d3eb605ef72b469da44982a56c6284389b953caa9e48a308",
+      "8539aaaa1844c9445f856f1cd1d09b861247388c772d1649d52c84e0a05aca59",
+      "ddcef1bcb27bd09d1dab02e62abd7815e75e08cebc5ebacba360f888ffb5321e"
+    ],
+    "selected_at": "github-actions-run:32393969521:1",
+    "selection_rule": "constant_only_three_fresh_generations_one_sample_each+slow_host_floors_v2",
+    "selection_source_commit": "2fca525270b6562a6fd9db03bb40fb875464ce4a",
+    "selection_source_tree": "882e8012b2ba461a1414ca6b157431a50de5dddd"
+  },
   "qualification_threshold_overrides": {
     "protected_windows_x64_vulkan": {
       "existing_owner_connect": 125,
@@ -66,5 +81,5 @@
   },
   "schema_version": 1,
   "selection_protocol": "codestory-per-user-embedding-server-v1",
-  "status": "unfrozen"
+  "status": "frozen"
 }

--- a/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
+++ b/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
@@ -43,22 +43,7 @@
     "query_queue_capacity": 64,
     "true_idle_observation_grace_ms": 2500
   },
-  "freeze_record": {
-    "calibration_bundle_sha256": "bbd058a1c4410002e0554f8059f5a215442615d1dbe3a5e7c2024d2ab6078ecb",
-    "calibration_freeze_digest": "6379ab52916fac118883243752475e87028f470088911af6c37c3226c75ebb7e",
-    "input_constant_set_sha256": "a913f3971db333f2d97c26e8bd7c5f3cb30c1b6a996608049c0a8cc88d7cdc6e",
-    "measurement_protocol_sha256": "9eb303b6204ca6218e97ae299356370b16921a485350146fe85203a298e59269",
-    "protocol_sha256": "25373a136cc1da119ed6829769b90aab075084406b0489f9f7698b370f5ee447",
-    "run_artifact_sha256s": [
-      "7c747b0e24a9df121fcc1f3317211e82a392389e68c9c271a29cfa1da6bbb659",
-      "b4e015ee27a521818264d110e0e95092b570cd4904d8994c2dd49d09ab15db0c",
-      "d638a189c881b6dced364cc21fb883542df5052b81fe2441187f7b67b9a140cb"
-    ],
-    "selected_at": "github-actions-run:32389005238:1",
-    "selection_rule": "constant_only_three_fresh_generations_one_sample_each+slow_host_floors_v2",
-    "selection_source_commit": "e1a4162a68c879e09be25d8ab387840135677e40",
-    "selection_source_tree": "0feebc3c8224515048383687c70f95513c845653"
-  },
+  "freeze_record": null,
   "qualification_threshold_overrides": {
     "protected_windows_x64_vulkan": {
       "existing_owner_connect": 125,
@@ -81,5 +66,5 @@
   },
   "schema_version": 1,
   "selection_protocol": "codestory-per-user-embedding-server-v1",
-  "status": "frozen"
+  "status": "unfrozen"
 }


### PR DESCRIPTION
Closes #1956

## Context

PRs #1957 and #1958 each passed exact-head source stabilization, calibration, generated freeze, and frozen-candidate acceptance. GitHub's rebase merge rewrote the accepted commits both times, preserving the tree but invalidating the calibration ancestry required for release.

Live repository policy confirms `dev/codestory-next` has no branch protection or ruleset. After this PR reaches exact-head acceptance, the accepted frozen head will therefore be landed with a guarded, non-force fast-forward push whose lease requires dev to remain at this PR's recorded base. That preserves the reviewed SHA and avoids a third rebase rewrite.

## What changed

- unfreeze the generated embedding-server constant set on the actual current dev head;
- retain every normalized constant value unchanged;
- re-establish the source stabilization → calibration → constant-only freeze → frozen-candidate acceptance chain one final time.

No workflow or product source changes in this PR.

## Review

Verify that this commit is the direct child of `3c61fab14c4420a0679690a2eb8a072b58b7ecb1`, changes only the constant-set JSON, clears `freeze_record`, sets `status` to `unfrozen`, and preserves normalized constants. Verify the recorded dev base again before the final fast-forward.

## Risk

No force push is permitted. If dev moves or the fast-forward is rejected, stop; do not rewrite history or weaken the lineage guard.
