### PR TITLE
Fix Windows plugin release proof

### DIFF
--- a/.github/scripts/check-workflow-policy-literal-ratchet.test.mjs
+++ b/.github/scripts/check-workflow-policy-literal-ratchet.test.mjs
@@ -337,7 +337,7 @@ const EXPECTED_LITERAL_SITES = {
   validatePackagedCoordinator: { permissionTuples: 2, stepNames: 38, workflowNames: 11 },
   validatePackagedProof: { digests: 2, permissionTuples: 2, stepNames: 106, workflowNames: 2 },
   validatePluginAndDraftWorkflows: { stepNames: 32, workflowNames: 13 },
-  validatePluginRelease: { permissionTuples: 1, stepNames: 13, workflowNames: 6 },
+  validatePluginRelease: { permissionTuples: 1, stepNames: 17, workflowNames: 6 },
   validatePostPublish: { stepNames: 38, workflowNames: 1 },
   validateReleaseArtifactRerunSafety: { workflowNames: 13 },
   validateReleaseCellUploadOwnership: { workflowNames: 18 },

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -10583,13 +10583,42 @@ export function validatePluginRelease(workflows, violations, graph) {
   requireStepRun(violations, file, preflight, "Refuse a changed tool surface", [
     "generated-mcp-catalog.json",
   ]);
-  requireStepRun(violations, file, object(jobs["plugin-proof"]), "Check the pinned provision proof", [
+  const pluginProof = object(jobs["plugin-proof"]);
+  const pluginProofSteps = Array.isArray(pluginProof.steps) ? pluginProof.steps : [];
+  const pluginProofHosts = at(pluginProof, "strategy", "matrix", "include");
+  const fullStaticSuite = namedStep(pluginProof, "Run the plugin static suite");
+  const windowsRootProof = namedStep(pluginProof, "Prove plugin root activation on Windows");
+  const pinnedProvisionSelfTest = namedStep(pluginProof, "Check the pinned provision proof");
+  const pinnedProvision = namedStep(pluginProof, "Provision the pinned CLI end to end");
+  const expectedWindowsRootRun = "node --test --test-name-pattern \"^portable plugin core and thin host adapters preserve their own contracts$\" plugins/codestory/tests/plugin-static.test.mjs";
+  const requiredProofHosts = ["ubuntu-latest", "macos-15", "windows-latest"];
+  add(
+    violations,
+    Array.isArray(pluginProofHosts)
+      && pluginProofHosts.every(row => hasExactKeys(object(row), ["os"]))
+      && sameMembers(pluginProofHosts.map(row => object(row).os), requiredProofHosts)
+      && fullStaticSuite?.if === "runner.os != 'Windows'"
+      && fullStaticSuite?.run === "node --test plugins/codestory/tests/plugin-static.test.mjs"
+      && fullStaticSuite?.["continue-on-error"] === undefined
+      && windowsRootProof?.if === "runner.os == 'Windows'"
+      && windowsRootProof?.run === expectedWindowsRootRun
+      && windowsRootProof?.["continue-on-error"] === undefined
+      && pinnedProvisionSelfTest?.if === undefined
+      && pinnedProvisionSelfTest?.["continue-on-error"] === undefined
+      && pinnedProvision?.if === undefined
+      && pinnedProvision?.["continue-on-error"] === undefined
+      && pluginProofSteps.indexOf(fullStaticSuite) < pluginProofSteps.indexOf(windowsRootProof)
+      && pluginProofSteps.indexOf(windowsRootProof) < pluginProofSteps.indexOf(pinnedProvisionSelfTest)
+      && pluginProofSteps.indexOf(pinnedProvisionSelfTest) < pluginProofSteps.indexOf(pinnedProvision),
+    `${file} plugin proof must run the full static suite off Windows, the portable root contract on Windows, and pinned provisioning on every host`,
+  );
+  requireStepRun(violations, file, pluginProof, "Check the pinned provision proof", [
     "node --test scripts/tests/prove-plugin-pinned-provision.test.mjs",
   ]);
   // The lane is stated, never defaulted. The native lane's pin lawfully carries no archive
   // digests, so a plugin-lane gate that stopped naming its lane could silently become one that
   // proves nothing about the source pin it exists to enforce.
-  requireStepRun(violations, file, object(jobs["plugin-proof"]), "Provision the pinned CLI end to end", [
+  requireStepRun(violations, file, pluginProof, "Provision the pinned CLI end to end", [
     "scripts/prove-plugin-pinned-provision.mjs",
     "--lane plugin",
   ]);

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -7020,6 +7020,54 @@ test("plugin publish must actually wait on preflight and plugin proof", async (t
   });
 });
 
+test("plugin proof keeps the full static suite off Windows without dropping Windows release proof", async (t) => {
+  const file = "plugin-release.yml";
+  const fullSuiteName = "Run the plugin static suite";
+  const windowsRootName = "Prove plugin root activation on Windows";
+  const expected = /plugin-release\.yml plugin proof must run the full static suite off Windows, the portable root contract on Windows, and pinned provisioning on every host/u;
+
+  await t.test("the platform split retains both proof tiers", () => {
+    const workflows = loadWorkflows();
+    assert.deepEqual(validateWorkflows(workflows), []);
+  });
+
+  const mutations = [
+    ["the Windows proof host disappears", workflow => {
+      workflow.jobs["plugin-proof"].strategy.matrix.include =
+        workflow.jobs["plugin-proof"].strategy.matrix.include.filter(row => row.os !== "windows-latest");
+    }],
+    ["the full static suite runs on Windows again", workflow => {
+      delete draftStep(workflow.jobs["plugin-proof"], fullSuiteName).if;
+    }],
+    ["the focused Windows root proof disappears", workflow => {
+      const job = workflow.jobs["plugin-proof"];
+      job.steps = job.steps.filter(step => step.name !== windowsRootName);
+    }],
+    ["the focused root proof is routed away from Windows", workflow => {
+      draftStep(workflow.jobs["plugin-proof"], windowsRootName).if = "runner.os != 'Windows'";
+    }],
+    ["the focused Windows proof selects another test", workflow => {
+      draftStep(workflow.jobs["plugin-proof"], windowsRootName).run =
+        "node --test plugins/codestory/tests/plugin-static.test.mjs";
+    }],
+    ["the pinned provision self-test skips Windows", workflow => {
+      draftStep(workflow.jobs["plugin-proof"], "Check the pinned provision proof").if =
+        "runner.os != 'Windows'";
+    }],
+    ["the real pinned provision skips Windows", workflow => {
+      draftStep(workflow.jobs["plugin-proof"], "Provision the pinned CLI end to end").if =
+        "runner.os != 'Windows'";
+    }],
+  ];
+  for (const [name, mutate] of mutations) {
+    await t.test(name, () => {
+      const workflows = loadWorkflows();
+      mutate(workflows.get(file));
+      assert.match(validateWorkflows(workflows).join("\n"), expected);
+    });
+  }
+});
+
 test("marketplace sync keeps dispatch inputs out of script text", async (t) => {
   assert.deepEqual(validateWorkflows(loadWorkflows()), []);
   const file = "marketplace-sync.yml";

--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -178,7 +178,12 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Run the plugin static suite
+        if: runner.os != 'Windows'
         run: node --test plugins/codestory/tests/plugin-static.test.mjs
+
+      - name: Prove plugin root activation on Windows
+        if: runner.os == 'Windows'
+        run: node --test --test-name-pattern "^portable plugin core and thin host adapters preserve their own contracts$" plugins/codestory/tests/plugin-static.test.mjs
 
       # Prove the gate below can still fail before trusting it to pass: its wait must bound
       # itself on readable non-managed metadata, and it must refuse to exit 0 without proving.


### PR DESCRIPTION
## Context

The first v0.17.2 plugin-only release attempt reached Windows proof, then ran the complete plugin static fixture suite there. That suite deliberately rejects Windows batch CLI overrides while many of its fixtures use `.cmd`, so it failed before the real pinned `.exe` provision gate and leaked a process until the job was cancelled.

## What changed

- Run the complete plugin static suite on Linux and macOS.
- On Windows, run the exact portable plugin-root regression that covers Cursor MCP activation from an unrelated project directory.
- Keep the pinned-provision self-test and real GitHub-release `.exe` provisioning mandatory on Linux, macOS, and Windows.
- Pin that split in the workflow-policy checker with hostile mutations for host removal, route drift, test substitution, and Windows provision bypass.

## Review

Exact head: `119378569a61f5ca869cbaf57232c31e5c209b37`
Tree: `e8936f638250e233d84863d03e9eb101c1491056`
Base: `22130e4856674724ddd54603cc8c76db4dc207ba`

This is release automation only. It does not change native source, the 0.17.1 CLI archives, signing, hardware proof, or calibration.

## Verification

- `node --test .github/scripts/check-workflow-policy.test.mjs` — 1430/1430 pass
- `node --test scripts/tests/prove-plugin-pinned-provision.test.mjs` — 29/29 pass
- `node --test plugins/codestory/tests/plugin-static.test.mjs` — 134 pass, 1 Windows-only skip
- focused portable plugin-root test — 1/1 pass
- workflow policy checker, actionlint, plugin 0.17.2 release validator, version sync check, and diff check pass

Closes #1956
Refs #704