### PR TITLE
release CodeStory 0.17.2

### DIFF
--- a/.github/scripts/check-workflow-policy-literal-ratchet.test.mjs
+++ b/.github/scripts/check-workflow-policy-literal-ratchet.test.mjs
@@ -336,7 +336,7 @@ const EXPECTED_LITERAL_SITES = {
   validatePackageMatrixExpression: { workflowNames: 3 },
   validatePackagedCoordinator: { permissionTuples: 2, stepNames: 38, workflowNames: 11 },
   validatePackagedProof: { digests: 2, permissionTuples: 2, stepNames: 106, workflowNames: 2 },
-  validatePluginAndDraftWorkflows: { stepNames: 31, workflowNames: 13 },
+  validatePluginAndDraftWorkflows: { stepNames: 32, workflowNames: 13 },
   validatePluginRelease: { permissionTuples: 1, stepNames: 13, workflowNames: 6 },
   validatePostPublish: { stepNames: 38, workflowNames: 1 },
   validateReleaseArtifactRerunSafety: { workflowNames: 13 },

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -1368,8 +1368,8 @@ const draftRunCommands = new Map([
     '} >> "$GITHUB_ENV"',
   ]],
   ["Install Rust stable", [
-    "rustup toolchain install stable --profile minimal --component clippy --component rustfmt",
-    "rustup default stable",
+    "rustup toolchain install 1.97.1 --profile minimal --component clippy --component rustfmt",
+    "rustup default 1.97.1",
   ]],
   ["Install Linux Vulkan build dependencies", [
     "bash .github/scripts/install-linux-vulkan-build-deps.sh",
@@ -2438,6 +2438,14 @@ function validatePluginAndDraftWorkflows(workflows, violations, graph) {
       add(violations, includesAll(at(plugin, "on", event, "paths"), requiredPaths), `${pluginFile} ${event} paths must cover policy and release surfaces`);
     }
     add(violations, includesAll(at(plugin, "on", "push", "branches"), ["dev/codestory-next"]), `${pluginFile} must run on dev pushes`);
+    const job = object(object(plugin.jobs)["plugin-static"]);
+    requireStepRun(violations, pluginFile, job, "Check release version surfaces", [
+      'cli_version="$(python -c',
+      'plugin_version="$(python -c',
+      'if [ "$plugin_version" = "$cli_version" ]',
+      '--version "$cli_version"',
+      '--version "$plugin_version" --lane plugin',
+    ]);
     // The plugin lane's structural pin (job existence) is a rule instance and
     // lives in release-claims.json under workflow_policy.structural_pins;
     // structuralPinViolations evaluates it. The lane's step fragments - the
@@ -3475,6 +3483,9 @@ function validateReleaseCoordinator(workflows, violations, graph) {
     violations,
     publishRun.includes("gh release create $TAG ${assets[@]}")
       && publishRun.includes("find target/release-assets -maxdepth 1 -type f")
+      && publishRun.includes("-name codestory-cli-v*.tar.gz.sha256")
+      && publishRun.includes("-name codestory-cli-v*.zip.sha256")
+      && publishRun.includes("-name SHA256SUMS.txt")
       && !publishRun.includes("qualification-driver")
       && !publishRun.includes("codestory_embedding_qualification"),
     `${releaseFile} must publish only graph-declared root assets and exclude the private qualification driver`,
@@ -4954,6 +4965,27 @@ function validatePostPublish(workflows, violations, graph) {
     JSON.stringify(at(job, "strategy", "matrix", "include")) === JSON.stringify(expected),
     `${file} must run the three supported release assets on protected accelerated hosts`,
   );
+  // The checker must keep aggregating violations when a hostile test mutates another graph
+  // contract, so derive this narrow publisher/consumer join from the already-loaded matrix instead
+  // of invoking the graph's fail-fast public validator a second time.
+  const graphReleaseAssets = new Set([
+    ...list(at(graph, "workflow_policy", "package_matrix")).flatMap(
+      ({ asset_target: target, extension }) => {
+        const archive = `codestory-cli-v0.0.0-${target}.${extension}`;
+        return [archive, `${archive}.sha256`];
+      },
+    ),
+    "SHA256SUMS.txt",
+  ]);
+  add(
+    violations,
+    expected.every(({ asset_target: target, extension }) => {
+      const archive = `codestory-cli-v0.0.0-${target}.${extension}`;
+      return graphReleaseAssets.has(archive)
+        && graphReleaseAssets.has(`${archive}.sha256`);
+    }) && graphReleaseAssets.has("SHA256SUMS.txt"),
+    `${file} published checksum companions must match the graph-declared release assets`,
+  );
   add(
     violations,
     job["runs-on"] === "${{ fromJSON(matrix.runs_on) }}"
@@ -5006,6 +5038,7 @@ function validatePostPublish(workflows, violations, graph) {
     'test "$(jq -r .draft <<<"$release")" = false',
     "expected one published release asset",
     'archive_asset="$(select_asset "$asset")"',
+    'checksum="$asset.sha256"',
     'checksum_asset="$(select_asset "$checksum")"',
     "manifest_asset=\"$(select_asset SHA256SUMS.txt)\"",
     '[[ "$(jq -r .id <<<"$value")" =~ ^[0-9]+$ ]]',

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -2466,6 +2466,14 @@ test("post-publish candidate reuse authenticates release metadata and transfers 
         "true",
       );
     }, /Authenticate published candidate assets/u],
+    ["the post-publish consumer selects an unpublished checksum suffix", workflow => {
+      replaceRun(
+        workflow,
+        "Authenticate published candidate assets",
+        'checksum="$asset.sha256"',
+        'checksum="$asset.checksum"',
+      );
+    }, /published checksum companions must match the graph-declared release assets|Authenticate published candidate assets/u],
     ["published asset size provenance is not validated", workflow => {
       replaceRun(
         workflow,
@@ -2588,6 +2596,18 @@ test("release workflows retain the closeout coordinator contract test", () => {
           && message.includes("scripts/tests/codestory-release-closeout.test.mjs")),
     );
   }
+});
+
+test("plugin static validates both native and plugin-only version surfaces", () => {
+  const workflows = loadWorkflows();
+  const step = workflows.get("plugin-static.yml").jobs["plugin-static"].steps.find(
+    ({ name }) => name === "Check release version surfaces",
+  );
+  step.run = step.run.replace('--version "$plugin_version" --lane plugin', '--version "$plugin_version"');
+  assert.match(
+    validateWorkflows(workflows).join("\n"),
+    /plugin-static\.yml.*Check release version surfaces/u,
+  );
 });
 
 test("workflow hygiene requires declared permissions and step-job timeouts", () => {
@@ -5080,6 +5100,10 @@ test("draft source cache reuse preserves exact serial proof structure", async (t
   assert.deepEqual(draftSourcePolicyViolations(draftSourceJob(), retrievalSourceJob()), []);
 
   const mutations = [
+    ["rolling Rust toolchain", job => {
+      const step = draftStep(job, "Install Rust stable");
+      step.run = step.run.replaceAll("1.97.1", "stable");
+    }],
     ["unversioned primary", job => {
       const step = draftStep(job, "Restore Cargo inputs and output");
       step.with.key = step.with.key.replace("-draft-v2-", "-draft-");
@@ -6709,6 +6733,22 @@ test("release policy rejects manifest producer, trusted-map, and publication byp
       const step = workflows.get("release.yml").jobs.publish.steps
         .find(({ name }) => name === "Create GitHub release");
       step.run = step.run.replace("main moved from publishable head", "main changed");
+    }],
+    ["publisher allowlist drops archive checksum companions", workflows => {
+      const step = workflows.get("release.yml").jobs.publish.steps
+        .find(({ name }) => name === "Create GitHub release");
+      step.run = step.run.replace(
+        "-name 'codestory-cli-v*.tar.gz.sha256'",
+        "-name 'unpublished-checksum'",
+      );
+    }],
+    ["publisher allowlist drops the global checksum manifest", workflows => {
+      const step = workflows.get("release.yml").jobs.publish.steps
+        .find(({ name }) => name === "Create GitHub release");
+      step.run = step.run.replace(
+        "-o -name 'SHA256SUMS.txt'",
+        "-o -name 'unpublished-global-checksum'",
+      );
     }],
     ["publish authority", workflows => { delete workflows.get("release.yml").jobs.publish.if; }],
     ["publish inherits a skipped reuse ancestor", workflows => {

--- a/.github/scripts/install-codestory-marketplace-proof.mjs
+++ b/.github/scripts/install-codestory-marketplace-proof.mjs
@@ -45,17 +45,26 @@ function required(values, key) {
   return value;
 }
 
-function run(executable, args, options = {}) {
-  let command = executable;
-  let commandArgs = args;
-  if (process.platform === "win32") {
+export function commandPlan(
+  executable,
+  args,
+  { platform = process.platform, comspec = process.env.ComSpec || "cmd.exe" } = {},
+) {
+  if (platform === "win32" && /\.(?:cmd|bat)$/iu.test(executable)) {
     const quote = (value) => {
       if (/[\r\n"]/u.test(value)) fail("Codex command arguments must be single-line");
       return `"${value.replaceAll("%", "%%")}"`;
     };
-    command = process.env.ComSpec || "cmd.exe";
-    commandArgs = ["/d", "/s", "/c", [executable, ...args].map(quote).join(" ")];
+    return {
+      command: comspec,
+      commandArgs: ["/d", "/s", "/c", [executable, ...args].map(quote).join(" ")],
+    };
   }
+  return { command: executable, commandArgs: args };
+}
+
+function run(executable, args, options = {}) {
+  const { command, commandArgs } = commandPlan(executable, args);
   const result = spawnSync(command, commandArgs, {
     ...options,
     encoding: "utf8",

--- a/.github/scripts/install-codestory-marketplace-proof.test.mjs
+++ b/.github/scripts/install-codestory-marketplace-proof.test.mjs
@@ -15,10 +15,41 @@ import process from "node:process";
 import test from "node:test";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
+import { commandPlan } from "./install-codestory-marketplace-proof.mjs";
+
 const scriptRoot = path.dirname(fileURLToPath(import.meta.url));
 const repositoryRoot = path.resolve(scriptRoot, "..", "..");
 const helper = path.join(scriptRoot, "install-codestory-marketplace-proof.mjs");
 const codexVersion = "0.144.5";
+
+test("Windows invokes native executables directly and wraps only command shims", () => {
+  const comspec = "C:\\Windows\\System32\\cmd.exe";
+  assert.deepEqual(
+    commandPlan("git", ["-C", "C:\\source tree", "rev-parse", "HEAD^{tree}"], {
+      platform: "win32",
+      comspec,
+    }),
+    {
+      command: "git",
+      commandArgs: ["-C", "C:\\source tree", "rev-parse", "HEAD^{tree}"],
+    },
+  );
+  assert.deepEqual(
+    commandPlan("C:\\tools\\codex.cmd", ["plugin", "list", "--json"], {
+      platform: "win32",
+      comspec,
+    }),
+    {
+      command: comspec,
+      commandArgs: [
+        "/d",
+        "/s",
+        "/c",
+        '"C:\\tools\\codex.cmd" "plugin" "list" "--json"',
+      ],
+    },
+  );
+});
 
 function run(executable, args, options = {}) {
   const result = spawnSync(executable, args, {

--- a/.github/scripts/restart-survival-receipt.mjs
+++ b/.github/scripts/restart-survival-receipt.mjs
@@ -77,6 +77,21 @@ function exact(value, expected, label) {
   return value;
 }
 
+function installedCodexCliVersion(value, label) {
+  nonEmpty(value, label);
+  if (!/^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/u.test(value)) {
+    fail(`${label} must be bare semver`);
+  }
+  return value;
+}
+
+function attestedCodexCliVersion(value, label) {
+  nonEmpty(value, label);
+  const match = /^codex-cli ([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)$/u.exec(value);
+  if (!match) fail(`${label} must use the exact codex-cli semver producer form`);
+  return match[1];
+}
+
 function commit(value, label) {
   if (typeof value !== "string" || !/^[0-9a-f]{40}$/u.test(value)) {
     fail(`${label} must be a full lowercase Git SHA`);
@@ -506,8 +521,14 @@ function validateCrossSessionIdentity(first, second, attestation, expected) {
       "installed catalog revision",
     );
     exact(
-      session.installedPlugin.codex_cli_version,
-      attestation.marketplace.codex_cli_version,
+      installedCodexCliVersion(
+        session.installedPlugin.codex_cli_version,
+        "installed Codex CLI version",
+      ),
+      attestedCodexCliVersion(
+        attestation.marketplace.codex_cli_version,
+        "attested Codex CLI version",
+      ),
       "installed Codex CLI version",
     );
     exact(

--- a/.github/scripts/restart-survival-receipt.test.mjs
+++ b/.github/scripts/restart-survival-receipt.test.mjs
@@ -30,7 +30,9 @@ function installedPlugin() {
   return {
     schema_version: 2,
     installation_source: LIVE_INSTALLATION_SOURCE,
-    codex_cli_version: "codex-cli 1.2.3",
+    // The installed-runtime summary normalizes the pinned producer to semver,
+    // while the installation attestation retains `codex --version` verbatim.
+    codex_cli_version: "1.2.3",
     marketplace_repository: LIVE_MARKETPLACE_REPOSITORY,
     marketplace_commit: MARKETPLACE,
     plugin_id: "codestory",
@@ -248,6 +250,23 @@ test("CLI writes the reusable receipt through explicit paths and metadata", () =
 });
 
 const hostileCases = [
+  ["installed summary retains the Codex producer prefix", state => {
+    state.first.runtime.installed_plugin.codex_cli_version = "codex-cli 1.2.3";
+    state.second.runtime.installed_plugin.codex_cli_version = "codex-cli 1.2.3";
+  }, /installed Codex CLI version/u],
+  ["attestation drops the Codex producer prefix", state => {
+    state.attestation.marketplace.codex_cli_version = "1.2.3";
+  }, /attested Codex CLI version/u],
+  ["installed Codex CLI version changes", state => {
+    state.second.runtime.installed_plugin.codex_cli_version = "1.2.4";
+  }, /installed plugin identity changed|installed Codex CLI version/u],
+  ["both installed sessions name the wrong Codex CLI version", state => {
+    state.first.runtime.installed_plugin.codex_cli_version = "1.2.4";
+    state.second.runtime.installed_plugin.codex_cli_version = "1.2.4";
+  }, /installed Codex CLI version/u],
+  ["attested Codex CLI version has an unknown producer prefix", state => {
+    state.attestation.marketplace.codex_cli_version = "codex 1.2.3";
+  }, /Codex CLI version/u],
   ["catalog installer disagrees with state", state => {
     state.options.expectedInstallerIdentity = DEFERRED_INSTALLATION_SOURCE;
   }, /catalog installer identity/u],

--- a/.github/workflows/plugin-static.yml
+++ b/.github/workflows/plugin-static.yml
@@ -242,5 +242,10 @@ jobs:
       - name: Check release version surfaces
         shell: bash
         run: |
-          version="$(python -c "import tomllib; print(tomllib.load(open('crates/codestory-cli/Cargo.toml', 'rb'))['package']['version'])")"
-          python .github/scripts/check-codestory-release.py --version "$version"
+          cli_version="$(python -c "import tomllib; print(tomllib.load(open('crates/codestory-cli/Cargo.toml', 'rb'))['package']['version'])")"
+          plugin_version="$(python -c "import json; print(json.load(open('plugins/codestory/plugin.json'))['version'])")"
+          if [ "$plugin_version" = "$cli_version" ]; then
+            python .github/scripts/check-codestory-release.py --version "$cli_version"
+          else
+            python .github/scripts/check-codestory-release.py --version "$plugin_version" --lane plugin
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -987,6 +987,8 @@ jobs:
           printf '%s\n' "${expected_names[@]}" | sort > "$expected_file"
           find target/release-assets -maxdepth 1 -type f \
             \( -name 'codestory-cli-v*.tar.gz' -o -name 'codestory-cli-v*.zip' \
+               -o -name 'codestory-cli-v*.tar.gz.sha256' \
+               -o -name 'codestory-cli-v*.zip.sha256' \
                -o -name 'SHA256SUMS.txt' -o -name 'release-closeout-summary.json' \
                -o -name 'codestory-release-manifest.json' \) \
             -exec basename {} \; | sort > "$actual_file"

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -35,8 +35,10 @@ jobs:
 
       - name: Install Rust stable
         run: |
-          rustup toolchain install stable --profile minimal --component clippy --component rustfmt
-          rustup default stable
+          # Keep draft CI deterministic. The stable alias moved from 1.97.1 to 1.98.0 during
+          # this release and introduced a new deny-by-default Clippy warning on unchanged source.
+          rustup toolchain install 1.97.1 --profile minimal --component clippy --component rustfmt
+          rustup default 1.97.1
 
       - name: Install Linux Vulkan build dependencies
         run: bash .github/scripts/install-linux-vulkan-build-deps.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.17.2
+
+Cursor installations now start CodeStory's MCP server from the installed plugin package. The launcher previously resolved relative to the project open in Cursor, so enabling CodeStory could fail with `Cannot find module <project>/scripts/codestory-mcp.cjs` before the server started.
+
 ## 0.17.1
 
 CodeStory 0.17.1 makes compact answers more accurate and more reliable. A packet keeps the production sources that implement the flow — the files an operator would actually change — instead of filling the answer with tests, samples, and workflow files that only share a name.

--- a/plugins/codestory/.claude-plugin/plugin.json
+++ b/plugins/codestory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.cursor-plugin/plugin.json
+++ b/plugins/codestory/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "CodeStory grounding for Cursor over the local codestory-cli runtime.",
   "author": {
     "name": "The Green Cedar"

--- a/plugins/codestory/.github/plugin/plugin.json
+++ b/plugins/codestory/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codestory",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "author": {
     "name": "The Green Cedar",
     "url": "https://github.com/TheGreenCedar"

--- a/plugins/codestory/cli-version.json
+++ b/plugins/codestory/cli-version.json
@@ -1,5 +1,10 @@
 {
   "schema_version": 1,
   "cli_version": "0.17.1",
-  "release_tag": "v0.17.1"
+  "release_tag": "v0.17.1",
+  "archives": {
+    "macos-arm64": "a71d58b9fdb1ca87f0835bf4d0459c4702e41fba599dd2eed556aec51dea7be2",
+    "windows-x64": "c3537ce8c4f4443bfa9655a50c6667763bc0afeb52664863a56106cc3df7aa73",
+    "linux-x64": "4ee46d990edd32d9066cf9f173a1d9cf087cd065529cade0eba5d0c132a0c6ce"
+  }
 }

--- a/plugins/codestory/mcp.json
+++ b/plugins/codestory/mcp.json
@@ -4,7 +4,7 @@
     "codestory": {
       "type": "stdio",
       "command": "node",
-      "args": ["./scripts/codestory-mcp.cjs"],
+      "args": ["${PLUGIN_ROOT}/scripts/codestory-mcp.cjs"],
       "cwd": "${PLUGIN_ROOT}",
       "env": {}
     }

--- a/plugins/codestory/plugin.json
+++ b/plugins/codestory/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "codestory",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "CodeStory grounding for coding agents over a local managed runtime.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -536,6 +536,14 @@ async function readPluginVersion() {
   return manifest.version;
 }
 
+async function readPinnedCliVersion() {
+  const pin = JSON.parse(
+    await readFile(join(pluginRoot, "cli-version.json"), "utf8"),
+  );
+  assert.match(pin.cli_version, /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/u);
+  return pin.cli_version;
+}
+
 function releaseAssetForPlatform(version) {
   const target = process.platform === "win32" && process.arch === "x64"
     ? "windows-x64"
@@ -997,7 +1005,7 @@ test("fail-open status reads refresh the preparing retry hint from live download
   ]);
 });
 
-async function writeAttestedDevPluginFixture(root, version) {
+async function writeAttestedDevPluginFixture(root, pluginVersion, cliVersion = pluginVersion) {
   const { cp } = await import("node:fs/promises");
   const installRoot = join(
     root,
@@ -1006,7 +1014,7 @@ async function writeAttestedDevPluginFixture(root, version) {
     "cache",
     "CodeStoryDev",
     "codestory",
-    version,
+    pluginVersion,
   );
   await cp(pluginRoot, installRoot, { recursive: true });
   const sourcePackageSha256 = devCliContract.directoryContractSha256(installRoot);
@@ -1023,7 +1031,7 @@ async function writeAttestedDevPluginFixture(root, version) {
       purpose: devCliContract.receiptPurpose,
       plugin_id: devCliContract.receiptPluginId,
       plugin_name: devCliContract.receiptPluginName,
-      plugin_version: version,
+      plugin_version: pluginVersion,
       source_commit: "a".repeat(40),
       source_package_sha256: sourcePackageSha256,
       target: devCliContract.sourceBuildTarget(),
@@ -1032,7 +1040,7 @@ async function writeAttestedDevPluginFixture(root, version) {
         name: cliName,
         bytes: cliBytes.length,
         sha256: cliSha256,
-        version,
+        version: cliVersion,
       },
     }, null, 2)}\n`,
     "utf8",
@@ -1441,7 +1449,7 @@ test("production hook code neither duplicates Git config nor spawns Git", async 
 
 test("mcp launcher prefers a checksummed explicit package without PATH", async () => {
   const { spawnSync } = await import("node:child_process");
-  const version = await readPluginVersion();
+  const version = await readPinnedCliVersion();
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-managed-cli-"));
   const outFile = join(dataDir, "env.json");
   const cliDir = join(dataDir, "codestory-cli", version);
@@ -1505,16 +1513,17 @@ test("mcp launcher uses an attested CodeStoryDev CLI from the installed cache wi
   const root = await mkdtemp(join(tmpdir(), "codestory-attested-dev-cli-"));
   const dataDir = join(root, "plugin-data");
   const outFile = join(root, "env.json");
-  const version = await readPluginVersion();
+  const pluginVersion = await readPluginVersion();
+  const cliVersion = await readPinnedCliVersion();
   try {
-    const fixture = await writeAttestedDevPluginFixture(root, version);
+    const fixture = await writeAttestedDevPluginFixture(root, pluginVersion, cliVersion);
     await mkdir(dataDir, { recursive: true });
     const result = spawnSync(process.execPath, [fixture.launcher], {
       env: {
         ...process.env,
         CODESTORY_CLI: "",
         PLUGIN_DATA: dataDir,
-        TEST_CODESTORY_VERSION: version,
+        TEST_CODESTORY_VERSION: cliVersion,
         TEST_OUT: outFile,
         PATH: "",
       },
@@ -1529,7 +1538,7 @@ test("mcp launcher uses an attested CodeStoryDev CLI from the installed cache wi
     assert.equal(observed.sha256, fixture.cliSha256);
     assert.equal(await realpath(observed.path), await realpath(fixture.cliPath));
     assert.equal(await realpath(observed.pluginRoot), await realpath(fixture.installRoot));
-    assert.equal(observed.pluginCacheVersion, version);
+    assert.equal(observed.pluginCacheVersion, pluginVersion);
     assert.match(observed.warnings, /codestory_dev_receipt:verified/u);
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -1538,21 +1547,22 @@ test("mcp launcher uses an attested CodeStoryDev CLI from the installed cache wi
 
 test("declared CodeStoryDev receipt failures never fall through to raw or managed CLI selection", async () => {
   if (process.platform === "win32") return;
-  const version = await readPluginVersion();
+  const pluginVersion = await readPluginVersion();
+  const cliVersion = await readPinnedCliVersion();
   for (const variant of ["invalid-receipt", "ambiguous-raw-override"]) {
     const root = await mkdtemp(join(tmpdir(), "codestory-dev-receipt-no-fallback-"));
     const dataDir = join(root, "plugin-data");
     const runtimeOut = join(root, "runtime.json");
     try {
-      const fixture = await writeAttestedDevPluginFixture(root, version);
-      const managedDir = join(dataDir, "codestory-cli", version);
+      const fixture = await writeAttestedDevPluginFixture(root, pluginVersion, cliVersion);
+      const managedDir = join(dataDir, "codestory-cli", cliVersion);
       const managedCli = join(managedDir, process.platform === "win32" ? "codestory-cli.exe" : "codestory-cli");
       await mkdir(managedDir, { recursive: true });
       await writeFakeCli(managedCli);
       const managedSha256 = createHash("sha256").update(await readFile(managedCli)).digest("hex");
       await writeFile(
         join(managedDir, "manifest.json"),
-        JSON.stringify(managedReleaseManifest(version, managedCli.slice(managedDir.length + 1), managedSha256)),
+        JSON.stringify(managedReleaseManifest(cliVersion, managedCli.slice(managedDir.length + 1), managedSha256)),
         "utf8",
       );
       if (variant === "invalid-receipt") {
@@ -1570,7 +1580,7 @@ test("declared CodeStoryDev receipt failures never fall through to raw or manage
           CODESTORY_CLI: variant === "ambiguous-raw-override" ? fixture.cliPath : "",
           CODESTORY_PLUGIN_DISABLE_PROVISION: "1",
           PLUGIN_DATA: dataDir,
-          TEST_CODESTORY_VERSION: version,
+          TEST_CODESTORY_VERSION: cliVersion,
           TEST_OUT: runtimeOut,
           PATH: "",
         },
@@ -3775,7 +3785,7 @@ test("mcp launcher blocks when managed runtime is unavailable", async () => {
 });
 
 test("mcp launcher preserves the managed CLI verification failure", async () => {
-  const version = await readPluginVersion();
+  const version = await readPinnedCliVersion();
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-invalid-managed-cli-"));
   const versionDir = join(dataDir, "codestory-cli", version);
   const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
@@ -4350,9 +4360,10 @@ test("mcp launcher fails open when CODESTORY_CLI override cannot spawn", async (
 });
 
 test("mcp launcher fails open when managed cli probe fails", async () => {
-  const version = await readPluginVersion();
+  const pluginVersion = await readPluginVersion();
+  const cliVersion = await readPinnedCliVersion();
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-failopen-managed-"));
-  const cliDir = join(dataDir, "codestory-cli", version);
+  const cliDir = join(dataDir, "codestory-cli", cliVersion);
   const cliPath = join(
     cliDir,
     process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli",
@@ -4380,7 +4391,7 @@ test("mcp launcher fails open when managed cli probe fails", async () => {
     await writeFile(
       join(cliDir, "manifest.json"),
       JSON.stringify(explicitPackageManifest(
-        version,
+        cliVersion,
         process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli",
         sha256,
       )),
@@ -4433,7 +4444,7 @@ test("mcp launcher fails open when managed cli probe fails", async () => {
     );
     assert.equal(
       status.plugin_runtime.plugin_version,
-      version,
+      pluginVersion,
     );
   } finally {
     await stopChildProcess(child);
@@ -4442,12 +4453,13 @@ test("mcp launcher fails open when managed cli probe fails", async () => {
 });
 
 test("mcp launcher upgrades a verified prior managed cli to the checksummed release", async () => {
-  const version = await readPluginVersion();
+  const pluginVersion = await readPluginVersion();
+  const cliVersion = await readPinnedCliVersion();
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-provisioned-cli-"));
   const releaseDir = await mkdtemp(join(tmpdir(), "codestory-release-"));
   const outFile = join(dataDir, "env.json");
   const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
-  const { archiveBase, archiveName } = releaseAssetForPlatform(version);
+  const { archiveBase, archiveName } = releaseAssetForPlatform(cliVersion);
   const stageDir = join(releaseDir, archiveBase);
   const cliName = process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli";
   const cliPath = join(stageDir, cliName);
@@ -4496,20 +4508,20 @@ test("mcp launcher upgrades a verified prior managed cli to the checksummed rele
       CODESTORY_PLUGIN_RELEASE_DIR: releaseDir,
       PLUGIN_DATA: dataDir,
       TEST_OUT: outFile,
-      TEST_CODESTORY_VERSION: version,
+      TEST_CODESTORY_VERSION: cliVersion,
     });
     const result = await launched.completed;
 
     assert.equal(result.status, 0, result.stderr);
     const observed = JSON.parse(await readFile(outFile, "utf8"));
     assert.equal(observed.source, "managed");
-    assert.equal(observed.version, version);
+    assert.equal(observed.version, cliVersion);
     assert.equal(observed.repoRef, "");
     assert.equal(observed.buildSource, "explicit_package");
     assert.equal(observed.archiveSha256, archiveSha256);
     assert.notEqual(observed.path, priorCli);
     const retention = JSON.parse(observed.retention);
-    assert.equal(retention.active_version, version);
+    assert.equal(retention.active_version, cliVersion);
     assert.equal(
       retention.retained.some((entry) => entry.version === priorVersion && entry.reason === "rollback"),
       true,
@@ -4517,14 +4529,14 @@ test("mcp launcher upgrades a verified prior managed cli to the checksummed rele
     );
     assert.match(
       observed.path,
-      new RegExp(String.raw`codestory-cli[\\/]+${version.replaceAll(".", String.raw`\.`)}[\\/]codestory-cli`, "u"),
+      new RegExp(String.raw`codestory-cli[\\/]+${cliVersion.replaceAll(".", String.raw`\.`)}[\\/]codestory-cli`, "u"),
     );
     assert.deepEqual(observed.args, ["serve", "--stdio", "--multi-project", "--refresh", "none"]);
 
     const manifest = JSON.parse(
-      await readFile(join(dataDir, "codestory-cli", version, "manifest.json"), "utf8"),
+      await readFile(join(dataDir, "codestory-cli", cliVersion, "manifest.json"), "utf8"),
     );
-    assert.equal(manifest.version, version);
+    assert.equal(manifest.version, cliVersion);
     assert.equal(manifest.repo_ref, null);
     assert.equal(manifest.build_source, "explicit_package");
     assert.equal(manifest.archive, archiveName);
@@ -4532,6 +4544,11 @@ test("mcp launcher upgrades a verified prior managed cli to the checksummed rele
     assert.equal(manifest.archive_sha256, archiveSha256);
     assert.equal(manifest.stdio_initialize_verified, true);
     assert.equal(typeof manifest.sha256, "string");
+    const runtime = JSON.parse(
+      await readFile(join(dataDir, ".codestory-mcp-runtime.json"), "utf8"),
+    );
+    assert.equal(runtime.pluginVersion, pluginVersion);
+    assert.equal(runtime.cliVersion, cliVersion);
   } finally {
     await rm(dataDir, { recursive: true, force: true });
     await rm(releaseDir, { recursive: true, force: true });
@@ -4540,7 +4557,8 @@ test("mcp launcher upgrades a verified prior managed cli to the checksummed rele
 
 test("mcp launcher serves diagnostics while managed provisioning runs, then hands off", { timeout: 30000 }, async () => {
   const { createServer } = await import("node:http");
-  const version = await readPluginVersion();
+  const pluginVersion = await readPluginVersion();
+  const cliVersion = await readPinnedCliVersion();
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-background-provision-"));
   const releaseDir = await mkdtemp(join(tmpdir(), "codestory-background-release-"));
   const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
@@ -4549,7 +4567,7 @@ test("mcp launcher serves diagnostics while managed provisioning runs, then hand
   let server;
   let releaseAssets = () => {};
   try {
-    const fixture = await writeReleaseFixture(releaseDir, version, writeLifecycleCli);
+    const fixture = await writeReleaseFixture(releaseDir, cliVersion, writeLifecycleCli);
     const assets = new Map([
       ["/SHA256SUMS.txt", await readFile(fixture.sumsPath)],
       [`/${fixture.archiveName}`, await readFile(fixture.archivePath)],
@@ -4569,7 +4587,7 @@ test("mcp launcher serves diagnostics while managed provisioning runs, then hand
         CODESTORY_CLI: "",
         CODESTORY_PLUGIN_RELEASE_BASE_URL: `http://127.0.0.1:${server.address().port}`,
         PLUGIN_DATA: dataDir,
-        TEST_CODESTORY_VERSION: version,
+        TEST_CODESTORY_VERSION: cliVersion,
         CODESTORY_TEST_PROBE_DELAY_MS: "1500",
         TEST_OUT: outFile,
       },
@@ -4706,11 +4724,11 @@ test("mcp launcher serves diagnostics while managed provisioning runs, then hand
     const probeDeadline = Date.now() + 5000;
     while (Date.now() < probeDeadline) {
       const entries = await readdir(managedRoot).catch(() => []);
-      if (entries.some((entry) => entry.startsWith(`.provisioning-${version}-`))) break;
+      if (entries.some((entry) => entry.startsWith(`.provisioning-${cliVersion}-`))) break;
       await delay(10);
     }
     assert.ok(
-      (await readdir(managedRoot)).some((entry) => entry.startsWith(`.provisioning-${version}-`)),
+      (await readdir(managedRoot)).some((entry) => entry.startsWith(`.provisioning-${cliVersion}-`)),
       "provisioning should reach its deliberately slow synchronous version probe",
     );
     const responsiveStartedAt = Date.now();
@@ -4735,6 +4753,8 @@ test("mcp launcher serves diagnostics while managed provisioning runs, then hand
     }
     const publishedRuntime = JSON.parse(await readFile(runtimeMetadata, "utf8"));
     assert.equal(publishedRuntime.source, "managed", JSON.stringify(publishedRuntime));
+    assert.equal(publishedRuntime.pluginVersion, pluginVersion);
+    assert.equal(publishedRuntime.cliVersion, cliVersion);
     assert.equal(
       responses.some((response) => response.method === "notifications/tools/list_changed"),
       false,
@@ -4800,7 +4820,7 @@ test("mcp launcher serves diagnostics while managed provisioning runs, then hand
 
 test("managed publication waiter keeps diagnostic MCP responsive", { timeout: 15000 }, async () => {
   const { createServer } = await import("node:http");
-  const version = await readPluginVersion();
+  const version = await readPinnedCliVersion();
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-responsive-waiter-"));
   const releaseDir = await mkdtemp(join(tmpdir(), "codestory-responsive-release-"));
   const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
@@ -4985,7 +5005,7 @@ test("fail-open status tool preserves primary runtime failures and no-project pr
 
 test("managed cli publication is single-flight and atomically visible across two processes", { timeout: 30000 }, async () => {
   const { createServer } = await import("node:http");
-  const version = await readPluginVersion();
+  const version = await readPinnedCliVersion();
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-publication-contention-"));
   const releaseDir = await mkdtemp(join(tmpdir(), "codestory-publication-release-"));
   const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
@@ -5066,7 +5086,7 @@ test("managed cli publication is single-flight and atomically visible across two
 
 test("managed cli publication reclaims crashes after lock and before publication", { timeout: 45000 }, async () => {
   const { createServer } = await import("node:http");
-  const version = await readPluginVersion();
+  const version = await readPinnedCliVersion();
   const releaseDir = await mkdtemp(join(tmpdir(), "codestory-crash-release-"));
   const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
   let server;
@@ -6975,10 +6995,26 @@ test("portable plugin core and thin host adapters preserve their own contracts",
   assert.deepEqual(portableMcp.mcpServers.codestory, {
     type: "stdio",
     command: "node",
-    args: ["./scripts/codestory-mcp.cjs"],
+    args: ["${PLUGIN_ROOT}/scripts/codestory-mcp.cjs"],
     cwd: "${PLUGIN_ROOT}",
     env: {},
   });
+  const arbitraryProject = await mkdtemp(join(tmpdir(), "codestory-cursor-project-"));
+  try {
+    const expandedLauncher = portableMcp.mcpServers.codestory.args[0]
+      .replaceAll("${PLUGIN_ROOT}", pluginRoot);
+    const check = spawnSync(process.execPath, ["--check", expandedLauncher], {
+      cwd: arbitraryProject,
+      encoding: "utf8",
+    });
+    assert.equal(
+      check.status,
+      0,
+      `portable MCP launcher must resolve outside the active project cwd:\n${check.stderr}`,
+    );
+  } finally {
+    await rm(arbitraryProject, { recursive: true, force: true });
+  }
   assert.doesNotMatch(
     portableMcpText,
     /CODESTORY_PLUGIN_DATA|CODESTORY_CURSOR_DOGFOOD|absolute\/path|tool_timeout_sec/iu,

--- a/scripts/codestory-release-claims.mjs
+++ b/scripts/codestory-release-claims.mjs
@@ -2651,9 +2651,11 @@ export function releaseAssetNames(graph, version) {
     fail("release asset version must be semver");
   }
   return [
-    ...graph.workflow_policy.package_matrix.map(
-      ({ asset_target: target, extension }) =>
-        `codestory-cli-v${version}-${target}.${extension}`,
+    ...graph.workflow_policy.package_matrix.flatMap(
+      ({ asset_target: target, extension }) => {
+        const archive = `codestory-cli-v${version}-${target}.${extension}`;
+        return [archive, `${archive}.sha256`];
+      },
     ),
     "SHA256SUMS.txt",
     // The native lane's archive digests. They cannot be pinned in source -- the archives are built

--- a/scripts/tests/codestory-release-claims.test.mjs
+++ b/scripts/tests/codestory-release-claims.test.mjs
@@ -1082,8 +1082,11 @@ test("public support, assets, and release notes derive from the package and clos
     releaseAssetNames(graph, "0.16.0"),
     [
       "codestory-cli-v0.16.0-windows-x64.zip",
+      "codestory-cli-v0.16.0-windows-x64.zip.sha256",
       "codestory-cli-v0.16.0-macos-arm64.tar.gz",
+      "codestory-cli-v0.16.0-macos-arm64.tar.gz.sha256",
       "codestory-cli-v0.16.0-linux-x64.tar.gz",
+      "codestory-cli-v0.16.0-linux-x64.tar.gz.sha256",
       "SHA256SUMS.txt",
       // A native release cannot pin its own archive digests in source, so the release generates
       // them from the archives it built and ships them as an asset the launcher can fetch.

--- a/scripts/tests/prove-plugin-pinned-provision.test.mjs
+++ b/scripts/tests/prove-plugin-pinned-provision.test.mjs
@@ -7,7 +7,10 @@ import path from "node:path";
 import test from "node:test";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
-import { requirePinnedArchiveDigest } from "../lib/pinned-archive-digests.mjs";
+import {
+  PINNED_ARCHIVE_TARGETS,
+  requirePinnedArchiveDigest,
+} from "../lib/pinned-archive-digests.mjs";
 import {
   assertProvisionedArchiveDigest,
   parseProvisionProofArguments,
@@ -40,6 +43,18 @@ function repositoryPin() {
   return JSON.parse(
     fs.readFileSync(path.join(repositoryRoot, "plugins/codestory/cli-version.json"), "utf8"),
   );
+}
+
+function repositoryPluginVersion() {
+  return JSON.parse(
+    fs.readFileSync(path.join(repositoryRoot, "plugins/codestory/plugin.json"), "utf8"),
+  ).version;
+}
+
+function archiveLessNativePin() {
+  const pin = repositoryPin();
+  delete pin.archives;
+  return pin;
 }
 
 function manifestFor(version, entries = {}) {
@@ -127,21 +142,30 @@ test("only the plugin lane may assert a source-pinned archive digest", () => {
   }
 });
 
-// The freeze-critical case, held against the pin this repository actually carries rather than a
-// hand-made one. The frozen native head's pin is lawfully archive-less -- bump-version.mjs deletes
-// `archives` on a native bump because the archives are built FROM this tree -- and the proof used
-// to run the source-pin assertion on it unconditionally, which can only fail.
-test("the frozen source carries no circular native archive digest", () => {
+// A native head is archive-less because it will build its own archives. A plugin-only head pins an
+// already-published older CLI and must carry all three digests. This test runs in both workflows,
+// so hold the repository's real pin to the contract for the lane its versions identify.
+test("the repository pin matches its native or plugin-only release lane", () => {
   const pin = repositoryPin();
-  assert.equal(
-    Object.hasOwn(pin, "archives"),
-    false,
-    "a native pin naming digests of archives built from its own tree is the circularity REL-MAN removes",
+  const pluginVersion = repositoryPluginVersion();
+  if (pluginVersion === pin.cli_version) {
+    assert.equal(
+      Object.hasOwn(pin, "archives"),
+      false,
+      "a native pin naming digests of archives built from its own tree is circular",
+    );
+    return;
+  }
+  assert.deepEqual(
+    Object.keys(pin.archives || {}).sort(),
+    Object.keys(PINNED_ARCHIVE_TARGETS).sort(),
+    "a plugin-only release must pin every published CLI archive",
   );
+  for (const digest of Object.values(pin.archives)) assert.match(digest, /^[0-9a-f]{64}$/u);
 });
 
 test("a lawful archive-less native pin fails the plugin lane and passes the native one", () => {
-  const pin = repositoryPin();
+  const pin = archiveLessNativePin();
   const target = "linux-x64";
   const provisioned = { sha256: VALID_DIGEST, bytes: 4096 };
 


### PR DESCRIPTION
## Context

CodeStory 0.17.1 is published, but its first complete post-publish execution exposed release-automation regressions, and Cursor plugin activation resolves the MCP launcher relative to the open project instead of the installed plugin.

## What changed

- Cursor installations now start CodeStory's MCP server from the installed plugin package. The launcher previously resolved relative to the project open in Cursor, so enabling CodeStory could fail with `Cannot find module <project>/scripts/codestory-mcp.cjs` before the server started.
- Release publication now includes the per-archive checksum assets consumed by post-publish smoke.
- Windows post-publish commands run native executables directly and use `cmd.exe` only for command shims.
- Restart receipts compare the strict version shapes produced by the installer and installed runtime.
- Plugin-only validation accepts a plugin version newer than its pinned native CLI version without weakening native-release checks.
- Draft CI uses the reviewed Rust 1.97.1 toolchain instead of changing behavior under a rolling `stable` alias.

## Release lane

This is a plugin-only 0.17.2 release. It reuses the authenticated CodeStory CLI 0.17.1 archives and checksums. It does not rebuild the native CLI and does not run calibration or hardware qualification.

## Verification

- Exact implementation head `fdf046352e1219c61af55eac1fcd36e0f8c76979` independently accepted.
- PR #1961 checks passed, including Cursor activation from an unrelated working directory, plugin marketplace installation, release-policy hostile mutations, Windows command planning, restart receipts, workflow policy, formatting, Cargo check, Clippy, and focused publication contracts.
- Plugin manifests are 0.17.2; the pinned CLI remains 0.17.1 with checksums matching the published release.

Closes #1956
Closes #704
