### PR TITLE
Promote repaired CodeStory 0.17.1 release

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -3439,8 +3439,8 @@ function validateReleaseCoordinator(workflows, violations, graph) {
   add(
     violations,
     publish.if
-      === "always() && inputs.publish_release && needs.preflight.result == 'success' && needs.pre-publish-closeout.result == 'success'",
-    `${releaseFile} publish must remain schedulable after accepted reuse while requiring trusted publication authority and successful direct dependencies`,
+      === "${{ !cancelled() && inputs.publish_release && needs.preflight.result == 'success' && needs.pre-publish-closeout.result == 'success' }}",
+    `${releaseFile} publish must remain schedulable after accepted reuse and cancellable while requiring trusted publication authority and successful direct dependencies`,
   );
   add(violations, sameMembers(needs(publish), releaseChain.dependencies.publish), `${releaseFile} publish dependencies must match the release claim graph`);
   // The published platform table is a claim about this release, so it is rendered from the accepted
@@ -3488,8 +3488,8 @@ function validateReleaseCoordinator(workflows, violations, graph) {
   add(
     violations,
     marketplacePublish.if
-      === "always() && inputs.publish_release && needs.preflight.result == 'success' && needs.publish.result == 'success'",
-    `${releaseFile} marketplace publication must remain schedulable after accepted reuse while requiring trusted publication authority and a successful publish`,
+      === "${{ !cancelled() && inputs.publish_release && needs.preflight.result == 'success' && needs.publish.result == 'success' }}",
+    `${releaseFile} marketplace publication must remain schedulable after accepted reuse and cancellable while requiring trusted publication authority and a successful publish`,
   );
   add(
     violations,
@@ -3581,8 +3581,8 @@ function validateReleaseCoordinator(workflows, violations, graph) {
   add(
     violations,
     postCloseout.if
-      === "always() && inputs.publish_release && needs.preflight.result == 'success' && needs.pre-publish-closeout.result == 'success' && needs.post-publish-smoke.result == 'success'",
-    `${releaseFile} post-publish closeout must remain schedulable after accepted reuse while requiring trusted publication authority and successful direct dependencies`,
+      === "${{ !cancelled() && inputs.publish_release && needs.preflight.result == 'success' && needs.pre-publish-closeout.result == 'success' && needs.post-publish-smoke.result == 'success' }}",
+    `${releaseFile} post-publish closeout must remain schedulable after accepted reuse and cancellable while requiring trusted publication authority and successful direct dependencies`,
   );
   add(violations, sameMembers(needs(postCloseout), releaseChain.dependencies["post-publish-closeout"]), `${releaseFile} post-publish closeout dependencies must match the release claim graph`);
   // The closeout reached marketplace-publish only through the smoke, so removing the smoke's gate

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -3436,7 +3436,12 @@ function validateReleaseCoordinator(workflows, violations, graph) {
   // release-claims.json under workflow_policy.step_fragments;
   // stepFragmentViolations evaluates them.
   const publish = object(object(release.jobs).publish);
-  add(violations, publish.if === "inputs.publish_release", `${releaseFile} publish must require trusted publication authority`);
+  add(
+    violations,
+    publish.if
+      === "always() && inputs.publish_release && needs.preflight.result == 'success' && needs.pre-publish-closeout.result == 'success'",
+    `${releaseFile} publish must remain schedulable after accepted reuse while requiring trusted publication authority and successful direct dependencies`,
+  );
   add(violations, sameMembers(needs(publish), releaseChain.dependencies.publish), `${releaseFile} publish dependencies must match the release claim graph`);
   // The published platform table is a claim about this release, so it is rendered from the accepted
   // ledger. Rendering it from the static graph is how a release whose accelerator proof was
@@ -3482,8 +3487,9 @@ function validateReleaseCoordinator(workflows, violations, graph) {
   const marketplacePublish = object(object(release.jobs)["marketplace-publish"]);
   add(
     violations,
-    marketplacePublish.if === "inputs.publish_release",
-    `${releaseFile} marketplace publication must require trusted publication authority`,
+    marketplacePublish.if
+      === "always() && inputs.publish_release && needs.preflight.result == 'success' && needs.publish.result == 'success'",
+    `${releaseFile} marketplace publication must remain schedulable after accepted reuse while requiring trusted publication authority and a successful publish`,
   );
   add(
     violations,
@@ -3572,7 +3578,12 @@ function validateReleaseCoordinator(workflows, violations, graph) {
   // the evaluation - are rule instances and live in release-claims.json under
   // workflow_policy.step_fragments; stepFragmentViolations evaluates them.
   const postCloseout = object(object(release.jobs)["post-publish-closeout"]);
-  add(violations, postCloseout.if === "inputs.publish_release", `${releaseFile} post-publish closeout must require trusted publication authority`);
+  add(
+    violations,
+    postCloseout.if
+      === "always() && inputs.publish_release && needs.preflight.result == 'success' && needs.pre-publish-closeout.result == 'success' && needs.post-publish-smoke.result == 'success'",
+    `${releaseFile} post-publish closeout must remain schedulable after accepted reuse while requiring trusted publication authority and successful direct dependencies`,
+  );
   add(violations, sameMembers(needs(postCloseout), releaseChain.dependencies["post-publish-closeout"]), `${releaseFile} post-publish closeout dependencies must match the release claim graph`);
   // The closeout reached marketplace-publish only through the smoke, so removing the smoke's gate
   // removed the closeout's too. Keep it that way rather than leaving it to be reintroduced here.

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -6711,8 +6711,17 @@ test("release policy rejects manifest producer, trusted-map, and publication byp
       step.run = step.run.replace("main moved from publishable head", "main changed");
     }],
     ["publish authority", workflows => { delete workflows.get("release.yml").jobs.publish.if; }],
+    ["publish inherits a skipped reuse ancestor", workflows => {
+      workflows.get("release.yml").jobs.publish.if = "inputs.publish_release";
+    }],
+    ["marketplace publication inherits a skipped reuse ancestor", workflows => {
+      workflows.get("release.yml").jobs["marketplace-publish"].if = "inputs.publish_release";
+    }],
     ["post-publish smoke authority", workflows => { delete workflows.get("release.yml").jobs["post-publish-smoke"].if; }],
     ["post-publish closeout authority", workflows => { delete workflows.get("release.yml").jobs["post-publish-closeout"].if; }],
+    ["post-publish closeout inherits a skipped reuse ancestor", workflows => {
+      workflows.get("release.yml").jobs["post-publish-closeout"].if = "inputs.publish_release";
+    }],
     ["trusted caller opt-in", workflows => { delete workflows.get("auto-release.yml").jobs.release.with.publish_release; }],
     ["trusted caller secret handoff", workflows => { delete workflows.get("auto-release.yml").jobs.release.secrets; }],
     ["duplicate automatic policy gate", workflows => {

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -6714,13 +6714,25 @@ test("release policy rejects manifest producer, trusted-map, and publication byp
     ["publish inherits a skipped reuse ancestor", workflows => {
       workflows.get("release.yml").jobs.publish.if = "inputs.publish_release";
     }],
+    ["publish loses its cancellation guard", workflows => {
+      workflows.get("release.yml").jobs.publish.if
+        = "always() && inputs.publish_release && needs.preflight.result == 'success' && needs.pre-publish-closeout.result == 'success'";
+    }],
     ["marketplace publication inherits a skipped reuse ancestor", workflows => {
       workflows.get("release.yml").jobs["marketplace-publish"].if = "inputs.publish_release";
+    }],
+    ["marketplace publication loses its cancellation guard", workflows => {
+      workflows.get("release.yml").jobs["marketplace-publish"].if
+        = "always() && inputs.publish_release && needs.preflight.result == 'success' && needs.publish.result == 'success'";
     }],
     ["post-publish smoke authority", workflows => { delete workflows.get("release.yml").jobs["post-publish-smoke"].if; }],
     ["post-publish closeout authority", workflows => { delete workflows.get("release.yml").jobs["post-publish-closeout"].if; }],
     ["post-publish closeout inherits a skipped reuse ancestor", workflows => {
       workflows.get("release.yml").jobs["post-publish-closeout"].if = "inputs.publish_release";
+    }],
+    ["post-publish closeout loses its cancellation guard", workflows => {
+      workflows.get("release.yml").jobs["post-publish-closeout"].if
+        = "always() && inputs.publish_release && needs.preflight.result == 'success' && needs.pre-publish-closeout.result == 'success' && needs.post-publish-smoke.result == 'success'";
     }],
     ["trusted caller opt-in", workflows => { delete workflows.get("auto-release.yml").jobs.release.with.publish_release; }],
     ["trusted caller secret handoff", workflows => { delete workflows.get("auto-release.yml").jobs.release.secrets; }],

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -866,7 +866,10 @@ jobs:
 
   publish:
     name: Publish GitHub release
-    if: inputs.publish_release
+    # source-proof may be intentionally skipped when preflight selected accepted reusable evidence.
+    # `always()` prevents that transitive skip from suppressing publication; the explicit direct
+    # dependency checks still fail closed on a rejected preflight or closeout.
+    if: always() && inputs.publish_release && needs.preflight.result == 'success' && needs.pre-publish-closeout.result == 'success'
     needs:
       - preflight
       - pre-publish-closeout
@@ -1009,7 +1012,7 @@ jobs:
   # explicit outcomes, and post-publish-smoke records that outcome in the release ledger.
   marketplace-publish:
     name: Publish the marketplace catalog
-    if: inputs.publish_release
+    if: always() && inputs.publish_release && needs.preflight.result == 'success' && needs.publish.result == 'success'
     needs:
       - preflight
       - publish
@@ -1207,7 +1210,7 @@ jobs:
 
   post-publish-closeout:
     name: Authenticate post-publish release cells
-    if: inputs.publish_release
+    if: always() && inputs.publish_release && needs.preflight.result == 'success' && needs.pre-publish-closeout.result == 'success' && needs.post-publish-smoke.result == 'success'
     needs:
       - preflight
       - pre-publish-closeout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -867,9 +867,10 @@ jobs:
   publish:
     name: Publish GitHub release
     # source-proof may be intentionally skipped when preflight selected accepted reusable evidence.
-    # `always()` prevents that transitive skip from suppressing publication; the explicit direct
-    # dependency checks still fail closed on a rejected preflight or closeout.
-    if: always() && inputs.publish_release && needs.preflight.result == 'success' && needs.pre-publish-closeout.result == 'success'
+    # `!cancelled()` prevents that transitive skip from suppressing publication without making a
+    # superseded run cancellation-resistant; the explicit direct dependency checks still fail
+    # closed on a rejected preflight or closeout.
+    if: ${{ !cancelled() && inputs.publish_release && needs.preflight.result == 'success' && needs.pre-publish-closeout.result == 'success' }}
     needs:
       - preflight
       - pre-publish-closeout
@@ -1012,7 +1013,7 @@ jobs:
   # explicit outcomes, and post-publish-smoke records that outcome in the release ledger.
   marketplace-publish:
     name: Publish the marketplace catalog
-    if: always() && inputs.publish_release && needs.preflight.result == 'success' && needs.publish.result == 'success'
+    if: ${{ !cancelled() && inputs.publish_release && needs.preflight.result == 'success' && needs.publish.result == 'success' }}
     needs:
       - preflight
       - publish
@@ -1210,7 +1211,7 @@ jobs:
 
   post-publish-closeout:
     name: Authenticate post-publish release cells
-    if: always() && inputs.publish_release && needs.preflight.result == 'success' && needs.pre-publish-closeout.result == 'success' && needs.post-publish-smoke.result == 'success'
+    if: ${{ !cancelled() && inputs.publish_release && needs.preflight.result == 'success' && needs.pre-publish-closeout.result == 'success' && needs.post-publish-smoke.result == 'success' }}
     needs:
       - preflight
       - pre-publish-closeout

--- a/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
+++ b/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
@@ -43,22 +43,7 @@
     "query_queue_capacity": 64,
     "true_idle_observation_grace_ms": 2500
   },
-  "freeze_record": {
-    "calibration_bundle_sha256": "1a5ef37823c919fb5d689b19e1cb1d929fbe7f88d363fa56f485c5a601486a69",
-    "calibration_freeze_digest": "6f85edf2ff8c25c57bed590ade555584d2fd53ba8b9909af240abf2c68ebfb28",
-    "input_constant_set_sha256": "e55cd293dbc9b6ab321c17f0827cfc6f6785ade262fb03b61b0a6b2818e547a5",
-    "measurement_protocol_sha256": "9eb303b6204ca6218e97ae299356370b16921a485350146fe85203a298e59269",
-    "protocol_sha256": "25373a136cc1da119ed6829769b90aab075084406b0489f9f7698b370f5ee447",
-    "run_artifact_sha256s": [
-      "533256a40fe1f6de5838cc2652afd172a7b30f1c80da3aa842de2afc9d32e605",
-      "b67b523f29c135863a63cd93bab0412707adb987bd3034b9e9b84a4b03c901b9",
-      "bd45844642ebc16cc5d5feebe7dbff7c51063970cfb52e653cb987f2e6f40688"
-    ],
-    "selected_at": "github-actions-run:32369286084:1",
-    "selection_rule": "constant_only_three_fresh_generations_one_sample_each+slow_host_floors_v2",
-    "selection_source_commit": "e97578e510498b0fb03587de8e33c3fd0890feae",
-    "selection_source_tree": "96e247b1e93fecd2f84202097d71f23d3d2be18c"
-  },
+  "freeze_record": null,
   "qualification_threshold_overrides": {
     "protected_windows_x64_vulkan": {
       "existing_owner_connect": 125,
@@ -81,5 +66,5 @@
   },
   "schema_version": 1,
   "selection_protocol": "codestory-per-user-embedding-server-v1",
-  "status": "frozen"
+  "status": "unfrozen"
 }

--- a/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
+++ b/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
@@ -43,22 +43,7 @@
     "query_queue_capacity": 64,
     "true_idle_observation_grace_ms": 2500
   },
-  "freeze_record": {
-    "calibration_bundle_sha256": "e31ea79dc8ec8b7acaeacfe0873e1c0c0e2e973100d8ba6fdb648977521c019c",
-    "calibration_freeze_digest": "43b9a097e7c7b48f8c6fe879eb87712177dadf5b41a56456af098191cdb539bb",
-    "input_constant_set_sha256": "4c3b926d87e7be6acd95f1ba8bb7eb47d7d129a6469f6831e13ecd8dcf47cdca",
-    "measurement_protocol_sha256": "9eb303b6204ca6218e97ae299356370b16921a485350146fe85203a298e59269",
-    "protocol_sha256": "25373a136cc1da119ed6829769b90aab075084406b0489f9f7698b370f5ee447",
-    "run_artifact_sha256s": [
-      "1737bc3a48c2dc462dd0e66429cfe3ede7d11f1c9621b09982548b98daa570dd",
-      "531167ad81370e3efe35053ba9c547af94aa98ce9f1249c3736ec59e6f73e1b6",
-      "f7b75783a7fc6f5bbc7f69ec709c82519581fdc3b8c515ce4aa29eea8eace3d7"
-    ],
-    "selected_at": "github-actions-run:32384586972:1",
-    "selection_rule": "constant_only_three_fresh_generations_one_sample_each+slow_host_floors_v2",
-    "selection_source_commit": "ab5293ffc6ac351876804fac82f0a30a5d5b1efe",
-    "selection_source_tree": "02258311c5aec3428918a7c612ab46bfbcc19270"
-  },
+  "freeze_record": null,
   "qualification_threshold_overrides": {
     "protected_windows_x64_vulkan": {
       "existing_owner_connect": 125,
@@ -81,5 +66,5 @@
   },
   "schema_version": 1,
   "selection_protocol": "codestory-per-user-embedding-server-v1",
-  "status": "frozen"
+  "status": "unfrozen"
 }

--- a/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
+++ b/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
@@ -7,7 +7,7 @@
     },
     "connect_timeout_ms": 2000,
     "election_backoff_policy": {
-      "initial_backoff_ms": 7,
+      "initial_backoff_ms": 8,
       "jitter": "sha256(process_start_id||attempt) modulo inclusive [initial_backoff_ms,maximum_backoff_ms]",
       "maximum_backoff_ms": 110
     },
@@ -43,7 +43,22 @@
     "query_queue_capacity": 64,
     "true_idle_observation_grace_ms": 2500
   },
-  "freeze_record": null,
+  "freeze_record": {
+    "calibration_bundle_sha256": "9978183c27431c88d049bcad1cc7846e5e62e39b1344cb22f17c686f21b2ad8a",
+    "calibration_freeze_digest": "02678ee032d901f409eaba41b6f4dafd01ca2443c2ace7f42b9ef9b9780fe174",
+    "input_constant_set_sha256": "d345146e0fbc62a35b930d9c009724e4d2482e4d4c9a69c3bd7ec0c5f442a106",
+    "measurement_protocol_sha256": "9eb303b6204ca6218e97ae299356370b16921a485350146fe85203a298e59269",
+    "protocol_sha256": "25373a136cc1da119ed6829769b90aab075084406b0489f9f7698b370f5ee447",
+    "run_artifact_sha256s": [
+      "10731b4a8d980cc5d3eb605ef72b469da44982a56c6284389b953caa9e48a308",
+      "8539aaaa1844c9445f856f1cd1d09b861247388c772d1649d52c84e0a05aca59",
+      "ddcef1bcb27bd09d1dab02e62abd7815e75e08cebc5ebacba360f888ffb5321e"
+    ],
+    "selected_at": "github-actions-run:32393969521:1",
+    "selection_rule": "constant_only_three_fresh_generations_one_sample_each+slow_host_floors_v2",
+    "selection_source_commit": "2fca525270b6562a6fd9db03bb40fb875464ce4a",
+    "selection_source_tree": "882e8012b2ba461a1414ca6b157431a50de5dddd"
+  },
   "qualification_threshold_overrides": {
     "protected_windows_x64_vulkan": {
       "existing_owner_connect": 125,
@@ -66,5 +81,5 @@
   },
   "schema_version": 1,
   "selection_protocol": "codestory-per-user-embedding-server-v1",
-  "status": "unfrozen"
+  "status": "frozen"
 }

--- a/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
+++ b/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
@@ -1,15 +1,15 @@
 {
   "calibration_required_values": {
     "capacity_retry_policy": {
-      "retry_after_ms": 40,
+      "retry_after_ms": 43,
       "retry_class": "after_capacity_change",
       "retry_condition_source": "named_condition_from_typed_capacity_response"
     },
     "connect_timeout_ms": 2000,
     "election_backoff_policy": {
-      "initial_backoff_ms": 9,
+      "initial_backoff_ms": 7,
       "jitter": "sha256(process_start_id||attempt) modulo inclusive [initial_backoff_ms,maximum_backoff_ms]",
-      "maximum_backoff_ms": 112
+      "maximum_backoff_ms": 111
     },
     "hard_native_no_progress_ms": 385431,
     "request_deadlines_ms": {
@@ -43,7 +43,22 @@
     "query_queue_capacity": 64,
     "true_idle_observation_grace_ms": 2500
   },
-  "freeze_record": null,
+  "freeze_record": {
+    "calibration_bundle_sha256": "e31ea79dc8ec8b7acaeacfe0873e1c0c0e2e973100d8ba6fdb648977521c019c",
+    "calibration_freeze_digest": "43b9a097e7c7b48f8c6fe879eb87712177dadf5b41a56456af098191cdb539bb",
+    "input_constant_set_sha256": "4c3b926d87e7be6acd95f1ba8bb7eb47d7d129a6469f6831e13ecd8dcf47cdca",
+    "measurement_protocol_sha256": "9eb303b6204ca6218e97ae299356370b16921a485350146fe85203a298e59269",
+    "protocol_sha256": "25373a136cc1da119ed6829769b90aab075084406b0489f9f7698b370f5ee447",
+    "run_artifact_sha256s": [
+      "1737bc3a48c2dc462dd0e66429cfe3ede7d11f1c9621b09982548b98daa570dd",
+      "531167ad81370e3efe35053ba9c547af94aa98ce9f1249c3736ec59e6f73e1b6",
+      "f7b75783a7fc6f5bbc7f69ec709c82519581fdc3b8c515ce4aa29eea8eace3d7"
+    ],
+    "selected_at": "github-actions-run:32384586972:1",
+    "selection_rule": "constant_only_three_fresh_generations_one_sample_each+slow_host_floors_v2",
+    "selection_source_commit": "ab5293ffc6ac351876804fac82f0a30a5d5b1efe",
+    "selection_source_tree": "02258311c5aec3428918a7c612ab46bfbcc19270"
+  },
   "qualification_threshold_overrides": {
     "protected_windows_x64_vulkan": {
       "existing_owner_connect": 125,
@@ -66,5 +81,5 @@
   },
   "schema_version": 1,
   "selection_protocol": "codestory-per-user-embedding-server-v1",
-  "status": "unfrozen"
+  "status": "frozen"
 }

--- a/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
+++ b/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
@@ -43,22 +43,7 @@
     "query_queue_capacity": 64,
     "true_idle_observation_grace_ms": 2500
   },
-  "freeze_record": {
-    "calibration_bundle_sha256": "bbd058a1c4410002e0554f8059f5a215442615d1dbe3a5e7c2024d2ab6078ecb",
-    "calibration_freeze_digest": "6379ab52916fac118883243752475e87028f470088911af6c37c3226c75ebb7e",
-    "input_constant_set_sha256": "a913f3971db333f2d97c26e8bd7c5f3cb30c1b6a996608049c0a8cc88d7cdc6e",
-    "measurement_protocol_sha256": "9eb303b6204ca6218e97ae299356370b16921a485350146fe85203a298e59269",
-    "protocol_sha256": "25373a136cc1da119ed6829769b90aab075084406b0489f9f7698b370f5ee447",
-    "run_artifact_sha256s": [
-      "7c747b0e24a9df121fcc1f3317211e82a392389e68c9c271a29cfa1da6bbb659",
-      "b4e015ee27a521818264d110e0e95092b570cd4904d8994c2dd49d09ab15db0c",
-      "d638a189c881b6dced364cc21fb883542df5052b81fe2441187f7b67b9a140cb"
-    ],
-    "selected_at": "github-actions-run:32389005238:1",
-    "selection_rule": "constant_only_three_fresh_generations_one_sample_each+slow_host_floors_v2",
-    "selection_source_commit": "e1a4162a68c879e09be25d8ab387840135677e40",
-    "selection_source_tree": "0feebc3c8224515048383687c70f95513c845653"
-  },
+  "freeze_record": null,
   "qualification_threshold_overrides": {
     "protected_windows_x64_vulkan": {
       "existing_owner_connect": 125,
@@ -81,5 +66,5 @@
   },
   "schema_version": 1,
   "selection_protocol": "codestory-per-user-embedding-server-v1",
-  "status": "frozen"
+  "status": "unfrozen"
 }

--- a/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
+++ b/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
@@ -1,7 +1,7 @@
 {
   "calibration_required_values": {
     "capacity_retry_policy": {
-      "retry_after_ms": 43,
+      "retry_after_ms": 40,
       "retry_class": "after_capacity_change",
       "retry_condition_source": "named_condition_from_typed_capacity_response"
     },
@@ -9,7 +9,7 @@
     "election_backoff_policy": {
       "initial_backoff_ms": 7,
       "jitter": "sha256(process_start_id||attempt) modulo inclusive [initial_backoff_ms,maximum_backoff_ms]",
-      "maximum_backoff_ms": 111
+      "maximum_backoff_ms": 110
     },
     "hard_native_no_progress_ms": 385431,
     "request_deadlines_ms": {
@@ -43,7 +43,22 @@
     "query_queue_capacity": 64,
     "true_idle_observation_grace_ms": 2500
   },
-  "freeze_record": null,
+  "freeze_record": {
+    "calibration_bundle_sha256": "bbd058a1c4410002e0554f8059f5a215442615d1dbe3a5e7c2024d2ab6078ecb",
+    "calibration_freeze_digest": "6379ab52916fac118883243752475e87028f470088911af6c37c3226c75ebb7e",
+    "input_constant_set_sha256": "a913f3971db333f2d97c26e8bd7c5f3cb30c1b6a996608049c0a8cc88d7cdc6e",
+    "measurement_protocol_sha256": "9eb303b6204ca6218e97ae299356370b16921a485350146fe85203a298e59269",
+    "protocol_sha256": "25373a136cc1da119ed6829769b90aab075084406b0489f9f7698b370f5ee447",
+    "run_artifact_sha256s": [
+      "7c747b0e24a9df121fcc1f3317211e82a392389e68c9c271a29cfa1da6bbb659",
+      "b4e015ee27a521818264d110e0e95092b570cd4904d8994c2dd49d09ab15db0c",
+      "d638a189c881b6dced364cc21fb883542df5052b81fe2441187f7b67b9a140cb"
+    ],
+    "selected_at": "github-actions-run:32389005238:1",
+    "selection_rule": "constant_only_three_fresh_generations_one_sample_each+slow_host_floors_v2",
+    "selection_source_commit": "e1a4162a68c879e09be25d8ab387840135677e40",
+    "selection_source_tree": "0feebc3c8224515048383687c70f95513c845653"
+  },
   "qualification_threshold_overrides": {
     "protected_windows_x64_vulkan": {
       "existing_owner_connect": 125,
@@ -66,5 +81,5 @@
   },
   "schema_version": 1,
   "selection_protocol": "codestory-per-user-embedding-server-v1",
-  "status": "unfrozen"
+  "status": "frozen"
 }


### PR DESCRIPTION
## Context

CodeStory 0.17.1 reached `main`, but Auto Release run 32371064484 skipped publication after intentionally reusing source proof. The publish jobs inherited a skipped transitive ancestor because their job conditions did not override GitHub Actions' implicit success check.

## What changed

- run publish, marketplace delivery, and post-publish closeout when their direct prerequisites succeed even if a transitive proof job was intentionally skipped;
- retain cancellation safety with `!cancelled()` on every state-changing job;
- pin those exact conditions in the workflow-policy checker and add hostile mutations for skip propagation and cancellation;
- freeze the generated per-user embedding-server constants from three fresh protected Apple Silicon Metal runs.

## Exact release candidate

- source head: `2fca525270b6562a6fd9db03bb40fb875464ce4a`
- frozen head: `100ad4e666c444a0b5f16418d66b5f6b77a4ea10`
- source stabilization: run 32391619987
- protected calibration: run 32393969521
- frozen-candidate acceptance: run 32395103747
- independent adversarial review: accepted with no counterexamples

`dev/codestory-next` points at the exact accepted frozen head. No further source or workflow changes are planned. Merge this PR with a merge commit so the release lineage guard can admit the tree-preserving promotion commit.

## Verification

- exact-head hostile publication-policy matrix
- full workflow-policy checker: 1,418 tests passed on the policy-fix head
- CodeStory 0.17.1 version validator
- full workspace source proof, all-target/all-feature clippy, Windows source contracts, and retrieval generalization
- three protected Metal calibration runs and canonical calibration-lineage replay
- frozen-head Windows native probe and hostile mutation matrix

Closes #1956
