### PR TITLE
[codex] align MCP output schemas with Cursor-validated payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+Cursor marketplace MCP tool results match the schemas Cursor validates. After the server started, Cursor rejected `status`, `packet`, and `files` because the advertised output schema forbade extra compact-status fields, typed packet `support` as an object, and omitted `files.coverage_gaps`.
+
 Cursor marketplace installs start CodeStory's MCP server. 0.17.3 found the installed launcher, then loaded it as a library, so the process exited immediately and Cursor reported `Connection closed`.
 
 ## 0.17.3

--- a/crates/codestory-cli/src/stdio_catalog.rs
+++ b/crates/codestory-cli/src/stdio_catalog.rs
@@ -844,6 +844,25 @@ static STATUS_OUTPUT_SCHEMA: SchemaObject = SchemaObject::object(
         .nullable(),
         SchemaProperty::string("next_action", "Direct next action for the caller."),
         SchemaProperty::integer("retry_after_ms", "Retry delay while preparing.").nullable(),
+        SchemaProperty::object(
+            "failure",
+            "Structured capability failure when the compact status is not live-ready.",
+        )
+        .nullable(),
+        SchemaProperty::string(
+            "retrieval_mode",
+            "Pinned retrieval publication class; full is eligibility, not live-ready.",
+        )
+        .nullable(),
+        SchemaProperty::string(
+            "degraded_reason",
+            "Why a full publication is not live-ready, when that is known.",
+        )
+        .nullable(),
+        SchemaProperty::boolean(
+            "live_ready",
+            "Whether packet/search may use full retrieval without a degraded reason.",
+        ),
         SchemaProperty::string("diagnostics_uri", "Optional full diagnostic resource URI."),
     ],
     &[
@@ -1046,6 +1065,36 @@ static INDEXED_FILE_SCHEMA: SchemaObject = SchemaObject::object(
     ],
 );
 
+static FILE_COVERAGE_DIAGNOSTIC_SCHEMA: SchemaObject = SchemaObject::object(
+    "File-level coverage limitation or source-integrity failure.",
+    &[
+        SchemaProperty::string("path", "Project-relative file path."),
+        SchemaProperty::string("reason", "Coverage limitation reason.").with_enum(&[
+            "parser_partial",
+            "source_changed",
+            "unreadable",
+            "malformed",
+            "binary",
+            "oversized",
+            "discovery_incomplete",
+            "collector_failure",
+        ]),
+        SchemaProperty::boolean("retryable", "Whether a later index can recover this file."),
+        SchemaProperty::boolean("verified_source", "Whether source bytes were verified."),
+        SchemaProperty::boolean(
+            "projection_available",
+            "Whether a usable projection remains.",
+        ),
+    ],
+    &[
+        "path",
+        "reason",
+        "retryable",
+        "verified_source",
+        "projection_available",
+    ],
+);
+
 static SOURCE_POLICY_EXCLUSION_SCHEMA: SchemaObject = SchemaObject::object(
     "Verified source intentionally excluded from parser scheduling without graph or semantic coverage.",
     &[
@@ -1092,6 +1141,11 @@ static INDEXED_FILES_OUTPUT_SCHEMA: SchemaObject = SchemaObject::object(
         SchemaProperty::boolean("usable", "Whether the index has usable files."),
         SchemaProperty::object("summary", "Indexed file summary DTO."),
         SchemaProperty::array("files", "Indexed file rows.", &INDEXED_FILE_SCHEMA),
+        SchemaProperty::array(
+            "coverage_gaps",
+            "File-level coverage limitations or source-integrity failures.",
+            &FILE_COVERAGE_DIAGNOSTIC_SCHEMA,
+        ),
         SchemaProperty::array(
             "policy_exclusions",
             "Verified policy exclusions without graph or semantic coverage.",
@@ -1619,6 +1673,30 @@ static CONTEXT_PACKET_SCHEMA: SchemaObject = SchemaObject::object(
     ],
 );
 
+static SUPPORT_UNIT_SCHEMA: SchemaObject = SchemaObject::object(
+    "Compiled evidence atom the agent judges.",
+    &[
+        SchemaProperty::string("id", "Stable support unit id."),
+        SchemaProperty::string("kind", "Support unit kind.").with_enum(&[
+            "symbol_location",
+            "source_range",
+            "typed_graph_edge",
+            "complete_query_negative",
+        ]),
+        SchemaProperty::string("summary", "Evidence summary."),
+        SchemaProperty::string("path", "Project-relative file path."),
+        SchemaProperty::string("symbol_id", "Stable symbol id."),
+        SchemaProperty::integer("start_line", "1-based start line."),
+        SchemaProperty::integer("end_line", "1-based end line."),
+        SchemaProperty::string("snippet", "Optional source excerpt."),
+        SchemaProperty::string("edge_kind", "Typed graph edge kind."),
+        SchemaProperty::string("from_symbol", "Edge source symbol."),
+        SchemaProperty::string("to_symbol", "Edge target symbol."),
+        SchemaProperty::string("query", "Complete-query negative text."),
+    ],
+    &["id", "kind", "summary"],
+);
+
 static AGENT_PACKET_SCHEMA: SchemaObject = SchemaObject::object(
     "CodeStory broad task packet DTO with compiled support units and a machine stop or one-round drill disposition.",
     &[
@@ -1630,9 +1708,10 @@ static AGENT_PACKET_SCHEMA: SchemaObject = SchemaObject::object(
         SchemaProperty::object("plan", "Packet planner trace."),
         SchemaProperty::object("answer", "Underlying DB-first answer packet."),
         SchemaProperty::object("budget", "Budget limits, usage, and truncation metadata."),
-        SchemaProperty::object(
+        SchemaProperty::array(
             "support",
             "Compiled evidence atoms: symbol locations, source ranges, typed graph edges, and complete-query negatives.",
+            &SUPPORT_UNIT_SCHEMA,
         ),
         SchemaProperty::object(
             "disposition",

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -8907,6 +8907,28 @@ version = "0.11.20"
             json!(true),
             "full publication class must not read as packet-ready when degraded: {compact}"
         );
+        let schema = stdio_tools_list_json()["result"]["tools"]
+            .as_array()
+            .expect("tools")
+            .iter()
+            .find(|tool| tool["name"] == "status")
+            .expect("status tool")["outputSchema"]
+            .clone();
+        let properties = schema["properties"]
+            .as_object()
+            .expect("status outputSchema properties");
+        let undeclared = compact
+            .as_object()
+            .expect("compact status is an object")
+            .keys()
+            .filter(|key| !properties.contains_key(*key))
+            .cloned()
+            .collect::<Vec<_>>();
+        assert!(
+            undeclared.is_empty(),
+            "Cursor validates status structuredContent against additionalProperties: false, \
+             but compact status emits {undeclared:?}"
+        );
     }
 
     #[test]

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -2441,6 +2441,7 @@ fn tool_catalog_exposes_output_schemas_for_stable_dto_backed_tools() {
         "references",
         "search",
         "snippet",
+        "status",
         "symbol",
         "symbols",
         "trace",
@@ -2478,11 +2479,27 @@ fn tool_catalog_exposes_output_schemas_for_stable_dto_backed_tools() {
                 "context outputSchema should not expose answer/prompt DTO names: {tool}"
             );
         }
+        if name == "status" {
+            for field in ["failure", "retrieval_mode", "degraded_reason", "live_ready"] {
+                assert!(
+                    output_schema
+                        .get("properties")
+                        .and_then(Value::as_object)
+                        .is_some_and(|properties| properties.contains_key(field)),
+                    "status outputSchema should declare compact field {field}: {tool}"
+                );
+            }
+        }
         if name == "packet" {
             assert_eq!(
                 schema_property(output_schema, "packet_id")["type"],
                 "string",
                 "packet outputSchema should expose a stable packet id: {tool}"
+            );
+            assert_eq!(
+                schema_property(output_schema, "support")["type"],
+                "array",
+                "packet support is a list of compiled units, not an object: {tool}"
             );
             for field in [
                 "plan",
@@ -2548,6 +2565,13 @@ fn tool_catalog_exposes_output_schemas_for_stable_dto_backed_tools() {
             );
         }
         if name == "files" {
+            assert!(
+                output_schema
+                    .get("properties")
+                    .and_then(Value::as_object)
+                    .is_some_and(|properties| properties.contains_key("coverage_gaps")),
+                "files outputSchema should declare coverage_gaps: {tool}"
+            );
             for field in [
                 "project_root",
                 "usable",

--- a/docs/users/cursor.md
+++ b/docs/users/cursor.md
@@ -94,6 +94,7 @@ installs use [Add Marketplace](#install).
 | MCP fails to start | Confirm `node` is on `PATH`, then reload. Inspect **MCP Logs** in the Output panel (**Cmd+Shift+U** / **Ctrl+Shift+U**) |
 | MCP dies looking for `<project>/scripts/codestory-mcp.cjs` | Refresh **codestory** to 0.17.3 or later in Customize, then reload. Cursor expanded `${PLUGIN_ROOT}` to the open project, so 0.17.2 still launched from the wrong folder. In a CodeStory checkout, the project `.cursor/mcp.json` server remains a working fallback |
 | MCP reports `Connection closed` with no missing-module error | Refresh **codestory** to 0.17.4 or later, then reload. 0.17.3 found the installed launcher and then exited without starting the server. In a CodeStory checkout, the project `.cursor/mcp.json` server remains a working fallback |
+| MCP connects, then tools fail with `output schema` / `additional properties` | Cursor validates tool JSON against CodeStory's advertised schema. 0.17.1 still declares packet `support` as an object and omits compact status fields and `files.coverage_gaps`. Use a CLI that includes that schema fix, then reload |
 | Runtime is stale after an update | Refresh the marketplace and the plugin in Customize, reload Cursor, and start a fresh session |
 | A tool remains preparing | Retry that same tool after its returned delay |
 

--- a/plugins/codestory/generated-mcp-catalog.json
+++ b/plugins/codestory/generated-mcp-catalog.json
@@ -47,9 +47,27 @@
               "null"
             ]
           },
+          "degraded_reason": {
+            "description": "Why a full publication is not live-ready, when that is known.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "diagnostics_uri": {
             "description": "Optional full diagnostic resource URI.",
             "type": "string"
+          },
+          "failure": {
+            "description": "Structured capability failure when the compact status is not live-ready.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "live_ready": {
+            "description": "Whether packet/search may use full retrieval without a degraded reason.",
+            "type": "boolean"
           },
           "next_action": {
             "description": "Direct next action for the caller.",
@@ -58,6 +76,13 @@
           "project": {
             "description": "Requested repository root.",
             "type": "string"
+          },
+          "retrieval_mode": {
+            "description": "Pinned retrieval publication class; full is eligibility, not live-ready.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "retry_after_ms": {
             "description": "Retry delay while preparing.",
@@ -672,7 +697,73 @@
           },
           "support": {
             "description": "Compiled evidence atoms: symbol locations, source ranges, typed graph edges, and complete-query negatives.",
-            "type": "object"
+            "items": {
+              "additionalProperties": false,
+              "description": "Compiled evidence atom the agent judges.",
+              "properties": {
+                "edge_kind": {
+                  "description": "Typed graph edge kind.",
+                  "type": "string"
+                },
+                "end_line": {
+                  "description": "1-based end line.",
+                  "type": "integer"
+                },
+                "from_symbol": {
+                  "description": "Edge source symbol.",
+                  "type": "string"
+                },
+                "id": {
+                  "description": "Stable support unit id.",
+                  "type": "string"
+                },
+                "kind": {
+                  "description": "Support unit kind.",
+                  "enum": [
+                    "symbol_location",
+                    "source_range",
+                    "typed_graph_edge",
+                    "complete_query_negative"
+                  ],
+                  "type": "string"
+                },
+                "path": {
+                  "description": "Project-relative file path.",
+                  "type": "string"
+                },
+                "query": {
+                  "description": "Complete-query negative text.",
+                  "type": "string"
+                },
+                "snippet": {
+                  "description": "Optional source excerpt.",
+                  "type": "string"
+                },
+                "start_line": {
+                  "description": "1-based start line.",
+                  "type": "integer"
+                },
+                "summary": {
+                  "description": "Evidence summary.",
+                  "type": "string"
+                },
+                "symbol_id": {
+                  "description": "Stable symbol id.",
+                  "type": "string"
+                },
+                "to_symbol": {
+                  "description": "Edge target symbol.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "kind",
+                "summary"
+              ],
+              "type": "object"
+            },
+            "type": "array"
           },
           "task_class": {
             "description": "Optional task class.",
@@ -1297,6 +1388,54 @@
           "code": {
             "description": "Typed API error code.",
             "type": "string"
+          },
+          "coverage_gaps": {
+            "description": "File-level coverage limitations or source-integrity failures.",
+            "items": {
+              "additionalProperties": false,
+              "description": "File-level coverage limitation or source-integrity failure.",
+              "properties": {
+                "path": {
+                  "description": "Project-relative file path.",
+                  "type": "string"
+                },
+                "projection_available": {
+                  "description": "Whether a usable projection remains.",
+                  "type": "boolean"
+                },
+                "reason": {
+                  "description": "Coverage limitation reason.",
+                  "enum": [
+                    "parser_partial",
+                    "source_changed",
+                    "unreadable",
+                    "malformed",
+                    "binary",
+                    "oversized",
+                    "discovery_incomplete",
+                    "collector_failure"
+                  ],
+                  "type": "string"
+                },
+                "retryable": {
+                  "description": "Whether a later index can recover this file.",
+                  "type": "boolean"
+                },
+                "verified_source": {
+                  "description": "Whether source bytes were verified.",
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "path",
+                "reason",
+                "retryable",
+                "verified_source",
+                "projection_available"
+              ],
+              "type": "object"
+            },
+            "type": "array"
           },
           "details": {
             "description": "Structured API error repair guidance.",


### PR DESCRIPTION
## Summary

- Cursor stayed connected after #1969, then rejected `tools/call` results because it validates `structuredContent` against `outputSchema` (`additionalProperties: false`).
- Compact `status` already emitted `failure`, `retrieval_mode`, `degraded_reason`, and `live_ready`; the schema now declares them. Packet `support` is an array of support units, matching `AgentPacketDto`. `files` declares `coverage_gaps`.
- Regenerated `plugins/codestory/generated-mcp-catalog.json` from the CLI. This is a native contract change, not a plugin-only 0.17.4 slice.

Closes #1971

## Test plan

- [x] `cargo test --locked -p codestory-cli --lib compact_stdio_status_keeps_full_publication_class`
- [x] `cargo test --locked -p codestory-cli --test stdio_protocol_contracts tool_catalog_exposes_output_schemas_for_stable_dto_backed_tools`
- [x] Cursor Ajv (`strict: false`, `allErrors: true`) accepts representative `status`, `packet`, and `files` payloads against the regenerated catalog
- [x] `node --test plugins/codestory/tests/plugin-static.test.mjs` (134 pass, 1 Windows skip)
- [x] `git diff --check`
- [x] `node .github/scripts/check-doc-links.mjs`
- [ ] Live Cursor still runs CLI 0.17.1 until a native release. After that CLI is installed, `status` / `packet` / `files` should return instead of `-32602`

## How to review

Exact head `cc6b4b03`. Read `STATUS_OUTPUT_SCHEMA`, `AGENT_PACKET_SCHEMA` / `SUPPORT_UNIT_SCHEMA`, and `INDEXED_FILES_OUTPUT_SCHEMA` in `crates/codestory-cli/src/stdio_catalog.rs`. Compact status still emits the four publication-class fields; they are now named in the schema instead of stripped.

## Risk

Hosts that already ignored `outputSchema` see the same JSON. Cursor will keep rejecting tools until it runs a CLI built from this head. No native rebuild, calibration, or version bump in this PR.

## Follow-up

Do not promote this PR to `main` by itself. Bundle it with the other 0.17.4 work, then decide whether that wave is plugin-only (it cannot be, once this catalog change is included) or a native CLI release.


Made with [Cursor](https://cursor.com)