### PR TITLE
[codex] add the dark call path proof kernel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,6 +527,8 @@ dependencies = [
  "codestory-contracts",
  "serde",
  "serde_json",
+ "serde_json_canonicalizer",
+ "sha2 0.10.9",
  "tempfile",
 ]
 
@@ -3823,6 +3825,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "ryu-js"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d056b875a9d2e6cb9a61d127afee9ac5999b9f87bcb32079d1318e505be714"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3919,6 +3927,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_json_canonicalizer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe52319a927259afbfa5180c5157cd8167edfd3e8c254f9558c7fef44c5649f2"
+dependencies = [
+ "ryu-js",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ tantivy = "0.26"
 # Utilities
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_json_canonicalizer = "=0.3.2"
 serde_with = "3.21.0"
 saphyr-parser = "0.0.11"
 specta = { version = "2.0.0-rc.22", features = ["derive", "serde"] }

--- a/crates/codestory-agent/Cargo.toml
+++ b/crates/codestory-agent/Cargo.toml
@@ -6,12 +6,16 @@ edition = "2024"
 [features]
 # Compiles the eval/holdout probe hooks for downstream unit tests. No product
 # build enables it.
-test-support = []
+test-support = ["dep:serde_json_canonicalizer", "dep:sha2"]
 
 [dependencies]
 codestory-contracts = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_json_canonicalizer = { workspace = true, optional = true }
+sha2 = { workspace = true, optional = true }
 
 [dev-dependencies]
+serde_json_canonicalizer = { workspace = true }
+sha2 = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/codestory-agent/src/indexed_source_call_path_v1.rs
+++ b/crates/codestory-agent/src/indexed_source_call_path_v1.rs
@@ -1,0 +1,2240 @@
+//! Pure dark kernel for the `indexed_source_call_path_v1` proof domain.
+//!
+//! The domain is an ordered sequence of direct, outgoing, indexed source-level
+//! `CALL` edges. A step's target is the next step's source. The kernel proves
+//! neither runtime execution nor general reachability, data flow, ownership,
+//! elapsed time, or the non-participation of excluded scopes. It performs no
+//! discovery, fuzzy matching, graph traversal, store access, or source read.
+//! Callers must resolve selectors and verify receipts before constructing the
+//! facts accepted here.
+//!
+//! This module is compiled only for crate tests or the explicit `test-support`
+//! feature. No production dispatcher enables that feature.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+
+pub const PROOF_CONTRACT_SCHEMA_VERSION: u32 = 1;
+pub const PROOF_DOMAIN: &str = "indexed_source_call_path_v1";
+pub const CLAUSE_GUARD_VERSION: &str = "clause_guard_v1";
+const DIGEST_DOMAIN_SEPARATOR: &[u8] = b"codestory.proof-contract.digest.v1\0";
+const MIN_STEPS: usize = 1;
+const MAX_STEPS: usize = 6;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnvalidatedCallPathContract {
+    source_text: String,
+    clauses: Vec<ClauseAnchor>,
+    spec: UnvalidatedCallPathSpec,
+}
+
+impl UnvalidatedCallPathContract {
+    pub fn new(
+        source_text: impl Into<String>,
+        clauses: Vec<ClauseAnchor>,
+        spec: UnvalidatedCallPathSpec,
+    ) -> Self {
+        Self {
+            source_text: source_text.into(),
+            clauses,
+            spec,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClauseAnchor {
+    pub clause_id: String,
+    pub start: usize,
+    pub end: usize,
+    pub quote: String,
+    pub classification: ClauseClassification,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ClauseClassification {
+    ResolvedMaterial { fields: Vec<ProofContractField> },
+    UnresolvedMaterial { reason: UnresolvedMaterialReason },
+    NonMaterial { kind: NonMaterialKind },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ProofContractField {
+    Start,
+    StepTarget,
+    Directness,
+    Ordering,
+    Relation,
+    TraversalProhibition,
+    ProjectionExclusion,
+}
+
+impl ProofContractField {
+    fn canonical_name(self) -> &'static str {
+        match self {
+            Self::Start => "start",
+            Self::StepTarget => "step_target",
+            Self::Directness => "directness",
+            Self::Ordering => "ordering",
+            Self::Relation => "relation",
+            Self::TraversalProhibition => "traversal_prohibition",
+            Self::ProjectionExclusion => "projection_exclusion",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum UnresolvedMaterialReason {
+    MissingSelectorResolution,
+    AmbiguousSelectorResolution,
+    UnsupportedInterpretation,
+}
+
+impl UnresolvedMaterialReason {
+    fn canonical_name(&self) -> &'static str {
+        match self {
+            Self::MissingSelectorResolution => "missing_selector_resolution",
+            Self::AmbiguousSelectorResolution => "ambiguous_selector_resolution",
+            Self::UnsupportedInterpretation => "unsupported_interpretation",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum NonMaterialKind {
+    Whitespace,
+    Punctuation,
+    Connector,
+    Commentary,
+}
+
+impl NonMaterialKind {
+    fn canonical_name(&self) -> &'static str {
+        match self {
+            Self::Whitespace => "whitespace",
+            Self::Punctuation => "punctuation",
+            Self::Connector => "connector",
+            Self::Commentary => "commentary",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnvalidatedCallPathSpec {
+    pub start: UnvalidatedExactSymbolSelector,
+    pub steps: Vec<UnvalidatedDirectCallStep>,
+    pub prohibit_traversal_through: Vec<UnvalidatedExactScopeSelector>,
+    pub exclude_from_projection: Vec<UnvalidatedExactScopeSelector>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnvalidatedDirectCallStep {
+    pub target: UnvalidatedExactSymbolSelector,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UnvalidatedExactSymbolSelector {
+    PinnedNode(PinnedNodeIdentity),
+    CanonicalId(String),
+    QualifiedName {
+        qualified_name: String,
+        project_file_components: Option<Vec<String>>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UnvalidatedExactScopeSelector {
+    PinnedNode(PinnedNodeIdentity),
+    CanonicalId(String),
+    QualifiedName {
+        qualified_name: String,
+        project_file_components: Option<Vec<String>>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct PinnedNodeIdentity {
+    pub project_id: String,
+    pub core_generation_id: String,
+    pub core_run_id: String,
+    pub node_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ExactSymbolSelector {
+    PinnedNode(PinnedNodeIdentity),
+    CanonicalId(String),
+    QualifiedName {
+        qualified_name: String,
+        project_file_components: Option<Vec<String>>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ExactScopeSelector {
+    PinnedNode(PinnedNodeIdentity),
+    CanonicalId(String),
+    QualifiedName {
+        qualified_name: String,
+        project_file_components: Option<Vec<String>>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DirectCallStep {
+    target: ExactSymbolSelector,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CallPathSpec {
+    start: ExactSymbolSelector,
+    steps: Vec<DirectCallStep>,
+    prohibit_traversal_through: Vec<ExactScopeSelector>,
+    exclude_from_projection: Vec<ExactScopeSelector>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidatedCallPathContract {
+    spec: CallPathSpec,
+    bound_hashes: ProofHashes,
+}
+
+impl ValidatedCallPathContract {
+    pub fn spec(&self) -> &CallPathSpec {
+        &self.spec
+    }
+}
+
+impl CallPathSpec {
+    pub fn start(&self) -> &ExactSymbolSelector {
+        &self.start
+    }
+
+    pub fn steps(&self) -> &[DirectCallStep] {
+        &self.steps
+    }
+
+    pub fn traversal_prohibitions(&self) -> &[ExactScopeSelector] {
+        &self.prohibit_traversal_through
+    }
+
+    pub fn projection_exclusions(&self) -> &[ExactScopeSelector] {
+        &self.exclude_from_projection
+    }
+}
+
+impl DirectCallStep {
+    pub fn target(&self) -> &ExactSymbolSelector {
+        &self.target
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidatedContractRendering {
+    normalized_clauses: Vec<NormalizedClause>,
+}
+
+impl ValidatedContractRendering {
+    pub fn clause_count(&self) -> usize {
+        self.normalized_clauses.len()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct NormalizedClause {
+    start: usize,
+    end: usize,
+    clause_id: String,
+    classification: NormalizedClauseClassification,
+    field: Option<ProofContractField>,
+    quote: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+enum NormalizedClauseClassification {
+    Resolved,
+    Unresolved(UnresolvedMaterialReason),
+    Ignored(NonMaterialKind),
+}
+
+impl NormalizedClauseClassification {
+    fn canonical_name(&self) -> &'static str {
+        match self {
+            Self::Resolved => "resolved_material",
+            Self::Unresolved(_) => "unresolved_material",
+            Self::Ignored(_) => "non_material",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ValidationOutcome {
+    Validated {
+        contract: Box<ValidatedCallPathContract>,
+        hashes: ProofHashes,
+        rendering: ValidatedContractRendering,
+    },
+    Unknown {
+        hashes: ProofHashes,
+        gaps: Vec<TranslationGap>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum TranslationGap {
+    UnclassifiedSourceText,
+    UnresolvedMaterialClause {
+        clause_id: String,
+        reason: UnresolvedMaterialReason,
+    },
+    MaterialTokenMisclassified {
+        clause_id: String,
+        guard_families: Vec<ClauseGuardFamily>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ValidationError {
+    StepCountOutOfRange {
+        actual: usize,
+    },
+    InvalidSelector(SelectorValidationError),
+    InvalidScope(SelectorValidationError),
+    EmptyClauseId,
+    EmptyClauseSpan {
+        clause_id: String,
+    },
+    ClauseSpanOutOfBounds {
+        clause_id: String,
+    },
+    ClauseSpanNotUtf8Boundary {
+        clause_id: String,
+    },
+    ClauseQuoteMismatch {
+        clause_id: String,
+    },
+    EmptyResolvedFieldSet {
+        clause_id: String,
+    },
+    ClassificationConflict {
+        clause_id: String,
+    },
+    MissingResolvedMaterialAnchor {
+        field: ProofContractField,
+        required: usize,
+        found: usize,
+    },
+    CanonicalJson(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SelectorValidationError {
+    EmptyIdentity,
+    IdentityContainsNul,
+    NonNormalizedQualifiedName,
+    SignatureOrPatternSelector,
+    RootPath,
+    EmptyPathComponent,
+    DotPathComponent,
+    SeparatorInsidePathComponent,
+    NulInsidePathComponent,
+    PlatformEscape,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProofHashes {
+    source_text_sha256: String,
+    contract_digest: String,
+}
+
+impl ProofHashes {
+    pub fn source_text_sha256(&self) -> &str {
+        &self.source_text_sha256
+    }
+
+    pub fn contract_digest(&self) -> &str {
+        &self.contract_digest
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct DigestDomain<'a> {
+    schema_version: u32,
+    proof_domain: &'a str,
+    guard_version: &'a str,
+}
+
+impl Default for DigestDomain<'static> {
+    fn default() -> Self {
+        Self {
+            schema_version: PROOF_CONTRACT_SCHEMA_VERSION,
+            proof_domain: PROOF_DOMAIN,
+            guard_version: CLAUSE_GUARD_VERSION,
+        }
+    }
+}
+
+pub fn validate_contract(
+    input: UnvalidatedCallPathContract,
+) -> Result<ValidationOutcome, ValidationError> {
+    validate_contract_with_domain(input, DigestDomain::default())
+}
+
+fn validate_contract_with_domain(
+    input: UnvalidatedCallPathContract,
+    domain: DigestDomain<'_>,
+) -> Result<ValidationOutcome, ValidationError> {
+    let UnvalidatedCallPathContract {
+        source_text,
+        clauses,
+        spec,
+    } = input;
+    let spec = validate_spec(spec)?;
+    let normalized_clauses = validate_and_normalize_clauses(&source_text, clauses)?;
+    validate_required_field_coverage(&normalized_clauses, &spec)?;
+    let hashes = compute_hashes(&source_text, &normalized_clauses, &spec, domain)?;
+    let gaps = classify_translation_gaps(&source_text, &normalized_clauses);
+    if gaps.is_empty() {
+        Ok(ValidationOutcome::Validated {
+            contract: Box::new(ValidatedCallPathContract {
+                spec,
+                bound_hashes: hashes.clone(),
+            }),
+            hashes,
+            rendering: ValidatedContractRendering { normalized_clauses },
+        })
+    } else {
+        Ok(ValidationOutcome::Unknown { hashes, gaps })
+    }
+}
+
+fn validate_spec(spec: UnvalidatedCallPathSpec) -> Result<CallPathSpec, ValidationError> {
+    if !(MIN_STEPS..=MAX_STEPS).contains(&spec.steps.len()) {
+        return Err(ValidationError::StepCountOutOfRange {
+            actual: spec.steps.len(),
+        });
+    }
+    let start = validate_symbol_selector(spec.start).map_err(ValidationError::InvalidSelector)?;
+    let steps = spec
+        .steps
+        .into_iter()
+        .map(|step| {
+            validate_symbol_selector(step.target)
+                .map(|target| DirectCallStep { target })
+                .map_err(ValidationError::InvalidSelector)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let mut prohibit_traversal_through = spec
+        .prohibit_traversal_through
+        .into_iter()
+        .map(validate_scope_selector)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(ValidationError::InvalidScope)?;
+    let mut exclude_from_projection = spec
+        .exclude_from_projection
+        .into_iter()
+        .map(validate_scope_selector)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(ValidationError::InvalidScope)?;
+    prohibit_traversal_through.sort();
+    prohibit_traversal_through.dedup();
+    exclude_from_projection.sort();
+    exclude_from_projection.dedup();
+    Ok(CallPathSpec {
+        start,
+        steps,
+        prohibit_traversal_through,
+        exclude_from_projection,
+    })
+}
+
+fn validate_symbol_selector(
+    selector: UnvalidatedExactSymbolSelector,
+) -> Result<ExactSymbolSelector, SelectorValidationError> {
+    match selector {
+        UnvalidatedExactSymbolSelector::PinnedNode(identity) => {
+            validate_pinned_identity(&identity)?;
+            Ok(ExactSymbolSelector::PinnedNode(identity))
+        }
+        UnvalidatedExactSymbolSelector::CanonicalId(canonical_id) => {
+            validate_identity(&canonical_id)?;
+            Ok(ExactSymbolSelector::CanonicalId(canonical_id))
+        }
+        UnvalidatedExactSymbolSelector::QualifiedName {
+            qualified_name,
+            project_file_components,
+        } => {
+            validate_qualified_name(&qualified_name)?;
+            validate_optional_path(project_file_components.as_deref())?;
+            Ok(ExactSymbolSelector::QualifiedName {
+                qualified_name,
+                project_file_components,
+            })
+        }
+    }
+}
+
+fn validate_scope_selector(
+    selector: UnvalidatedExactScopeSelector,
+) -> Result<ExactScopeSelector, SelectorValidationError> {
+    match selector {
+        UnvalidatedExactScopeSelector::PinnedNode(identity) => {
+            validate_pinned_identity(&identity)?;
+            Ok(ExactScopeSelector::PinnedNode(identity))
+        }
+        UnvalidatedExactScopeSelector::CanonicalId(canonical_id) => {
+            validate_identity(&canonical_id)?;
+            Ok(ExactScopeSelector::CanonicalId(canonical_id))
+        }
+        UnvalidatedExactScopeSelector::QualifiedName {
+            qualified_name,
+            project_file_components,
+        } => {
+            validate_qualified_name(&qualified_name)?;
+            validate_optional_path(project_file_components.as_deref())?;
+            Ok(ExactScopeSelector::QualifiedName {
+                qualified_name,
+                project_file_components,
+            })
+        }
+    }
+}
+
+fn validate_pinned_identity(identity: &PinnedNodeIdentity) -> Result<(), SelectorValidationError> {
+    validate_identity(&identity.project_id)?;
+    validate_identity(&identity.core_generation_id)?;
+    validate_identity(&identity.core_run_id)?;
+    validate_identity(&identity.node_id)
+}
+
+fn validate_identity(value: &str) -> Result<(), SelectorValidationError> {
+    if value.is_empty() {
+        return Err(SelectorValidationError::EmptyIdentity);
+    }
+    if value.contains('\0') {
+        return Err(SelectorValidationError::IdentityContainsNul);
+    }
+    Ok(())
+}
+
+fn validate_qualified_name(value: &str) -> Result<(), SelectorValidationError> {
+    validate_identity(value)?;
+    if value.trim() != value {
+        return Err(SelectorValidationError::NonNormalizedQualifiedName);
+    }
+    if value
+        .chars()
+        .any(|character| character.is_whitespace() || matches!(character, '(' | ')' | '*' | '?'))
+    {
+        return Err(SelectorValidationError::SignatureOrPatternSelector);
+    }
+    Ok(())
+}
+
+fn validate_optional_path(components: Option<&[String]>) -> Result<(), SelectorValidationError> {
+    let Some(components) = components else {
+        return Ok(());
+    };
+    if components.is_empty() {
+        return Err(SelectorValidationError::RootPath);
+    }
+    for component in components {
+        if component.is_empty() {
+            return Err(SelectorValidationError::EmptyPathComponent);
+        }
+        if component == "." || component == ".." {
+            return Err(SelectorValidationError::DotPathComponent);
+        }
+        if component.contains('/') || component.contains('\\') {
+            return Err(SelectorValidationError::SeparatorInsidePathComponent);
+        }
+        if component.contains('\0') {
+            return Err(SelectorValidationError::NulInsidePathComponent);
+        }
+        if component.starts_with('~') || component.contains(':') {
+            return Err(SelectorValidationError::PlatformEscape);
+        }
+    }
+    Ok(())
+}
+
+fn validate_and_normalize_clauses(
+    source_text: &str,
+    clauses: Vec<ClauseAnchor>,
+) -> Result<Vec<NormalizedClause>, ValidationError> {
+    let mut normalized = Vec::new();
+    let mut classifications = BTreeMap::<(usize, usize, String), ClauseClassification>::new();
+    for clause in clauses {
+        if clause.clause_id.is_empty() {
+            return Err(ValidationError::EmptyClauseId);
+        }
+        if clause.start == clause.end {
+            return Err(ValidationError::EmptyClauseSpan {
+                clause_id: clause.clause_id,
+            });
+        }
+        if clause.start > clause.end || clause.end > source_text.len() {
+            return Err(ValidationError::ClauseSpanOutOfBounds {
+                clause_id: clause.clause_id,
+            });
+        }
+        if !source_text.is_char_boundary(clause.start) || !source_text.is_char_boundary(clause.end)
+        {
+            return Err(ValidationError::ClauseSpanNotUtf8Boundary {
+                clause_id: clause.clause_id,
+            });
+        }
+        if source_text[clause.start..clause.end] != clause.quote {
+            return Err(ValidationError::ClauseQuoteMismatch {
+                clause_id: clause.clause_id,
+            });
+        }
+        let conflict_key = (clause.start, clause.end, clause.clause_id.clone());
+        if let Some(existing) = classifications.get(&conflict_key) {
+            if classification_family(existing) != classification_family(&clause.classification)
+                || classification_detail_conflicts(existing, &clause.classification)
+            {
+                return Err(ValidationError::ClassificationConflict {
+                    clause_id: clause.clause_id,
+                });
+            }
+        } else {
+            classifications.insert(conflict_key, clause.classification.clone());
+        }
+        match clause.classification {
+            ClauseClassification::ResolvedMaterial { mut fields } => {
+                if fields.is_empty() {
+                    return Err(ValidationError::EmptyResolvedFieldSet {
+                        clause_id: clause.clause_id,
+                    });
+                }
+                fields.sort();
+                fields.dedup();
+                for field in fields {
+                    normalized.push(NormalizedClause {
+                        start: clause.start,
+                        end: clause.end,
+                        clause_id: clause.clause_id.clone(),
+                        quote: clause.quote.clone(),
+                        classification: NormalizedClauseClassification::Resolved,
+                        field: Some(field),
+                    });
+                }
+            }
+            ClauseClassification::UnresolvedMaterial { reason } => {
+                normalized.push(NormalizedClause {
+                    start: clause.start,
+                    end: clause.end,
+                    clause_id: clause.clause_id,
+                    quote: clause.quote,
+                    classification: NormalizedClauseClassification::Unresolved(reason),
+                    field: None,
+                });
+            }
+            ClauseClassification::NonMaterial { kind } => {
+                normalized.push(NormalizedClause {
+                    start: clause.start,
+                    end: clause.end,
+                    clause_id: clause.clause_id,
+                    quote: clause.quote,
+                    classification: NormalizedClauseClassification::Ignored(kind),
+                    field: None,
+                });
+            }
+        }
+    }
+    normalized.sort();
+    normalized.dedup();
+    Ok(normalized)
+}
+
+fn classification_family(classification: &ClauseClassification) -> u8 {
+    match classification {
+        ClauseClassification::ResolvedMaterial { .. } => 0,
+        ClauseClassification::UnresolvedMaterial { .. } => 1,
+        ClauseClassification::NonMaterial { .. } => 2,
+    }
+}
+
+fn classification_detail_conflicts(
+    left: &ClauseClassification,
+    right: &ClauseClassification,
+) -> bool {
+    match (left, right) {
+        (
+            ClauseClassification::UnresolvedMaterial { reason: left },
+            ClauseClassification::UnresolvedMaterial { reason: right },
+        ) => left != right,
+        (
+            ClauseClassification::NonMaterial { kind: left },
+            ClauseClassification::NonMaterial { kind: right },
+        ) => left != right,
+        _ => false,
+    }
+}
+
+fn validate_required_field_coverage(
+    clauses: &[NormalizedClause],
+    spec: &CallPathSpec,
+) -> Result<(), ValidationError> {
+    let requirements = [
+        (ProofContractField::Start, 1),
+        (ProofContractField::StepTarget, spec.steps.len()),
+        (ProofContractField::Directness, 1),
+        (ProofContractField::Ordering, 1),
+        (ProofContractField::Relation, 1),
+        (
+            ProofContractField::TraversalProhibition,
+            spec.prohibit_traversal_through.len(),
+        ),
+        (
+            ProofContractField::ProjectionExclusion,
+            spec.exclude_from_projection.len(),
+        ),
+    ];
+    for (field, required) in requirements {
+        let found = clauses
+            .iter()
+            .filter(|clause| clause.field == Some(field))
+            .count();
+        if found < required {
+            return Err(ValidationError::MissingResolvedMaterialAnchor {
+                field,
+                required,
+                found,
+            });
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct ByteCoverage {
+    unresolved: bool,
+    resolved: bool,
+    non_material: bool,
+}
+
+fn classify_translation_gaps(
+    source_text: &str,
+    clauses: &[NormalizedClause],
+) -> Vec<TranslationGap> {
+    let mut coverage = vec![ByteCoverage::default(); source_text.len()];
+    for clause in clauses {
+        for byte in &mut coverage[clause.start..clause.end] {
+            match clause.classification {
+                NormalizedClauseClassification::Resolved => byte.resolved = true,
+                NormalizedClauseClassification::Unresolved(_) => byte.unresolved = true,
+                NormalizedClauseClassification::Ignored(_) => byte.non_material = true,
+            }
+        }
+    }
+    let mut gaps = BTreeSet::new();
+    for clause in clauses {
+        match &clause.classification {
+            NormalizedClauseClassification::Unresolved(reason) => {
+                gaps.insert(TranslationGap::UnresolvedMaterialClause {
+                    clause_id: clause.clause_id.clone(),
+                    reason: reason.clone(),
+                });
+            }
+            NormalizedClauseClassification::Ignored(_) => {
+                let guard_families = clause_guard_families(&clause.quote);
+                let disappears_as_only_non_material = (clause.start..clause.end).any(|offset| {
+                    coverage[offset].non_material
+                        && !coverage[offset].resolved
+                        && !coverage[offset].unresolved
+                        && !source_text.as_bytes()[offset].is_ascii_whitespace()
+                });
+                if !guard_families.is_empty() && disappears_as_only_non_material {
+                    gaps.insert(TranslationGap::MaterialTokenMisclassified {
+                        clause_id: clause.clause_id.clone(),
+                        guard_families,
+                    });
+                }
+            }
+            NormalizedClauseClassification::Resolved => {}
+        }
+    }
+    let has_unclassified_material = source_text.char_indices().any(|(offset, character)| {
+        let end = offset + character.len_utf8();
+        !character.is_whitespace()
+            && coverage[offset..end]
+                .iter()
+                .any(|byte| !byte.unresolved && !byte.resolved && !byte.non_material)
+    });
+    if has_unclassified_material {
+        gaps.insert(TranslationGap::UnclassifiedSourceText);
+    }
+    gaps.into_iter().collect()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ClauseGuardFamily {
+    QuotedOrBacktickedIdentifier,
+    ArrowOrRelationNotation,
+    Directness,
+    OrderingOrOrdinal,
+    Only,
+    NegationOrExclusion,
+    PathLikeString,
+    QualifiedSymbolNotation,
+}
+
+pub fn clause_guard_families(text: &str) -> Vec<ClauseGuardFamily> {
+    let mut families = BTreeSet::new();
+    let lower = text.to_lowercase();
+    let words = lower
+        .split(|character: char| !character.is_alphanumeric() && character != '_')
+        .filter(|word| !word.is_empty())
+        .collect::<Vec<_>>();
+    if contains_nonempty_quoted(text, '`')
+        || contains_nonempty_quoted(text, '"')
+        || contains_nonempty_quoted(text, '\'')
+    {
+        families.insert(ClauseGuardFamily::QuotedOrBacktickedIdentifier);
+    }
+    if text.contains("->")
+        || text.contains("=>")
+        || text.contains('→')
+        || words.iter().any(|word| {
+            matches!(
+                *word,
+                "call" | "calls" | "called" | "invoke" | "invokes" | "invoked"
+            )
+        })
+    {
+        families.insert(ClauseGuardFamily::ArrowOrRelationNotation);
+    }
+    if words
+        .iter()
+        .any(|word| matches!(*word, "direct" | "directly" | "immediate" | "immediately"))
+    {
+        families.insert(ClauseGuardFamily::Directness);
+    }
+    if words.iter().any(|word| {
+        matches!(
+            *word,
+            "first"
+                | "second"
+                | "third"
+                | "fourth"
+                | "fifth"
+                | "sixth"
+                | "then"
+                | "before"
+                | "after"
+                | "ordered"
+                | "order"
+        ) || has_ordinal_suffix(word)
+    }) {
+        families.insert(ClauseGuardFamily::OrderingOrOrdinal);
+    }
+    if words.contains(&"only") {
+        families.insert(ClauseGuardFamily::Only);
+    }
+    if words.iter().any(|word| {
+        matches!(
+            *word,
+            "no" | "not"
+                | "never"
+                | "without"
+                | "exclude"
+                | "excludes"
+                | "excluding"
+                | "excluded"
+                | "except"
+                | "prohibit"
+                | "prohibits"
+                | "avoid"
+        )
+    }) {
+        families.insert(ClauseGuardFamily::NegationOrExclusion);
+    }
+    if text.contains('/')
+        || text.contains('\\')
+        || [".rs", ".ts", ".tsx", ".js", ".py", ".go", ".java"]
+            .iter()
+            .any(|extension| lower.contains(extension))
+    {
+        families.insert(ClauseGuardFamily::PathLikeString);
+    }
+    if text.contains("::") || contains_dotted_qualified_name(text) {
+        families.insert(ClauseGuardFamily::QualifiedSymbolNotation);
+    }
+    families.into_iter().collect()
+}
+
+fn contains_nonempty_quoted(text: &str, delimiter: char) -> bool {
+    let positions = text
+        .match_indices(delimiter)
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+    positions
+        .chunks_exact(2)
+        .any(|pair| pair[0] + delimiter.len_utf8() < pair[1])
+}
+
+fn has_ordinal_suffix(word: &str) -> bool {
+    ["st", "nd", "rd", "th"].iter().any(|suffix| {
+        word.strip_suffix(suffix).is_some_and(|number| {
+            !number.is_empty() && number.bytes().all(|byte| byte.is_ascii_digit())
+        })
+    })
+}
+
+fn contains_dotted_qualified_name(text: &str) -> bool {
+    let characters = text.chars().collect::<Vec<_>>();
+    characters.windows(3).any(|window| {
+        (window[0].is_alphanumeric() || window[0] == '_')
+            && window[1] == '.'
+            && (window[2].is_alphanumeric() || window[2] == '_')
+    })
+}
+
+fn compute_hashes(
+    source_text: &str,
+    clauses: &[NormalizedClause],
+    spec: &CallPathSpec,
+    domain: DigestDomain<'_>,
+) -> Result<ProofHashes, ValidationError> {
+    let source_text_sha256 = sha256_hex(source_text.as_bytes());
+    let digest_document = json!({
+        "schema_version": domain.schema_version,
+        "proof_domain": domain.proof_domain,
+        "guard_version": domain.guard_version,
+        "source_text_sha256": source_text_sha256,
+        "clauses": clauses.iter().map(normalized_clause_json).collect::<Vec<_>>(),
+        "spec": spec_json(spec),
+    });
+    let canonical = serde_json_canonicalizer::to_vec(&digest_document)
+        .map_err(|error| ValidationError::CanonicalJson(error.to_string()))?;
+    let mut digest_bytes = Vec::with_capacity(DIGEST_DOMAIN_SEPARATOR.len() + canonical.len());
+    digest_bytes.extend_from_slice(DIGEST_DOMAIN_SEPARATOR);
+    digest_bytes.extend_from_slice(&canonical);
+    Ok(ProofHashes {
+        source_text_sha256,
+        contract_digest: sha256_hex(&digest_bytes),
+    })
+}
+
+fn normalized_clause_json(clause: &NormalizedClause) -> Value {
+    let (reason, non_material_kind) = match &clause.classification {
+        NormalizedClauseClassification::Resolved => (None, None),
+        NormalizedClauseClassification::Unresolved(reason) => (Some(reason.canonical_name()), None),
+        NormalizedClauseClassification::Ignored(kind) => (None, Some(kind.canonical_name())),
+    };
+    json!({
+        "start": clause.start,
+        "end": clause.end,
+        "clause_id": clause.clause_id,
+        "quote": clause.quote,
+        "classification": clause.classification.canonical_name(),
+        "field": clause.field.map(ProofContractField::canonical_name),
+        "reason": reason,
+        "non_material_kind": non_material_kind,
+    })
+}
+
+fn spec_json(spec: &CallPathSpec) -> Value {
+    json!({
+        "start": symbol_selector_json(&spec.start),
+        "steps": spec.steps.iter().map(|step| json!({
+            "relation": "direct_outgoing_call",
+            "target": symbol_selector_json(&step.target),
+        })).collect::<Vec<_>>(),
+        "prohibit_traversal_through": spec.prohibit_traversal_through
+            .iter().map(scope_selector_json).collect::<Vec<_>>(),
+        "exclude_from_projection": spec.exclude_from_projection
+            .iter().map(scope_selector_json).collect::<Vec<_>>(),
+    })
+}
+
+fn symbol_selector_json(selector: &ExactSymbolSelector) -> Value {
+    match selector {
+        ExactSymbolSelector::PinnedNode(identity) => pinned_identity_json(identity),
+        ExactSymbolSelector::CanonicalId(canonical_id) => json!({
+            "kind": "canonical_id", "canonical_id": canonical_id,
+        }),
+        ExactSymbolSelector::QualifiedName {
+            qualified_name,
+            project_file_components,
+        } => json!({
+            "kind": "qualified_name",
+            "qualified_name": qualified_name,
+            "project_file_components": project_file_components,
+        }),
+    }
+}
+
+fn scope_selector_json(selector: &ExactScopeSelector) -> Value {
+    match selector {
+        ExactScopeSelector::PinnedNode(identity) => pinned_identity_json(identity),
+        ExactScopeSelector::CanonicalId(canonical_id) => json!({
+            "kind": "canonical_id", "canonical_id": canonical_id,
+        }),
+        ExactScopeSelector::QualifiedName {
+            qualified_name,
+            project_file_components,
+        } => json!({
+            "kind": "qualified_name",
+            "qualified_name": qualified_name,
+            "project_file_components": project_file_components,
+        }),
+    }
+}
+
+fn pinned_identity_json(identity: &PinnedNodeIdentity) -> Value {
+    json!({
+        "kind": "pinned_node",
+        "project_id": identity.project_id,
+        "core_generation_id": identity.core_generation_id,
+        "core_run_id": identity.core_run_id,
+        "node_id": identity.node_id,
+    })
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    Sha256::digest(bytes)
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ResolvedNodeIdentity {
+    pub pinned: PinnedNodeIdentity,
+    pub canonical_id: String,
+    pub qualified_name: String,
+    pub project_file_components: Vec<String>,
+}
+
+impl ResolvedNodeIdentity {
+    pub fn new(
+        pinned: PinnedNodeIdentity,
+        canonical_id: impl Into<String>,
+        qualified_name: impl Into<String>,
+        project_file_components: Vec<String>,
+    ) -> Result<Self, SelectorValidationError> {
+        validate_pinned_identity(&pinned)?;
+        let canonical_id = canonical_id.into();
+        let qualified_name = qualified_name.into();
+        validate_identity(&canonical_id)?;
+        validate_qualified_name(&qualified_name)?;
+        validate_optional_path(Some(&project_file_components))?;
+        Ok(Self {
+            pinned,
+            canonical_id,
+            qualified_name,
+            project_file_components,
+        })
+    }
+}
+
+fn symbol_selector_matches(selector: &ExactSymbolSelector, node: &ResolvedNodeIdentity) -> bool {
+    match selector {
+        ExactSymbolSelector::PinnedNode(identity) => identity == &node.pinned,
+        ExactSymbolSelector::CanonicalId(canonical_id) => canonical_id == &node.canonical_id,
+        ExactSymbolSelector::QualifiedName {
+            qualified_name,
+            project_file_components,
+        } => {
+            qualified_name == &node.qualified_name
+                && project_file_components
+                    .as_ref()
+                    .is_none_or(|path| path == &node.project_file_components)
+        }
+    }
+}
+
+fn scope_selector_matches(selector: &ExactScopeSelector, node: &ResolvedNodeIdentity) -> bool {
+    match selector {
+        ExactScopeSelector::PinnedNode(identity) => identity == &node.pinned,
+        ExactScopeSelector::CanonicalId(canonical_id) => canonical_id == &node.canonical_id,
+        ExactScopeSelector::QualifiedName {
+            qualified_name,
+            project_file_components,
+        } => {
+            qualified_name == &node.qualified_name
+                && project_file_components
+                    .as_ref()
+                    .is_none_or(|scope_path| node.project_file_components.starts_with(scope_path))
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ReceiptRef {
+    pub receipt_id: String,
+    pub edge_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedDirectCallFact {
+    pub receipt: ReceiptRef,
+    pub source: ResolvedNodeIdentity,
+    pub target: ResolvedNodeIdentity,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PositiveContradictionFact {
+    pub receipt_id: String,
+    pub source: ResolvedNodeIdentity,
+    pub expected_target: ExactSymbolSelector,
+    pub kind: PositiveContradictionKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PositiveContradictionKind {
+    RelationIsNotDirectCall,
+    DirectionIsNotOutgoing,
+    ResolvedTargetDiffers,
+}
+
+#[cfg(any(test, feature = "test-support"))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CertifiedAbsenceFact {
+    pub source: ResolvedNodeIdentity,
+    pub expected_target: ExactSymbolSelector,
+    pub extractor_capability_receipt_id: String,
+    pub untruncated_enumeration_receipt_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnavailableProofFact {
+    pub reason: UnavailableReason,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VerifiedProofFact {
+    DirectCall(VerifiedDirectCallFact),
+    PositiveContradiction(PositiveContradictionFact),
+    #[cfg(any(test, feature = "test-support"))]
+    CertifiedAbsence(CertifiedAbsenceFact),
+    Unavailable(UnavailableProofFact),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProofDisposition {
+    ContractProven {
+        contract_digest: String,
+        receipts: Vec<ReceiptRef>,
+    },
+    ContractRefuted {
+        contract_digest: String,
+        refutation: Refutation,
+    },
+    Unknown {
+        contract_digest: String,
+        gaps: Vec<ProofGap>,
+    },
+    Unavailable {
+        contract_digest: String,
+        reasons: Vec<UnavailableReason>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Refutation {
+    PositiveContradiction {
+        step_index: usize,
+        receipt_id: String,
+        kind: PositiveContradictionKind,
+    },
+    TraversalProhibitionViolated {
+        step_index: usize,
+        receipt: ReceiptRef,
+    },
+    #[cfg(any(test, feature = "test-support"))]
+    CertifiedAbsence {
+        step_index: usize,
+        extractor_capability_receipt_id: String,
+        untruncated_enumeration_receipt_id: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ProofGap {
+    MissingDirectCallReceipt { step_index: usize },
+    ReceiptOrEdgeAlreadyUsed { step_index: usize },
+    ProjectionExclusionConflictsWithRequiredReceipt { step_index: usize },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum UnavailableReason {
+    ValidatedContractHashMismatch,
+    SourceNotBoundToPublication,
+    ProofFactsUnavailable,
+}
+
+pub fn check_call_path(
+    contract: &ValidatedCallPathContract,
+    hashes: &ProofHashes,
+    facts: &[VerifiedProofFact],
+) -> ProofDisposition {
+    if hashes != &contract.bound_hashes {
+        return ProofDisposition::Unavailable {
+            contract_digest: hashes.contract_digest.clone(),
+            reasons: vec![UnavailableReason::ValidatedContractHashMismatch],
+        };
+    }
+    let unavailable_reasons = facts
+        .iter()
+        .filter_map(|fact| match fact {
+            VerifiedProofFact::Unavailable(fact) => Some(fact.reason.clone()),
+            _ => None,
+        })
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    if !unavailable_reasons.is_empty() {
+        return ProofDisposition::Unavailable {
+            contract_digest: hashes.contract_digest.clone(),
+            reasons: unavailable_reasons,
+        };
+    }
+    let direct_facts = facts
+        .iter()
+        .filter_map(|fact| match fact {
+            VerifiedProofFact::DirectCall(fact)
+                if !fact.receipt.receipt_id.is_empty() && !fact.receipt.edge_id.is_empty() =>
+            {
+                Some(fact)
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    if let Some(path) = find_path(contract, &direct_facts, PathPolicy::Strict) {
+        return ProofDisposition::ContractProven {
+            contract_digest: hashes.contract_digest.clone(),
+            receipts: path.into_iter().map(|fact| fact.receipt.clone()).collect(),
+        };
+    }
+    if let Some(path) = find_path(
+        contract,
+        &direct_facts,
+        PathPolicy::AllowProjectionExclusions,
+    ) {
+        let step_index = first_projection_conflict(contract, &path).unwrap_or(0);
+        return ProofDisposition::Unknown {
+            contract_digest: hashes.contract_digest.clone(),
+            gaps: vec![ProofGap::ProjectionExclusionConflictsWithRequiredReceipt { step_index }],
+        };
+    }
+    if let Some((path, step_index)) = find_path(
+        contract,
+        &direct_facts,
+        PathPolicy::AllowTraversalProhibitions,
+    )
+    .and_then(|path| first_traversal_prohibition(contract, &path).map(|index| (path, index)))
+    {
+        return ProofDisposition::ContractRefuted {
+            contract_digest: hashes.contract_digest.clone(),
+            refutation: Refutation::TraversalProhibitionViolated {
+                step_index,
+                receipt: path[step_index].receipt.clone(),
+            },
+        };
+    }
+    let mut reachable = reachable_prefixes(contract, &direct_facts);
+    for source in facts.iter().filter_map(|fact| match fact {
+        VerifiedProofFact::PositiveContradiction(fact) => Some(&fact.source),
+        #[cfg(any(test, feature = "test-support"))]
+        VerifiedProofFact::CertifiedAbsence(fact) => Some(&fact.source),
+        _ => None,
+    }) {
+        if symbol_selector_matches(&contract.spec.start, source)
+            && !reachable
+                .iter()
+                .any(|state| state.step_index == 0 && &state.current == source)
+        {
+            reachable.push(PrefixState {
+                step_index: 0,
+                current: source.clone(),
+                used_receipts: BTreeSet::new(),
+                used_edges: BTreeSet::new(),
+            });
+        }
+    }
+    for state in reachable.iter().rev() {
+        if state.step_index >= contract.spec.steps.len() {
+            continue;
+        }
+        let target = &contract.spec.steps[state.step_index].target;
+        if let Some(contradiction) = facts
+            .iter()
+            .filter_map(|fact| match fact {
+                VerifiedProofFact::PositiveContradiction(fact) => Some(fact),
+                _ => None,
+            })
+            .find(|fact| {
+                fact.source == state.current
+                    && &fact.expected_target == target
+                    && !fact.receipt_id.is_empty()
+            })
+        {
+            return ProofDisposition::ContractRefuted {
+                contract_digest: hashes.contract_digest.clone(),
+                refutation: Refutation::PositiveContradiction {
+                    step_index: state.step_index,
+                    receipt_id: contradiction.receipt_id.clone(),
+                    kind: contradiction.kind.clone(),
+                },
+            };
+        }
+        #[cfg(any(test, feature = "test-support"))]
+        if let Some(absence) = facts
+            .iter()
+            .filter_map(|fact| match fact {
+                VerifiedProofFact::CertifiedAbsence(fact) => Some(fact),
+                _ => None,
+            })
+            .find(|fact| {
+                fact.source == state.current
+                    && &fact.expected_target == target
+                    && !fact.extractor_capability_receipt_id.is_empty()
+                    && !fact.untruncated_enumeration_receipt_id.is_empty()
+            })
+        {
+            return ProofDisposition::ContractRefuted {
+                contract_digest: hashes.contract_digest.clone(),
+                refutation: Refutation::CertifiedAbsence {
+                    step_index: state.step_index,
+                    extractor_capability_receipt_id: absence
+                        .extractor_capability_receipt_id
+                        .clone(),
+                    untruncated_enumeration_receipt_id: absence
+                        .untruncated_enumeration_receipt_id
+                        .clone(),
+                },
+            };
+        }
+    }
+    let step_index = reachable
+        .iter()
+        .map(|state| state.step_index)
+        .max()
+        .unwrap_or(0)
+        .min(contract.spec.steps.len() - 1);
+    let reuse_blocked = reachable.iter().any(|state| {
+        state.step_index == step_index
+            && direct_facts.iter().any(|fact| {
+                fact.source == state.current
+                    && symbol_selector_matches(
+                        &contract.spec.steps[step_index].target,
+                        &fact.target,
+                    )
+                    && (state.used_receipts.contains(&fact.receipt.receipt_id)
+                        || state.used_edges.contains(&fact.receipt.edge_id))
+            })
+    });
+    ProofDisposition::Unknown {
+        contract_digest: hashes.contract_digest.clone(),
+        gaps: vec![if reuse_blocked {
+            ProofGap::ReceiptOrEdgeAlreadyUsed { step_index }
+        } else {
+            ProofGap::MissingDirectCallReceipt { step_index }
+        }],
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PathPolicy {
+    Strict,
+    AllowProjectionExclusions,
+    AllowTraversalProhibitions,
+}
+
+fn find_path<'a>(
+    contract: &ValidatedCallPathContract,
+    facts: &[&'a VerifiedDirectCallFact],
+    policy: PathPolicy,
+) -> Option<Vec<&'a VerifiedDirectCallFact>> {
+    let mut ordered = facts.to_vec();
+    ordered.sort_by(|left, right| left.receipt.cmp(&right.receipt));
+    search_path(
+        contract,
+        &ordered,
+        0,
+        None,
+        &mut BTreeSet::new(),
+        &mut BTreeSet::new(),
+        &mut Vec::new(),
+        policy,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn search_path<'a>(
+    contract: &ValidatedCallPathContract,
+    facts: &[&'a VerifiedDirectCallFact],
+    step_index: usize,
+    current: Option<&ResolvedNodeIdentity>,
+    used_receipts: &mut BTreeSet<String>,
+    used_edges: &mut BTreeSet<String>,
+    path: &mut Vec<&'a VerifiedDirectCallFact>,
+    policy: PathPolicy,
+) -> Option<Vec<&'a VerifiedDirectCallFact>> {
+    if step_index == contract.spec.steps.len() {
+        return Some(path.clone());
+    }
+    let step = &contract.spec.steps[step_index];
+    for fact in facts {
+        let source_matches = current.map_or_else(
+            || symbol_selector_matches(&contract.spec.start, &fact.source),
+            |current| current == &fact.source,
+        );
+        if !source_matches || !symbol_selector_matches(&step.target, &fact.target) {
+            continue;
+        }
+        if used_receipts.contains(&fact.receipt.receipt_id)
+            || used_edges.contains(&fact.receipt.edge_id)
+        {
+            continue;
+        }
+        if policy != PathPolicy::AllowProjectionExclusions
+            && receipt_hits_projection_exclusion(contract, fact)
+        {
+            continue;
+        }
+        if policy != PathPolicy::AllowTraversalProhibitions
+            && step_index + 1 < contract.spec.steps.len()
+            && contract
+                .spec
+                .prohibit_traversal_through
+                .iter()
+                .any(|scope| scope_selector_matches(scope, &fact.target))
+        {
+            continue;
+        }
+        used_receipts.insert(fact.receipt.receipt_id.clone());
+        used_edges.insert(fact.receipt.edge_id.clone());
+        path.push(fact);
+        if let Some(found) = search_path(
+            contract,
+            facts,
+            step_index + 1,
+            Some(&fact.target),
+            used_receipts,
+            used_edges,
+            path,
+            policy,
+        ) {
+            return Some(found);
+        }
+        path.pop();
+        used_edges.remove(&fact.receipt.edge_id);
+        used_receipts.remove(&fact.receipt.receipt_id);
+    }
+    None
+}
+
+fn receipt_hits_projection_exclusion(
+    contract: &ValidatedCallPathContract,
+    fact: &VerifiedDirectCallFact,
+) -> bool {
+    contract.spec.exclude_from_projection.iter().any(|scope| {
+        scope_selector_matches(scope, &fact.source) || scope_selector_matches(scope, &fact.target)
+    })
+}
+
+fn first_projection_conflict(
+    contract: &ValidatedCallPathContract,
+    path: &[&VerifiedDirectCallFact],
+) -> Option<usize> {
+    path.iter()
+        .position(|fact| receipt_hits_projection_exclusion(contract, fact))
+}
+
+fn first_traversal_prohibition(
+    contract: &ValidatedCallPathContract,
+    path: &[&VerifiedDirectCallFact],
+) -> Option<usize> {
+    path.iter().enumerate().find_map(|(step_index, fact)| {
+        (step_index + 1 < path.len()
+            && contract
+                .spec
+                .prohibit_traversal_through
+                .iter()
+                .any(|scope| scope_selector_matches(scope, &fact.target)))
+        .then_some(step_index)
+    })
+}
+
+#[derive(Debug, Clone)]
+struct PrefixState {
+    step_index: usize,
+    current: ResolvedNodeIdentity,
+    used_receipts: BTreeSet<String>,
+    used_edges: BTreeSet<String>,
+}
+
+fn reachable_prefixes(
+    contract: &ValidatedCallPathContract,
+    facts: &[&VerifiedDirectCallFact],
+) -> Vec<PrefixState> {
+    let initial_nodes = facts
+        .iter()
+        .filter(|fact| symbol_selector_matches(&contract.spec.start, &fact.source))
+        .map(|fact| fact.source.clone())
+        .collect::<BTreeSet<_>>();
+    let mut states = initial_nodes
+        .into_iter()
+        .map(|current| PrefixState {
+            step_index: 0,
+            current,
+            used_receipts: BTreeSet::new(),
+            used_edges: BTreeSet::new(),
+        })
+        .collect::<Vec<_>>();
+    let mut all = states.clone();
+    for step_index in 0..contract.spec.steps.len() {
+        let mut next = Vec::new();
+        for state in states {
+            for fact in facts {
+                if fact.source != state.current
+                    || !symbol_selector_matches(
+                        &contract.spec.steps[step_index].target,
+                        &fact.target,
+                    )
+                    || state.used_receipts.contains(&fact.receipt.receipt_id)
+                    || state.used_edges.contains(&fact.receipt.edge_id)
+                {
+                    continue;
+                }
+                let mut used_receipts = state.used_receipts.clone();
+                let mut used_edges = state.used_edges.clone();
+                used_receipts.insert(fact.receipt.receipt_id.clone());
+                used_edges.insert(fact.receipt.edge_id.clone());
+                next.push(PrefixState {
+                    step_index: step_index + 1,
+                    current: fact.target.clone(),
+                    used_receipts,
+                    used_edges,
+                });
+            }
+        }
+        if next.is_empty() {
+            break;
+        }
+        all.extend(next.clone());
+        states = next;
+    }
+    all
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn canonical_selector(name: &str) -> UnvalidatedExactSymbolSelector {
+        UnvalidatedExactSymbolSelector::CanonicalId(name.to_owned())
+    }
+
+    fn canonical_scope(name: &str) -> UnvalidatedExactScopeSelector {
+        UnvalidatedExactScopeSelector::CanonicalId(name.to_owned())
+    }
+
+    fn spec(targets: &[&str]) -> UnvalidatedCallPathSpec {
+        UnvalidatedCallPathSpec {
+            start: canonical_selector("A"),
+            steps: targets
+                .iter()
+                .map(|target| UnvalidatedDirectCallStep {
+                    target: canonical_selector(target),
+                })
+                .collect(),
+            prohibit_traversal_through: Vec::new(),
+            exclude_from_projection: Vec::new(),
+        }
+    }
+
+    fn full_anchor(
+        source: &str,
+        extra_fields: impl IntoIterator<Item = ProofContractField>,
+    ) -> ClauseAnchor {
+        let mut fields = vec![
+            ProofContractField::Start,
+            ProofContractField::Directness,
+            ProofContractField::Ordering,
+            ProofContractField::Relation,
+        ];
+        fields.extend(extra_fields);
+        ClauseAnchor {
+            clause_id: "whole".to_owned(),
+            start: 0,
+            end: source.len(),
+            quote: source.to_owned(),
+            classification: ClauseClassification::ResolvedMaterial { fields },
+        }
+    }
+
+    fn valid_input(targets: &[&str]) -> UnvalidatedCallPathContract {
+        let source = "exact direct ordered call path";
+        let mut clauses = vec![full_anchor(source, [])];
+        for (index, _) in targets.iter().enumerate() {
+            clauses.push(ClauseAnchor {
+                clause_id: format!("target-{index}"),
+                start: 0,
+                end: source.len(),
+                quote: source.to_owned(),
+                classification: ClauseClassification::ResolvedMaterial {
+                    fields: vec![ProofContractField::StepTarget],
+                },
+            });
+        }
+        UnvalidatedCallPathContract::new(source, clauses, spec(targets))
+    }
+
+    fn validate(targets: &[&str]) -> (ValidatedCallPathContract, ProofHashes) {
+        match validate_contract(valid_input(targets)).expect("valid contract") {
+            ValidationOutcome::Validated {
+                contract, hashes, ..
+            } => (*contract, hashes),
+            other => panic!("expected validated contract, got {other:?}"),
+        }
+    }
+
+    fn node(name: &str) -> ResolvedNodeIdentity {
+        ResolvedNodeIdentity::new(
+            PinnedNodeIdentity {
+                project_id: "project".to_owned(),
+                core_generation_id: "generation".to_owned(),
+                core_run_id: "run".to_owned(),
+                node_id: format!("node-{name}"),
+            },
+            name,
+            format!("crate::{name}"),
+            vec!["src".to_owned(), format!("{name}.rs")],
+        )
+        .expect("valid node")
+    }
+
+    fn call(receipt: &str, edge: &str, source: &str, target: &str) -> VerifiedProofFact {
+        VerifiedProofFact::DirectCall(VerifiedDirectCallFact {
+            receipt: ReceiptRef {
+                receipt_id: receipt.to_owned(),
+                edge_id: edge.to_owned(),
+            },
+            source: node(source),
+            target: node(target),
+        })
+    }
+
+    #[test]
+    fn validates_a_fully_anchored_one_step_direct_call_contract() {
+        assert!(matches!(
+            validate_contract(valid_input(&["B"])),
+            Ok(ValidationOutcome::Validated { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_zero_and_seven_steps() {
+        for actual in [0, 7] {
+            let targets = (0..actual).map(|_| "B").collect::<Vec<_>>();
+            assert_eq!(
+                validate_contract(valid_input(&targets)),
+                Err(ValidationError::StepCountOutOfRange { actual })
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_selector_paths_and_accepts_normalized_components() {
+        let invalid: Vec<(Vec<&str>, SelectorValidationError)> = vec![
+            (vec![], SelectorValidationError::RootPath),
+            (vec![""], SelectorValidationError::EmptyPathComponent),
+            (vec!["."], SelectorValidationError::DotPathComponent),
+            (vec![".."], SelectorValidationError::DotPathComponent),
+            (
+                vec!["src/lib.rs"],
+                SelectorValidationError::SeparatorInsidePathComponent,
+            ),
+            (
+                vec!["src\\lib.rs"],
+                SelectorValidationError::SeparatorInsidePathComponent,
+            ),
+            (
+                vec!["bad\0name"],
+                SelectorValidationError::NulInsidePathComponent,
+            ),
+            (vec!["C:"], SelectorValidationError::PlatformEscape),
+            (vec!["~escape"], SelectorValidationError::PlatformEscape),
+        ];
+        for (components, expected) in invalid {
+            let result = validate_symbol_selector(UnvalidatedExactSymbolSelector::QualifiedName {
+                qualified_name: "crate::symbol".to_owned(),
+                project_file_components: Some(components.into_iter().map(str::to_owned).collect()),
+            });
+            assert_eq!(result, Err(expected));
+        }
+        assert!(
+            validate_symbol_selector(UnvalidatedExactSymbolSelector::QualifiedName {
+                qualified_name: "crate::symbol".to_owned(),
+                project_file_components: Some(vec!["src".to_owned(), "lib.rs".to_owned()]),
+            })
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn exact_selector_forms_reject_empty_nul_and_non_normalized_values() {
+        assert_eq!(
+            validate_symbol_selector(canonical_selector("")),
+            Err(SelectorValidationError::EmptyIdentity)
+        );
+        assert_eq!(
+            validate_symbol_selector(canonical_selector("bad\0id")),
+            Err(SelectorValidationError::IdentityContainsNul)
+        );
+        assert_eq!(
+            validate_symbol_selector(UnvalidatedExactSymbolSelector::QualifiedName {
+                qualified_name: " crate::A".to_owned(),
+                project_file_components: None,
+            }),
+            Err(SelectorValidationError::NonNormalizedQualifiedName)
+        );
+        assert!(
+            validate_symbol_selector(UnvalidatedExactSymbolSelector::QualifiedName {
+                qualified_name: "crate::A()".to_owned(),
+                project_file_components: None,
+            })
+            .is_err(),
+            "signature syntax is not an exact qualified-name selector"
+        );
+        let pinned = PinnedNodeIdentity {
+            project_id: "project".to_owned(),
+            core_generation_id: "generation".to_owned(),
+            core_run_id: "run".to_owned(),
+            node_id: "node".to_owned(),
+        };
+        assert!(
+            validate_symbol_selector(UnvalidatedExactSymbolSelector::PinnedNode(pinned)).is_ok()
+        );
+    }
+
+    #[test]
+    fn scope_paths_match_only_at_component_boundaries() {
+        let candidate = ResolvedNodeIdentity::new(
+            node("A").pinned,
+            "A",
+            "crate::A",
+            vec!["src".to_owned(), "indexer".to_owned(), "lib.rs".to_owned()],
+        )
+        .unwrap();
+        let exact_prefix = validate_scope_selector(UnvalidatedExactScopeSelector::QualifiedName {
+            qualified_name: "crate::A".to_owned(),
+            project_file_components: Some(vec!["src".to_owned(), "indexer".to_owned()]),
+        })
+        .unwrap();
+        let lexical_prefix =
+            validate_scope_selector(UnvalidatedExactScopeSelector::QualifiedName {
+                qualified_name: "crate::A".to_owned(),
+                project_file_components: Some(vec!["src".to_owned(), "index".to_owned()]),
+            })
+            .unwrap();
+        assert!(scope_selector_matches(&exact_prefix, &candidate));
+        assert!(!scope_selector_matches(&lexical_prefix, &candidate));
+    }
+
+    #[test]
+    fn rejects_utf8_boundary_and_quote_mismatch() {
+        let source = "é direct call";
+        let mut boundary = valid_input(&["B"]);
+        boundary.source_text = source.to_owned();
+        boundary.clauses = vec![ClauseAnchor {
+            clause_id: "bad-boundary".to_owned(),
+            start: 1,
+            end: source.len(),
+            quote: source[2..].to_owned(),
+            classification: ClauseClassification::ResolvedMaterial {
+                fields: vec![ProofContractField::Start],
+            },
+        }];
+        assert_eq!(
+            validate_contract(boundary),
+            Err(ValidationError::ClauseSpanNotUtf8Boundary {
+                clause_id: "bad-boundary".to_owned()
+            })
+        );
+        let mut mismatch = valid_input(&["B"]);
+        mismatch.clauses[0].quote = "different bytes".to_owned();
+        assert_eq!(
+            validate_contract(mismatch),
+            Err(ValidationError::ClauseQuoteMismatch {
+                clause_id: "whole".to_owned()
+            })
+        );
+    }
+
+    #[test]
+    fn accepts_overlapping_and_nested_spans() {
+        let mut input = valid_input(&["B"]);
+        input.clauses.push(ClauseAnchor {
+            clause_id: "nested".to_owned(),
+            start: 6,
+            end: 12,
+            quote: input.source_text[6..12].to_owned(),
+            classification: ClauseClassification::ResolvedMaterial {
+                fields: vec![ProofContractField::Directness],
+            },
+        });
+        assert!(matches!(
+            validate_contract(input),
+            Ok(ValidationOutcome::Validated { .. })
+        ));
+    }
+
+    #[test]
+    fn whitespace_may_be_uncovered_but_material_bytes_may_not() {
+        let source = "A B";
+        let mut input = valid_input(&["B"]);
+        input.source_text = source.to_owned();
+        input.clauses = vec![
+            ClauseAnchor {
+                clause_id: "a".to_owned(),
+                start: 0,
+                end: 1,
+                quote: "A".to_owned(),
+                classification: ClauseClassification::ResolvedMaterial {
+                    fields: vec![
+                        ProofContractField::Start,
+                        ProofContractField::Directness,
+                        ProofContractField::Ordering,
+                        ProofContractField::Relation,
+                    ],
+                },
+            },
+            ClauseAnchor {
+                clause_id: "b".to_owned(),
+                start: 2,
+                end: 3,
+                quote: "B".to_owned(),
+                classification: ClauseClassification::ResolvedMaterial {
+                    fields: vec![ProofContractField::StepTarget],
+                },
+            },
+        ];
+        assert!(matches!(
+            validate_contract(input.clone()),
+            Ok(ValidationOutcome::Validated { .. })
+        ));
+        input.clauses.pop();
+        input.clauses[0].classification = ClauseClassification::ResolvedMaterial {
+            fields: vec![
+                ProofContractField::Start,
+                ProofContractField::StepTarget,
+                ProofContractField::Directness,
+                ProofContractField::Ordering,
+                ProofContractField::Relation,
+            ],
+        };
+        assert!(matches!(
+            validate_contract(input),
+            Ok(ValidationOutcome::Unknown { gaps, .. })
+                if gaps.contains(&TranslationGap::UnclassifiedSourceText)
+        ));
+    }
+
+    #[test]
+    fn rejects_missing_typed_field_coverage() {
+        let mut input = valid_input(&["B"]);
+        input
+            .clauses
+            .retain(|clause| clause.clause_id != "target-0");
+        assert_eq!(
+            validate_contract(input),
+            Err(ValidationError::MissingResolvedMaterialAnchor {
+                field: ProofContractField::StepTarget,
+                required: 1,
+                found: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_classification_conflicts() {
+        let mut input = valid_input(&["B"]);
+        input.clauses.push(ClauseAnchor {
+            clause_id: "whole".to_owned(),
+            start: 0,
+            end: input.source_text.len(),
+            quote: input.source_text.clone(),
+            classification: ClauseClassification::NonMaterial {
+                kind: NonMaterialKind::Commentary,
+            },
+        });
+        assert_eq!(
+            validate_contract(input),
+            Err(ValidationError::ClassificationConflict {
+                clause_id: "whole".to_owned()
+            })
+        );
+    }
+
+    #[test]
+    fn unresolved_material_is_a_typed_unknown() {
+        let mut input = valid_input(&["B"]);
+        input.clauses.push(ClauseAnchor {
+            clause_id: "uncertain".to_owned(),
+            start: 0,
+            end: input.source_text.len(),
+            quote: input.source_text.clone(),
+            classification: ClauseClassification::UnresolvedMaterial {
+                reason: UnresolvedMaterialReason::AmbiguousSelectorResolution,
+            },
+        });
+        assert!(matches!(
+            validate_contract(input),
+            Ok(ValidationOutcome::Unknown { gaps, .. })
+                if gaps.contains(&TranslationGap::UnresolvedMaterialClause {
+                    clause_id: "uncertain".to_owned(),
+                    reason: UnresolvedMaterialReason::AmbiguousSelectorResolution,
+                })
+        ));
+    }
+
+    #[test]
+    fn clause_guard_covers_every_declared_family() {
+        let cases = [
+            (
+                "`crate::A`",
+                ClauseGuardFamily::QuotedOrBacktickedIdentifier,
+            ),
+            ("A -> B", ClauseGuardFamily::ArrowOrRelationNotation),
+            ("directly", ClauseGuardFamily::Directness),
+            ("then 2nd", ClauseGuardFamily::OrderingOrOrdinal),
+            ("only", ClauseGuardFamily::Only),
+            ("without excluded", ClauseGuardFamily::NegationOrExclusion),
+            ("src/lib.rs", ClauseGuardFamily::PathLikeString),
+            ("lib.rs", ClauseGuardFamily::PathLikeString),
+            (
+                "crate::module::A",
+                ClauseGuardFamily::QualifiedSymbolNotation,
+            ),
+        ];
+        for (text, expected) in cases {
+            assert!(
+                clause_guard_families(text).contains(&expected),
+                "{text:?} did not trigger {expected:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn guarded_material_with_only_non_material_coverage_is_unknown() {
+        let source = "only";
+        let mut input = valid_input(&["B"]);
+        input.source_text = source.to_owned();
+        input.clauses = vec![
+            ClauseAnchor {
+                clause_id: "fields".to_owned(),
+                start: 0,
+                end: 1,
+                quote: "o".to_owned(),
+                classification: ClauseClassification::ResolvedMaterial {
+                    fields: vec![
+                        ProofContractField::Start,
+                        ProofContractField::StepTarget,
+                        ProofContractField::Directness,
+                        ProofContractField::Ordering,
+                        ProofContractField::Relation,
+                    ],
+                },
+            },
+            ClauseAnchor {
+                clause_id: "guarded".to_owned(),
+                start: 0,
+                end: source.len(),
+                quote: source.to_owned(),
+                classification: ClauseClassification::NonMaterial {
+                    kind: NonMaterialKind::Commentary,
+                },
+            },
+        ];
+        assert!(matches!(
+            validate_contract(input),
+            Ok(ValidationOutcome::Unknown { gaps, .. })
+                if gaps.contains(&TranslationGap::MaterialTokenMisclassified {
+                    clause_id: "guarded".to_owned(),
+                    guard_families: vec![ClauseGuardFamily::Only],
+                })
+        ));
+    }
+
+    #[test]
+    fn digest_is_stable_under_clause_order_and_exact_duplicates() {
+        let input = valid_input(&["B"]);
+        let (_, baseline) = validate(&["B"]);
+        let mut reordered = input.clone();
+        reordered.clauses.reverse();
+        let reordered = match validate_contract(reordered).unwrap() {
+            ValidationOutcome::Validated { hashes, .. } => hashes,
+            other => panic!("unexpected {other:?}"),
+        };
+        let mut duplicated = input;
+        duplicated.clauses.push(duplicated.clauses[0].clone());
+        let duplicated = match validate_contract(duplicated).unwrap() {
+            ValidationOutcome::Validated { hashes, .. } => hashes,
+            other => panic!("unexpected {other:?}"),
+        };
+        assert_eq!(baseline, reordered);
+        assert_eq!(baseline, duplicated);
+    }
+
+    #[test]
+    fn digest_changes_with_schema_guard_domain_source_and_ordered_spec() {
+        let input = valid_input(&["B", "C"]);
+        let baseline = match validate_contract(input.clone()).unwrap() {
+            ValidationOutcome::Validated { hashes, .. } => hashes,
+            other => panic!("unexpected {other:?}"),
+        };
+        for domain in [
+            DigestDomain {
+                schema_version: 2,
+                ..DigestDomain::default()
+            },
+            DigestDomain {
+                guard_version: "clause_guard_v2",
+                ..DigestDomain::default()
+            },
+            DigestDomain {
+                proof_domain: "other_domain",
+                ..DigestDomain::default()
+            },
+        ] {
+            let changed = match validate_contract_with_domain(input.clone(), domain).unwrap() {
+                ValidationOutcome::Validated { hashes, .. } => hashes,
+                other => panic!("unexpected {other:?}"),
+            };
+            assert_ne!(baseline.contract_digest(), changed.contract_digest());
+        }
+        let mut changed_source = input.clone();
+        changed_source.source_text.push('!');
+        changed_source.clauses[0].end += 1;
+        changed_source.clauses[0].quote.push('!');
+        let changed_source = match validate_contract(changed_source).unwrap() {
+            ValidationOutcome::Validated { hashes, .. } => hashes,
+            other => panic!("unexpected {other:?}"),
+        };
+        assert_ne!(baseline.contract_digest(), changed_source.contract_digest());
+        let reordered_spec = match validate_contract(valid_input(&["C", "B"])).unwrap() {
+            ValidationOutcome::Validated { hashes, .. } => hashes,
+            other => panic!("unexpected {other:?}"),
+        };
+        assert_ne!(baseline.contract_digest(), reordered_spec.contract_digest());
+    }
+
+    #[test]
+    fn rfc8785_appendix_number_and_string_vector_is_exact() {
+        let value: Value = serde_json::from_str(
+            r#"{"numbers":[333333333.33333329,1E30,4.50,2e-3,0.000000000000000000000000001],"string":"€$\u000f\nA'B\"\\\\\"/","literals":[null,true,false]}"#,
+        )
+        .unwrap();
+        let canonical =
+            String::from_utf8(serde_json_canonicalizer::to_vec(&value).unwrap()).unwrap();
+        assert_eq!(
+            canonical,
+            r#"{"literals":[null,true,false],"numbers":[333333333.3333333,1e+30,4.5,0.002,1e-27],"string":"€$\u000f\nA'B\"\\\\\"/"}"#
+        );
+    }
+
+    #[test]
+    fn rfc8785_orders_unicode_keys_by_utf16_code_units() {
+        let value = json!({"\u{e000}": "bmp", "\u{10000}": "supplementary", "a": "ascii"});
+        let canonical =
+            String::from_utf8(serde_json_canonicalizer::to_vec(&value).unwrap()).unwrap();
+        assert_eq!(
+            canonical,
+            "{\"a\":\"ascii\",\"𐀀\":\"supplementary\",\"\":\"bmp\"}"
+        );
+    }
+
+    #[test]
+    fn proves_only_a_connected_ordered_direct_fact_per_step_path() {
+        let (contract, hashes) = validate(&["B", "C"]);
+        let facts = vec![
+            call("receipt-2", "edge-2", "B", "C"),
+            call("receipt-1", "edge-1", "A", "B"),
+        ];
+        assert!(matches!(
+            check_call_path(&contract, &hashes, &facts),
+            ProofDisposition::ContractProven { receipts, .. }
+                if receipts.iter().map(|receipt| receipt.edge_id.as_str()).collect::<Vec<_>>()
+                    == ["edge-1", "edge-2"]
+        ));
+        for hostile in [
+            vec![call("r1", "e1", "A", "B"), call("r2", "e2", "D", "C")],
+            vec![call("r1", "e1", "A", "C"), call("r2", "e2", "C", "B")],
+        ] {
+            assert!(matches!(
+                check_call_path(&contract, &hashes, &hostile),
+                ProofDisposition::Unknown { .. }
+            ));
+        }
+    }
+
+    #[test]
+    fn repeated_vertices_and_self_edges_are_valid_with_distinct_receipts() {
+        let (contract, hashes) = validate(&["A", "A"]);
+        let distinct = vec![
+            call("receipt-1", "edge-1", "A", "A"),
+            call("receipt-2", "edge-2", "A", "A"),
+        ];
+        assert!(matches!(
+            check_call_path(&contract, &hashes, &distinct),
+            ProofDisposition::ContractProven { .. }
+        ));
+        for duplicate in [
+            vec![
+                call("receipt-1", "edge-1", "A", "A"),
+                call("receipt-1", "edge-2", "A", "A"),
+            ],
+            vec![
+                call("receipt-1", "edge-1", "A", "A"),
+                call("receipt-2", "edge-1", "A", "A"),
+            ],
+        ] {
+            assert!(matches!(
+                check_call_path(&contract, &hashes, &duplicate),
+                ProofDisposition::Unknown { gaps, .. }
+                    if gaps == [ProofGap::ReceiptOrEdgeAlreadyUsed { step_index: 1 }]
+            ));
+        }
+    }
+
+    #[test]
+    fn positive_contradiction_and_fixture_absence_are_receipt_backed() {
+        let (contract, hashes) = validate(&["B"]);
+        let contradiction = VerifiedProofFact::PositiveContradiction(PositiveContradictionFact {
+            receipt_id: "contradiction-receipt".to_owned(),
+            source: node("A"),
+            expected_target: ExactSymbolSelector::CanonicalId("B".to_owned()),
+            kind: PositiveContradictionKind::ResolvedTargetDiffers,
+        });
+        assert!(matches!(
+            check_call_path(&contract, &hashes, &[contradiction]),
+            ProofDisposition::ContractRefuted {
+                refutation: Refutation::PositiveContradiction { .. },
+                ..
+            }
+        ));
+        let absence = VerifiedProofFact::CertifiedAbsence(CertifiedAbsenceFact {
+            source: node("A"),
+            expected_target: ExactSymbolSelector::CanonicalId("B".to_owned()),
+            extractor_capability_receipt_id: "capability".to_owned(),
+            untruncated_enumeration_receipt_id: "enumeration".to_owned(),
+        });
+        assert!(matches!(
+            check_call_path(&contract, &hashes, &[absence]),
+            ProofDisposition::ContractRefuted {
+                refutation: Refutation::CertifiedAbsence { .. },
+                ..
+            }
+        ));
+        let incomplete_absence = VerifiedProofFact::CertifiedAbsence(CertifiedAbsenceFact {
+            source: node("A"),
+            expected_target: ExactSymbolSelector::CanonicalId("B".to_owned()),
+            extractor_capability_receipt_id: "capability".to_owned(),
+            untruncated_enumeration_receipt_id: String::new(),
+        });
+        assert!(matches!(
+            check_call_path(&contract, &hashes, &[incomplete_absence]),
+            ProofDisposition::Unknown { .. }
+        ));
+    }
+
+    #[test]
+    fn missing_completeness_is_unknown_and_unavailability_is_distinct() {
+        let (contract, hashes) = validate(&["B"]);
+        assert!(matches!(
+            check_call_path(&contract, &hashes, &[]),
+            ProofDisposition::Unknown { gaps, .. }
+                if gaps == [ProofGap::MissingDirectCallReceipt { step_index: 0 }]
+        ));
+        assert!(matches!(
+            check_call_path(
+                &contract,
+                &hashes,
+                &[VerifiedProofFact::Unavailable(UnavailableProofFact {
+                    reason: UnavailableReason::SourceNotBoundToPublication,
+                })]
+            ),
+            ProofDisposition::Unavailable { .. }
+        ));
+        assert!(matches!(
+            check_call_path(&contract, &hashes, &[call("", "edge", "A", "B")]),
+            ProofDisposition::Unknown { .. }
+        ));
+    }
+
+    #[test]
+    fn projection_exclusion_hiding_required_receipt_is_unknown() {
+        let mut input = valid_input(&["B"]);
+        input.spec.exclude_from_projection = vec![canonical_scope("B")];
+        input.clauses.push(ClauseAnchor {
+            clause_id: "projection".to_owned(),
+            start: 0,
+            end: input.source_text.len(),
+            quote: input.source_text.clone(),
+            classification: ClauseClassification::ResolvedMaterial {
+                fields: vec![ProofContractField::ProjectionExclusion],
+            },
+        });
+        let (contract, hashes) = match validate_contract(input).unwrap() {
+            ValidationOutcome::Validated {
+                contract, hashes, ..
+            } => (contract, hashes),
+            other => panic!("unexpected {other:?}"),
+        };
+        assert!(matches!(
+            check_call_path(&contract, &hashes, &[call("r", "e", "A", "B")]),
+            ProofDisposition::Unknown { gaps, .. }
+                if gaps == [ProofGap::ProjectionExclusionConflictsWithRequiredReceipt { step_index: 0 }]
+        ));
+    }
+
+    #[test]
+    fn traversal_prohibition_is_receipt_backed_positive_refutation() {
+        let mut input = valid_input(&["B", "C"]);
+        input.spec.prohibit_traversal_through = vec![canonical_scope("B")];
+        input.clauses.push(ClauseAnchor {
+            clause_id: "prohibition".to_owned(),
+            start: 0,
+            end: input.source_text.len(),
+            quote: input.source_text.clone(),
+            classification: ClauseClassification::ResolvedMaterial {
+                fields: vec![ProofContractField::TraversalProhibition],
+            },
+        });
+        let (contract, hashes) = match validate_contract(input).unwrap() {
+            ValidationOutcome::Validated {
+                contract, hashes, ..
+            } => (contract, hashes),
+            other => panic!("unexpected {other:?}"),
+        };
+        let facts = [call("r1", "e1", "A", "B"), call("r2", "e2", "B", "C")];
+        assert!(matches!(
+            check_call_path(&contract, &hashes, &facts),
+            ProofDisposition::ContractRefuted {
+                refutation: Refutation::TraversalProhibitionViolated { step_index: 0, .. },
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn checker_boundary_accepts_validated_contract_hashes_and_facts_only() {
+        type CheckerBoundary =
+            fn(&ValidatedCallPathContract, &ProofHashes, &[VerifiedProofFact]) -> ProofDisposition;
+        let checker: CheckerBoundary = check_call_path;
+        let (contract, hashes) = validate(&["B"]);
+        assert!(matches!(
+            checker(&contract, &hashes, &[call("r", "e", "A", "B")]),
+            ProofDisposition::ContractProven { .. }
+        ));
+    }
+}

--- a/crates/codestory-agent/src/indexed_source_call_path_v1.rs
+++ b/crates/codestory-agent/src/indexed_source_call_path_v1.rs
@@ -1783,10 +1783,348 @@ fn reachable_prefixes(
     all
 }
 
+pub const INTERNAL_PROOF_CAP_BYTES: usize = 64 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InternalCorePublicationIdentity {
+    pub project_id: String,
+    pub generation_id: String,
+    pub run_id: String,
+}
+
+pub struct InternalProjectionInput<'a> {
+    pub contract: &'a ValidatedCallPathContract,
+    pub hashes: &'a ProofHashes,
+    pub rendering: &'a ValidatedContractRendering,
+    pub publication: InternalCorePublicationIdentity,
+    pub disposition: &'a ProofDisposition,
+    pub receipts: &'a [IndexedCallEdgeReceipt],
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InternalProjection {
+    Complete {
+        root: Value,
+        serialized_size: usize,
+    },
+    BudgetExceeded {
+        root: Value,
+        required_complete_size: usize,
+        serialized_size: usize,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InternalProjectionError {
+    MissingAuthoritativeReceipt {
+        receipt_id: String,
+        edge_id: String,
+    },
+    Serialization(String),
+    FallbackExceedsCap {
+        cap_bytes: usize,
+        serialized_size: usize,
+    },
+}
+
+pub fn project_internal_call_path_result(
+    input: InternalProjectionInput<'_>,
+) -> Result<InternalProjection, InternalProjectionError> {
+    project_internal_call_path_result_with_cap(input, INTERNAL_PROOF_CAP_BYTES)
+}
+
+fn project_internal_call_path_result_with_cap(
+    input: InternalProjectionInput<'_>,
+    cap_bytes: usize,
+) -> Result<InternalProjection, InternalProjectionError> {
+    validate_authoritative_receipts(input.disposition, input.receipts)?;
+    let complete = complete_projection_json(&input);
+    let required_complete_size = serialized_json_size(&complete)?;
+    if required_complete_size <= cap_bytes {
+        return Ok(InternalProjection::Complete {
+            root: complete,
+            serialized_size: required_complete_size,
+        });
+    }
+
+    let fallback = json!({
+        "kind": "budget_exceeded",
+        "schema_version": PROOF_CONTRACT_SCHEMA_VERSION,
+        "domain": PROOF_DOMAIN,
+        "contract_interpretation": "host_supplied",
+        "guard_version": CLAUSE_GUARD_VERSION,
+        "source_text_sha256": input.hashes.source_text_sha256,
+        "contract_digest": input.hashes.contract_digest,
+        "core_publication": publication_json(&input.publication),
+        "disposition": {
+            "kind": "unknown",
+            "contract_digest": input.hashes.contract_digest,
+            "gaps": [{ "kind": "output_budget_exceeded" }],
+        },
+        "cap_bytes": cap_bytes,
+        "required_complete_size": required_complete_size,
+    });
+    let fallback_size = serialized_json_size(&fallback)?;
+    if fallback_size > cap_bytes {
+        return Err(InternalProjectionError::FallbackExceedsCap {
+            cap_bytes,
+            serialized_size: fallback_size,
+        });
+    }
+    Ok(InternalProjection::BudgetExceeded {
+        root: fallback,
+        required_complete_size,
+        serialized_size: fallback_size,
+    })
+}
+
+fn validate_authoritative_receipts(
+    disposition: &ProofDisposition,
+    receipts: &[IndexedCallEdgeReceipt],
+) -> Result<(), InternalProjectionError> {
+    let required = match disposition {
+        ProofDisposition::ContractProven { receipts, .. } => receipts.as_slice(),
+        ProofDisposition::ContractRefuted {
+            refutation:
+                Refutation::ProhibitedScopeTraversal {
+                    connected_receipts, ..
+                },
+            ..
+        } => connected_receipts.as_slice(),
+        _ => &[],
+    };
+    for receipt in required {
+        if !receipts
+            .iter()
+            .any(|candidate| candidate.receipt == *receipt)
+        {
+            return Err(InternalProjectionError::MissingAuthoritativeReceipt {
+                receipt_id: receipt.receipt_id.clone(),
+                edge_id: receipt.edge_id.clone(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn complete_projection_json(input: &InternalProjectionInput<'_>) -> Value {
+    json!({
+        "kind": "complete",
+        "schema_version": PROOF_CONTRACT_SCHEMA_VERSION,
+        "domain": PROOF_DOMAIN,
+        "contract_interpretation": "host_supplied",
+        "guard_version": CLAUSE_GUARD_VERSION,
+        "source_text_sha256": input.hashes.source_text_sha256,
+        "contract_digest": input.hashes.contract_digest,
+        "core_publication": publication_json(&input.publication),
+        "spec": spec_json(&input.contract.spec),
+        "clauses": input
+            .rendering
+            .normalized_clauses
+            .iter()
+            .map(normalized_clause_json)
+            .collect::<Vec<_>>(),
+        "disposition": disposition_json(input.disposition),
+        "steps": step_results_json(input.contract, input.disposition),
+        "receipts": input.receipts.iter().map(indexed_receipt_json).collect::<Vec<_>>(),
+    })
+}
+
+fn publication_json(publication: &InternalCorePublicationIdentity) -> Value {
+    json!({
+        "project_id": publication.project_id,
+        "generation_id": publication.generation_id,
+        "run_id": publication.run_id,
+    })
+}
+
+fn disposition_json(disposition: &ProofDisposition) -> Value {
+    match disposition {
+        ProofDisposition::ContractProven {
+            contract_digest,
+            receipts,
+        } => json!({
+            "kind": "contract_proven",
+            "contract_digest": contract_digest,
+            "receipts": receipts.iter().map(receipt_ref_json).collect::<Vec<_>>(),
+        }),
+        ProofDisposition::ContractRefuted {
+            contract_digest,
+            refutation,
+        } => json!({
+            "kind": "contract_refuted",
+            "contract_digest": contract_digest,
+            "refutation": refutation_json(refutation),
+        }),
+        ProofDisposition::Unknown {
+            contract_digest,
+            gaps,
+        } => json!({
+            "kind": "unknown",
+            "contract_digest": contract_digest,
+            "gaps": gaps.iter().map(proof_gap_json).collect::<Vec<_>>(),
+        }),
+        ProofDisposition::Unavailable {
+            contract_digest,
+            reasons,
+        } => json!({
+            "kind": "unavailable",
+            "contract_digest": contract_digest,
+            "reasons": reasons.iter().map(unavailable_reason_name).collect::<Vec<_>>(),
+        }),
+    }
+}
+
+fn refutation_json(refutation: &Refutation) -> Value {
+    match refutation {
+        Refutation::ProhibitedScopeTraversal {
+            step_index,
+            prohibition_index,
+            connected_receipts,
+        } => json!({
+            "kind": "prohibited_scope_traversal",
+            "step_index": step_index,
+            "prohibition_index": prohibition_index,
+            "connected_receipts": connected_receipts
+                .iter()
+                .map(receipt_ref_json)
+                .collect::<Vec<_>>(),
+        }),
+        #[cfg(any(test, feature = "test-support"))]
+        Refutation::CertifiedAbsence {
+            step_index,
+            extractor_capability_receipt_id,
+            untruncated_enumeration_receipt_id,
+        } => json!({
+            "kind": "certified_absence",
+            "step_index": step_index,
+            "extractor_capability_receipt_id": extractor_capability_receipt_id,
+            "untruncated_enumeration_receipt_id": untruncated_enumeration_receipt_id,
+        }),
+    }
+}
+
+fn proof_gap_json(gap: &ProofGap) -> Value {
+    match gap {
+        ProofGap::MissingDirectCallReceipt { step_index } => {
+            json!({ "kind": "missing_direct_call_receipt", "step_index": step_index })
+        }
+        ProofGap::ReceiptOrEdgeAlreadyUsed { step_index } => {
+            json!({ "kind": "receipt_or_edge_already_used", "step_index": step_index })
+        }
+        ProofGap::ProjectionExclusionConflictsWithRequiredReceipt { step_index } => json!({
+            "kind": "projection_exclusion_conflicts_with_required_receipt",
+            "step_index": step_index,
+        }),
+    }
+}
+
+fn unavailable_reason_name(reason: &UnavailableReason) -> &'static str {
+    match reason {
+        UnavailableReason::ValidatedContractHashMismatch => "validated_contract_hash_mismatch",
+        UnavailableReason::PublicationPinMismatch => "publication_pin_mismatch",
+        UnavailableReason::SourceNotBoundToPublication => "source_not_bound_to_publication",
+        UnavailableReason::ProofFactsUnavailable => "proof_facts_unavailable",
+    }
+}
+
+fn step_results_json(
+    contract: &ValidatedCallPathContract,
+    disposition: &ProofDisposition,
+) -> Vec<Value> {
+    let receipts = match disposition {
+        ProofDisposition::ContractProven { receipts, .. } => receipts.as_slice(),
+        ProofDisposition::ContractRefuted {
+            refutation:
+                Refutation::ProhibitedScopeTraversal {
+                    connected_receipts, ..
+                },
+            ..
+        } => connected_receipts.as_slice(),
+        _ => &[],
+    };
+    contract
+        .spec
+        .steps
+        .iter()
+        .enumerate()
+        .map(|(step_index, step)| {
+            let status = match disposition {
+                ProofDisposition::ContractProven { .. } => "proven",
+                ProofDisposition::ContractRefuted { .. } if step_index < receipts.len() => {
+                    "positive_contradiction"
+                }
+                ProofDisposition::Unavailable { .. } => "unavailable",
+                _ => "unknown",
+            };
+            json!({
+                "step_index": step_index,
+                "target": symbol_selector_json(&step.target),
+                "status": status,
+                "receipt": receipts.get(step_index).map(receipt_ref_json),
+            })
+        })
+        .collect()
+}
+
+fn receipt_ref_json(receipt: &ReceiptRef) -> Value {
+    json!({
+        "receipt_id": receipt.receipt_id,
+        "edge_id": receipt.edge_id,
+    })
+}
+
+fn indexed_receipt_json(receipt: &IndexedCallEdgeReceipt) -> Value {
+    json!({
+        "receipt": receipt_ref_json(&receipt.receipt),
+        "source": resolved_node_json(&receipt.source),
+        "target": resolved_node_json(&receipt.target),
+        "certainty": match receipt.certainty {
+            ResolutionCertainty::Certain => "certain",
+            ResolutionCertainty::Probable => "probable",
+            ResolutionCertainty::Uncertain => "uncertain",
+        },
+        "callsite_identity": receipt.callsite_identity,
+        "containment": {
+            "file_node_id": receipt.containment.file_node_id.0.to_string(),
+            "owner_node_id": receipt.containment.owner_node_id.0.to_string(),
+            "start_line": receipt.containment.start_line,
+            "end_line": receipt.containment.end_line,
+        },
+        "line_window": {
+            "kind": receipt.line_window.kind,
+            "project_file_components": receipt.line_window.project_file_components,
+            "indexed_sha256": receipt.line_window.indexed_sha256,
+            "observed_sha256": receipt.line_window.observed_sha256,
+            "anchor_line": receipt.line_window.anchor_line,
+            "byte_start": receipt.line_window.byte_start,
+            "byte_end": receipt.line_window.byte_end,
+            "text": receipt.line_window.text,
+        },
+    })
+}
+
+fn resolved_node_json(node: &ResolvedNodeIdentity) -> Value {
+    json!({
+        "pinned": pinned_identity_json(&node.pinned),
+        "canonical_id": node.canonical_id,
+        "qualified_name": node.qualified_name,
+        "project_file_components": node.project_file_components,
+    })
+}
+
+fn serialized_json_size(value: &Value) -> Result<usize, InternalProjectionError> {
+    serde_json::to_vec(value)
+        .map(|bytes| bytes.len())
+        .map_err(|error| InternalProjectionError::Serialization(error.to_string()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use codestory_contracts::graph::{Edge, EdgeId, EdgeKind, NodeId, ResolutionCertainty};
+
+    const MAX_SOURCE_RECEIPT_LINE_BYTES: usize = 8_192;
 
     fn canonical_selector(name: &str) -> UnvalidatedExactSymbolSelector {
         UnvalidatedExactSymbolSelector::CanonicalId(name.to_owned())
@@ -1854,6 +2192,23 @@ mod tests {
         }
     }
 
+    fn validate_for_projection(
+        targets: &[&str],
+    ) -> (
+        ValidatedCallPathContract,
+        ProofHashes,
+        ValidatedContractRendering,
+    ) {
+        match validate_contract(valid_input(targets)).expect("valid contract") {
+            ValidationOutcome::Validated {
+                contract,
+                hashes,
+                rendering,
+            } => (*contract, hashes, rendering),
+            other => panic!("expected validated contract, got {other:?}"),
+        }
+    }
+
     fn node(name: &str) -> ResolvedNodeIdentity {
         ResolvedNodeIdentity::new(
             PinnedNodeIdentity {
@@ -1878,6 +2233,327 @@ mod tests {
             source: node(source),
             target: node(target),
         })
+    }
+
+    fn indexed_receipt(
+        index: usize,
+        source: &str,
+        target: &str,
+        text: String,
+    ) -> IndexedCallEdgeReceipt {
+        IndexedCallEdgeReceipt {
+            receipt: ReceiptRef {
+                receipt_id: format!("receipt-{index}"),
+                edge_id: format!("edge-{index}"),
+            },
+            source: node(source),
+            target: node(target),
+            certainty: ResolutionCertainty::Certain,
+            callsite_identity: format!("{index}:{}:0:{}|rust", index + 1, index + 2),
+            containment: CallableContainmentEvidence {
+                file_node_id: NodeId(i64::try_from(index + 1).unwrap()),
+                owner_node_id: NodeId(i64::try_from(index + 10).unwrap()),
+                start_line: u32::try_from(index + 1).unwrap(),
+                end_line: u32::try_from(index + 1).unwrap(),
+            },
+            line_window: IndexedLineWindow {
+                kind: "indexed_line_v1",
+                project_file_components: vec!["src".to_owned(), format!("step{index}.rs")],
+                indexed_sha256: format!("indexed-{index}"),
+                observed_sha256: format!("indexed-{index}"),
+                anchor_line: u32::try_from(index + 1).unwrap(),
+                byte_start: index * 10,
+                byte_end: index * 10 + text.len(),
+                text,
+            },
+        }
+    }
+
+    fn six_step_projection_fixture(
+        texts: Vec<String>,
+    ) -> (
+        ValidatedCallPathContract,
+        ProofHashes,
+        ValidatedContractRendering,
+        Vec<IndexedCallEdgeReceipt>,
+        ProofDisposition,
+    ) {
+        assert_eq!(texts.len(), 6);
+        let names = ["A", "B", "C", "D", "E", "F", "G"];
+        let (contract, hashes, rendering) = validate_for_projection(&names[1..]);
+        let mut receipts = texts
+            .into_iter()
+            .enumerate()
+            .map(|(index, text)| indexed_receipt(index, names[index], names[index + 1], text))
+            .collect::<Vec<_>>();
+        for receipt in &mut receipts {
+            receipt.line_window.byte_start = 0;
+            receipt.line_window.byte_end = MAX_SOURCE_RECEIPT_LINE_BYTES;
+        }
+        let disposition = ProofDisposition::ContractProven {
+            contract_digest: hashes.contract_digest().to_owned(),
+            receipts: receipts
+                .iter()
+                .map(|receipt| receipt.receipt.clone())
+                .collect(),
+        };
+        (contract, hashes, rendering, receipts, disposition)
+    }
+
+    #[test]
+    fn internal_projection_is_a_complete_tagged_root_with_every_authoritative_receipt() {
+        let (contract, hashes, rendering) = validate_for_projection(&["B"]);
+        let receipts = vec![indexed_receipt(0, "A", "B", "A calls B();\n".to_owned())];
+        let disposition = ProofDisposition::ContractProven {
+            contract_digest: hashes.contract_digest().to_owned(),
+            receipts: vec![receipts[0].receipt.clone()],
+        };
+        let projected = project_internal_call_path_result(InternalProjectionInput {
+            contract: &contract,
+            hashes: &hashes,
+            rendering: &rendering,
+            publication: InternalCorePublicationIdentity {
+                project_id: "project".to_owned(),
+                generation_id: "generation".to_owned(),
+                run_id: "run".to_owned(),
+            },
+            disposition: &disposition,
+            receipts: &receipts,
+        })
+        .unwrap();
+
+        let InternalProjection::Complete {
+            root,
+            serialized_size,
+        } = projected
+        else {
+            panic!("small complete proof must fit")
+        };
+        assert_eq!(root["kind"], "complete");
+        assert_eq!(root["schema_version"], 1);
+        assert_eq!(root["domain"], "indexed_source_call_path_v1");
+        assert_eq!(root["contract_interpretation"], "host_supplied");
+        assert_eq!(root["guard_version"], "clause_guard_v1");
+        assert_eq!(root["receipts"].as_array().unwrap().len(), 1);
+        assert_eq!(root["steps"].as_array().unwrap().len(), 1);
+        assert_eq!(serialized_size, serde_json::to_vec(&root).unwrap().len());
+    }
+
+    #[test]
+    fn internal_projection_accepts_exactly_64_kib_and_replaces_64_kib_plus_one_whole() {
+        let (contract, hashes, rendering, mut receipts, mut disposition) =
+            six_step_projection_fixture(vec![String::new(); 6]);
+        let baseline = project_internal_call_path_result_with_cap(
+            InternalProjectionInput {
+                contract: &contract,
+                hashes: &hashes,
+                rendering: &rendering,
+                publication: InternalCorePublicationIdentity {
+                    project_id: "project".to_owned(),
+                    generation_id: "generation".to_owned(),
+                    run_id: "run".to_owned(),
+                },
+                disposition: &disposition,
+                receipts: &receipts,
+            },
+            usize::MAX,
+        )
+        .unwrap();
+        let InternalProjection::Complete {
+            serialized_size: baseline_size,
+            ..
+        } = baseline
+        else {
+            panic!("unbounded baseline must be complete")
+        };
+        let mut remaining = INTERNAL_PROOF_CAP_BYTES - baseline_size;
+        for receipt in &mut receipts {
+            let quote_count = (remaining / 2).min(MAX_SOURCE_RECEIPT_LINE_BYTES);
+            receipt.line_window.text.push_str(&"\"".repeat(quote_count));
+            remaining -= quote_count * 2;
+            if remaining == 1 && receipt.line_window.text.len() < MAX_SOURCE_RECEIPT_LINE_BYTES {
+                receipt.line_window.text.push('x');
+                remaining = 0;
+            }
+        }
+        assert_eq!(remaining, 0, "six bounded lines can reach the exact cap");
+
+        let exact = project_internal_call_path_result(InternalProjectionInput {
+            contract: &contract,
+            hashes: &hashes,
+            rendering: &rendering,
+            publication: InternalCorePublicationIdentity {
+                project_id: "project".to_owned(),
+                generation_id: "generation".to_owned(),
+                run_id: "run".to_owned(),
+            },
+            disposition: &disposition,
+            receipts: &receipts,
+        })
+        .unwrap();
+        assert!(matches!(
+            exact,
+            InternalProjection::Complete {
+                serialized_size: INTERNAL_PROOF_CAP_BYTES,
+                ..
+            }
+        ));
+
+        receipts
+            .iter_mut()
+            .find(|receipt| receipt.line_window.text.len() < MAX_SOURCE_RECEIPT_LINE_BYTES)
+            .expect("one line retains room for the cap+1 byte")
+            .line_window
+            .text
+            .push('x');
+        let required_receipts = receipts
+            .iter()
+            .map(|receipt| receipt.receipt.clone())
+            .collect::<Vec<_>>();
+        let ProofDisposition::ContractProven {
+            receipts: disposition_receipts,
+            ..
+        } = &mut disposition
+        else {
+            unreachable!()
+        };
+        *disposition_receipts = required_receipts;
+        let plus_one = project_internal_call_path_result(InternalProjectionInput {
+            contract: &contract,
+            hashes: &hashes,
+            rendering: &rendering,
+            publication: InternalCorePublicationIdentity {
+                project_id: "project".to_owned(),
+                generation_id: "generation".to_owned(),
+                run_id: "run".to_owned(),
+            },
+            disposition: &disposition,
+            receipts: &receipts,
+        })
+        .unwrap();
+        let InternalProjection::BudgetExceeded {
+            root,
+            required_complete_size,
+            serialized_size,
+        } = plus_one
+        else {
+            panic!("cap+1 must replace the complete result")
+        };
+        assert_eq!(required_complete_size, INTERNAL_PROOF_CAP_BYTES + 1);
+        assert!(serialized_size < INTERNAL_PROOF_CAP_BYTES);
+        assert_eq!(root["kind"], "budget_exceeded");
+        assert_eq!(root["disposition"]["kind"], "unknown");
+        assert_eq!(
+            root["disposition"]["gaps"],
+            json!([{ "kind": "output_budget_exceeded" }])
+        );
+        for forbidden in ["spec", "clauses", "steps", "receipts"] {
+            assert!(
+                root.get(forbidden).is_none(),
+                "fallback carried {forbidden}"
+            );
+        }
+    }
+
+    #[test]
+    fn internal_projection_measures_escaping_and_never_transports_partial_receipts() {
+        let escape_unit = "\"\\\u{0000}é";
+        let escape_heavy = escape_unit.repeat(MAX_SOURCE_RECEIPT_LINE_BYTES / escape_unit.len());
+        assert!(escape_heavy.len() <= MAX_SOURCE_RECEIPT_LINE_BYTES);
+        assert!(escape_heavy.contains('é'));
+        let (contract, hashes, rendering, receipts, disposition) =
+            six_step_projection_fixture(vec![escape_heavy; 6]);
+        let projected = project_internal_call_path_result(InternalProjectionInput {
+            contract: &contract,
+            hashes: &hashes,
+            rendering: &rendering,
+            publication: InternalCorePublicationIdentity {
+                project_id: "project".to_owned(),
+                generation_id: "generation".to_owned(),
+                run_id: "run".to_owned(),
+            },
+            disposition: &disposition,
+            receipts: &receipts,
+        })
+        .unwrap();
+        let InternalProjection::BudgetExceeded { root, .. } = projected else {
+            panic!("escaped receipt JSON must be measured after escaping")
+        };
+        assert!(root.get("receipts").is_none());
+        assert!(root.get("steps").is_none());
+
+        let mut missing = receipts.clone();
+        let omitted = missing.pop().unwrap();
+        assert_eq!(
+            project_internal_call_path_result(InternalProjectionInput {
+                contract: &contract,
+                hashes: &hashes,
+                rendering: &rendering,
+                publication: InternalCorePublicationIdentity {
+                    project_id: "project".to_owned(),
+                    generation_id: "generation".to_owned(),
+                    run_id: "run".to_owned(),
+                },
+                disposition: &disposition,
+                receipts: &missing,
+            }),
+            Err(InternalProjectionError::MissingAuthoritativeReceipt {
+                receipt_id: omitted.receipt.receipt_id,
+                edge_id: omitted.receipt.edge_id,
+            })
+        );
+    }
+
+    #[test]
+    fn six_maximum_lines_are_kept_complete_or_replaced_as_one_and_tiny_fallbacks_error() {
+        let maximum = "x".repeat(MAX_SOURCE_RECEIPT_LINE_BYTES);
+        let (contract, hashes, rendering, receipts, disposition) =
+            six_step_projection_fixture(vec![maximum; 6]);
+        let projected = project_internal_call_path_result(InternalProjectionInput {
+            contract: &contract,
+            hashes: &hashes,
+            rendering: &rendering,
+            publication: InternalCorePublicationIdentity {
+                project_id: "project".to_owned(),
+                generation_id: "generation".to_owned(),
+                run_id: "run".to_owned(),
+            },
+            disposition: &disposition,
+            receipts: &receipts,
+        })
+        .unwrap();
+        match projected {
+            InternalProjection::Complete {
+                root,
+                serialized_size,
+            } => {
+                assert!(serialized_size <= INTERNAL_PROOF_CAP_BYTES);
+                assert_eq!(root["receipts"].as_array().unwrap().len(), 6);
+            }
+            InternalProjection::BudgetExceeded { root, .. } => {
+                assert!(root.get("receipts").is_none());
+                assert!(root.get("steps").is_none());
+            }
+        }
+
+        assert!(matches!(
+            project_internal_call_path_result_with_cap(
+                InternalProjectionInput {
+                    contract: &contract,
+                    hashes: &hashes,
+                    rendering: &rendering,
+                    publication: InternalCorePublicationIdentity {
+                        project_id: "project".to_owned(),
+                        generation_id: "generation".to_owned(),
+                        run_id: "run".to_owned(),
+                    },
+                    disposition: &disposition,
+                    receipts: &receipts,
+                },
+                1,
+            ),
+            Err(InternalProjectionError::FallbackExceedsCap { cap_bytes: 1, .. })
+        ));
     }
 
     #[test]

--- a/crates/codestory-agent/src/indexed_source_call_path_v1.rs
+++ b/crates/codestory-agent/src/indexed_source_call_path_v1.rs
@@ -22,6 +22,7 @@ pub const CLAUSE_GUARD_VERSION: &str = "clause_guard_v1";
 const DIGEST_DOMAIN_SEPARATOR: &[u8] = b"codestory.proof-contract.digest.v1\0";
 const MIN_STEPS: usize = 1;
 const MAX_STEPS: usize = 6;
+const MAX_INDEXED_SCOPES: usize = u8::MAX as usize + 1;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UnvalidatedCallPathContract {
@@ -63,24 +64,41 @@ pub enum ClauseClassification {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ProofContractField {
     Start,
-    StepTarget,
-    Directness,
-    Ordering,
-    Relation,
-    TraversalProhibition,
-    ProjectionExclusion,
+    StepTarget { step: u8 },
+    Directness { step: u8 },
+    Ordering { step: u8 },
+    Relation { step: u8 },
+    TraversalProhibition { index: u8 },
+    ProjectionExclusion { index: u8 },
 }
 
 impl ProofContractField {
     fn canonical_name(self) -> &'static str {
         match self {
             Self::Start => "start",
-            Self::StepTarget => "step_target",
-            Self::Directness => "directness",
-            Self::Ordering => "ordering",
-            Self::Relation => "relation",
-            Self::TraversalProhibition => "traversal_prohibition",
-            Self::ProjectionExclusion => "projection_exclusion",
+            Self::StepTarget { .. } => "step_target",
+            Self::Directness { .. } => "directness",
+            Self::Ordering { .. } => "ordering",
+            Self::Relation { .. } => "relation",
+            Self::TraversalProhibition { .. } => "traversal_prohibition",
+            Self::ProjectionExclusion { .. } => "projection_exclusion",
+        }
+    }
+
+    fn canonical_json(self) -> Value {
+        match self {
+            Self::Start => json!({ "kind": self.canonical_name() }),
+            Self::StepTarget { step }
+            | Self::Directness { step }
+            | Self::Ordering { step }
+            | Self::Relation { step } => json!({
+                "kind": self.canonical_name(),
+                "step": step,
+            }),
+            Self::TraversalProhibition { index } | Self::ProjectionExclusion { index } => json!({
+                "kind": self.canonical_name(),
+                "index": index,
+            }),
         }
     }
 }
@@ -300,6 +318,10 @@ pub enum ValidationError {
     StepCountOutOfRange {
         actual: usize,
     },
+    ScopeCountOutOfRange {
+        field: ProofContractField,
+        actual: usize,
+    },
     InvalidSelector(SelectorValidationError),
     InvalidScope(SelectorValidationError),
     EmptyClauseId,
@@ -325,6 +347,9 @@ pub enum ValidationError {
         field: ProofContractField,
         required: usize,
         found: usize,
+    },
+    OutOfRangeFieldReference {
+        field: ProofContractField,
     },
     CanonicalJson(String),
 }
@@ -416,6 +441,18 @@ fn validate_spec(spec: UnvalidatedCallPathSpec) -> Result<CallPathSpec, Validati
             actual: spec.steps.len(),
         });
     }
+    if spec.prohibit_traversal_through.len() > MAX_INDEXED_SCOPES {
+        return Err(ValidationError::ScopeCountOutOfRange {
+            field: ProofContractField::TraversalProhibition { index: u8::MAX },
+            actual: spec.prohibit_traversal_through.len(),
+        });
+    }
+    if spec.exclude_from_projection.len() > MAX_INDEXED_SCOPES {
+        return Err(ValidationError::ScopeCountOutOfRange {
+            field: ProofContractField::ProjectionExclusion { index: u8::MAX },
+            actual: spec.exclude_from_projection.len(),
+        });
+    }
     let start = validate_symbol_selector(spec.start).map_err(ValidationError::InvalidSelector)?;
     let steps = spec
         .steps
@@ -426,22 +463,18 @@ fn validate_spec(spec: UnvalidatedCallPathSpec) -> Result<CallPathSpec, Validati
                 .map_err(ValidationError::InvalidSelector)
         })
         .collect::<Result<Vec<_>, _>>()?;
-    let mut prohibit_traversal_through = spec
+    let prohibit_traversal_through = spec
         .prohibit_traversal_through
         .into_iter()
         .map(validate_scope_selector)
         .collect::<Result<Vec<_>, _>>()
         .map_err(ValidationError::InvalidScope)?;
-    let mut exclude_from_projection = spec
+    let exclude_from_projection = spec
         .exclude_from_projection
         .into_iter()
         .map(validate_scope_selector)
         .collect::<Result<Vec<_>, _>>()
         .map_err(ValidationError::InvalidScope)?;
-    prohibit_traversal_through.sort();
-    prohibit_traversal_through.dedup();
-    exclude_from_projection.sort();
-    exclude_from_projection.dedup();
     Ok(CallPathSpec {
         start,
         steps,
@@ -679,30 +712,58 @@ fn validate_required_field_coverage(
     clauses: &[NormalizedClause],
     spec: &CallPathSpec,
 ) -> Result<(), ValidationError> {
-    let requirements = [
-        (ProofContractField::Start, 1),
-        (ProofContractField::StepTarget, spec.steps.len()),
-        (ProofContractField::Directness, 1),
-        (ProofContractField::Ordering, 1),
-        (ProofContractField::Relation, 1),
-        (
-            ProofContractField::TraversalProhibition,
-            spec.prohibit_traversal_through.len(),
-        ),
-        (
-            ProofContractField::ProjectionExclusion,
-            spec.exclude_from_projection.len(),
-        ),
-    ];
-    for (field, required) in requirements {
+    let fields = clauses
+        .iter()
+        .filter_map(|clause| clause.field)
+        .collect::<Vec<_>>();
+    for field in &fields {
+        let in_range = match field {
+            ProofContractField::Start => true,
+            ProofContractField::StepTarget { step }
+            | ProofContractField::Directness { step }
+            | ProofContractField::Ordering { step }
+            | ProofContractField::Relation { step } => usize::from(*step) < spec.steps.len(),
+            ProofContractField::TraversalProhibition { index } => {
+                usize::from(*index) < spec.prohibit_traversal_through.len()
+            }
+            ProofContractField::ProjectionExclusion { index } => {
+                usize::from(*index) < spec.exclude_from_projection.len()
+            }
+        };
+        if !in_range {
+            return Err(ValidationError::OutOfRangeFieldReference { field: *field });
+        }
+    }
+
+    let mut requirements = vec![ProofContractField::Start];
+    for step in 0..spec.steps.len() {
+        let step = u8::try_from(step).expect("step count is bounded below u8::MAX");
+        requirements.extend([
+            ProofContractField::StepTarget { step },
+            ProofContractField::Directness { step },
+            ProofContractField::Ordering { step },
+            ProofContractField::Relation { step },
+        ]);
+    }
+    requirements.extend((0..spec.prohibit_traversal_through.len()).map(|index| {
+        ProofContractField::TraversalProhibition {
+            index: u8::try_from(index).expect("scope count was validated"),
+        }
+    }));
+    requirements.extend((0..spec.exclude_from_projection.len()).map(|index| {
+        ProofContractField::ProjectionExclusion {
+            index: u8::try_from(index).expect("scope count was validated"),
+        }
+    }));
+    for field in requirements {
         let found = clauses
             .iter()
             .filter(|clause| clause.field == Some(field))
             .count();
-        if found < required {
+        if found == 0 {
             return Err(ValidationError::MissingResolvedMaterialAnchor {
                 field,
-                required,
+                required: 1,
                 found,
             });
         }
@@ -741,14 +802,21 @@ fn classify_translation_gaps(
                 });
             }
             NormalizedClauseClassification::Ignored(_) => {
-                let guard_families = clause_guard_families(&clause.quote);
-                let disappears_as_only_non_material = (clause.start..clause.end).any(|offset| {
-                    coverage[offset].non_material
-                        && !coverage[offset].resolved
-                        && !coverage[offset].unresolved
-                        && !source_text.as_bytes()[offset].is_ascii_whitespace()
-                });
-                if !guard_families.is_empty() && disappears_as_only_non_material {
+                let guard_families = clause_guard_spans(&clause.quote)
+                    .into_iter()
+                    .filter(|span| {
+                        (clause.start + span.start..clause.start + span.end).any(|offset| {
+                            coverage[offset].non_material
+                                && !coverage[offset].resolved
+                                && !coverage[offset].unresolved
+                                && !source_text.as_bytes()[offset].is_ascii_whitespace()
+                        })
+                    })
+                    .map(|span| span.family)
+                    .collect::<BTreeSet<_>>()
+                    .into_iter()
+                    .collect::<Vec<_>>();
+                if !guard_families.is_empty() {
                     gaps.insert(TranslationGap::MaterialTokenMisclassified {
                         clause_id: clause.clause_id.clone(),
                         guard_families,
@@ -783,40 +851,56 @@ pub enum ClauseGuardFamily {
     QualifiedSymbolNotation,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct ClauseGuardSpan {
+    start: usize,
+    end: usize,
+    family: ClauseGuardFamily,
+}
+
 pub fn clause_guard_families(text: &str) -> Vec<ClauseGuardFamily> {
-    let mut families = BTreeSet::new();
-    let lower = text.to_lowercase();
-    let words = lower
-        .split(|character: char| !character.is_alphanumeric() && character != '_')
-        .filter(|word| !word.is_empty())
-        .collect::<Vec<_>>();
-    if contains_nonempty_quoted(text, '`')
-        || contains_nonempty_quoted(text, '"')
-        || contains_nonempty_quoted(text, '\'')
-    {
-        families.insert(ClauseGuardFamily::QuotedOrBacktickedIdentifier);
+    clause_guard_spans(text)
+        .into_iter()
+        .map(|span| span.family)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn clause_guard_spans(text: &str) -> Vec<ClauseGuardSpan> {
+    let mut spans = BTreeSet::new();
+    for delimiter in ['`', '"', '\''] {
+        for (start, end) in nonempty_quoted_spans(text, delimiter) {
+            spans.insert(ClauseGuardSpan {
+                start,
+                end,
+                family: ClauseGuardFamily::QuotedOrBacktickedIdentifier,
+            });
+        }
     }
-    if text.contains("->")
-        || text.contains("=>")
-        || text.contains('→')
-        || words.iter().any(|word| {
-            matches!(
-                *word,
-                "call" | "calls" | "called" | "invoke" | "invokes" | "invoked"
-            )
-        })
-    {
-        families.insert(ClauseGuardFamily::ArrowOrRelationNotation);
+    for notation in ["->", "=>", "→"] {
+        for (start, _) in text.match_indices(notation) {
+            spans.insert(ClauseGuardSpan {
+                start,
+                end: start + notation.len(),
+                family: ClauseGuardFamily::ArrowOrRelationNotation,
+            });
+        }
     }
-    if words
-        .iter()
-        .any(|word| matches!(*word, "direct" | "directly" | "immediate" | "immediately"))
-    {
-        families.insert(ClauseGuardFamily::Directness);
-    }
-    if words.iter().any(|word| {
-        matches!(
-            *word,
+    for (start, end) in word_spans(text) {
+        let word = text[start..end].to_ascii_lowercase();
+        let family = if matches!(
+            word.as_str(),
+            "call" | "calls" | "called" | "invoke" | "invokes" | "invoked"
+        ) {
+            Some(ClauseGuardFamily::ArrowOrRelationNotation)
+        } else if matches!(
+            word.as_str(),
+            "direct" | "directly" | "immediate" | "immediately"
+        ) {
+            Some(ClauseGuardFamily::Directness)
+        } else if matches!(
+            word.as_str(),
             "first"
                 | "second"
                 | "third"
@@ -828,16 +912,13 @@ pub fn clause_guard_families(text: &str) -> Vec<ClauseGuardFamily> {
                 | "after"
                 | "ordered"
                 | "order"
-        ) || has_ordinal_suffix(word)
-    }) {
-        families.insert(ClauseGuardFamily::OrderingOrOrdinal);
-    }
-    if words.contains(&"only") {
-        families.insert(ClauseGuardFamily::Only);
-    }
-    if words.iter().any(|word| {
-        matches!(
-            *word,
+        ) || has_ordinal_suffix(&word)
+        {
+            Some(ClauseGuardFamily::OrderingOrOrdinal)
+        } else if word == "only" {
+            Some(ClauseGuardFamily::Only)
+        } else if matches!(
+            word.as_str(),
             "no" | "not"
                 | "never"
                 | "without"
@@ -849,32 +930,79 @@ pub fn clause_guard_families(text: &str) -> Vec<ClauseGuardFamily> {
                 | "prohibit"
                 | "prohibits"
                 | "avoid"
-        )
-    }) {
-        families.insert(ClauseGuardFamily::NegationOrExclusion);
+        ) {
+            Some(ClauseGuardFamily::NegationOrExclusion)
+        } else {
+            None
+        };
+        if let Some(family) = family {
+            spans.insert(ClauseGuardSpan { start, end, family });
+        }
     }
-    if text.contains('/')
-        || text.contains('\\')
-        || [".rs", ".ts", ".tsx", ".js", ".py", ".go", ".java"]
-            .iter()
-            .any(|extension| lower.contains(extension))
-    {
-        families.insert(ClauseGuardFamily::PathLikeString);
+    for (start, end) in token_spans(text) {
+        let token = &text[start..end];
+        let lower = token.to_ascii_lowercase();
+        if token.contains('/')
+            || token.contains('\\')
+            || [".rs", ".ts", ".tsx", ".js", ".py", ".go", ".java"]
+                .iter()
+                .any(|extension| lower.contains(extension))
+        {
+            spans.insert(ClauseGuardSpan {
+                start,
+                end,
+                family: ClauseGuardFamily::PathLikeString,
+            });
+        }
+        if token.contains("::") || contains_dotted_qualified_name(token) {
+            spans.insert(ClauseGuardSpan {
+                start,
+                end,
+                family: ClauseGuardFamily::QualifiedSymbolNotation,
+            });
+        }
     }
-    if text.contains("::") || contains_dotted_qualified_name(text) {
-        families.insert(ClauseGuardFamily::QualifiedSymbolNotation);
-    }
-    families.into_iter().collect()
+    spans.into_iter().collect()
 }
 
-fn contains_nonempty_quoted(text: &str, delimiter: char) -> bool {
+fn nonempty_quoted_spans(text: &str, delimiter: char) -> Vec<(usize, usize)> {
     let positions = text
         .match_indices(delimiter)
         .map(|(index, _)| index)
         .collect::<Vec<_>>();
     positions
         .chunks_exact(2)
-        .any(|pair| pair[0] + delimiter.len_utf8() < pair[1])
+        .filter(|pair| pair[0] + delimiter.len_utf8() < pair[1])
+        .map(|pair| (pair[0], pair[1] + delimiter.len_utf8()))
+        .collect()
+}
+
+fn word_spans(text: &str) -> Vec<(usize, usize)> {
+    delimited_spans(text, |character| {
+        character.is_alphanumeric() || character == '_'
+    })
+}
+
+fn token_spans(text: &str) -> Vec<(usize, usize)> {
+    delimited_spans(text, |character| {
+        !character.is_whitespace() && !matches!(character, ',' | ';' | '(' | ')' | '[' | ']')
+    })
+}
+
+fn delimited_spans(text: &str, keep: impl Fn(char) -> bool) -> Vec<(usize, usize)> {
+    let mut spans = Vec::new();
+    let mut start = None;
+    for (offset, character) in text.char_indices() {
+        if keep(character) {
+            start.get_or_insert(offset);
+        } else if let Some(start) = start.take() {
+            spans.push((start, offset));
+        }
+    }
+    if let Some(start) = start {
+        spans.push((start, text.len()));
+    }
+    spans
 }
 
 fn has_ordinal_suffix(word: &str) -> bool {
@@ -932,7 +1060,7 @@ fn normalized_clause_json(clause: &NormalizedClause) -> Value {
         "clause_id": clause.clause_id,
         "quote": clause.quote,
         "classification": clause.classification.canonical_name(),
-        "field": clause.field.map(ProofContractField::canonical_name),
+        "field": clause.field.map(ProofContractField::canonical_json),
         "reason": reason,
         "non_material_kind": non_material_kind,
     })
@@ -1078,21 +1206,6 @@ pub struct VerifiedDirectCallFact {
     pub target: ResolvedNodeIdentity,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PositiveContradictionFact {
-    pub receipt_id: String,
-    pub source: ResolvedNodeIdentity,
-    pub expected_target: ExactSymbolSelector,
-    pub kind: PositiveContradictionKind,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum PositiveContradictionKind {
-    RelationIsNotDirectCall,
-    DirectionIsNotOutgoing,
-    ResolvedTargetDiffers,
-}
-
 #[cfg(any(test, feature = "test-support"))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CertifiedAbsenceFact {
@@ -1110,7 +1223,6 @@ pub struct UnavailableProofFact {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VerifiedProofFact {
     DirectCall(VerifiedDirectCallFact),
-    PositiveContradiction(PositiveContradictionFact),
     #[cfg(any(test, feature = "test-support"))]
     CertifiedAbsence(CertifiedAbsenceFact),
     Unavailable(UnavailableProofFact),
@@ -1138,14 +1250,10 @@ pub enum ProofDisposition {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Refutation {
-    PositiveContradiction {
+    ProhibitedScopeTraversal {
         step_index: usize,
-        receipt_id: String,
-        kind: PositiveContradictionKind,
-    },
-    TraversalProhibitionViolated {
-        step_index: usize,
-        receipt: ReceiptRef,
+        prohibition_index: usize,
+        connected_receipts: Vec<ReceiptRef>,
     },
     #[cfg(any(test, feature = "test-support"))]
     CertifiedAbsence {
@@ -1223,24 +1331,8 @@ pub fn check_call_path(
             gaps: vec![ProofGap::ProjectionExclusionConflictsWithRequiredReceipt { step_index }],
         };
     }
-    if let Some((path, step_index)) = find_path(
-        contract,
-        &direct_facts,
-        PathPolicy::AllowTraversalProhibitions,
-    )
-    .and_then(|path| first_traversal_prohibition(contract, &path).map(|index| (path, index)))
-    {
-        return ProofDisposition::ContractRefuted {
-            contract_digest: hashes.contract_digest.clone(),
-            refutation: Refutation::TraversalProhibitionViolated {
-                step_index,
-                receipt: path[step_index].receipt.clone(),
-            },
-        };
-    }
     let mut reachable = reachable_prefixes(contract, &direct_facts);
     for source in facts.iter().filter_map(|fact| match fact {
-        VerifiedProofFact::PositiveContradiction(fact) => Some(&fact.source),
         #[cfg(any(test, feature = "test-support"))]
         VerifiedProofFact::CertifiedAbsence(fact) => Some(&fact.source),
         _ => None,
@@ -1255,35 +1347,56 @@ pub fn check_call_path(
                 current: source.clone(),
                 used_receipts: BTreeSet::new(),
                 used_edges: BTreeSet::new(),
+                connected_receipts: Vec::new(),
+                projection_conflict_step: None,
             });
         }
     }
+    if let Some((state, prohibition_index)) = reachable.iter().find_map(|state| {
+        (state.step_index > 0
+            && state.step_index < contract.spec.steps.len()
+            && state.projection_conflict_step.is_none())
+        .then(|| {
+            contract
+                .spec
+                .prohibit_traversal_through
+                .iter()
+                .position(|scope| scope_selector_matches(scope, &state.current))
+                .map(|index| (state, index))
+        })
+        .flatten()
+    }) {
+        return ProofDisposition::ContractRefuted {
+            contract_digest: hashes.contract_digest.clone(),
+            refutation: Refutation::ProhibitedScopeTraversal {
+                step_index: state.step_index - 1,
+                prohibition_index,
+                connected_receipts: state.connected_receipts.clone(),
+            },
+        };
+    }
+    if let Some(step_index) = reachable.iter().find_map(|state| {
+        (state.step_index > 0
+            && state.step_index < contract.spec.steps.len()
+            && contract
+                .spec
+                .prohibit_traversal_through
+                .iter()
+                .any(|scope| scope_selector_matches(scope, &state.current)))
+        .then_some(state.projection_conflict_step)
+        .flatten()
+    }) {
+        return ProofDisposition::Unknown {
+            contract_digest: hashes.contract_digest.clone(),
+            gaps: vec![ProofGap::ProjectionExclusionConflictsWithRequiredReceipt { step_index }],
+        };
+    }
     for state in reachable.iter().rev() {
-        if state.step_index >= contract.spec.steps.len() {
+        if state.step_index >= contract.spec.steps.len() || state.projection_conflict_step.is_some()
+        {
             continue;
         }
         let target = &contract.spec.steps[state.step_index].target;
-        if let Some(contradiction) = facts
-            .iter()
-            .filter_map(|fact| match fact {
-                VerifiedProofFact::PositiveContradiction(fact) => Some(fact),
-                _ => None,
-            })
-            .find(|fact| {
-                fact.source == state.current
-                    && &fact.expected_target == target
-                    && !fact.receipt_id.is_empty()
-            })
-        {
-            return ProofDisposition::ContractRefuted {
-                contract_digest: hashes.contract_digest.clone(),
-                refutation: Refutation::PositiveContradiction {
-                    step_index: state.step_index,
-                    receipt_id: contradiction.receipt_id.clone(),
-                    kind: contradiction.kind.clone(),
-                },
-            };
-        }
         #[cfg(any(test, feature = "test-support"))]
         if let Some(absence) = facts
             .iter()
@@ -1312,14 +1425,33 @@ pub fn check_call_path(
             };
         }
     }
+    let furthest_clean_step = reachable
+        .iter()
+        .filter(|state| state.projection_conflict_step.is_none())
+        .map(|state| state.step_index)
+        .max()
+        .unwrap_or(0);
+    if let Some(step_index) = reachable
+        .iter()
+        .filter(|state| state.step_index > furthest_clean_step)
+        .filter_map(|state| state.projection_conflict_step)
+        .min()
+    {
+        return ProofDisposition::Unknown {
+            contract_digest: hashes.contract_digest.clone(),
+            gaps: vec![ProofGap::ProjectionExclusionConflictsWithRequiredReceipt { step_index }],
+        };
+    }
     let step_index = reachable
         .iter()
+        .filter(|state| state.projection_conflict_step.is_none())
         .map(|state| state.step_index)
         .max()
         .unwrap_or(0)
         .min(contract.spec.steps.len() - 1);
     let reuse_blocked = reachable.iter().any(|state| {
         state.step_index == step_index
+            && state.projection_conflict_step.is_none()
             && direct_facts.iter().any(|fact| {
                 fact.source == state.current
                     && symbol_selector_matches(
@@ -1344,7 +1476,6 @@ pub fn check_call_path(
 enum PathPolicy {
     Strict,
     AllowProjectionExclusions,
-    AllowTraversalProhibitions,
 }
 
 fn find_path<'a>(
@@ -1399,8 +1530,7 @@ fn search_path<'a>(
         {
             continue;
         }
-        if policy != PathPolicy::AllowTraversalProhibitions
-            && step_index + 1 < contract.spec.steps.len()
+        if step_index + 1 < contract.spec.steps.len()
             && contract
                 .spec
                 .prohibit_traversal_through
@@ -1448,33 +1578,22 @@ fn first_projection_conflict(
         .position(|fact| receipt_hits_projection_exclusion(contract, fact))
 }
 
-fn first_traversal_prohibition(
-    contract: &ValidatedCallPathContract,
-    path: &[&VerifiedDirectCallFact],
-) -> Option<usize> {
-    path.iter().enumerate().find_map(|(step_index, fact)| {
-        (step_index + 1 < path.len()
-            && contract
-                .spec
-                .prohibit_traversal_through
-                .iter()
-                .any(|scope| scope_selector_matches(scope, &fact.target)))
-        .then_some(step_index)
-    })
-}
-
 #[derive(Debug, Clone)]
 struct PrefixState {
     step_index: usize,
     current: ResolvedNodeIdentity,
     used_receipts: BTreeSet<String>,
     used_edges: BTreeSet<String>,
+    connected_receipts: Vec<ReceiptRef>,
+    projection_conflict_step: Option<usize>,
 }
 
 fn reachable_prefixes(
     contract: &ValidatedCallPathContract,
     facts: &[&VerifiedDirectCallFact],
 ) -> Vec<PrefixState> {
+    let mut facts = facts.to_vec();
+    facts.sort_by(|left, right| left.receipt.cmp(&right.receipt));
     let initial_nodes = facts
         .iter()
         .filter(|fact| symbol_selector_matches(&contract.spec.start, &fact.source))
@@ -1487,13 +1606,15 @@ fn reachable_prefixes(
             current,
             used_receipts: BTreeSet::new(),
             used_edges: BTreeSet::new(),
+            connected_receipts: Vec::new(),
+            projection_conflict_step: None,
         })
         .collect::<Vec<_>>();
     let mut all = states.clone();
     for step_index in 0..contract.spec.steps.len() {
         let mut next = Vec::new();
         for state in states {
-            for fact in facts {
+            for fact in &facts {
                 if fact.source != state.current
                     || !symbol_selector_matches(
                         &contract.spec.steps[step_index].target,
@@ -1506,13 +1627,19 @@ fn reachable_prefixes(
                 }
                 let mut used_receipts = state.used_receipts.clone();
                 let mut used_edges = state.used_edges.clone();
+                let mut connected_receipts = state.connected_receipts.clone();
                 used_receipts.insert(fact.receipt.receipt_id.clone());
                 used_edges.insert(fact.receipt.edge_id.clone());
+                connected_receipts.push(fact.receipt.clone());
                 next.push(PrefixState {
                     step_index: step_index + 1,
                     current: fact.target.clone(),
                     used_receipts,
                     used_edges,
+                    connected_receipts,
+                    projection_conflict_step: state.projection_conflict_step.or_else(|| {
+                        receipt_hits_projection_exclusion(contract, fact).then_some(step_index)
+                    }),
                 });
             }
         }
@@ -1551,37 +1678,35 @@ mod tests {
         }
     }
 
-    fn full_anchor(
-        source: &str,
-        extra_fields: impl IntoIterator<Item = ProofContractField>,
-    ) -> ClauseAnchor {
-        let mut fields = vec![
-            ProofContractField::Start,
-            ProofContractField::Directness,
-            ProofContractField::Ordering,
-            ProofContractField::Relation,
-        ];
-        fields.extend(extra_fields);
+    fn start_anchor(source: &str) -> ClauseAnchor {
         ClauseAnchor {
             clause_id: "whole".to_owned(),
             start: 0,
             end: source.len(),
             quote: source.to_owned(),
-            classification: ClauseClassification::ResolvedMaterial { fields },
+            classification: ClauseClassification::ResolvedMaterial {
+                fields: vec![ProofContractField::Start],
+            },
         }
     }
 
     fn valid_input(targets: &[&str]) -> UnvalidatedCallPathContract {
         let source = "exact direct ordered call path";
-        let mut clauses = vec![full_anchor(source, [])];
+        let mut clauses = vec![start_anchor(source)];
         for (index, _) in targets.iter().enumerate() {
+            let step = u8::try_from(index).expect("test step index fits u8");
             clauses.push(ClauseAnchor {
                 clause_id: format!("target-{index}"),
                 start: 0,
                 end: source.len(),
                 quote: source.to_owned(),
                 classification: ClauseClassification::ResolvedMaterial {
-                    fields: vec![ProofContractField::StepTarget],
+                    fields: vec![
+                        ProofContractField::StepTarget { step },
+                        ProofContractField::Directness { step },
+                        ProofContractField::Ordering { step },
+                        ProofContractField::Relation { step },
+                    ],
                 },
             });
         }
@@ -1779,7 +1904,7 @@ mod tests {
             end: 12,
             quote: input.source_text[6..12].to_owned(),
             classification: ClauseClassification::ResolvedMaterial {
-                fields: vec![ProofContractField::Directness],
+                fields: vec![ProofContractField::Directness { step: 0 }],
             },
         });
         assert!(matches!(
@@ -1802,9 +1927,9 @@ mod tests {
                 classification: ClauseClassification::ResolvedMaterial {
                     fields: vec![
                         ProofContractField::Start,
-                        ProofContractField::Directness,
-                        ProofContractField::Ordering,
-                        ProofContractField::Relation,
+                        ProofContractField::Directness { step: 0 },
+                        ProofContractField::Ordering { step: 0 },
+                        ProofContractField::Relation { step: 0 },
                     ],
                 },
             },
@@ -1814,7 +1939,7 @@ mod tests {
                 end: 3,
                 quote: "B".to_owned(),
                 classification: ClauseClassification::ResolvedMaterial {
-                    fields: vec![ProofContractField::StepTarget],
+                    fields: vec![ProofContractField::StepTarget { step: 0 }],
                 },
             },
         ];
@@ -1826,10 +1951,10 @@ mod tests {
         input.clauses[0].classification = ClauseClassification::ResolvedMaterial {
             fields: vec![
                 ProofContractField::Start,
-                ProofContractField::StepTarget,
-                ProofContractField::Directness,
-                ProofContractField::Ordering,
-                ProofContractField::Relation,
+                ProofContractField::StepTarget { step: 0 },
+                ProofContractField::Directness { step: 0 },
+                ProofContractField::Ordering { step: 0 },
+                ProofContractField::Relation { step: 0 },
             ],
         };
         assert!(matches!(
@@ -1848,10 +1973,71 @@ mod tests {
         assert_eq!(
             validate_contract(input),
             Err(ValidationError::MissingResolvedMaterialAnchor {
-                field: ProofContractField::StepTarget,
+                field: ProofContractField::StepTarget { step: 0 },
                 required: 1,
                 found: 0,
             })
+        );
+    }
+
+    #[test]
+    fn duplicate_step_zero_anchors_cannot_cover_step_one() {
+        let mut input = valid_input(&["B", "C"]);
+        input.clauses[2].classification = ClauseClassification::ResolvedMaterial {
+            fields: vec![
+                ProofContractField::StepTarget { step: 0 },
+                ProofContractField::Directness { step: 0 },
+                ProofContractField::Ordering { step: 0 },
+                ProofContractField::Relation { step: 0 },
+            ],
+        };
+        assert_eq!(
+            validate_contract(input),
+            Err(ValidationError::MissingResolvedMaterialAnchor {
+                field: ProofContractField::StepTarget { step: 1 },
+                required: 1,
+                found: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_out_of_range_or_unpopulated_indexed_field_references() {
+        for field in [
+            ProofContractField::Relation { step: 1 },
+            ProofContractField::TraversalProhibition { index: 0 },
+            ProofContractField::ProjectionExclusion { index: 0 },
+        ] {
+            let mut input = valid_input(&["B"]);
+            input.clauses.push(ClauseAnchor {
+                clause_id: format!("out-of-range-{field:?}"),
+                start: 0,
+                end: input.source_text.len(),
+                quote: input.source_text.clone(),
+                classification: ClauseClassification::ResolvedMaterial {
+                    fields: vec![field],
+                },
+            });
+            assert_eq!(
+                validate_contract(input),
+                Err(ValidationError::OutOfRangeFieldReference { field })
+            );
+        }
+    }
+
+    #[test]
+    fn canonical_clause_json_commits_the_typed_field_index() {
+        let clause = NormalizedClause {
+            start: 0,
+            end: 1,
+            clause_id: "target".to_owned(),
+            classification: NormalizedClauseClassification::Resolved,
+            field: Some(ProofContractField::StepTarget { step: 2 }),
+            quote: "B".to_owned(),
+        };
+        assert_eq!(
+            normalized_clause_json(&clause)["field"],
+            json!({ "kind": "step_target", "step": 2 })
         );
     }
 
@@ -1938,10 +2124,10 @@ mod tests {
                 classification: ClauseClassification::ResolvedMaterial {
                     fields: vec![
                         ProofContractField::Start,
-                        ProofContractField::StepTarget,
-                        ProofContractField::Directness,
-                        ProofContractField::Ordering,
-                        ProofContractField::Relation,
+                        ProofContractField::StepTarget { step: 0 },
+                        ProofContractField::Directness { step: 0 },
+                        ProofContractField::Ordering { step: 0 },
+                        ProofContractField::Relation { step: 0 },
                     ],
                 },
             },
@@ -1962,6 +2148,43 @@ mod tests {
                     clause_id: "guarded".to_owned(),
                     guard_families: vec![ClauseGuardFamily::Only],
                 })
+        ));
+    }
+
+    #[test]
+    fn resolved_guard_span_wins_over_a_broader_non_material_anchor() {
+        let source = "only x";
+        let mut input = valid_input(&["B"]);
+        input.source_text = source.to_owned();
+        input.clauses = vec![
+            ClauseAnchor {
+                clause_id: "resolved-guard".to_owned(),
+                start: 0,
+                end: 4,
+                quote: "only".to_owned(),
+                classification: ClauseClassification::ResolvedMaterial {
+                    fields: vec![
+                        ProofContractField::Start,
+                        ProofContractField::StepTarget { step: 0 },
+                        ProofContractField::Directness { step: 0 },
+                        ProofContractField::Ordering { step: 0 },
+                        ProofContractField::Relation { step: 0 },
+                    ],
+                },
+            },
+            ClauseAnchor {
+                clause_id: "broad-commentary".to_owned(),
+                start: 0,
+                end: source.len(),
+                quote: source.to_owned(),
+                classification: ClauseClassification::NonMaterial {
+                    kind: NonMaterialKind::Commentary,
+                },
+            },
+        ];
+        assert!(matches!(
+            validate_contract(input),
+            Ok(ValidationOutcome::Validated { .. })
         ));
     }
 
@@ -2026,6 +2249,30 @@ mod tests {
             other => panic!("unexpected {other:?}"),
         };
         assert_ne!(baseline.contract_digest(), reordered_spec.contract_digest());
+    }
+
+    #[test]
+    fn scope_input_order_is_committed_to_the_contract_digest() {
+        let mut first = valid_input(&["B"]);
+        first.spec.prohibit_traversal_through = vec![canonical_scope("B"), canonical_scope("C")];
+        for index in 0..2_u8 {
+            first.clauses.push(ClauseAnchor {
+                clause_id: format!("prohibition-{index}"),
+                start: 0,
+                end: first.source_text.len(),
+                quote: first.source_text.clone(),
+                classification: ClauseClassification::ResolvedMaterial {
+                    fields: vec![ProofContractField::TraversalProhibition { index }],
+                },
+            });
+        }
+        let mut second = first.clone();
+        second.spec.prohibit_traversal_through.reverse();
+        let digest = |input| match validate_contract(input).unwrap() {
+            ValidationOutcome::Validated { hashes, .. } => hashes.contract_digest,
+            other => panic!("unexpected {other:?}"),
+        };
+        assert_ne!(digest(first), digest(second));
     }
 
     #[test]
@@ -2107,21 +2354,33 @@ mod tests {
     }
 
     #[test]
-    fn positive_contradiction_and_fixture_absence_are_receipt_backed() {
+    fn wrong_relation_direction_or_target_cannot_refute_a_required_direct_edge() {
+        enum NonDirectObservation {
+            OtherRelation,
+            ReversedDirection,
+            DifferentTarget,
+        }
         let (contract, hashes) = validate(&["B"]);
-        let contradiction = VerifiedProofFact::PositiveContradiction(PositiveContradictionFact {
-            receipt_id: "contradiction-receipt".to_owned(),
-            source: node("A"),
-            expected_target: ExactSymbolSelector::CanonicalId("B".to_owned()),
-            kind: PositiveContradictionKind::ResolvedTargetDiffers,
-        });
-        assert!(matches!(
-            check_call_path(&contract, &hashes, &[contradiction]),
-            ProofDisposition::ContractRefuted {
-                refutation: Refutation::PositiveContradiction { .. },
-                ..
-            }
-        ));
+        for observation in [
+            NonDirectObservation::OtherRelation,
+            NonDirectObservation::ReversedDirection,
+            NonDirectObservation::DifferentTarget,
+        ] {
+            let admitted_facts = match observation {
+                NonDirectObservation::OtherRelation => Vec::new(),
+                NonDirectObservation::ReversedDirection => vec![call("r", "e", "B", "A")],
+                NonDirectObservation::DifferentTarget => vec![call("r", "e", "A", "C")],
+            };
+            assert!(matches!(
+                check_call_path(&contract, &hashes, &admitted_facts),
+                ProofDisposition::Unknown { .. }
+            ));
+        }
+    }
+
+    #[test]
+    fn fixture_absence_requires_both_completeness_receipts() {
+        let (contract, hashes) = validate(&["B"]);
         let absence = VerifiedProofFact::CertifiedAbsence(CertifiedAbsenceFact {
             source: node("A"),
             expected_target: ExactSymbolSelector::CanonicalId("B".to_owned()),
@@ -2181,7 +2440,7 @@ mod tests {
             end: input.source_text.len(),
             quote: input.source_text.clone(),
             classification: ClauseClassification::ResolvedMaterial {
-                fields: vec![ProofContractField::ProjectionExclusion],
+                fields: vec![ProofContractField::ProjectionExclusion { index: 0 }],
             },
         });
         let (contract, hashes) = match validate_contract(input).unwrap() {
@@ -2198,16 +2457,16 @@ mod tests {
     }
 
     #[test]
-    fn traversal_prohibition_is_receipt_backed_positive_refutation() {
+    fn fixture_absence_reached_only_through_an_excluded_receipt_stays_unknown() {
         let mut input = valid_input(&["B", "C"]);
-        input.spec.prohibit_traversal_through = vec![canonical_scope("B")];
+        input.spec.exclude_from_projection = vec![canonical_scope("B")];
         input.clauses.push(ClauseAnchor {
-            clause_id: "prohibition".to_owned(),
+            clause_id: "projection".to_owned(),
             start: 0,
             end: input.source_text.len(),
             quote: input.source_text.clone(),
             classification: ClauseClassification::ResolvedMaterial {
-                fields: vec![ProofContractField::TraversalProhibition],
+                fields: vec![ProofContractField::ProjectionExclusion { index: 0 }],
             },
         });
         let (contract, hashes) = match validate_contract(input).unwrap() {
@@ -2216,13 +2475,61 @@ mod tests {
             } => (contract, hashes),
             other => panic!("unexpected {other:?}"),
         };
-        let facts = [call("r1", "e1", "A", "B"), call("r2", "e2", "B", "C")];
+        let facts = [
+            call("r1", "e1", "A", "B"),
+            VerifiedProofFact::CertifiedAbsence(CertifiedAbsenceFact {
+                source: node("B"),
+                expected_target: ExactSymbolSelector::CanonicalId("C".to_owned()),
+                extractor_capability_receipt_id: "capability".to_owned(),
+                untruncated_enumeration_receipt_id: "enumeration".to_owned(),
+            }),
+        ];
+        assert!(matches!(
+            check_call_path(&contract, &hashes, &facts),
+            ProofDisposition::Unknown { gaps, .. }
+                if gaps == [ProofGap::ProjectionExclusionConflictsWithRequiredReceipt {
+                    step_index: 0,
+                }]
+        ));
+    }
+
+    #[test]
+    fn traversal_prohibition_is_receipt_backed_positive_refutation() {
+        let mut input = valid_input(&["B", "C", "D"]);
+        input.spec.prohibit_traversal_through = vec![canonical_scope("C")];
+        input.clauses.push(ClauseAnchor {
+            clause_id: "prohibition".to_owned(),
+            start: 0,
+            end: input.source_text.len(),
+            quote: input.source_text.clone(),
+            classification: ClauseClassification::ResolvedMaterial {
+                fields: vec![ProofContractField::TraversalProhibition { index: 0 }],
+            },
+        });
+        let (contract, hashes) = match validate_contract(input).unwrap() {
+            ValidationOutcome::Validated {
+                contract, hashes, ..
+            } => (contract, hashes),
+            other => panic!("unexpected {other:?}"),
+        };
+        let facts = [
+            call("r1", "e1", "A", "B"),
+            call("r2", "e2", "B", "C"),
+            call("r3", "e3", "C", "D"),
+        ];
         assert!(matches!(
             check_call_path(&contract, &hashes, &facts),
             ProofDisposition::ContractRefuted {
-                refutation: Refutation::TraversalProhibitionViolated { step_index: 0, .. },
+                refutation: Refutation::ProhibitedScopeTraversal {
+                    step_index: 1,
+                    prohibition_index: 0,
+                    connected_receipts,
+                },
                 ..
-            }
+            } if connected_receipts == [
+                ReceiptRef { receipt_id: "r1".to_owned(), edge_id: "e1".to_owned() },
+                ReceiptRef { receipt_id: "r2".to_owned(), edge_id: "e2".to_owned() },
+            ]
         ));
     }
 

--- a/crates/codestory-agent/src/indexed_source_call_path_v1.rs
+++ b/crates/codestory-agent/src/indexed_source_call_path_v1.rs
@@ -13,6 +13,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
+use codestory_contracts::graph::{Edge, EdgeId, EdgeKind, NodeId, ResolutionCertainty};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 
@@ -23,6 +24,135 @@ const DIGEST_DOMAIN_SEPARATOR: &[u8] = b"codestory.proof-contract.digest.v1\0";
 const MIN_STEPS: usize = 1;
 const MAX_STEPS: usize = 6;
 const MAX_INDEXED_SCOPES: usize = u8::MAX as usize + 1;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AdmittedRawCallEdge {
+    pub edge_id: EdgeId,
+    pub file_node_id: NodeId,
+    pub line: u32,
+    pub column_or_ordinal: u32,
+    pub raw_target: NodeId,
+    pub callsite_identity: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RawCallEdgeAdmission {
+    Admitted(AdmittedRawCallEdge),
+    Rejected,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CallableContainmentEvidence {
+    pub file_node_id: NodeId,
+    pub owner_node_id: NodeId,
+    pub start_line: u32,
+    pub end_line: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexedLineWindow {
+    pub kind: &'static str,
+    pub project_file_components: Vec<String>,
+    pub indexed_sha256: String,
+    pub observed_sha256: String,
+    pub anchor_line: u32,
+    pub byte_start: usize,
+    pub byte_end: usize,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexedCallEdgeReceipt {
+    pub receipt: ReceiptRef,
+    pub source: ResolvedNodeIdentity,
+    pub target: ResolvedNodeIdentity,
+    pub certainty: ResolutionCertainty,
+    pub callsite_identity: String,
+    pub containment: CallableContainmentEvidence,
+    pub line_window: IndexedLineWindow,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum FactBuildGap {
+    SelectorMissing { selector_index: usize },
+    SelectorAmbiguous { selector_index: usize },
+    NonCallableSelector { selector_index: usize },
+    DirectCallMissing { step_index: usize },
+    RecursiveCallNotRepresentable { step_index: usize },
+    SourceWindowTooLarge { step_index: usize },
+    InvalidUtf8 { step_index: usize },
+    SourceLineOutOfRange { step_index: usize },
+    EdgeContainmentUnproven { step_index: usize },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BuiltCallPathFacts {
+    pub facts: Vec<VerifiedProofFact>,
+    pub receipts: Vec<IndexedCallEdgeReceipt>,
+    pub gaps: Vec<FactBuildGap>,
+    pub unavailable: Vec<UnavailableReason>,
+}
+
+/// Admit one persisted edge as direct-call evidence without rewriting either
+/// endpoint or deriving certainty from its diagnostic confidence score.
+pub fn admit_raw_call_edge(
+    edge: &Edge,
+    expected_source: NodeId,
+    expected_target: NodeId,
+) -> RawCallEdgeAdmission {
+    if edge.kind != EdgeKind::CALL
+        || edge.certainty != Some(ResolutionCertainty::Certain)
+        || edge.effective_source() != expected_source
+        || edge.effective_target() != expected_target
+        || edge.resolved_target != Some(expected_target)
+        || !edge.candidate_targets.is_empty()
+    {
+        return RawCallEdgeAdmission::Rejected;
+    }
+    let (Some(file_node_id), Some(line), Some(callsite_identity)) = (
+        edge.file_node_id,
+        edge.line.filter(|line| *line >= 1),
+        edge.callsite_identity.as_deref(),
+    ) else {
+        return RawCallEdgeAdmission::Rejected;
+    };
+    if callsite_identity.is_empty() {
+        return RawCallEdgeAdmission::Rejected;
+    }
+    let pre_marker = callsite_identity
+        .split_once('|')
+        .map_or(callsite_identity, |(identity, _)| identity);
+    let mut fields = pre_marker.split(':');
+    let parsed = (
+        fields.next().and_then(|value| value.parse::<i64>().ok()),
+        fields.next().and_then(|value| value.parse::<u32>().ok()),
+        fields.next().and_then(|value| value.parse::<u32>().ok()),
+        fields.next().and_then(|value| value.parse::<i64>().ok()),
+    );
+    if fields.next().is_some() {
+        return RawCallEdgeAdmission::Rejected;
+    }
+    let (Some(parsed_file), Some(parsed_line), Some(column_or_ordinal), Some(parsed_target)) =
+        parsed
+    else {
+        return RawCallEdgeAdmission::Rejected;
+    };
+    if parsed_file != file_node_id.0
+        || parsed_line != line
+        || parsed_target != edge.target.0
+        || format!("{parsed_file}:{parsed_line}:{column_or_ordinal}:{parsed_target}") != pre_marker
+    {
+        return RawCallEdgeAdmission::Rejected;
+    }
+    RawCallEdgeAdmission::Admitted(AdmittedRawCallEdge {
+        edge_id: edge.id,
+        file_node_id,
+        line,
+        column_or_ordinal,
+        raw_target: NodeId(parsed_target),
+        callsite_identity: callsite_identity.to_owned(),
+    })
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UnvalidatedCallPathContract {
@@ -1273,6 +1403,7 @@ pub enum ProofGap {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum UnavailableReason {
     ValidatedContractHashMismatch,
+    PublicationPinMismatch,
     SourceNotBoundToPublication,
     ProofFactsUnavailable,
 }
@@ -1655,6 +1786,7 @@ fn reachable_prefixes(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use codestory_contracts::graph::{Edge, EdgeId, EdgeKind, NodeId, ResolutionCertainty};
 
     fn canonical_selector(name: &str) -> UnvalidatedExactSymbolSelector {
         UnvalidatedExactSymbolSelector::CanonicalId(name.to_owned())
@@ -1754,6 +1886,154 @@ mod tests {
             validate_contract(valid_input(&["B"])),
             Ok(ValidationOutcome::Validated { .. })
         ));
+    }
+
+    #[test]
+    fn raw_call_edge_admission_requires_the_persisted_certain_canonical_identity() {
+        let edge = Edge {
+            id: EdgeId(41),
+            source: NodeId(7),
+            target: NodeId(19),
+            kind: EdgeKind::CALL,
+            file_node_id: Some(NodeId(-3)),
+            line: Some(12),
+            resolved_source: Some(NodeId(11)),
+            resolved_target: Some(NodeId(23)),
+            confidence: Some(1.0),
+            certainty: Some(ResolutionCertainty::Certain),
+            callsite_identity: Some("-3:12:0:19|collector-marker".to_owned()),
+            candidate_targets: Vec::new(),
+        };
+
+        assert_eq!(
+            admit_raw_call_edge(&edge, NodeId(11), NodeId(23)),
+            RawCallEdgeAdmission::Admitted(AdmittedRawCallEdge {
+                edge_id: EdgeId(41),
+                file_node_id: NodeId(-3),
+                line: 12,
+                column_or_ordinal: 0,
+                raw_target: NodeId(19),
+                callsite_identity: "-3:12:0:19|collector-marker".to_owned(),
+            })
+        );
+
+        let mut probable = edge;
+        probable.certainty = Some(ResolutionCertainty::Probable);
+        assert_eq!(
+            admit_raw_call_edge(&probable, NodeId(11), NodeId(23)),
+            RawCallEdgeAdmission::Rejected
+        );
+    }
+
+    #[test]
+    fn raw_call_edge_admission_rejects_each_hostile_mutation() {
+        type EdgeMutation = (&'static str, Box<dyn Fn(&mut Edge)>);
+
+        let lawful = Edge {
+            id: EdgeId(41),
+            source: NodeId(7),
+            target: NodeId(19),
+            kind: EdgeKind::CALL,
+            file_node_id: Some(NodeId(-3)),
+            line: Some(12),
+            resolved_source: Some(NodeId(11)),
+            resolved_target: Some(NodeId(23)),
+            confidence: Some(1.0),
+            certainty: Some(ResolutionCertainty::Certain),
+            callsite_identity: Some("-3:12:0:19|collector-marker".to_owned()),
+            candidate_targets: Vec::new(),
+        };
+        let mut mutations: Vec<EdgeMutation> = vec![
+            ("wrong kind", Box::new(|edge| edge.kind = EdgeKind::USAGE)),
+            ("missing certainty", Box::new(|edge| edge.certainty = None)),
+            (
+                "probable certainty",
+                Box::new(|edge| edge.certainty = Some(ResolutionCertainty::Probable)),
+            ),
+            (
+                "wrong raw source",
+                Box::new(|edge| {
+                    edge.source = NodeId(12);
+                    edge.resolved_source = None;
+                }),
+            ),
+            (
+                "wrong raw target",
+                Box::new(|edge| edge.target = NodeId(18)),
+            ),
+            (
+                "wrong effective source",
+                Box::new(|edge| edge.resolved_source = Some(NodeId(12))),
+            ),
+            (
+                "wrong resolved target",
+                Box::new(|edge| edge.resolved_target = Some(NodeId(24))),
+            ),
+            (
+                "missing resolved target",
+                Box::new(|edge| edge.resolved_target = None),
+            ),
+            (
+                "candidates present",
+                Box::new(|edge| edge.candidate_targets = vec![NodeId(23)]),
+            ),
+            ("file absent", Box::new(|edge| edge.file_node_id = None)),
+            ("line absent", Box::new(|edge| edge.line = None)),
+            ("line zero", Box::new(|edge| edge.line = Some(0))),
+        ];
+        for identity in [
+            "",
+            " ",
+            "|marker",
+            "-3:12:19",
+            "-3:12:0:19:5",
+            "x:12:0:19",
+            "-3:x:0:19",
+            "-3:12:x:19",
+            "-3:12:0:x",
+            " -3:12:0:19",
+            "-03:12:0:19",
+            "-3:012:0:19",
+            "-3:12:00:19",
+            "-3:12:0:+19",
+            "opaque-legacy-id",
+            "-3:12:0:18",
+        ] {
+            let identity = identity.to_owned();
+            mutations.push((
+                "malformed identity",
+                Box::new(move |edge| {
+                    edge.callsite_identity = Some(identity.clone());
+                }),
+            ));
+        }
+        mutations.push((
+            "identity absent",
+            Box::new(|edge| edge.callsite_identity = None),
+        ));
+
+        for (label, mutate) in mutations {
+            let mut edge = lawful.clone();
+            mutate(&mut edge);
+            assert_eq!(
+                admit_raw_call_edge(&edge, NodeId(11), NodeId(23)),
+                RawCallEdgeAdmission::Rejected,
+                "{label}"
+            );
+        }
+
+        let mut same_display_different_resolution = lawful;
+        same_display_different_resolution.resolved_target = Some(NodeId(24));
+        assert_eq!(
+            same_display_different_resolution
+                .callsite_identity
+                .as_deref(),
+            Some("-3:12:0:19|collector-marker")
+        );
+        assert_eq!(
+            admit_raw_call_edge(&same_display_different_resolution, NodeId(11), NodeId(23)),
+            RawCallEdgeAdmission::Rejected
+        );
     }
 
     #[test]

--- a/crates/codestory-agent/src/indexed_source_call_path_v1.rs
+++ b/crates/codestory-agent/src/indexed_source_call_path_v1.rs
@@ -72,6 +72,13 @@ pub struct IndexedCallEdgeReceipt {
     pub line_window: IndexedLineWindow,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InternalCorePublicationIdentity {
+    pub project_id: String,
+    pub generation_id: String,
+    pub run_id: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum FactBuildGap {
     SelectorMissing { selector_index: usize },
@@ -87,6 +94,7 @@ pub enum FactBuildGap {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BuiltCallPathFacts {
+    pub publication: InternalCorePublicationIdentity,
     pub facts: Vec<VerifiedProofFact>,
     pub receipts: Vec<IndexedCallEdgeReceipt>,
     pub gaps: Vec<FactBuildGap>,
@@ -1159,6 +1167,19 @@ fn compute_hashes(
     domain: DigestDomain<'_>,
 ) -> Result<ProofHashes, ValidationError> {
     let source_text_sha256 = sha256_hex(source_text.as_bytes());
+    let contract_digest = compute_contract_digest(&source_text_sha256, clauses, spec, domain)?;
+    Ok(ProofHashes {
+        source_text_sha256,
+        contract_digest,
+    })
+}
+
+fn compute_contract_digest(
+    source_text_sha256: &str,
+    clauses: &[NormalizedClause],
+    spec: &CallPathSpec,
+    domain: DigestDomain<'_>,
+) -> Result<String, ValidationError> {
     let digest_document = json!({
         "schema_version": domain.schema_version,
         "proof_domain": domain.proof_domain,
@@ -1172,10 +1193,7 @@ fn compute_hashes(
     let mut digest_bytes = Vec::with_capacity(DIGEST_DOMAIN_SEPARATOR.len() + canonical.len());
     digest_bytes.extend_from_slice(DIGEST_DOMAIN_SEPARATOR);
     digest_bytes.extend_from_slice(&canonical);
-    Ok(ProofHashes {
-        source_text_sha256,
-        contract_digest: sha256_hex(&digest_bytes),
-    })
+    Ok(sha256_hex(&digest_bytes))
 }
 
 fn normalized_clause_json(clause: &NormalizedClause) -> Value {
@@ -1371,6 +1389,7 @@ pub enum ProofDisposition {
     Unknown {
         contract_digest: String,
         gaps: Vec<ProofGap>,
+        connected_receipts: Vec<ReceiptRef>,
     },
     Unavailable {
         contract_digest: String,
@@ -1390,11 +1409,13 @@ pub enum Refutation {
         step_index: usize,
         extractor_capability_receipt_id: String,
         untruncated_enumeration_receipt_id: String,
+        connected_receipts: Vec<ReceiptRef>,
     },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ProofGap {
+    FactBuild(FactBuildGap),
     MissingDirectCallReceipt { step_index: usize },
     ReceiptOrEdgeAlreadyUsed { step_index: usize },
     ProjectionExclusionConflictsWithRequiredReceipt { step_index: usize },
@@ -1460,6 +1481,10 @@ pub fn check_call_path(
         return ProofDisposition::Unknown {
             contract_digest: hashes.contract_digest.clone(),
             gaps: vec![ProofGap::ProjectionExclusionConflictsWithRequiredReceipt { step_index }],
+            connected_receipts: path[..step_index]
+                .iter()
+                .map(|fact| fact.receipt.clone())
+                .collect(),
         };
     }
     let mut reachable = reachable_prefixes(contract, &direct_facts);
@@ -1520,9 +1545,20 @@ pub fn check_call_path(
         return ProofDisposition::Unknown {
             contract_digest: hashes.contract_digest.clone(),
             gaps: vec![ProofGap::ProjectionExclusionConflictsWithRequiredReceipt { step_index }],
+            connected_receipts: longest_clean_prefix(&reachable),
         };
     }
-    for state in reachable.iter().rev() {
+    let mut clean_states = reachable
+        .iter()
+        .filter(|state| state.projection_conflict_step.is_none())
+        .collect::<Vec<_>>();
+    clean_states.sort_by(|left, right| {
+        right
+            .step_index
+            .cmp(&left.step_index)
+            .then_with(|| left.connected_receipts.cmp(&right.connected_receipts))
+    });
+    for state in clean_states {
         if state.step_index >= contract.spec.steps.len() || state.projection_conflict_step.is_some()
         {
             continue;
@@ -1552,6 +1588,7 @@ pub fn check_call_path(
                     untruncated_enumeration_receipt_id: absence
                         .untruncated_enumeration_receipt_id
                         .clone(),
+                    connected_receipts: state.connected_receipts.clone(),
                 },
             };
         }
@@ -1571,6 +1608,7 @@ pub fn check_call_path(
         return ProofDisposition::Unknown {
             contract_digest: hashes.contract_digest.clone(),
             gaps: vec![ProofGap::ProjectionExclusionConflictsWithRequiredReceipt { step_index }],
+            connected_receipts: longest_clean_prefix(&reachable),
         };
     }
     let step_index = reachable
@@ -1600,6 +1638,7 @@ pub fn check_call_path(
         } else {
             ProofGap::MissingDirectCallReceipt { step_index }
         }],
+        connected_receipts: longest_clean_prefix(&reachable),
     }
 }
 
@@ -1783,22 +1822,294 @@ fn reachable_prefixes(
     all
 }
 
+fn longest_clean_prefix(states: &[PrefixState]) -> Vec<ReceiptRef> {
+    states
+        .iter()
+        .filter(|state| state.projection_conflict_step.is_none())
+        .map(|state| state.connected_receipts.clone())
+        .min_by(|left, right| right.len().cmp(&left.len()).then_with(|| left.cmp(right)))
+        .unwrap_or_default()
+}
+
 pub const INTERNAL_PROOF_CAP_BYTES: usize = 64 * 1024;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct InternalCorePublicationIdentity {
-    pub project_id: String,
-    pub generation_id: String,
-    pub run_id: String,
+pub struct CheckedBuiltCallPathIntegration {
+    contract: ValidatedCallPathContract,
+    hashes: ProofHashes,
+    rendering: ValidatedContractRendering,
+    built: BuiltCallPathFacts,
+    disposition: ProofDisposition,
+    authoritative_receipts: Vec<IndexedCallEdgeReceipt>,
 }
 
-pub struct InternalProjectionInput<'a> {
-    pub contract: &'a ValidatedCallPathContract,
-    pub hashes: &'a ProofHashes,
-    pub rendering: &'a ValidatedContractRendering,
-    pub publication: InternalCorePublicationIdentity,
-    pub disposition: &'a ProofDisposition,
-    pub receipts: &'a [IndexedCallEdgeReceipt],
+impl CheckedBuiltCallPathIntegration {
+    pub fn built_facts(&self) -> &BuiltCallPathFacts {
+        &self.built
+    }
+
+    pub fn disposition(&self) -> &ProofDisposition {
+        &self.disposition
+    }
+
+    pub fn authoritative_receipts(&self) -> &[IndexedCallEdgeReceipt] {
+        &self.authoritative_receipts
+    }
+
+    pub fn publication(&self) -> &InternalCorePublicationIdentity {
+        &self.built.publication
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CheckedIntegrationError {
+    ValidatedContractHashMismatch,
+    ContractDigestMismatch,
+    CanonicalJson(String),
+    PublicationBindingMismatch,
+    FactReceiptMismatch,
+    DuplicateFactReceipt,
+    DuplicateAuthoritativeReceipt,
+}
+
+pub fn check_built_call_path_integration(
+    contract: &ValidatedCallPathContract,
+    hashes: &ProofHashes,
+    rendering: &ValidatedContractRendering,
+    built: BuiltCallPathFacts,
+) -> Result<CheckedBuiltCallPathIntegration, CheckedIntegrationError> {
+    if hashes != &contract.bound_hashes {
+        return Err(CheckedIntegrationError::ValidatedContractHashMismatch);
+    }
+    let recomputed_digest = compute_contract_digest(
+        &hashes.source_text_sha256,
+        &rendering.normalized_clauses,
+        &contract.spec,
+        DigestDomain::default(),
+    )
+    .map_err(|error| CheckedIntegrationError::CanonicalJson(format!("{error:?}")))?;
+    if recomputed_digest != hashes.contract_digest {
+        return Err(CheckedIntegrationError::ContractDigestMismatch);
+    }
+    validate_built_publication_and_receipts(&built)?;
+
+    let disposition = integrate_built_disposition(contract, hashes, &built);
+    let authoritative_refs = authoritative_receipt_refs(&disposition);
+    let mut seen = BTreeSet::new();
+    let mut authoritative_receipts = Vec::with_capacity(authoritative_refs.len());
+    for receipt_ref in authoritative_refs {
+        if !seen.insert(receipt_ref.clone()) {
+            return Err(CheckedIntegrationError::DuplicateAuthoritativeReceipt);
+        }
+        let mut matches = built
+            .receipts
+            .iter()
+            .filter(|receipt| receipt.receipt == *receipt_ref);
+        let Some(receipt) = matches.next() else {
+            return Err(CheckedIntegrationError::FactReceiptMismatch);
+        };
+        if matches.next().is_some() {
+            return Err(CheckedIntegrationError::DuplicateFactReceipt);
+        }
+        authoritative_receipts.push(receipt.clone());
+    }
+
+    Ok(CheckedBuiltCallPathIntegration {
+        contract: contract.clone(),
+        hashes: hashes.clone(),
+        rendering: rendering.clone(),
+        built,
+        disposition,
+        authoritative_receipts,
+    })
+}
+
+fn validate_built_publication_and_receipts(
+    built: &BuiltCallPathFacts,
+) -> Result<(), CheckedIntegrationError> {
+    let publication = &built.publication;
+    if publication.project_id.is_empty()
+        || publication.generation_id.is_empty()
+        || publication.run_id.is_empty()
+    {
+        return Err(CheckedIntegrationError::PublicationBindingMismatch);
+    }
+    let direct_facts = built
+        .facts
+        .iter()
+        .filter_map(|fact| match fact {
+            VerifiedProofFact::DirectCall(fact) => Some(fact),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    for fact in &built.facts {
+        let nodes = match fact {
+            VerifiedProofFact::DirectCall(fact) => vec![&fact.source, &fact.target],
+            #[cfg(any(test, feature = "test-support"))]
+            VerifiedProofFact::CertifiedAbsence(fact) => vec![&fact.source],
+            VerifiedProofFact::Unavailable(_) => Vec::new(),
+        };
+        if nodes
+            .iter()
+            .any(|node| !node_matches_publication(node, publication))
+        {
+            return Err(CheckedIntegrationError::PublicationBindingMismatch);
+        }
+    }
+    for receipt in &built.receipts {
+        if receipt.certainty != ResolutionCertainty::Certain
+            || !node_matches_publication(&receipt.source, publication)
+            || !node_matches_publication(&receipt.target, publication)
+        {
+            return Err(CheckedIntegrationError::PublicationBindingMismatch);
+        }
+    }
+    for fact in &direct_facts {
+        let count = built
+            .receipts
+            .iter()
+            .filter(|receipt| indexed_receipt_matches_fact(receipt, fact))
+            .count();
+        match count {
+            1 => {}
+            0 => return Err(CheckedIntegrationError::FactReceiptMismatch),
+            _ => return Err(CheckedIntegrationError::DuplicateFactReceipt),
+        }
+    }
+    for receipt in &built.receipts {
+        let count = direct_facts
+            .iter()
+            .filter(|fact| indexed_receipt_matches_fact(receipt, fact))
+            .count();
+        match count {
+            1 => {}
+            0 => return Err(CheckedIntegrationError::FactReceiptMismatch),
+            _ => return Err(CheckedIntegrationError::DuplicateFactReceipt),
+        }
+    }
+    Ok(())
+}
+
+fn node_matches_publication(
+    node: &ResolvedNodeIdentity,
+    publication: &InternalCorePublicationIdentity,
+) -> bool {
+    node.pinned.project_id == publication.project_id
+        && node.pinned.core_generation_id == publication.generation_id
+        && node.pinned.core_run_id == publication.run_id
+}
+
+fn indexed_receipt_matches_fact(
+    receipt: &IndexedCallEdgeReceipt,
+    fact: &VerifiedDirectCallFact,
+) -> bool {
+    receipt.receipt == fact.receipt
+        && receipt.source == fact.source
+        && receipt.target == fact.target
+}
+
+fn integrate_built_disposition(
+    contract: &ValidatedCallPathContract,
+    hashes: &ProofHashes,
+    built: &BuiltCallPathFacts,
+) -> ProofDisposition {
+    let mut facts = built.facts.clone();
+    facts.extend(
+        built
+            .unavailable
+            .iter()
+            .cloned()
+            .map(|reason| VerifiedProofFact::Unavailable(UnavailableProofFact { reason })),
+    );
+    let raw = check_call_path(contract, hashes, &facts);
+    if matches!(
+        raw,
+        ProofDisposition::Unavailable { .. } | ProofDisposition::ContractRefuted { .. }
+    ) || built.gaps.is_empty()
+    {
+        return raw;
+    }
+
+    let (mut gaps, mut connected_receipts) = match raw {
+        ProofDisposition::ContractProven { receipts, .. } => (Vec::new(), receipts),
+        ProofDisposition::Unknown {
+            gaps,
+            connected_receipts,
+            ..
+        } => (gaps, connected_receipts),
+        _ => unreachable!("unavailable and refuted dispositions returned above"),
+    };
+    let exact_builder_gaps = built
+        .gaps
+        .iter()
+        .cloned()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let explained_steps = exact_builder_gaps
+        .iter()
+        .filter_map(|gap| fact_build_gap_step(gap, contract.spec.steps.len()))
+        .collect::<BTreeSet<_>>();
+    gaps.retain(|gap| {
+        !matches!(
+            gap,
+            ProofGap::MissingDirectCallReceipt { step_index }
+                if explained_steps.contains(step_index)
+        )
+    });
+    gaps.extend(exact_builder_gaps.into_iter().map(ProofGap::FactBuild));
+    gaps.sort();
+    gaps.dedup();
+    if let Some(first_blocked_step) = explained_steps.iter().next().copied() {
+        connected_receipts.truncate(first_blocked_step);
+    }
+    ProofDisposition::Unknown {
+        contract_digest: hashes.contract_digest.clone(),
+        gaps,
+        connected_receipts,
+    }
+}
+
+fn fact_build_gap_step(gap: &FactBuildGap, step_count: usize) -> Option<usize> {
+    match gap {
+        FactBuildGap::SelectorMissing { selector_index }
+        | FactBuildGap::SelectorAmbiguous { selector_index }
+        | FactBuildGap::NonCallableSelector { selector_index } => match selector_index {
+            0 => Some(0),
+            index if *index <= step_count => Some(index - 1),
+            _ => None,
+        },
+        FactBuildGap::DirectCallMissing { step_index }
+        | FactBuildGap::RecursiveCallNotRepresentable { step_index }
+        | FactBuildGap::SourceWindowTooLarge { step_index }
+        | FactBuildGap::InvalidUtf8 { step_index }
+        | FactBuildGap::SourceLineOutOfRange { step_index }
+        | FactBuildGap::EdgeContainmentUnproven { step_index } => Some(*step_index),
+    }
+}
+
+fn authoritative_receipt_refs(disposition: &ProofDisposition) -> &[ReceiptRef] {
+    match disposition {
+        ProofDisposition::ContractProven { receipts, .. } => receipts,
+        ProofDisposition::ContractRefuted {
+            refutation:
+                Refutation::ProhibitedScopeTraversal {
+                    connected_receipts, ..
+                },
+            ..
+        }
+        | ProofDisposition::ContractRefuted {
+            refutation:
+                Refutation::CertifiedAbsence {
+                    connected_receipts, ..
+                },
+            ..
+        } => connected_receipts,
+        ProofDisposition::Unknown {
+            connected_receipts, ..
+        } => connected_receipts,
+        ProofDisposition::Unavailable { .. } => &[],
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1816,10 +2127,6 @@ pub enum InternalProjection {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum InternalProjectionError {
-    MissingAuthoritativeReceipt {
-        receipt_id: String,
-        edge_id: String,
-    },
     Serialization(String),
     FallbackExceedsCap {
         cap_bytes: usize,
@@ -1828,17 +2135,16 @@ pub enum InternalProjectionError {
 }
 
 pub fn project_internal_call_path_result(
-    input: InternalProjectionInput<'_>,
+    integration: &CheckedBuiltCallPathIntegration,
 ) -> Result<InternalProjection, InternalProjectionError> {
-    project_internal_call_path_result_with_cap(input, INTERNAL_PROOF_CAP_BYTES)
+    project_internal_call_path_result_with_cap(integration, INTERNAL_PROOF_CAP_BYTES)
 }
 
 fn project_internal_call_path_result_with_cap(
-    input: InternalProjectionInput<'_>,
+    integration: &CheckedBuiltCallPathIntegration,
     cap_bytes: usize,
 ) -> Result<InternalProjection, InternalProjectionError> {
-    validate_authoritative_receipts(input.disposition, input.receipts)?;
-    let complete = complete_projection_json(&input);
+    let complete = complete_projection_json(integration);
     let required_complete_size = serialized_json_size(&complete)?;
     if required_complete_size <= cap_bytes {
         return Ok(InternalProjection::Complete {
@@ -1853,12 +2159,12 @@ fn project_internal_call_path_result_with_cap(
         "domain": PROOF_DOMAIN,
         "contract_interpretation": "host_supplied",
         "guard_version": CLAUSE_GUARD_VERSION,
-        "source_text_sha256": input.hashes.source_text_sha256,
-        "contract_digest": input.hashes.contract_digest,
-        "core_publication": publication_json(&input.publication),
+        "source_text_sha256": integration.hashes.source_text_sha256,
+        "contract_digest": integration.hashes.contract_digest,
+        "core_publication": publication_json(&integration.built.publication),
         "disposition": {
             "kind": "unknown",
-            "contract_digest": input.hashes.contract_digest,
+            "contract_digest": integration.hashes.contract_digest,
             "gaps": [{ "kind": "output_budget_exceeded" }],
         },
         "cap_bytes": cap_bytes,
@@ -1878,55 +2184,30 @@ fn project_internal_call_path_result_with_cap(
     })
 }
 
-fn validate_authoritative_receipts(
-    disposition: &ProofDisposition,
-    receipts: &[IndexedCallEdgeReceipt],
-) -> Result<(), InternalProjectionError> {
-    let required = match disposition {
-        ProofDisposition::ContractProven { receipts, .. } => receipts.as_slice(),
-        ProofDisposition::ContractRefuted {
-            refutation:
-                Refutation::ProhibitedScopeTraversal {
-                    connected_receipts, ..
-                },
-            ..
-        } => connected_receipts.as_slice(),
-        _ => &[],
-    };
-    for receipt in required {
-        if !receipts
-            .iter()
-            .any(|candidate| candidate.receipt == *receipt)
-        {
-            return Err(InternalProjectionError::MissingAuthoritativeReceipt {
-                receipt_id: receipt.receipt_id.clone(),
-                edge_id: receipt.edge_id.clone(),
-            });
-        }
-    }
-    Ok(())
-}
-
-fn complete_projection_json(input: &InternalProjectionInput<'_>) -> Value {
+fn complete_projection_json(integration: &CheckedBuiltCallPathIntegration) -> Value {
     json!({
         "kind": "complete",
         "schema_version": PROOF_CONTRACT_SCHEMA_VERSION,
         "domain": PROOF_DOMAIN,
         "contract_interpretation": "host_supplied",
         "guard_version": CLAUSE_GUARD_VERSION,
-        "source_text_sha256": input.hashes.source_text_sha256,
-        "contract_digest": input.hashes.contract_digest,
-        "core_publication": publication_json(&input.publication),
-        "spec": spec_json(&input.contract.spec),
-        "clauses": input
+        "source_text_sha256": integration.hashes.source_text_sha256,
+        "contract_digest": integration.hashes.contract_digest,
+        "core_publication": publication_json(&integration.built.publication),
+        "spec": spec_json(&integration.contract.spec),
+        "clauses": integration
             .rendering
             .normalized_clauses
             .iter()
             .map(normalized_clause_json)
             .collect::<Vec<_>>(),
-        "disposition": disposition_json(input.disposition),
-        "steps": step_results_json(input.contract, input.disposition),
-        "receipts": input.receipts.iter().map(indexed_receipt_json).collect::<Vec<_>>(),
+        "disposition": disposition_json(&integration.disposition),
+        "steps": step_results_json(&integration.contract, &integration.disposition),
+        "receipts": integration
+            .authoritative_receipts
+            .iter()
+            .map(indexed_receipt_json)
+            .collect::<Vec<_>>(),
     })
 }
 
@@ -1959,10 +2240,15 @@ fn disposition_json(disposition: &ProofDisposition) -> Value {
         ProofDisposition::Unknown {
             contract_digest,
             gaps,
+            connected_receipts,
         } => json!({
             "kind": "unknown",
             "contract_digest": contract_digest,
             "gaps": gaps.iter().map(proof_gap_json).collect::<Vec<_>>(),
+            "connected_receipts": connected_receipts
+                .iter()
+                .map(receipt_ref_json)
+                .collect::<Vec<_>>(),
         }),
         ProofDisposition::Unavailable {
             contract_digest,
@@ -1995,17 +2281,23 @@ fn refutation_json(refutation: &Refutation) -> Value {
             step_index,
             extractor_capability_receipt_id,
             untruncated_enumeration_receipt_id,
+            connected_receipts,
         } => json!({
             "kind": "certified_absence",
             "step_index": step_index,
             "extractor_capability_receipt_id": extractor_capability_receipt_id,
             "untruncated_enumeration_receipt_id": untruncated_enumeration_receipt_id,
+            "connected_receipts": connected_receipts
+                .iter()
+                .map(receipt_ref_json)
+                .collect::<Vec<_>>(),
         }),
     }
 }
 
 fn proof_gap_json(gap: &ProofGap) -> Value {
     match gap {
+        ProofGap::FactBuild(gap) => fact_build_gap_json(gap),
         ProofGap::MissingDirectCallReceipt { step_index } => {
             json!({ "kind": "missing_direct_call_receipt", "step_index": step_index })
         }
@@ -2016,6 +2308,39 @@ fn proof_gap_json(gap: &ProofGap) -> Value {
             "kind": "projection_exclusion_conflicts_with_required_receipt",
             "step_index": step_index,
         }),
+    }
+}
+
+fn fact_build_gap_json(gap: &FactBuildGap) -> Value {
+    match gap {
+        FactBuildGap::SelectorMissing { selector_index } => {
+            json!({ "kind": "selector_missing", "selector_index": selector_index })
+        }
+        FactBuildGap::SelectorAmbiguous { selector_index } => {
+            json!({ "kind": "selector_ambiguous", "selector_index": selector_index })
+        }
+        FactBuildGap::NonCallableSelector { selector_index } => {
+            json!({ "kind": "non_callable_selector", "selector_index": selector_index })
+        }
+        FactBuildGap::DirectCallMissing { step_index } => {
+            json!({ "kind": "direct_call_missing", "step_index": step_index })
+        }
+        FactBuildGap::RecursiveCallNotRepresentable { step_index } => json!({
+            "kind": "recursive_call_not_representable",
+            "step_index": step_index,
+        }),
+        FactBuildGap::SourceWindowTooLarge { step_index } => {
+            json!({ "kind": "source_window_too_large", "step_index": step_index })
+        }
+        FactBuildGap::InvalidUtf8 { step_index } => {
+            json!({ "kind": "invalid_utf8", "step_index": step_index })
+        }
+        FactBuildGap::SourceLineOutOfRange { step_index } => {
+            json!({ "kind": "source_line_out_of_range", "step_index": step_index })
+        }
+        FactBuildGap::EdgeContainmentUnproven { step_index } => {
+            json!({ "kind": "edge_containment_unproven", "step_index": step_index })
+        }
     }
 }
 
@@ -2032,36 +2357,70 @@ fn step_results_json(
     contract: &ValidatedCallPathContract,
     disposition: &ProofDisposition,
 ) -> Vec<Value> {
-    let receipts = match disposition {
-        ProofDisposition::ContractProven { receipts, .. } => receipts.as_slice(),
-        ProofDisposition::ContractRefuted {
-            refutation:
-                Refutation::ProhibitedScopeTraversal {
-                    connected_receipts, ..
-                },
-            ..
-        } => connected_receipts.as_slice(),
-        _ => &[],
-    };
     contract
         .spec
         .steps
         .iter()
         .enumerate()
         .map(|(step_index, step)| {
-            let status = match disposition {
-                ProofDisposition::ContractProven { .. } => "proven",
-                ProofDisposition::ContractRefuted { .. } if step_index < receipts.len() => {
-                    "positive_contradiction"
+            let (status, receipt) = match disposition {
+                ProofDisposition::ContractProven { receipts, .. } => {
+                    ("proven", receipts.get(step_index))
                 }
-                ProofDisposition::Unavailable { .. } => "unavailable",
-                _ => "unknown",
+                ProofDisposition::Unknown {
+                    connected_receipts, ..
+                } if step_index < connected_receipts.len() => {
+                    ("proven", connected_receipts.get(step_index))
+                }
+                ProofDisposition::ContractRefuted {
+                    refutation:
+                        Refutation::ProhibitedScopeTraversal {
+                            step_index: refutation_step,
+                            connected_receipts,
+                            ..
+                        },
+                    ..
+                } if step_index < *refutation_step => {
+                    ("proven", connected_receipts.get(step_index))
+                }
+                ProofDisposition::ContractRefuted {
+                    refutation:
+                        Refutation::ProhibitedScopeTraversal {
+                            step_index: refutation_step,
+                            connected_receipts,
+                            ..
+                        },
+                    ..
+                } if step_index == *refutation_step => {
+                    ("positive_contradiction", connected_receipts.get(step_index))
+                }
+                #[cfg(any(test, feature = "test-support"))]
+                ProofDisposition::ContractRefuted {
+                    refutation:
+                        Refutation::CertifiedAbsence {
+                            step_index: absence_step,
+                            connected_receipts,
+                            ..
+                        },
+                    ..
+                } if step_index < *absence_step => ("proven", connected_receipts.get(step_index)),
+                #[cfg(any(test, feature = "test-support"))]
+                ProofDisposition::ContractRefuted {
+                    refutation:
+                        Refutation::CertifiedAbsence {
+                            step_index: absence_step,
+                            ..
+                        },
+                    ..
+                } if step_index == *absence_step => ("certified_absence", None),
+                ProofDisposition::Unavailable { .. } => ("unavailable", None),
+                _ => ("unknown", None),
             };
             json!({
                 "step_index": step_index,
                 "target": symbol_selector_json(&step.target),
                 "status": status,
-                "receipt": receipts.get(step_index).map(receipt_ref_json),
+                "receipt": receipt.map(receipt_ref_json),
             })
         })
         .collect()
@@ -2269,6 +2628,403 @@ mod tests {
         }
     }
 
+    fn publication() -> InternalCorePublicationIdentity {
+        InternalCorePublicationIdentity {
+            project_id: "project".to_owned(),
+            generation_id: "generation".to_owned(),
+            run_id: "run".to_owned(),
+        }
+    }
+
+    fn built_from_receipts(
+        receipts: Vec<IndexedCallEdgeReceipt>,
+        gaps: Vec<FactBuildGap>,
+        unavailable: Vec<UnavailableReason>,
+    ) -> BuiltCallPathFacts {
+        let facts = receipts
+            .iter()
+            .map(|receipt| {
+                VerifiedProofFact::DirectCall(VerifiedDirectCallFact {
+                    receipt: receipt.receipt.clone(),
+                    source: receipt.source.clone(),
+                    target: receipt.target.clone(),
+                })
+            })
+            .collect();
+        BuiltCallPathFacts {
+            publication: publication(),
+            facts,
+            receipts,
+            gaps,
+            unavailable,
+        }
+    }
+
+    fn validated_with_policies(
+        targets: &[&str],
+        prohibitions: &[&str],
+        exclusions: &[&str],
+    ) -> (
+        ValidatedCallPathContract,
+        ProofHashes,
+        ValidatedContractRendering,
+    ) {
+        let mut input = valid_input(targets);
+        input.spec.prohibit_traversal_through = prohibitions
+            .iter()
+            .map(|scope| canonical_scope(scope))
+            .collect();
+        input.spec.exclude_from_projection = exclusions
+            .iter()
+            .map(|scope| canonical_scope(scope))
+            .collect();
+        for (index, _) in prohibitions.iter().enumerate() {
+            input.clauses.push(ClauseAnchor {
+                clause_id: format!("prohibition-{index}"),
+                start: 0,
+                end: input.source_text.len(),
+                quote: input.source_text.clone(),
+                classification: ClauseClassification::ResolvedMaterial {
+                    fields: vec![ProofContractField::TraversalProhibition {
+                        index: u8::try_from(index).unwrap(),
+                    }],
+                },
+            });
+        }
+        for (index, _) in exclusions.iter().enumerate() {
+            input.clauses.push(ClauseAnchor {
+                clause_id: format!("exclusion-{index}"),
+                start: 0,
+                end: input.source_text.len(),
+                quote: input.source_text.clone(),
+                classification: ClauseClassification::ResolvedMaterial {
+                    fields: vec![ProofContractField::ProjectionExclusion {
+                        index: u8::try_from(index).unwrap(),
+                    }],
+                },
+            });
+        }
+        match validate_contract(input).unwrap() {
+            ValidationOutcome::Validated {
+                contract,
+                hashes,
+                rendering,
+            } => (*contract, hashes, rendering),
+            other => panic!("expected validated contract, got {other:?}"),
+        }
+    }
+
+    fn checked_integration(
+        contract: &ValidatedCallPathContract,
+        hashes: &ProofHashes,
+        rendering: &ValidatedContractRendering,
+        built: BuiltCallPathFacts,
+    ) -> CheckedBuiltCallPathIntegration {
+        check_built_call_path_integration(contract, hashes, rendering, built).unwrap()
+    }
+
+    #[test]
+    fn checked_integration_preserves_all_builder_gaps_exactly_and_unavailable_wins() {
+        let (contract, hashes, rendering) = validate_for_projection(&["B"]);
+        let receipt = indexed_receipt(0, "A", "B", "A calls B();\n".to_owned());
+        let all_gaps = vec![
+            FactBuildGap::EdgeContainmentUnproven { step_index: 0 },
+            FactBuildGap::SelectorMissing { selector_index: 0 },
+            FactBuildGap::InvalidUtf8 { step_index: 0 },
+            FactBuildGap::SelectorAmbiguous { selector_index: 1 },
+            FactBuildGap::DirectCallMissing { step_index: 0 },
+            FactBuildGap::NonCallableSelector { selector_index: 1 },
+            FactBuildGap::SourceLineOutOfRange { step_index: 0 },
+            FactBuildGap::RecursiveCallNotRepresentable { step_index: 0 },
+            FactBuildGap::SourceWindowTooLarge { step_index: 0 },
+            FactBuildGap::DirectCallMissing { step_index: 0 },
+        ];
+        let integrated = checked_integration(
+            &contract,
+            &hashes,
+            &rendering,
+            built_from_receipts(vec![receipt.clone()], all_gaps.clone(), Vec::new()),
+        );
+        assert_eq!(
+            integrated.disposition(),
+            &ProofDisposition::Unknown {
+                contract_digest: hashes.contract_digest().to_owned(),
+                connected_receipts: Vec::new(),
+                gaps: vec![
+                    ProofGap::FactBuild(FactBuildGap::SelectorMissing { selector_index: 0 }),
+                    ProofGap::FactBuild(FactBuildGap::SelectorAmbiguous { selector_index: 1 }),
+                    ProofGap::FactBuild(FactBuildGap::NonCallableSelector { selector_index: 1 }),
+                    ProofGap::FactBuild(FactBuildGap::DirectCallMissing { step_index: 0 }),
+                    ProofGap::FactBuild(FactBuildGap::RecursiveCallNotRepresentable {
+                        step_index: 0,
+                    }),
+                    ProofGap::FactBuild(FactBuildGap::SourceWindowTooLarge { step_index: 0 }),
+                    ProofGap::FactBuild(FactBuildGap::InvalidUtf8 { step_index: 0 }),
+                    ProofGap::FactBuild(FactBuildGap::SourceLineOutOfRange { step_index: 0 }),
+                    ProofGap::FactBuild(FactBuildGap::EdgeContainmentUnproven { step_index: 0 }),
+                ],
+            }
+        );
+
+        let unavailable = checked_integration(
+            &contract,
+            &hashes,
+            &rendering,
+            built_from_receipts(
+                vec![receipt],
+                all_gaps,
+                vec![UnavailableReason::SourceNotBoundToPublication],
+            ),
+        );
+        assert_eq!(
+            unavailable.disposition(),
+            &ProofDisposition::Unavailable {
+                contract_digest: hashes.contract_digest().to_owned(),
+                reasons: vec![UnavailableReason::SourceNotBoundToPublication],
+            }
+        );
+        assert!(unavailable.authoritative_receipts().is_empty());
+    }
+
+    #[test]
+    fn unknown_projection_keeps_the_longest_clean_prefix_and_exact_gap_only() {
+        let (contract, hashes, rendering) = validate_for_projection(&["B", "C", "D"]);
+        let r0 = indexed_receipt(0, "A", "B", "A calls B();\n".to_owned());
+        let r1 = indexed_receipt(1, "B", "C", "B calls C();\n".to_owned());
+        let unused = indexed_receipt(9, "X", "Y", "X calls Y();\n".to_owned());
+        let integrated = checked_integration(
+            &contract,
+            &hashes,
+            &rendering,
+            built_from_receipts(
+                vec![r0.clone(), r1.clone(), unused],
+                vec![FactBuildGap::DirectCallMissing { step_index: 2 }],
+                Vec::new(),
+            ),
+        );
+        assert_eq!(
+            integrated.disposition(),
+            &ProofDisposition::Unknown {
+                contract_digest: hashes.contract_digest().to_owned(),
+                connected_receipts: vec![r0.receipt.clone(), r1.receipt.clone()],
+                gaps: vec![ProofGap::FactBuild(FactBuildGap::DirectCallMissing {
+                    step_index: 2,
+                })],
+            }
+        );
+        let InternalProjection::Complete { root, .. } =
+            project_internal_call_path_result(&integrated).unwrap()
+        else {
+            panic!("small checked integration fits")
+        };
+        assert_eq!(
+            root["steps"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|step| step["status"].as_str().unwrap())
+                .collect::<Vec<_>>(),
+            ["proven", "proven", "unknown"]
+        );
+        assert_eq!(
+            root["disposition"]["gaps"],
+            json!([{ "kind": "direct_call_missing", "step_index": 2 }])
+        );
+        assert_eq!(
+            root["receipts"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|receipt| receipt["receipt"]["receipt_id"].as_str().unwrap())
+                .collect::<Vec<_>>(),
+            ["receipt-0", "receipt-1"]
+        );
+    }
+
+    #[test]
+    fn unknown_prefix_ties_choose_the_smallest_receipt_sequence() {
+        let (contract, hashes) = validate(&["B", "C"]);
+        let facts = [
+            call("receipt-b", "edge-a", "A", "B"),
+            call("receipt-a", "edge-z", "A", "B"),
+        ];
+        assert_eq!(
+            check_call_path(&contract, &hashes, &facts),
+            ProofDisposition::Unknown {
+                contract_digest: hashes.contract_digest().to_owned(),
+                gaps: vec![ProofGap::MissingDirectCallReceipt { step_index: 1 }],
+                connected_receipts: vec![ReceiptRef {
+                    receipt_id: "receipt-a".to_owned(),
+                    edge_id: "edge-z".to_owned(),
+                }],
+            }
+        );
+    }
+
+    #[test]
+    fn prohibited_projection_marks_only_the_refuting_step_and_drops_later_candidates() {
+        let (contract, hashes, rendering) = validated_with_policies(&["B", "C", "D"], &["C"], &[]);
+        let r0 = indexed_receipt(0, "A", "B", "A calls B();\n".to_owned());
+        let r1 = indexed_receipt(1, "B", "C", "B calls C();\n".to_owned());
+        let later = indexed_receipt(2, "C", "D", "C calls D();\n".to_owned());
+        let integrated = checked_integration(
+            &contract,
+            &hashes,
+            &rendering,
+            built_from_receipts(vec![r0, r1, later], Vec::new(), Vec::new()),
+        );
+        let InternalProjection::Complete { root, .. } =
+            project_internal_call_path_result(&integrated).unwrap()
+        else {
+            panic!("small checked integration fits")
+        };
+        assert_eq!(
+            root["steps"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|step| step["status"].as_str().unwrap())
+                .collect::<Vec<_>>(),
+            ["proven", "positive_contradiction", "unknown"]
+        );
+        assert_eq!(
+            root["receipts"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|receipt| receipt["receipt"]["receipt_id"].as_str().unwrap())
+                .collect::<Vec<_>>(),
+            ["receipt-0", "receipt-1"]
+        );
+    }
+
+    #[test]
+    fn certified_absence_projection_keeps_only_the_proven_prefix_receipts() {
+        let (contract, hashes, rendering) = validate_for_projection(&["B", "C", "D"]);
+        let r0 = indexed_receipt(0, "A", "B", "A calls B();\n".to_owned());
+        let r1 = indexed_receipt(1, "B", "C", "B calls C();\n".to_owned());
+        let unused = indexed_receipt(9, "X", "Y", "X calls Y();\n".to_owned());
+        let mut built = built_from_receipts(vec![r0, r1, unused], Vec::new(), Vec::new());
+        built
+            .facts
+            .push(VerifiedProofFact::CertifiedAbsence(CertifiedAbsenceFact {
+                source: node("C"),
+                expected_target: ExactSymbolSelector::CanonicalId("D".to_owned()),
+                extractor_capability_receipt_id: "capability".to_owned(),
+                untruncated_enumeration_receipt_id: "enumeration".to_owned(),
+            }));
+        let integrated = checked_integration(&contract, &hashes, &rendering, built);
+        assert!(matches!(
+            integrated.disposition(),
+            ProofDisposition::ContractRefuted {
+                refutation: Refutation::CertifiedAbsence {
+                    step_index: 2,
+                    connected_receipts,
+                    ..
+                },
+                ..
+            } if connected_receipts.iter().map(|receipt| receipt.receipt_id.as_str()).collect::<Vec<_>>() == ["receipt-0", "receipt-1"]
+        ));
+        let InternalProjection::Complete { root, .. } =
+            project_internal_call_path_result(&integrated).unwrap()
+        else {
+            panic!("small checked integration fits")
+        };
+        assert_eq!(
+            root["steps"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|step| step["status"].as_str().unwrap())
+                .collect::<Vec<_>>(),
+            ["proven", "proven", "certified_absence"]
+        );
+        assert_eq!(
+            root["receipts"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|receipt| receipt["receipt"]["receipt_id"].as_str().unwrap())
+                .collect::<Vec<_>>(),
+            ["receipt-0", "receipt-1"]
+        );
+    }
+
+    #[test]
+    fn checked_integration_rejects_every_mixable_projection_binding() {
+        type CheckedBoundary =
+            fn(
+                &ValidatedCallPathContract,
+                &ProofHashes,
+                &ValidatedContractRendering,
+                BuiltCallPathFacts,
+            ) -> Result<CheckedBuiltCallPathIntegration, CheckedIntegrationError>;
+        type ProjectionBoundary = fn(
+            &CheckedBuiltCallPathIntegration,
+        )
+            -> Result<InternalProjection, InternalProjectionError>;
+        let _checked_boundary: CheckedBoundary = check_built_call_path_integration;
+        let _projection_boundary: ProjectionBoundary = project_internal_call_path_result;
+
+        let (contract, hashes, rendering) = validate_for_projection(&["B"]);
+        let receipt = indexed_receipt(0, "A", "B", "A calls B();\n".to_owned());
+
+        let mut foreign_input = valid_input(&["B"]);
+        foreign_input.source_text.push('!');
+        for clause in &mut foreign_input.clauses {
+            clause.end += 1;
+            clause.quote.push('!');
+        }
+        let foreign_rendering = match validate_contract(foreign_input).unwrap() {
+            ValidationOutcome::Validated { rendering, .. } => rendering,
+            other => panic!("expected validated foreign rendering, got {other:?}"),
+        };
+        assert!(matches!(
+            check_built_call_path_integration(
+                &contract,
+                &hashes,
+                &foreign_rendering,
+                built_from_receipts(vec![receipt.clone()], Vec::new(), Vec::new()),
+            ),
+            Err(CheckedIntegrationError::ContractDigestMismatch)
+        ));
+
+        let mut forged_hashes = hashes.clone();
+        forged_hashes.contract_digest = "forged".to_owned();
+        assert!(matches!(
+            check_built_call_path_integration(
+                &contract,
+                &forged_hashes,
+                &rendering,
+                built_from_receipts(vec![receipt.clone()], Vec::new(), Vec::new()),
+            ),
+            Err(CheckedIntegrationError::ValidatedContractHashMismatch)
+        ));
+
+        let mut wrong_publication =
+            built_from_receipts(vec![receipt.clone()], Vec::new(), Vec::new());
+        wrong_publication.publication.run_id = "other-run".to_owned();
+        assert!(matches!(
+            check_built_call_path_integration(&contract, &hashes, &rendering, wrong_publication,),
+            Err(CheckedIntegrationError::PublicationBindingMismatch)
+        ));
+
+        let mut mismatched_receipt =
+            built_from_receipts(vec![receipt.clone()], Vec::new(), Vec::new());
+        mismatched_receipt.receipts[0].receipt.edge_id = "other-edge".to_owned();
+        assert!(matches!(
+            check_built_call_path_integration(&contract, &hashes, &rendering, mismatched_receipt,),
+            Err(CheckedIntegrationError::FactReceiptMismatch)
+        ));
+
+        let mut duplicate = built_from_receipts(vec![receipt], Vec::new(), Vec::new());
+        duplicate.receipts.push(duplicate.receipts[0].clone());
+        assert!(matches!(
+            check_built_call_path_integration(&contract, &hashes, &rendering, duplicate),
+            Err(CheckedIntegrationError::DuplicateFactReceipt)
+        ));
+    }
+
     fn six_step_projection_fixture(
         texts: Vec<String>,
     ) -> (
@@ -2276,7 +3032,6 @@ mod tests {
         ProofHashes,
         ValidatedContractRendering,
         Vec<IndexedCallEdgeReceipt>,
-        ProofDisposition,
     ) {
         assert_eq!(texts.len(), 6);
         let names = ["A", "B", "C", "D", "E", "F", "G"];
@@ -2290,37 +3045,20 @@ mod tests {
             receipt.line_window.byte_start = 0;
             receipt.line_window.byte_end = MAX_SOURCE_RECEIPT_LINE_BYTES;
         }
-        let disposition = ProofDisposition::ContractProven {
-            contract_digest: hashes.contract_digest().to_owned(),
-            receipts: receipts
-                .iter()
-                .map(|receipt| receipt.receipt.clone())
-                .collect(),
-        };
-        (contract, hashes, rendering, receipts, disposition)
+        (contract, hashes, rendering, receipts)
     }
 
     #[test]
     fn internal_projection_is_a_complete_tagged_root_with_every_authoritative_receipt() {
         let (contract, hashes, rendering) = validate_for_projection(&["B"]);
         let receipts = vec![indexed_receipt(0, "A", "B", "A calls B();\n".to_owned())];
-        let disposition = ProofDisposition::ContractProven {
-            contract_digest: hashes.contract_digest().to_owned(),
-            receipts: vec![receipts[0].receipt.clone()],
-        };
-        let projected = project_internal_call_path_result(InternalProjectionInput {
-            contract: &contract,
-            hashes: &hashes,
-            rendering: &rendering,
-            publication: InternalCorePublicationIdentity {
-                project_id: "project".to_owned(),
-                generation_id: "generation".to_owned(),
-                run_id: "run".to_owned(),
-            },
-            disposition: &disposition,
-            receipts: &receipts,
-        })
-        .unwrap();
+        let integration = checked_integration(
+            &contract,
+            &hashes,
+            &rendering,
+            built_from_receipts(receipts, Vec::new(), Vec::new()),
+        );
+        let projected = project_internal_call_path_result(&integration).unwrap();
 
         let InternalProjection::Complete {
             root,
@@ -2341,24 +3079,16 @@ mod tests {
 
     #[test]
     fn internal_projection_accepts_exactly_64_kib_and_replaces_64_kib_plus_one_whole() {
-        let (contract, hashes, rendering, mut receipts, mut disposition) =
+        let (contract, hashes, rendering, mut receipts) =
             six_step_projection_fixture(vec![String::new(); 6]);
-        let baseline = project_internal_call_path_result_with_cap(
-            InternalProjectionInput {
-                contract: &contract,
-                hashes: &hashes,
-                rendering: &rendering,
-                publication: InternalCorePublicationIdentity {
-                    project_id: "project".to_owned(),
-                    generation_id: "generation".to_owned(),
-                    run_id: "run".to_owned(),
-                },
-                disposition: &disposition,
-                receipts: &receipts,
-            },
-            usize::MAX,
-        )
-        .unwrap();
+        let baseline_integration = checked_integration(
+            &contract,
+            &hashes,
+            &rendering,
+            built_from_receipts(receipts.clone(), Vec::new(), Vec::new()),
+        );
+        let baseline =
+            project_internal_call_path_result_with_cap(&baseline_integration, usize::MAX).unwrap();
         let InternalProjection::Complete {
             serialized_size: baseline_size,
             ..
@@ -2378,19 +3108,13 @@ mod tests {
         }
         assert_eq!(remaining, 0, "six bounded lines can reach the exact cap");
 
-        let exact = project_internal_call_path_result(InternalProjectionInput {
-            contract: &contract,
-            hashes: &hashes,
-            rendering: &rendering,
-            publication: InternalCorePublicationIdentity {
-                project_id: "project".to_owned(),
-                generation_id: "generation".to_owned(),
-                run_id: "run".to_owned(),
-            },
-            disposition: &disposition,
-            receipts: &receipts,
-        })
-        .unwrap();
+        let exact_integration = checked_integration(
+            &contract,
+            &hashes,
+            &rendering,
+            built_from_receipts(receipts.clone(), Vec::new(), Vec::new()),
+        );
+        let exact = project_internal_call_path_result(&exact_integration).unwrap();
         assert!(matches!(
             exact,
             InternalProjection::Complete {
@@ -2406,31 +3130,13 @@ mod tests {
             .line_window
             .text
             .push('x');
-        let required_receipts = receipts
-            .iter()
-            .map(|receipt| receipt.receipt.clone())
-            .collect::<Vec<_>>();
-        let ProofDisposition::ContractProven {
-            receipts: disposition_receipts,
-            ..
-        } = &mut disposition
-        else {
-            unreachable!()
-        };
-        *disposition_receipts = required_receipts;
-        let plus_one = project_internal_call_path_result(InternalProjectionInput {
-            contract: &contract,
-            hashes: &hashes,
-            rendering: &rendering,
-            publication: InternalCorePublicationIdentity {
-                project_id: "project".to_owned(),
-                generation_id: "generation".to_owned(),
-                run_id: "run".to_owned(),
-            },
-            disposition: &disposition,
-            receipts: &receipts,
-        })
-        .unwrap();
+        let plus_one_integration = checked_integration(
+            &contract,
+            &hashes,
+            &rendering,
+            built_from_receipts(receipts, Vec::new(), Vec::new()),
+        );
+        let plus_one = project_internal_call_path_result(&plus_one_integration).unwrap();
         let InternalProjection::BudgetExceeded {
             root,
             required_complete_size,
@@ -2461,67 +3167,33 @@ mod tests {
         let escape_heavy = escape_unit.repeat(MAX_SOURCE_RECEIPT_LINE_BYTES / escape_unit.len());
         assert!(escape_heavy.len() <= MAX_SOURCE_RECEIPT_LINE_BYTES);
         assert!(escape_heavy.contains('é'));
-        let (contract, hashes, rendering, receipts, disposition) =
+        let (contract, hashes, rendering, receipts) =
             six_step_projection_fixture(vec![escape_heavy; 6]);
-        let projected = project_internal_call_path_result(InternalProjectionInput {
-            contract: &contract,
-            hashes: &hashes,
-            rendering: &rendering,
-            publication: InternalCorePublicationIdentity {
-                project_id: "project".to_owned(),
-                generation_id: "generation".to_owned(),
-                run_id: "run".to_owned(),
-            },
-            disposition: &disposition,
-            receipts: &receipts,
-        })
-        .unwrap();
+        let integration = checked_integration(
+            &contract,
+            &hashes,
+            &rendering,
+            built_from_receipts(receipts, Vec::new(), Vec::new()),
+        );
+        let projected = project_internal_call_path_result(&integration).unwrap();
         let InternalProjection::BudgetExceeded { root, .. } = projected else {
             panic!("escaped receipt JSON must be measured after escaping")
         };
         assert!(root.get("receipts").is_none());
         assert!(root.get("steps").is_none());
-
-        let mut missing = receipts.clone();
-        let omitted = missing.pop().unwrap();
-        assert_eq!(
-            project_internal_call_path_result(InternalProjectionInput {
-                contract: &contract,
-                hashes: &hashes,
-                rendering: &rendering,
-                publication: InternalCorePublicationIdentity {
-                    project_id: "project".to_owned(),
-                    generation_id: "generation".to_owned(),
-                    run_id: "run".to_owned(),
-                },
-                disposition: &disposition,
-                receipts: &missing,
-            }),
-            Err(InternalProjectionError::MissingAuthoritativeReceipt {
-                receipt_id: omitted.receipt.receipt_id,
-                edge_id: omitted.receipt.edge_id,
-            })
-        );
     }
 
     #[test]
     fn six_maximum_lines_are_kept_complete_or_replaced_as_one_and_tiny_fallbacks_error() {
         let maximum = "x".repeat(MAX_SOURCE_RECEIPT_LINE_BYTES);
-        let (contract, hashes, rendering, receipts, disposition) =
-            six_step_projection_fixture(vec![maximum; 6]);
-        let projected = project_internal_call_path_result(InternalProjectionInput {
-            contract: &contract,
-            hashes: &hashes,
-            rendering: &rendering,
-            publication: InternalCorePublicationIdentity {
-                project_id: "project".to_owned(),
-                generation_id: "generation".to_owned(),
-                run_id: "run".to_owned(),
-            },
-            disposition: &disposition,
-            receipts: &receipts,
-        })
-        .unwrap();
+        let (contract, hashes, rendering, receipts) = six_step_projection_fixture(vec![maximum; 6]);
+        let integration = checked_integration(
+            &contract,
+            &hashes,
+            &rendering,
+            built_from_receipts(receipts, Vec::new(), Vec::new()),
+        );
+        let projected = project_internal_call_path_result(&integration).unwrap();
         match projected {
             InternalProjection::Complete {
                 root,
@@ -2537,21 +3209,7 @@ mod tests {
         }
 
         assert!(matches!(
-            project_internal_call_path_result_with_cap(
-                InternalProjectionInput {
-                    contract: &contract,
-                    hashes: &hashes,
-                    rendering: &rendering,
-                    publication: InternalCorePublicationIdentity {
-                        project_id: "project".to_owned(),
-                        generation_id: "generation".to_owned(),
-                        run_id: "run".to_owned(),
-                    },
-                    disposition: &disposition,
-                    receipts: &receipts,
-                },
-                1,
-            ),
+            project_internal_call_path_result_with_cap(&integration, 1),
             Err(InternalProjectionError::FallbackExceedsCap { cap_bytes: 1, .. })
         ));
     }

--- a/crates/codestory-agent/src/lib.rs
+++ b/crates/codestory-agent/src/lib.rs
@@ -16,6 +16,9 @@
 pub mod citation;
 #[cfg(any(test, feature = "test-support"))]
 pub mod eval_probes;
+#[cfg(any(test, feature = "test-support"))]
+#[doc(hidden)]
+pub mod indexed_source_call_path_v1;
 pub mod packet_citations;
 pub mod packet_claim_profile_registry;
 pub mod packet_claim_profiles;

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -629,7 +629,9 @@ fn dark_call_path_kernel_stays_on_the_test_support_side_of_the_crate_root() {
         ),
         "the dark Store/source adapter must remain test-support-only until the atomic v3 cut"
     );
-    let adapter = read("crates/codestory-runtime/src/indexed_source_call_path_v1.rs");
+    let adapter = production_source(&read(
+        "crates/codestory-runtime/src/indexed_source_call_path_v1.rs",
+    ));
     for forbidden in [
         "GraphEdgeDto",
         "with_effective_endpoints",
@@ -667,6 +669,108 @@ fn dark_call_path_raw_source_text_stays_out_of_the_proof_boundary() {
     assert!(
         !contains_word(&outside_allowed_regions, "source_text"),
         "raw source_text must stay confined to unvalidated input, clause validation, translation diagnostics, and hashing; it must not enter validated specs/contracts, verified facts, selector matching, path search/checking, ranking, search, or source matching:\n{outside_allowed_regions}"
+    );
+}
+
+fn dark_call_path_release_surface_violations() -> Vec<String> {
+    const DARK_TOKENS: [&str; 6] = [
+        "indexed_source_call_path_v1",
+        "ValidatedCallPathContract",
+        "InternalProjection",
+        "InternalCorePublicationIdentity",
+        "IntegratedProjectedCallPathResult",
+        "output_budget_exceeded",
+    ];
+    let mut surfaces = vec![
+        (
+            "cli command/dispatcher/ToolSpec/HTTP/serializer source",
+            read_source_tree("crates/codestory-cli/src"),
+        ),
+        (
+            "public API DTO source",
+            format!(
+                "{}\n{}",
+                read("crates/codestory-contracts/src/api.rs"),
+                read_source_tree("crates/codestory-contracts/src/api")
+            ),
+        ),
+        (
+            "generated MCP catalog",
+            read("plugins/codestory/generated-mcp-catalog.json"),
+        ),
+        ("plugin manifest", read("plugins/codestory/plugin.json")),
+        (
+            "Codex plugin manifest",
+            read("plugins/codestory/.codex-plugin/plugin.json"),
+        ),
+        (
+            "Cursor plugin manifest",
+            read("plugins/codestory/.cursor-plugin/plugin.json"),
+        ),
+        (
+            "Claude plugin manifest",
+            read("plugins/codestory/.claude-plugin/plugin.json"),
+        ),
+        (
+            "grounding skill syntax",
+            read("plugins/codestory/skills/codestory-grounding/SKILL.md"),
+        ),
+        (
+            "generated MCP skill syntax",
+            read("plugins/codestory/skills/codestory-grounding/references/generated-mcp-syntax.md"),
+        ),
+    ];
+    let gate = "#[cfg(any(test, feature = \"test-support\"))]\nmod indexed_source_call_path_v1;";
+    let runtime_facade = read("crates/codestory-runtime/src/lib.rs").replace(gate, "");
+    surfaces.push(("public runtime facade", runtime_facade));
+    surfaces.push((
+        "public runtime services",
+        production_source(&read("crates/codestory-runtime/src/services.rs")),
+    ));
+
+    let mut violations = Vec::new();
+    for (surface, source) in surfaces {
+        for token in DARK_TOKENS {
+            if source.contains(token) {
+                violations.push(format!("{surface}: {token}"));
+            }
+        }
+    }
+
+    let adapter = production_source(&read(
+        "crates/codestory-runtime/src/indexed_source_call_path_v1.rs",
+    ));
+    if contains_word(&adapter, "source_text") {
+        violations.push("dark runtime adapter: raw source_text".to_owned());
+    }
+
+    for consumer in [
+        "crates/codestory-runtime/Cargo.toml",
+        "crates/codestory-cli/Cargo.toml",
+        "crates/codestory-bench/Cargo.toml",
+    ] {
+        let consumer_manifest = manifest(consumer);
+        let features = consumer_manifest
+            .get("dependencies")
+            .and_then(|table| table.get("codestory-agent"))
+            .and_then(|entry| entry.get("features"))
+            .and_then(Value::as_array)
+            .map(|values| values.iter().filter_map(Value::as_str).collect::<Vec<_>>())
+            .unwrap_or_default();
+        if features.contains(&"test-support") {
+            violations.push(format!("{consumer}: ships codestory-agent/test-support"));
+        }
+    }
+    violations
+}
+
+#[test]
+fn dark_call_path_release_surfaces_remain_v2_only_and_test_support_unshipped() {
+    let violations = dark_call_path_release_surface_violations();
+    assert!(
+        violations.is_empty(),
+        "dark v3 call-path symbols reached a production route, DTO, serializer, manifest, skill, or shipping feature edge:\n{}",
+        violations.join("\n")
     );
 }
 

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -241,6 +241,29 @@ fn source_between<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
     &tail[..end_index]
 }
 
+fn redact_braced_rust_item(source: &mut String, header: &str) {
+    let masked = mask_comments_and_strings(source);
+    let start = masked.find(header).expect("item header exists");
+    let open = start + masked[start..].find('{').expect("item body starts");
+    let mut depth = 0_usize;
+    let mut end = None;
+    for (offset, byte) in masked.as_bytes()[open..].iter().enumerate() {
+        match byte {
+            b'{' => depth += 1,
+            b'}' => {
+                depth -= 1;
+                if depth == 0 {
+                    end = Some(open + offset + 1);
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+    let end = end.expect("item body closes");
+    source.replace_range(start..end, &" ".repeat(end - start));
+}
+
 #[test]
 fn cli_sidecar_construction_stays_behind_test_safe_gateway() {
     let source_root = repo_root().join("crates/codestory-cli/src");
@@ -597,6 +620,28 @@ fn dark_call_path_kernel_stays_on_the_test_support_side_of_the_crate_root() {
     assert!(
         AGENT_MODULE_ALLOWLIST_EXCLUSIONS.contains(&"indexed_source_call_path_v1.rs"),
         "the dark proof kernel must not be counted as a production packet-planning module"
+    );
+}
+
+#[test]
+fn dark_call_path_raw_source_text_stays_out_of_the_proof_boundary() {
+    let module = production_source(&read(
+        "crates/codestory-agent/src/indexed_source_call_path_v1.rs",
+    ));
+    let mut outside_allowed_regions = module.clone();
+    for item in [
+        "pub struct UnvalidatedCallPathContract",
+        "impl UnvalidatedCallPathContract",
+        "fn validate_contract_with_domain",
+        "fn validate_and_normalize_clauses",
+        "fn classify_translation_gaps",
+        "fn compute_hashes",
+    ] {
+        redact_braced_rust_item(&mut outside_allowed_regions, item);
+    }
+    assert!(
+        !contains_word(&outside_allowed_regions, "source_text"),
+        "raw source_text must stay confined to unvalidated input, clause validation, translation diagnostics, and hashing; it must not enter validated specs/contracts, verified facts, selector matching, path search/checking, ranking, search, or source matching:\n{outside_allowed_regions}"
     );
 }
 

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -621,6 +621,31 @@ fn dark_call_path_kernel_stays_on_the_test_support_side_of_the_crate_root() {
         AGENT_MODULE_ALLOWLIST_EXCLUSIONS.contains(&"indexed_source_call_path_v1.rs"),
         "the dark proof kernel must not be counted as a production packet-planning module"
     );
+
+    let runtime_lib = read("crates/codestory-runtime/src/lib.rs");
+    assert!(
+        runtime_lib.contains(
+            "#[cfg(any(test, feature = \"test-support\"))]\nmod indexed_source_call_path_v1;"
+        ),
+        "the dark Store/source adapter must remain test-support-only until the atomic v3 cut"
+    );
+    let adapter = read("crates/codestory-runtime/src/indexed_source_call_path_v1.rs");
+    for forbidden in [
+        "GraphEdgeDto",
+        "with_effective_endpoints",
+        "Occurrence",
+        "source_text",
+        "codestory_retrieval",
+        "nucleo",
+        "ToolSpec",
+        "pub fn ",
+        "pub use ",
+    ] {
+        assert!(
+            !adapter.contains(forbidden),
+            "dark raw-edge adapter crossed a forbidden boundary via {forbidden}"
+        );
+    }
 }
 
 #[test]

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -580,7 +580,25 @@ const AGENT_PLANNING_MODULES: [&str; 27] = [
 ///   `agent_eval_hooks_stay_on_for_runtime_tests_and_off_for_product_builds`
 ///   pins how it compiles. Listing it as a planning module would hand the
 ///   import-DAG guard a file no product build links.
-const AGENT_MODULE_ALLOWLIST_EXCLUSIONS: [&str; 2] = ["lib.rs", "eval_probes.rs"];
+/// - `indexed_source_call_path_v1.rs` is the dark v3 proof kernel. Task 2 keeps
+///   it behind the same test-support gate until the atomic public v3 cut.
+const AGENT_MODULE_ALLOWLIST_EXCLUSIONS: [&str; 3] =
+    ["lib.rs", "eval_probes.rs", "indexed_source_call_path_v1.rs"];
+
+#[test]
+fn dark_call_path_kernel_stays_on_the_test_support_side_of_the_crate_root() {
+    let lib = read("crates/codestory-agent/src/lib.rs");
+    assert!(
+        lib.contains(
+            "#[cfg(any(test, feature = \"test-support\"))]\n#[doc(hidden)]\npub mod indexed_source_call_path_v1;"
+        ),
+        "the dark call-path kernel must remain test-support-only until the atomic v3 cut"
+    );
+    assert!(
+        AGENT_MODULE_ALLOWLIST_EXCLUSIONS.contains(&"indexed_source_call_path_v1.rs"),
+        "the dark proof kernel must not be counted as a production packet-planning module"
+    );
+}
 
 /// Packet planning lives in `codestory-agent`, and the crate DAG is what keeps
 /// it from growing the powers it was extracted away from.

--- a/crates/codestory-runtime/src/indexed_source_call_path_v1.rs
+++ b/crates/codestory-runtime/src/indexed_source_call_path_v1.rs
@@ -1,0 +1,1542 @@
+//! Dark core-snapshot adapter for indexed source call-path proof facts.
+//!
+//! This module is deliberately not a product facade. Its caller must already
+//! be inside `PublicOperationService::run_with_cancel`, which installs the
+//! complete core snapshot used for every Store read below.
+
+use std::collections::{BTreeSet, HashMap};
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use codestory_agent::indexed_source_call_path_v1::{
+    AdmittedRawCallEdge, BuiltCallPathFacts, CallableContainmentEvidence, ExactScopeSelector,
+    ExactSymbolSelector, FactBuildGap, IndexedCallEdgeReceipt, IndexedLineWindow,
+    PinnedNodeIdentity, RawCallEdgeAdmission, ReceiptRef, ResolvedNodeIdentity, UnavailableReason,
+    ValidatedCallPathContract, VerifiedDirectCallFact, VerifiedProofFact, admit_raw_call_edge,
+};
+use codestory_contracts::api::ApiError;
+use codestory_contracts::graph::{Node, NodeId, NodeKind, ResolutionCertainty};
+use codestory_store::{FileInfo, IndexPublicationRecord, Store};
+use codestory_workspace::{
+    ProjectRelativePathResolution, WorkspacePathIdentity, project_identity_v3,
+    resolve_project_relative_path, workspace_relative_path,
+};
+use sha2::{Digest, Sha256};
+
+use crate::AppController;
+use crate::path_identity::OperationPathIdentityResolver;
+
+const INDEXED_LINE_KIND: &str = "indexed_line_v1";
+const MAX_LINE_WINDOW_BYTES: usize = 8_192;
+const RECEIPT_DOMAIN: &[u8] = b"codestory.indexed-call-edge-receipt.v1\0";
+const CALLABLE_KINDS: [NodeKind; 3] = [NodeKind::FUNCTION, NodeKind::METHOD, NodeKind::MACRO];
+
+#[allow(dead_code)] // Task 2C wires the accepted dark contract into this leaf.
+pub(crate) fn build_indexed_source_call_path_facts(
+    controller: &AppController,
+    contract: &ValidatedCallPathContract,
+) -> Result<BuiltCallPathFacts, ApiError> {
+    let publication = controller.active_core_publication().ok_or_else(|| {
+        ApiError::internal("indexed call-path proof requires an active core publication")
+    })?;
+    let project_root = controller.require_project_root()?;
+    let project_id = project_identity_v3(&project_root).project_id;
+    let storage = controller.open_storage_read_only()?;
+    build_from_store(
+        &storage,
+        &project_root,
+        &project_id,
+        &publication,
+        contract,
+        |path| fs::read(path),
+    )
+}
+
+fn build_from_store<R>(
+    store: &Store,
+    project_root: &Path,
+    project_id: &str,
+    publication: &IndexPublicationRecord,
+    contract: &ValidatedCallPathContract,
+    mut read_source: R,
+) -> Result<BuiltCallPathFacts, ApiError>
+where
+    R: FnMut(&Path) -> io::Result<Vec<u8>>,
+{
+    let files = store.files().inventory().map_err(store_error)?;
+    let file_rows = store.files().get_files().map_err(store_error)?;
+    let mut path_identities = OperationPathIdentityResolver::native();
+    let mut resolved = Vec::with_capacity(contract.spec().steps().len() + 1);
+    let mut gaps = Vec::new();
+    let mut unavailable = Vec::new();
+    let selector_context = SelectorContext {
+        store,
+        project_root,
+        project_id,
+        publication,
+        files: &file_rows,
+    };
+
+    for (selector_index, selector) in std::iter::once(contract.spec().start())
+        .chain(contract.spec().steps().iter().map(|step| step.target()))
+        .enumerate()
+    {
+        match resolve_symbol_selector(&selector_context, selector, &mut path_identities)? {
+            SelectorResolution::Resolved(node) => resolved.push(node),
+            SelectorResolution::Missing => {
+                gaps.push(FactBuildGap::SelectorMissing { selector_index })
+            }
+            SelectorResolution::Ambiguous => {
+                gaps.push(FactBuildGap::SelectorAmbiguous { selector_index })
+            }
+            SelectorResolution::NonCallable => {
+                gaps.push(FactBuildGap::NonCallableSelector { selector_index })
+            }
+            SelectorResolution::Unavailable(reason) => unavailable.push(reason),
+        }
+    }
+
+    for (scope_index, selector) in (contract.spec().steps().len() + 1..).zip(
+        contract
+            .spec()
+            .traversal_prohibitions()
+            .iter()
+            .chain(contract.spec().projection_exclusions()),
+    ) {
+        match resolve_scope_selector(&selector_context, selector, &mut path_identities)? {
+            SelectorResolution::Resolved(_) => {}
+            SelectorResolution::Missing => gaps.push(FactBuildGap::SelectorMissing {
+                selector_index: scope_index,
+            }),
+            SelectorResolution::Ambiguous => gaps.push(FactBuildGap::SelectorAmbiguous {
+                selector_index: scope_index,
+            }),
+            SelectorResolution::NonCallable => gaps.push(FactBuildGap::NonCallableSelector {
+                selector_index: scope_index,
+            }),
+            SelectorResolution::Unavailable(reason) => unavailable.push(reason),
+        }
+    }
+
+    unavailable.sort();
+    unavailable.dedup();
+    if !unavailable.is_empty()
+        || !gaps.is_empty()
+        || resolved.len() != contract.spec().steps().len() + 1
+    {
+        gaps.sort();
+        gaps.dedup();
+        return Ok(BuiltCallPathFacts {
+            facts: Vec::new(),
+            receipts: Vec::new(),
+            gaps,
+            unavailable,
+        });
+    }
+
+    let files_by_id = files
+        .into_iter()
+        .map(|file| (file.id, file))
+        .collect::<HashMap<_, _>>();
+    let rows_by_id = file_rows
+        .into_iter()
+        .map(|file| (file.id, file))
+        .collect::<HashMap<_, _>>();
+    let mut source_cache = HashMap::<WorkspacePathIdentity, SourceObservation>::new();
+    let mut facts = Vec::new();
+    let mut receipts = Vec::new();
+
+    for (step_index, pair) in resolved.windows(2).enumerate() {
+        let source = &pair[0];
+        let target = &pair[1];
+        let Some(source_id) = parse_pinned_node_id(&source.pinned) else {
+            return Err(ApiError::internal(
+                "resolved call-path source lost its numeric publication pin",
+            ));
+        };
+        let Some(target_id) = parse_pinned_node_id(&target.pinned) else {
+            return Err(ApiError::internal(
+                "resolved call-path target lost its numeric publication pin",
+            ));
+        };
+        let Some(source_node) = store.get_node(source_id).map_err(store_error)? else {
+            return Err(ApiError::internal(
+                "resolved call-path source disappeared from the pinned snapshot",
+            ));
+        };
+        let Some(target_node) = store.get_node(target_id).map_err(store_error)? else {
+            return Err(ApiError::internal(
+                "resolved call-path target disappeared from the pinned snapshot",
+            ));
+        };
+        let mut admitted_any = false;
+        let mut step_unavailable = Vec::new();
+        let mut step_gaps = Vec::new();
+        let mut containment_failed = false;
+        for edge in store
+            .get_raw_call_edges_by_effective_source(source_id)
+            .map_err(store_error)?
+        {
+            let RawCallEdgeAdmission::Admitted(admitted) =
+                admit_raw_call_edge(&edge, source_id, target_id)
+            else {
+                continue;
+            };
+            if !is_callable(source_node.kind) || !is_callable(target_node.kind) {
+                continue;
+            }
+            let Some(source_file_id) = source_node.file_node_id else {
+                continue;
+            };
+            if admitted.file_node_id != source_file_id {
+                continue;
+            }
+            let Some(containment) = authenticate_containment(
+                store,
+                &source_node,
+                admitted.file_node_id,
+                admitted.line,
+            )?
+            else {
+                containment_failed = true;
+                continue;
+            };
+            let Some(file) = files_by_id.get(&admitted.file_node_id.0) else {
+                step_unavailable.push(UnavailableReason::SourceNotBoundToPublication);
+                continue;
+            };
+            if !file.indexed || !file.complete {
+                step_unavailable.push(UnavailableReason::SourceNotBoundToPublication);
+                continue;
+            }
+            let Some(file_row) = rows_by_id.get(&file.id) else {
+                step_unavailable.push(UnavailableReason::SourceNotBoundToPublication);
+                continue;
+            };
+            let Some(indexed_hash) = file.content_hash.as_deref() else {
+                step_unavailable.push(UnavailableReason::SourceNotBoundToPublication);
+                continue;
+            };
+            let bound = match bind_source_once(
+                project_root,
+                file_row,
+                indexed_hash,
+                &mut path_identities,
+                &mut source_cache,
+                &mut read_source,
+            ) {
+                Ok(bound) => bound,
+                Err(BindSourceError::Unavailable) => {
+                    step_unavailable.push(UnavailableReason::SourceNotBoundToPublication);
+                    continue;
+                }
+                Err(BindSourceError::InvalidUtf8) => {
+                    step_gaps.push(FactBuildGap::InvalidUtf8 { step_index });
+                    continue;
+                }
+            };
+            let Some((byte_start, byte_end, text)) = complete_line(&bound.bytes, admitted.line)
+            else {
+                step_gaps.push(FactBuildGap::SourceLineOutOfRange { step_index });
+                continue;
+            };
+            if byte_end - byte_start > MAX_LINE_WINDOW_BYTES {
+                step_gaps.push(FactBuildGap::SourceWindowTooLarge { step_index });
+                continue;
+            }
+            let line_window = IndexedLineWindow {
+                kind: INDEXED_LINE_KIND,
+                project_file_components: bound.project_file_components.clone(),
+                indexed_sha256: indexed_hash.to_owned(),
+                observed_sha256: bound.observed_sha256.clone(),
+                anchor_line: admitted.line,
+                byte_start,
+                byte_end,
+                text,
+            };
+            let receipt_id = receipt_id(
+                project_id,
+                publication,
+                &admitted,
+                source_id.0,
+                target_id.0,
+                indexed_hash,
+            );
+            let receipt_ref = ReceiptRef {
+                receipt_id,
+                edge_id: admitted.edge_id.0.to_string(),
+            };
+            receipts.push(IndexedCallEdgeReceipt {
+                receipt: receipt_ref.clone(),
+                source: source.clone(),
+                target: target.clone(),
+                certainty: ResolutionCertainty::Certain,
+                callsite_identity: admitted.callsite_identity,
+                containment,
+                line_window,
+            });
+            facts.push(VerifiedProofFact::DirectCall(VerifiedDirectCallFact {
+                receipt: receipt_ref,
+                source: source.clone(),
+                target: target.clone(),
+            }));
+            admitted_any = true;
+        }
+        if admitted_any {
+            continue;
+        }
+        if !step_unavailable.is_empty() || !step_gaps.is_empty() {
+            unavailable.append(&mut step_unavailable);
+            gaps.append(&mut step_gaps);
+        } else {
+            gaps.push(if source_id == target_id {
+                FactBuildGap::RecursiveCallNotRepresentable { step_index }
+            } else if containment_failed {
+                FactBuildGap::EdgeContainmentUnproven { step_index }
+            } else {
+                FactBuildGap::DirectCallMissing { step_index }
+            });
+        }
+    }
+    gaps.sort();
+    gaps.dedup();
+    unavailable.sort();
+    unavailable.dedup();
+    Ok(BuiltCallPathFacts {
+        facts,
+        receipts,
+        gaps,
+        unavailable,
+    })
+}
+
+#[derive(Debug)]
+enum SelectorResolution {
+    Resolved(ResolvedNodeIdentity),
+    Missing,
+    Ambiguous,
+    NonCallable,
+    Unavailable(UnavailableReason),
+}
+
+struct SelectorContext<'a> {
+    store: &'a Store,
+    project_root: &'a Path,
+    project_id: &'a str,
+    publication: &'a IndexPublicationRecord,
+    files: &'a [FileInfo],
+}
+
+fn resolve_scope_selector(
+    context: &SelectorContext<'_>,
+    selector: &ExactScopeSelector,
+    identities: &mut OperationPathIdentityResolver,
+) -> Result<SelectorResolution, ApiError> {
+    match selector {
+        ExactScopeSelector::PinnedNode(identity) => resolve_pinned(context, identity, identities),
+        ExactScopeSelector::CanonicalId(value) => resolve_canonical(context, value, identities),
+        ExactScopeSelector::QualifiedName {
+            qualified_name,
+            project_file_components,
+        } => resolve_qualified(
+            context,
+            qualified_name,
+            project_file_components.as_deref(),
+            identities,
+        ),
+    }
+}
+
+fn resolve_symbol_selector(
+    context: &SelectorContext<'_>,
+    selector: &ExactSymbolSelector,
+    identities: &mut OperationPathIdentityResolver,
+) -> Result<SelectorResolution, ApiError> {
+    match selector {
+        ExactSymbolSelector::PinnedNode(identity) => resolve_pinned(context, identity, identities),
+        ExactSymbolSelector::CanonicalId(value) => resolve_canonical(context, value, identities),
+        ExactSymbolSelector::QualifiedName {
+            qualified_name,
+            project_file_components,
+        } => resolve_qualified(
+            context,
+            qualified_name,
+            project_file_components.as_deref(),
+            identities,
+        ),
+    }
+}
+
+fn resolve_pinned(
+    context: &SelectorContext<'_>,
+    identity: &PinnedNodeIdentity,
+    identities: &mut OperationPathIdentityResolver,
+) -> Result<SelectorResolution, ApiError> {
+    if identity.project_id != context.project_id
+        || identity.core_generation_id != context.publication.generation_id
+        || identity.core_run_id != context.publication.run_id
+    {
+        return Ok(SelectorResolution::Unavailable(
+            UnavailableReason::PublicationPinMismatch,
+        ));
+    }
+    let Some(node_id) = parse_pinned_node_id(identity) else {
+        return Ok(SelectorResolution::Missing);
+    };
+    let Some(node) = context.store.get_node(node_id).map_err(store_error)? else {
+        return Ok(SelectorResolution::Missing);
+    };
+    resolved_node(context, node, identities)
+}
+
+fn resolve_canonical(
+    context: &SelectorContext<'_>,
+    canonical_id: &str,
+    identities: &mut OperationPathIdentityResolver,
+) -> Result<SelectorResolution, ApiError> {
+    let matches = context
+        .store
+        .node_ids_by_canonical_ids(&[canonical_id.to_owned()])
+        .map_err(store_error)?
+        .remove(canonical_id)
+        .unwrap_or_default();
+    resolve_unique_node(context, matches, identities)
+}
+
+fn resolve_qualified(
+    context: &SelectorContext<'_>,
+    qualified_name: &str,
+    components: Option<&[String]>,
+    identities: &mut OperationPathIdentityResolver,
+) -> Result<SelectorResolution, ApiError> {
+    let selected_files = match components {
+        Some(components) => {
+            let requested = components.iter().collect::<PathBuf>();
+            let Ok(ProjectRelativePathResolution::Existing { absolute, .. }) =
+                resolve_project_relative_path(context.project_root, &requested)
+            else {
+                return Ok(SelectorResolution::Unavailable(
+                    UnavailableReason::SourceNotBoundToPublication,
+                ));
+            };
+            let Ok(wanted) = identities.resolve(&absolute) else {
+                return Ok(SelectorResolution::Unavailable(
+                    UnavailableReason::SourceNotBoundToPublication,
+                ));
+            };
+            context
+                .files
+                .iter()
+                .filter(|file| {
+                    stored_absolute(context.project_root, &file.path)
+                        .and_then(|path| identities.resolve(&path).ok())
+                        .is_some_and(|identity| identity == wanted)
+                })
+                .collect::<Vec<_>>()
+        }
+        None => {
+            let mut files = context.files.iter().collect::<Vec<_>>();
+            files.sort_by_key(|file| file.id);
+            files
+        }
+    };
+    if selected_files.is_empty() {
+        return Ok(SelectorResolution::Missing);
+    }
+    let mut matches = BTreeSet::new();
+    for file in selected_files {
+        let Some(path) = file.path.to_str() else {
+            return Ok(SelectorResolution::Unavailable(
+                UnavailableReason::SourceNotBoundToPublication,
+            ));
+        };
+        for kind in CALLABLE_KINDS {
+            matches.extend(
+                context
+                    .store
+                    .node_ids_by_file_identity_qualified_name_and_kind(path, qualified_name, kind)
+                    .map_err(store_error)?,
+            );
+        }
+    }
+    resolve_unique_node(context, matches.into_iter().collect(), identities)
+}
+
+fn resolve_unique_node(
+    context: &SelectorContext<'_>,
+    mut matches: Vec<NodeId>,
+    identities: &mut OperationPathIdentityResolver,
+) -> Result<SelectorResolution, ApiError> {
+    matches.sort();
+    matches.dedup();
+    match matches.as_slice() {
+        [] => Ok(SelectorResolution::Missing),
+        [node_id] => match context.store.get_node(*node_id).map_err(store_error)? {
+            Some(node) => resolved_node(context, node, identities),
+            None => Ok(SelectorResolution::Missing),
+        },
+        _ => Ok(SelectorResolution::Ambiguous),
+    }
+}
+
+fn resolved_node(
+    context: &SelectorContext<'_>,
+    node: Node,
+    identities: &mut OperationPathIdentityResolver,
+) -> Result<SelectorResolution, ApiError> {
+    if !is_callable(node.kind) {
+        return Ok(SelectorResolution::NonCallable);
+    }
+    let Some(file_id) = node.file_node_id else {
+        return Ok(SelectorResolution::Unavailable(
+            UnavailableReason::SourceNotBoundToPublication,
+        ));
+    };
+    let Some(file) = context.files.iter().find(|file| file.id == file_id.0) else {
+        return Ok(SelectorResolution::Unavailable(
+            UnavailableReason::SourceNotBoundToPublication,
+        ));
+    };
+    let Some(absolute) = stored_absolute(context.project_root, &file.path) else {
+        return Ok(SelectorResolution::Unavailable(
+            UnavailableReason::SourceNotBoundToPublication,
+        ));
+    };
+    if identities.resolve(&absolute).is_err() {
+        return Ok(SelectorResolution::Unavailable(
+            UnavailableReason::SourceNotBoundToPublication,
+        ));
+    }
+    let Some(relative) = workspace_relative_path(context.project_root, &absolute) else {
+        return Ok(SelectorResolution::Unavailable(
+            UnavailableReason::SourceNotBoundToPublication,
+        ));
+    };
+    let Some(components) = relative
+        .iter()
+        .map(|part| part.to_str().map(str::to_owned))
+        .collect::<Option<Vec<_>>>()
+    else {
+        return Ok(SelectorResolution::Unavailable(
+            UnavailableReason::SourceNotBoundToPublication,
+        ));
+    };
+    Ok(SelectorResolution::Resolved(ResolvedNodeIdentity {
+        pinned: PinnedNodeIdentity {
+            project_id: context.project_id.to_owned(),
+            core_generation_id: context.publication.generation_id.clone(),
+            core_run_id: context.publication.run_id.clone(),
+            node_id: node.id.0.to_string(),
+        },
+        canonical_id: node
+            .canonical_id
+            .unwrap_or_else(|| format!("node:{}", node.id.0)),
+        qualified_name: node.qualified_name.unwrap_or(node.serialized_name),
+        project_file_components: components,
+    }))
+}
+
+fn authenticate_containment(
+    store: &Store,
+    selected_source: &Node,
+    file_node_id: NodeId,
+    line: u32,
+) -> Result<Option<CallableContainmentEvidence>, ApiError> {
+    let projections = store
+        .get_callable_projection_states_for_file(file_node_id.0)
+        .map_err(store_error)?;
+    let ids = projections
+        .iter()
+        .map(|projection| projection.node_id)
+        .collect::<Vec<_>>();
+    let nodes = store.get_nodes_by_ids(&ids).map_err(store_error)?;
+    let mut candidates = projections
+        .into_iter()
+        .filter_map(|projection| {
+            let node = nodes.get(&projection.node_id)?;
+            (is_callable(node.kind)
+                && node.file_node_id == Some(file_node_id)
+                && projection.file_id == file_node_id.0
+                && projection.start_line <= line
+                && line <= projection.end_line)
+                .then_some(projection)
+        })
+        .collect::<Vec<_>>();
+    candidates.sort_by_key(|projection| {
+        (
+            projection.end_line.saturating_sub(projection.start_line),
+            projection.node_id,
+        )
+    });
+    let Some(smallest) = candidates.first() else {
+        return Ok(None);
+    };
+    let smallest_span = smallest.end_line.saturating_sub(smallest.start_line);
+    if candidates
+        .iter()
+        .take_while(|candidate| {
+            candidate.end_line.saturating_sub(candidate.start_line) == smallest_span
+        })
+        .count()
+        != 1
+        || smallest.node_id != selected_source.id
+    {
+        return Ok(None);
+    }
+    Ok(Some(CallableContainmentEvidence {
+        file_node_id,
+        owner_node_id: smallest.node_id,
+        start_line: smallest.start_line,
+        end_line: smallest.end_line,
+    }))
+}
+
+struct BoundSource {
+    bytes: Vec<u8>,
+    observed_sha256: String,
+    project_file_components: Vec<String>,
+}
+
+enum SourceObservation {
+    Bound(BoundSource),
+    Unavailable,
+    InvalidUtf8,
+}
+
+enum BindSourceError {
+    Unavailable,
+    InvalidUtf8,
+}
+
+fn bind_source_once<'a, R>(
+    project_root: &Path,
+    file: &FileInfo,
+    indexed_hash: &str,
+    identities: &mut OperationPathIdentityResolver,
+    cache: &'a mut HashMap<WorkspacePathIdentity, SourceObservation>,
+    read_source: &mut R,
+) -> Result<&'a BoundSource, BindSourceError>
+where
+    R: FnMut(&Path) -> io::Result<Vec<u8>>,
+{
+    let absolute = stored_absolute(project_root, &file.path).ok_or(BindSourceError::Unavailable)?;
+    let ProjectRelativePathResolution::Existing { absolute, relative } =
+        resolve_project_relative_path(project_root, &absolute)
+            .map_err(|_| BindSourceError::Unavailable)?
+    else {
+        return Err(BindSourceError::Unavailable);
+    };
+    let identity = identities
+        .resolve(&absolute)
+        .map_err(|_| BindSourceError::Unavailable)?;
+    if !cache.contains_key(&identity) {
+        let observation = match read_source(&absolute) {
+            Err(_) => SourceObservation::Unavailable,
+            Ok(bytes) if std::str::from_utf8(&bytes).is_err() => SourceObservation::InvalidUtf8,
+            Ok(bytes) => {
+                let observed_sha256 = sha256_hex(&bytes);
+                let Some(project_file_components) = relative
+                    .iter()
+                    .map(|part| part.to_str().map(str::to_owned))
+                    .collect::<Option<Vec<_>>>()
+                else {
+                    cache.insert(identity.clone(), SourceObservation::Unavailable);
+                    return Err(BindSourceError::Unavailable);
+                };
+                SourceObservation::Bound(BoundSource {
+                    bytes,
+                    observed_sha256,
+                    project_file_components,
+                })
+            }
+        };
+        cache.insert(identity.clone(), observation);
+    }
+    let Some(observation) = cache.get(&identity) else {
+        return Err(BindSourceError::Unavailable);
+    };
+    match observation {
+        SourceObservation::Bound(bound) if bound.observed_sha256 == indexed_hash => Ok(bound),
+        SourceObservation::Bound(_) | SourceObservation::Unavailable => {
+            Err(BindSourceError::Unavailable)
+        }
+        SourceObservation::InvalidUtf8 => Err(BindSourceError::InvalidUtf8),
+    }
+}
+
+fn complete_line(bytes: &[u8], requested_line: u32) -> Option<(usize, usize, String)> {
+    if requested_line == 0 {
+        return None;
+    }
+    let mut line = 1_u32;
+    let mut start = 0_usize;
+    for (index, byte) in bytes.iter().enumerate() {
+        if *byte == b'\n' {
+            if line == requested_line {
+                let end = index + 1;
+                return Some((
+                    start,
+                    end,
+                    std::str::from_utf8(&bytes[start..end]).ok()?.to_owned(),
+                ));
+            }
+            line += 1;
+            start = index + 1;
+        }
+    }
+    if line == requested_line && start < bytes.len() {
+        return Some((
+            start,
+            bytes.len(),
+            std::str::from_utf8(&bytes[start..]).ok()?.to_owned(),
+        ));
+    }
+    None
+}
+
+fn receipt_id(
+    project_id: &str,
+    publication: &IndexPublicationRecord,
+    admitted: &AdmittedRawCallEdge,
+    source_id: i64,
+    target_id: i64,
+    indexed_hash: &str,
+) -> String {
+    let mut digest = Sha256::new();
+    digest.update(RECEIPT_DOMAIN);
+    for part in [
+        project_id.as_bytes(),
+        publication.generation_id.as_bytes(),
+        publication.run_id.as_bytes(),
+        &admitted.edge_id.0.to_le_bytes(),
+        &source_id.to_le_bytes(),
+        &target_id.to_le_bytes(),
+        &admitted.file_node_id.0.to_le_bytes(),
+        indexed_hash.as_bytes(),
+        &admitted.line.to_le_bytes(),
+        admitted.callsite_identity.as_bytes(),
+    ] {
+        digest.update((part.len() as u64).to_le_bytes());
+        digest.update(part);
+    }
+    format!("indexed-call-edge:{:x}", digest.finalize())
+}
+
+fn stored_absolute(project_root: &Path, stored: &Path) -> Option<PathBuf> {
+    let requested = if stored.is_absolute() {
+        stored.to_path_buf()
+    } else {
+        project_root.join(stored)
+    };
+    match resolve_project_relative_path(project_root, &requested).ok()? {
+        ProjectRelativePathResolution::Existing { absolute, .. } => Some(absolute),
+        _ => None,
+    }
+}
+
+fn parse_pinned_node_id(identity: &PinnedNodeIdentity) -> Option<NodeId> {
+    let value = identity.node_id.parse::<i64>().ok()?;
+    (value.to_string() == identity.node_id).then_some(NodeId(value))
+}
+
+fn is_callable(kind: NodeKind) -> bool {
+    CALLABLE_KINDS.contains(&kind)
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}
+
+fn store_error(error: codestory_store::StorageError) -> ApiError {
+    ApiError::internal(format!("indexed call-path Store read failed: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    use codestory_agent::indexed_source_call_path_v1::{
+        ClauseAnchor, ClauseClassification, ProofContractField, UnvalidatedCallPathContract,
+        UnvalidatedCallPathSpec, UnvalidatedDirectCallStep, UnvalidatedExactSymbolSelector,
+        ValidationOutcome, validate_contract,
+    };
+    use codestory_contracts::graph::{
+        CallableProjectionState, Edge, EdgeId, EdgeKind, Node, ResolutionCertainty,
+    };
+    use codestory_store::{FileInfo, FileRole, IndexPublicationMode};
+    use tempfile::TempDir;
+
+    struct Fixture {
+        _root: TempDir,
+        root: PathBuf,
+        store: Store,
+        publication: IndexPublicationRecord,
+        project_id: String,
+        contract: ValidatedCallPathContract,
+        source_path: PathBuf,
+    }
+
+    fn canonical(value: &str) -> UnvalidatedExactSymbolSelector {
+        UnvalidatedExactSymbolSelector::CanonicalId(value.to_owned())
+    }
+
+    fn contract(start: &str, targets: &[&str]) -> ValidatedCallPathContract {
+        let source = "exact direct ordered call path";
+        let mut clauses = vec![ClauseAnchor {
+            clause_id: "start".to_owned(),
+            start: 0,
+            end: source.len(),
+            quote: source.to_owned(),
+            classification: ClauseClassification::ResolvedMaterial {
+                fields: vec![ProofContractField::Start],
+            },
+        }];
+        for (index, _) in targets.iter().enumerate() {
+            let step = u8::try_from(index).unwrap();
+            clauses.push(ClauseAnchor {
+                clause_id: format!("step-{index}"),
+                start: 0,
+                end: source.len(),
+                quote: source.to_owned(),
+                classification: ClauseClassification::ResolvedMaterial {
+                    fields: vec![
+                        ProofContractField::StepTarget { step },
+                        ProofContractField::Directness { step },
+                        ProofContractField::Ordering { step },
+                        ProofContractField::Relation { step },
+                    ],
+                },
+            });
+        }
+        let input = UnvalidatedCallPathContract::new(
+            source,
+            clauses,
+            UnvalidatedCallPathSpec {
+                start: canonical(start),
+                steps: targets
+                    .iter()
+                    .map(|target| UnvalidatedDirectCallStep {
+                        target: canonical(target),
+                    })
+                    .collect(),
+                prohibit_traversal_through: Vec::new(),
+                exclude_from_projection: Vec::new(),
+            },
+        );
+        match validate_contract(input).unwrap() {
+            ValidationOutcome::Validated { contract, .. } => *contract,
+            other => panic!("expected validated contract, got {other:?}"),
+        }
+    }
+
+    fn node(
+        id: i64,
+        kind: NodeKind,
+        name: &str,
+        canonical_id: &str,
+        file_id: i64,
+        start_line: u32,
+        end_line: u32,
+    ) -> Node {
+        Node {
+            id: NodeId(id),
+            kind,
+            serialized_name: name.to_owned(),
+            qualified_name: Some(format!("crate::{name}")),
+            canonical_id: Some(canonical_id.to_owned()),
+            file_node_id: Some(NodeId(file_id)),
+            start_line: Some(start_line),
+            start_col: Some(1),
+            end_line: Some(end_line),
+            end_col: Some(1),
+        }
+    }
+
+    fn projection(
+        file_id: i64,
+        node_id: i64,
+        start_line: u32,
+        end_line: u32,
+    ) -> CallableProjectionState {
+        CallableProjectionState {
+            file_id,
+            symbol_key: format!("symbol-{node_id}"),
+            node_id: NodeId(node_id),
+            signature_hash: node_id,
+            normalized_signature: Some(format!("signature-{node_id}")),
+            body_hash: node_id,
+            start_line,
+            end_line,
+        }
+    }
+
+    fn fixture(bytes: &[u8]) -> Fixture {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().to_path_buf();
+        let source_path = root.join("src/lib.rs");
+        fs::create_dir_all(source_path.parent().unwrap()).unwrap();
+        fs::write(&source_path, bytes).unwrap();
+        let mut store = Store::new_in_memory().unwrap();
+        let file = FileInfo {
+            id: 1,
+            path: source_path.clone(),
+            language: "rust".to_owned(),
+            modification_time: 1,
+            indexed: true,
+            complete: true,
+            line_count: 2,
+            file_role: FileRole::Source,
+        };
+        store.insert_file(&file).unwrap();
+        store
+            .update_file_metadata(&file, Some(&sha256_hex(bytes)))
+            .unwrap();
+        store
+            .insert_node(&Node {
+                id: NodeId(1),
+                kind: NodeKind::FILE,
+                serialized_name: source_path.to_string_lossy().into_owned(),
+                qualified_name: None,
+                canonical_id: None,
+                file_node_id: None,
+                start_line: Some(1),
+                start_col: Some(1),
+                end_line: Some(2),
+                end_col: Some(1),
+            })
+            .unwrap();
+        store
+            .insert_node(&node(2, NodeKind::FUNCTION, "source", "source-id", 1, 1, 1))
+            .unwrap();
+        store
+            .insert_node(&node(3, NodeKind::FUNCTION, "target", "target-id", 1, 2, 2))
+            .unwrap();
+        store
+            .insert_edge(&Edge {
+                id: EdgeId(10),
+                source: NodeId(2),
+                target: NodeId(3),
+                kind: EdgeKind::CALL,
+                file_node_id: Some(NodeId(1)),
+                line: Some(1),
+                resolved_source: Some(NodeId(2)),
+                resolved_target: Some(NodeId(3)),
+                confidence: Some(1.0),
+                certainty: Some(ResolutionCertainty::Certain),
+                callsite_identity: Some("1:1:0:3|rust".to_owned()),
+                candidate_targets: Vec::new(),
+            })
+            .unwrap();
+        store
+            .upsert_callable_projection_states(&[
+                projection(1, 1, 1, 2),
+                projection(1, 2, 1, 1),
+                projection(1, 3, 2, 2),
+            ])
+            .unwrap();
+        let publication = IndexPublicationRecord {
+            generation: 4,
+            generation_id: "generation-4".to_owned(),
+            run_id: "run-4".to_owned(),
+            mode: IndexPublicationMode::Full,
+            published_at_epoch_ms: 1,
+        };
+        let project_id = project_identity_v3(&root).project_id;
+        Fixture {
+            _root: temp,
+            root,
+            store,
+            publication,
+            project_id,
+            contract: contract("source-id", &["target-id"]),
+            source_path,
+        }
+    }
+
+    #[test]
+    fn builds_a_hash_bound_raw_edge_receipt_and_reads_source_once() {
+        let fixture = fixture(b"fn source() { target(); }\r\nfn target() {}\n");
+        fixture
+            .store
+            .insert_edge(&Edge {
+                id: EdgeId(12),
+                source: NodeId(2),
+                target: NodeId(3),
+                kind: EdgeKind::CALL,
+                file_node_id: Some(NodeId(1)),
+                line: Some(1),
+                resolved_source: Some(NodeId(2)),
+                resolved_target: Some(NodeId(3)),
+                confidence: Some(1.0),
+                certainty: Some(ResolutionCertainty::Certain),
+                callsite_identity: Some("1:1:1:3|rust".to_owned()),
+                candidate_targets: Vec::new(),
+            })
+            .unwrap();
+        fixture
+            .store
+            .insert_node(&Node {
+                id: NodeId(6),
+                kind: NodeKind::FILE,
+                serialized_name: fixture.root.join("src/other.rs").display().to_string(),
+                qualified_name: None,
+                canonical_id: None,
+                file_node_id: None,
+                start_line: Some(1),
+                start_col: Some(1),
+                end_line: Some(1),
+                end_col: Some(1),
+            })
+            .unwrap();
+        fixture
+            .store
+            .insert_edge(&Edge {
+                id: EdgeId(13),
+                source: NodeId(2),
+                target: NodeId(3),
+                kind: EdgeKind::CALL,
+                file_node_id: Some(NodeId(6)),
+                line: Some(1),
+                resolved_source: Some(NodeId(2)),
+                resolved_target: Some(NodeId(3)),
+                confidence: Some(1.0),
+                certainty: Some(ResolutionCertainty::Certain),
+                callsite_identity: Some("6:1:0:3|wrong-file".to_owned()),
+                candidate_targets: Vec::new(),
+            })
+            .unwrap();
+        let reads = Cell::new(0);
+        let built = build_from_store(
+            &fixture.store,
+            &fixture.root,
+            &fixture.project_id,
+            &fixture.publication,
+            &fixture.contract,
+            |path| {
+                reads.set(reads.get() + 1);
+                fs::read(path)
+            },
+        )
+        .unwrap();
+
+        assert_eq!(reads.get(), 1);
+        assert_eq!(built.facts.len(), 2);
+        assert!(built.gaps.is_empty());
+        assert!(built.unavailable.is_empty());
+        assert_eq!(built.receipts.len(), 2);
+        let receipt = &built.receipts[0];
+        assert_eq!(receipt.receipt.edge_id, "10");
+        assert_eq!(receipt.certainty, ResolutionCertainty::Certain);
+        assert_eq!(receipt.callsite_identity, "1:1:0:3|rust");
+        assert_eq!(receipt.containment.owner_node_id, NodeId(2));
+        assert_eq!(receipt.line_window.kind, "indexed_line_v1");
+        assert_eq!(receipt.line_window.text, "fn source() { target(); }\r\n");
+        assert_eq!(receipt.line_window.byte_start, 0);
+        assert_eq!(receipt.line_window.byte_end, 27);
+
+        let repeated = build_from_store(
+            &fixture.store,
+            &fixture.root,
+            &fixture.project_id,
+            &fixture.publication,
+            &fixture.contract,
+            |path| fs::read(path),
+        )
+        .unwrap();
+        assert_eq!(repeated.receipts[0].receipt, receipt.receipt);
+        assert_eq!(repeated.receipts, built.receipts);
+    }
+
+    #[test]
+    fn source_binding_fails_closed_for_hash_and_utf8_drift() {
+        let missing_fixture = fixture(b"fn source() { target(); }\nfn target() {}\n");
+        let file = missing_fixture.store.files().get_files().unwrap().remove(0);
+        missing_fixture
+            .store
+            .update_file_metadata(&file, None)
+            .unwrap();
+        let reads = Cell::new(0);
+        let missing_result = build_from_store(
+            &missing_fixture.store,
+            &missing_fixture.root,
+            &missing_fixture.project_id,
+            &missing_fixture.publication,
+            &missing_fixture.contract,
+            |path| {
+                reads.set(reads.get() + 1);
+                fs::read(path)
+            },
+        )
+        .unwrap();
+        assert_eq!(reads.get(), 0);
+        assert_eq!(
+            missing_result.unavailable,
+            vec![UnavailableReason::SourceNotBoundToPublication]
+        );
+
+        let hash_fixture = fixture(b"fn source() { target(); }\nfn target() {}\n");
+        fs::write(
+            &hash_fixture.source_path,
+            b"fn source() { changed(); }\nfn target() {}\n",
+        )
+        .unwrap();
+        let hash_result = build_from_store(
+            &hash_fixture.store,
+            &hash_fixture.root,
+            &hash_fixture.project_id,
+            &hash_fixture.publication,
+            &hash_fixture.contract,
+            |path| fs::read(path),
+        )
+        .unwrap();
+        assert_eq!(
+            hash_result.unavailable,
+            vec![UnavailableReason::SourceNotBoundToPublication]
+        );
+        assert!(hash_result.facts.is_empty());
+
+        let utf8_fixture = fixture(&[b'f', b'n', b' ', 0xff, b'\n']);
+        let utf8_result = build_from_store(
+            &utf8_fixture.store,
+            &utf8_fixture.root,
+            &utf8_fixture.project_id,
+            &utf8_fixture.publication,
+            &utf8_fixture.contract,
+            |path| fs::read(path),
+        )
+        .unwrap();
+        assert_eq!(
+            utf8_result.gaps,
+            vec![FactBuildGap::InvalidUtf8 { step_index: 0 }]
+        );
+        assert!(utf8_result.facts.is_empty());
+    }
+
+    #[test]
+    fn containment_rejects_nested_and_equal_smallest_owners() {
+        for nested in [true, false] {
+            let mut fixture = fixture(b"fn source() { target(); }\nfn target() {}\n");
+            let intruder_id = if nested { 4 } else { 5 };
+            fixture
+                .store
+                .insert_node(&node(
+                    intruder_id,
+                    NodeKind::METHOD,
+                    "inner",
+                    &format!("inner-{intruder_id}"),
+                    1,
+                    1,
+                    1,
+                ))
+                .unwrap();
+            fixture
+                .store
+                .upsert_callable_projection_states(&[
+                    if nested {
+                        projection(1, 2, 1, 2)
+                    } else {
+                        projection(1, 2, 1, 1)
+                    },
+                    projection(1, intruder_id, 1, 1),
+                ])
+                .unwrap();
+            let built = build_from_store(
+                &fixture.store,
+                &fixture.root,
+                &fixture.project_id,
+                &fixture.publication,
+                &fixture.contract,
+                |path| fs::read(path),
+            )
+            .unwrap();
+            assert_eq!(
+                built.gaps,
+                vec![FactBuildGap::EdgeContainmentUnproven { step_index: 0 }]
+            );
+            assert!(built.facts.is_empty());
+        }
+    }
+
+    #[test]
+    fn line_windows_preserve_lf_crlf_last_line_and_exact_cap() {
+        assert_eq!(
+            complete_line(b"one\ntwo", 1),
+            Some((0, 4, "one\n".to_owned()))
+        );
+        assert_eq!(
+            complete_line(b"one\ntwo", 2),
+            Some((4, 7, "two".to_owned()))
+        );
+        assert_eq!(
+            complete_line(b"one\r\ntwo\r\n", 1),
+            Some((0, 5, "one\r\n".to_owned()))
+        );
+        assert_eq!(complete_line(b"one\n", 3), None);
+        assert_eq!(
+            complete_line(&vec![b'a'; MAX_LINE_WINDOW_BYTES], 1)
+                .unwrap()
+                .1,
+            MAX_LINE_WINDOW_BYTES
+        );
+        assert!(
+            complete_line(&vec![b'a'; MAX_LINE_WINDOW_BYTES + 1], 1)
+                .unwrap()
+                .1
+                > MAX_LINE_WINDOW_BYTES
+        );
+
+        let mut fixture = fixture(b"fn source() { target(); }\nfn target() {}");
+        fixture
+            .store
+            .insert_node(&node(
+                4,
+                NodeKind::FUNCTION,
+                "other_target",
+                "other-target-id",
+                1,
+                2,
+                2,
+            ))
+            .unwrap();
+        fixture
+            .store
+            .insert_edge(&Edge {
+                id: EdgeId(14),
+                source: NodeId(2),
+                target: NodeId(4),
+                kind: EdgeKind::CALL,
+                file_node_id: Some(NodeId(1)),
+                line: Some(3),
+                resolved_source: Some(NodeId(2)),
+                resolved_target: Some(NodeId(4)),
+                confidence: Some(1.0),
+                certainty: Some(ResolutionCertainty::Certain),
+                callsite_identity: Some("1:3:0:4|out-of-range".to_owned()),
+                candidate_targets: Vec::new(),
+            })
+            .unwrap();
+        fixture
+            .store
+            .upsert_callable_projection_states(&[projection(1, 2, 1, 3)])
+            .unwrap();
+        let built = build_from_store(
+            &fixture.store,
+            &fixture.root,
+            &fixture.project_id,
+            &fixture.publication,
+            &contract("source-id", &["other-target-id"]),
+            |path| fs::read(path),
+        )
+        .unwrap();
+        assert!(built.facts.is_empty());
+        assert_eq!(
+            built.gaps,
+            vec![FactBuildGap::SourceLineOutOfRange { step_index: 0 }]
+        );
+    }
+
+    #[test]
+    fn builder_accepts_exactly_eight_kib_and_rejects_eight_kib_plus_one() {
+        for (length, accepted) in [
+            (MAX_LINE_WINDOW_BYTES, true),
+            (MAX_LINE_WINDOW_BYTES + 1, false),
+        ] {
+            let fixture = fixture(&vec![b'a'; length]);
+            let built = build_from_store(
+                &fixture.store,
+                &fixture.root,
+                &fixture.project_id,
+                &fixture.publication,
+                &fixture.contract,
+                |path| fs::read(path),
+            )
+            .unwrap();
+            if accepted {
+                assert_eq!(built.facts.len(), 1);
+                assert!(built.gaps.is_empty());
+            } else {
+                assert!(built.facts.is_empty());
+                assert_eq!(
+                    built.gaps,
+                    vec![FactBuildGap::SourceWindowTooLarge { step_index: 0 }]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn synthetic_self_edge_is_positive_but_an_ordinary_missing_edge_is_only_unknown() {
+        let fixture = fixture(b"fn source() { source(); }\nfn target() {}\n");
+        fixture
+            .store
+            .insert_edge(&Edge {
+                id: EdgeId(11),
+                source: NodeId(2),
+                target: NodeId(2),
+                kind: EdgeKind::CALL,
+                file_node_id: Some(NodeId(1)),
+                line: Some(1),
+                resolved_source: Some(NodeId(2)),
+                resolved_target: Some(NodeId(2)),
+                confidence: Some(1.0),
+                certainty: Some(ResolutionCertainty::Certain),
+                callsite_identity: Some("1:1:0:2|synthetic".to_owned()),
+                candidate_targets: Vec::new(),
+            })
+            .unwrap();
+        let recursive = contract("source-id", &["source-id"]);
+        let self_edge = build_from_store(
+            &fixture.store,
+            &fixture.root,
+            &fixture.project_id,
+            &fixture.publication,
+            &recursive,
+            |path| fs::read(path),
+        )
+        .unwrap();
+        assert_eq!(self_edge.facts.len(), 1);
+        assert!(self_edge.gaps.is_empty());
+
+        let missing = contract("target-id", &["source-id"]);
+        let absent = build_from_store(
+            &fixture.store,
+            &fixture.root,
+            &fixture.project_id,
+            &fixture.publication,
+            &missing,
+            |path| fs::read(path),
+        )
+        .unwrap();
+        assert!(absent.facts.is_empty());
+        assert_eq!(
+            absent.gaps,
+            vec![FactBuildGap::DirectCallMissing { step_index: 0 }]
+        );
+    }
+
+    #[test]
+    fn exact_selector_resolution_never_picks_first_or_prefix_matches() {
+        let fixture = fixture(b"fn source() { target(); }\nfn target() {}\n");
+        fixture
+            .store
+            .insert_node(&node(
+                4,
+                NodeKind::METHOD,
+                "duplicate",
+                "source-id",
+                1,
+                1,
+                1,
+            ))
+            .unwrap();
+        fixture
+            .store
+            .insert_node(&node(
+                5,
+                NodeKind::STRUCT,
+                "structural",
+                "structural-id",
+                1,
+                1,
+                1,
+            ))
+            .unwrap();
+        let ambiguous = build_from_store(
+            &fixture.store,
+            &fixture.root,
+            &fixture.project_id,
+            &fixture.publication,
+            &fixture.contract,
+            |path| fs::read(path),
+        )
+        .unwrap();
+        assert_eq!(
+            ambiguous.gaps,
+            vec![FactBuildGap::SelectorAmbiguous { selector_index: 0 }]
+        );
+
+        let missing = build_from_store(
+            &fixture.store,
+            &fixture.root,
+            &fixture.project_id,
+            &fixture.publication,
+            &contract("source", &["target-id"]),
+            |path| fs::read(path),
+        )
+        .unwrap();
+        assert_eq!(
+            missing.gaps,
+            vec![FactBuildGap::SelectorMissing { selector_index: 0 }]
+        );
+
+        let non_callable = build_from_store(
+            &fixture.store,
+            &fixture.root,
+            &fixture.project_id,
+            &fixture.publication,
+            &contract("structural-id", &["target-id"]),
+            |path| fs::read(path),
+        )
+        .unwrap();
+        assert_eq!(
+            non_callable.gaps,
+            vec![FactBuildGap::NonCallableSelector { selector_index: 0 }]
+        );
+        let non_callable_target = build_from_store(
+            &fixture.store,
+            &fixture.root,
+            &fixture.project_id,
+            &fixture.publication,
+            &contract("target-id", &["structural-id"]),
+            |path| fs::read(path),
+        )
+        .unwrap();
+        assert_eq!(
+            non_callable_target.gaps,
+            vec![FactBuildGap::NonCallableSelector { selector_index: 1 }]
+        );
+    }
+
+    #[test]
+    fn qualified_resolution_uses_exact_names_components_and_native_file_identity() {
+        let fixture = fixture(b"fn source() { target(); }\nfn target() {}\n");
+        let files = fixture.store.files().get_files().unwrap();
+        let context = SelectorContext {
+            store: &fixture.store,
+            project_root: &fixture.root,
+            project_id: &fixture.project_id,
+            publication: &fixture.publication,
+            files: &files,
+        };
+        let exact_path = ["src".to_owned(), "lib.rs".to_owned()];
+        let exact = resolve_qualified(
+            &context,
+            "crate::target",
+            Some(&exact_path),
+            &mut OperationPathIdentityResolver::native(),
+        )
+        .unwrap();
+        assert!(matches!(
+            exact,
+            SelectorResolution::Resolved(node) if node.pinned.node_id == "3"
+        ));
+
+        for wrong_path in [
+            vec!["src".to_owned(), "index".to_owned()],
+            vec!["src".to_owned(), "indexer".to_owned()],
+        ] {
+            assert!(matches!(
+                resolve_qualified(
+                    &context,
+                    "crate::target",
+                    Some(&wrong_path),
+                    &mut OperationPathIdentityResolver::native(),
+                )
+                .unwrap(),
+                SelectorResolution::Unavailable(UnavailableReason::SourceNotBoundToPublication)
+            ));
+        }
+
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(&fixture.source_path, fixture.root.join("src/alias.rs"))
+                .unwrap();
+            let alias_path = ["src".to_owned(), "alias.rs".to_owned()];
+            assert!(matches!(
+                resolve_qualified(
+                    &context,
+                    "crate::target",
+                    Some(&alias_path),
+                    &mut OperationPathIdentityResolver::native(),
+                )
+                .unwrap(),
+                SelectorResolution::Resolved(node) if node.pinned.node_id == "3"
+            ));
+
+            let outside = tempfile::tempdir().unwrap();
+            fs::write(outside.path().join("outside.rs"), "fn outside() {}\n").unwrap();
+            std::os::unix::fs::symlink(outside.path(), fixture.root.join("src/escape")).unwrap();
+            let escape_path = [
+                "src".to_owned(),
+                "escape".to_owned(),
+                "outside.rs".to_owned(),
+            ];
+            assert!(matches!(
+                resolve_qualified(
+                    &context,
+                    "crate::target",
+                    Some(&escape_path),
+                    &mut OperationPathIdentityResolver::native(),
+                )
+                .unwrap(),
+                SelectorResolution::Unavailable(UnavailableReason::SourceNotBoundToPublication)
+            ));
+        }
+
+        fixture
+            .store
+            .insert_node(&node(
+                4,
+                NodeKind::METHOD,
+                "source",
+                "another-source-id",
+                1,
+                1,
+                1,
+            ))
+            .unwrap();
+        assert!(matches!(
+            resolve_qualified(
+                &context,
+                "crate::source",
+                None,
+                &mut OperationPathIdentityResolver::native(),
+            )
+            .unwrap(),
+            SelectorResolution::Ambiguous
+        ));
+    }
+
+    #[test]
+    fn pin_mismatch_and_missing_recursive_edges_are_typed_unknown_or_unavailable() {
+        let fixture = fixture(b"fn source() { target(); }\nfn target() {}\n");
+        let mut wrong_publication = fixture.publication.clone();
+        wrong_publication.run_id = "other-run".to_owned();
+        let pin = PinnedNodeIdentity {
+            project_id: fixture.project_id.clone(),
+            core_generation_id: fixture.publication.generation_id.clone(),
+            core_run_id: fixture.publication.run_id.clone(),
+            node_id: "2".to_owned(),
+        };
+        let files = fixture.store.files().get_files().unwrap();
+        let context = SelectorContext {
+            store: &fixture.store,
+            project_root: &fixture.root,
+            project_id: &fixture.project_id,
+            publication: &wrong_publication,
+            files: &files,
+        };
+        assert!(matches!(
+            resolve_pinned(&context, &pin, &mut OperationPathIdentityResolver::native(),).unwrap(),
+            SelectorResolution::Unavailable(UnavailableReason::PublicationPinMismatch)
+        ));
+
+        let recursive = contract("source-id", &["source-id"]);
+        let built = build_from_store(
+            &fixture.store,
+            &fixture.root,
+            &fixture.project_id,
+            &fixture.publication,
+            &recursive,
+            |path| fs::read(path),
+        )
+        .unwrap();
+        assert_eq!(
+            built.gaps,
+            vec![FactBuildGap::RecursiveCallNotRepresentable { step_index: 0 }]
+        );
+        assert!(built.facts.is_empty());
+    }
+}

--- a/crates/codestory-runtime/src/indexed_source_call_path_v1.rs
+++ b/crates/codestory-runtime/src/indexed_source_call_path_v1.rs
@@ -4,16 +4,26 @@
 //! be inside `PublicOperationService::run_with_cancel`, which installs the
 //! complete core snapshot used for every Store read below.
 
+// The complete adapter stays dark until the atomic v3 surface cut. Building
+// `codestory-runtime` as a dependency with `test-support` must not turn that
+// deliberate lack of production callers into warning noise.
+#![allow(dead_code)]
+
 use std::collections::{BTreeSet, HashMap};
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 
 use codestory_agent::indexed_source_call_path_v1::{
     AdmittedRawCallEdge, BuiltCallPathFacts, CallableContainmentEvidence, ExactScopeSelector,
     ExactSymbolSelector, FactBuildGap, IndexedCallEdgeReceipt, IndexedLineWindow,
-    PinnedNodeIdentity, RawCallEdgeAdmission, ReceiptRef, ResolvedNodeIdentity, UnavailableReason,
-    ValidatedCallPathContract, VerifiedDirectCallFact, VerifiedProofFact, admit_raw_call_edge,
+    InternalCorePublicationIdentity, InternalProjection, InternalProjectionInput, PROOF_DOMAIN,
+    PinnedNodeIdentity, ProofDisposition, ProofHashes, RawCallEdgeAdmission, ReceiptRef,
+    ResolvedNodeIdentity, UnavailableProofFact, UnavailableReason, ValidatedCallPathContract,
+    ValidatedContractRendering, VerifiedDirectCallFact, VerifiedProofFact, admit_raw_call_edge,
+    check_call_path, project_internal_call_path_result,
 };
 use codestory_contracts::api::ApiError;
 use codestory_contracts::graph::{Node, NodeId, NodeKind, ResolutionCertainty};
@@ -26,13 +36,13 @@ use sha2::{Digest, Sha256};
 
 use crate::AppController;
 use crate::path_identity::OperationPathIdentityResolver;
+use crate::services::{PublicOperation, PublicOperationService};
 
 const INDEXED_LINE_KIND: &str = "indexed_line_v1";
 const MAX_LINE_WINDOW_BYTES: usize = 8_192;
 const RECEIPT_DOMAIN: &[u8] = b"codestory.indexed-call-edge-receipt.v1\0";
 const CALLABLE_KINDS: [NodeKind; 3] = [NodeKind::FUNCTION, NodeKind::METHOD, NodeKind::MACRO];
 
-#[allow(dead_code)] // Task 2C wires the accepted dark contract into this leaf.
 pub(crate) fn build_indexed_source_call_path_facts(
     controller: &AppController,
     contract: &ValidatedCallPathContract,
@@ -309,6 +319,97 @@ where
         gaps,
         unavailable,
     })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct IntegratedCallPathResult {
+    pub built: BuiltCallPathFacts,
+    pub disposition: ProofDisposition,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct IntegratedProjectedCallPathResult {
+    pub integrated: IntegratedCallPathResult,
+    pub projection: InternalProjection,
+}
+
+pub(crate) fn run_integrated_projected_public_operation(
+    service: &PublicOperationService,
+    controller: &AppController,
+    contract: &ValidatedCallPathContract,
+    hashes: &ProofHashes,
+    rendering: &ValidatedContractRendering,
+    cancelled: Arc<AtomicBool>,
+) -> Result<PublicOperation<IntegratedProjectedCallPathResult>, ApiError> {
+    service.run_with_cancel(PROOF_DOMAIN, cancelled, || {
+        let publication = controller.active_core_publication().ok_or_else(|| {
+            ApiError::internal("indexed call-path projection requires an active core publication")
+        })?;
+        let project_root = controller.require_project_root()?;
+        let built = build_indexed_source_call_path_facts(controller, contract)?;
+        let integrated = integrate_built_facts(contract, hashes, built);
+        let projection = project_internal_call_path_result(InternalProjectionInput {
+            contract,
+            hashes,
+            rendering,
+            publication: InternalCorePublicationIdentity {
+                project_id: project_identity_v3(&project_root).project_id,
+                generation_id: publication.generation_id,
+                run_id: publication.run_id,
+            },
+            disposition: &integrated.disposition,
+            receipts: &integrated.built.receipts,
+        })
+        .map_err(|error| {
+            ApiError::internal(format!(
+                "indexed call-path projection construction failed: {error:?}"
+            ))
+        })?;
+        Ok(IntegratedProjectedCallPathResult {
+            integrated,
+            projection,
+        })
+    })
+}
+
+fn evaluate_from_store<R>(
+    store: &Store,
+    project_root: &Path,
+    project_id: &str,
+    publication: &IndexPublicationRecord,
+    contract: &ValidatedCallPathContract,
+    hashes: &ProofHashes,
+    read_source: R,
+) -> Result<IntegratedCallPathResult, ApiError>
+where
+    R: FnMut(&Path) -> io::Result<Vec<u8>>,
+{
+    let built = build_from_store(
+        store,
+        project_root,
+        project_id,
+        publication,
+        contract,
+        read_source,
+    )?;
+    Ok(integrate_built_facts(contract, hashes, built))
+}
+
+fn integrate_built_facts(
+    contract: &ValidatedCallPathContract,
+    hashes: &ProofHashes,
+    built: BuiltCallPathFacts,
+) -> IntegratedCallPathResult {
+    let mut facts = built.facts.clone();
+    facts.extend(
+        built
+            .unavailable
+            .iter()
+            .cloned()
+            .map(|reason| VerifiedProofFact::Unavailable(UnavailableProofFact { reason })),
+    );
+    let disposition = check_call_path(contract, hashes, &facts);
+    IntegratedCallPathResult { built, disposition }
 }
 
 #[derive(Debug)]
@@ -762,16 +863,25 @@ fn store_error(error: codestory_store::StorageError) -> ApiError {
 mod tests {
     use super::*;
     use std::cell::Cell;
+    use std::rc::Rc;
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicBool;
 
     use codestory_agent::indexed_source_call_path_v1::{
         ClauseAnchor, ClauseClassification, ProofContractField, UnvalidatedCallPathContract,
-        UnvalidatedCallPathSpec, UnvalidatedDirectCallStep, UnvalidatedExactSymbolSelector,
-        ValidationOutcome, validate_contract,
+        UnvalidatedCallPathSpec, UnvalidatedDirectCallStep, UnvalidatedExactScopeSelector,
+        UnvalidatedExactSymbolSelector, ValidatedContractRendering, ValidationOutcome,
+        validate_contract,
     };
+    use codestory_contracts::api::IndexMode;
+    use codestory_contracts::events::EventBus;
     use codestory_contracts::graph::{
         CallableProjectionState, Edge, EdgeId, EdgeKind, Node, ResolutionCertainty,
     };
+    use codestory_indexer::WorkspaceIndexer;
     use codestory_store::{FileInfo, FileRole, IndexPublicationMode};
+    use codestory_workspace::{BuildMode, RefreshInfo};
+    use serde_json::json;
     use tempfile::TempDir;
 
     struct Fixture {
@@ -788,7 +898,27 @@ mod tests {
         UnvalidatedExactSymbolSelector::CanonicalId(value.to_owned())
     }
 
-    fn contract(start: &str, targets: &[&str]) -> ValidatedCallPathContract {
+    fn validated_contract(
+        start: &str,
+        targets: &[&str],
+    ) -> (
+        ValidatedCallPathContract,
+        ProofHashes,
+        ValidatedContractRendering,
+    ) {
+        validated_contract_with_policies(start, targets, &[], &[])
+    }
+
+    fn validated_contract_with_policies(
+        start: &str,
+        targets: &[&str],
+        traversal_prohibitions: &[&str],
+        projection_exclusions: &[&str],
+    ) -> (
+        ValidatedCallPathContract,
+        ProofHashes,
+        ValidatedContractRendering,
+    ) {
         let source = "exact direct ordered call path";
         let mut clauses = vec![ClauseAnchor {
             clause_id: "start".to_owned(),
@@ -816,6 +946,32 @@ mod tests {
                 },
             });
         }
+        for (index, _) in traversal_prohibitions.iter().enumerate() {
+            clauses.push(ClauseAnchor {
+                clause_id: format!("traversal-{index}"),
+                start: 0,
+                end: source.len(),
+                quote: source.to_owned(),
+                classification: ClauseClassification::ResolvedMaterial {
+                    fields: vec![ProofContractField::TraversalProhibition {
+                        index: u8::try_from(index).unwrap(),
+                    }],
+                },
+            });
+        }
+        for (index, _) in projection_exclusions.iter().enumerate() {
+            clauses.push(ClauseAnchor {
+                clause_id: format!("projection-{index}"),
+                start: 0,
+                end: source.len(),
+                quote: source.to_owned(),
+                classification: ClauseClassification::ResolvedMaterial {
+                    fields: vec![ProofContractField::ProjectionExclusion {
+                        index: u8::try_from(index).unwrap(),
+                    }],
+                },
+            });
+        }
         let input = UnvalidatedCallPathContract::new(
             source,
             clauses,
@@ -827,14 +983,28 @@ mod tests {
                         target: canonical(target),
                     })
                     .collect(),
-                prohibit_traversal_through: Vec::new(),
-                exclude_from_projection: Vec::new(),
+                prohibit_traversal_through: traversal_prohibitions
+                    .iter()
+                    .map(|scope| UnvalidatedExactScopeSelector::CanonicalId((*scope).to_owned()))
+                    .collect(),
+                exclude_from_projection: projection_exclusions
+                    .iter()
+                    .map(|scope| UnvalidatedExactScopeSelector::CanonicalId((*scope).to_owned()))
+                    .collect(),
             },
         );
         match validate_contract(input).unwrap() {
-            ValidationOutcome::Validated { contract, .. } => *contract,
+            ValidationOutcome::Validated {
+                contract,
+                hashes,
+                rendering,
+            } => (*contract, hashes, rendering),
             other => panic!("expected validated contract, got {other:?}"),
         }
+    }
+
+    fn contract(start: &str, targets: &[&str]) -> ValidatedCallPathContract {
+        validated_contract(start, targets).0
     }
 
     fn node(
@@ -959,6 +1129,592 @@ mod tests {
             contract: contract("source-id", &["target-id"]),
             source_path,
         }
+    }
+
+    struct SourceBuiltFixture {
+        _root: TempDir,
+        root: PathBuf,
+        source_path: PathBuf,
+        store: Store,
+        publication: IndexPublicationRecord,
+        project_id: String,
+    }
+
+    fn source_built_fixture(source: &str) -> SourceBuiltFixture {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().to_path_buf();
+        let source_path = root.join("src/lib.rs");
+        fs::create_dir_all(source_path.parent().unwrap()).unwrap();
+        fs::write(&source_path, source).unwrap();
+        let mut store = Store::new_in_memory().unwrap();
+        WorkspaceIndexer::new(root.clone())
+            .run_incremental(
+                &mut store,
+                &RefreshInfo {
+                    mode: BuildMode::Incremental,
+                    files_to_index: vec![source_path.clone()],
+                    files_to_remove: Vec::new(),
+                    existing_file_ids: HashMap::new(),
+                },
+                &EventBus::new(),
+                None,
+            )
+            .unwrap();
+        SourceBuiltFixture {
+            _root: temp,
+            root: root.clone(),
+            source_path,
+            store,
+            publication: IndexPublicationRecord {
+                generation: 1,
+                generation_id: "source-built-generation-1".to_owned(),
+                run_id: "source-built-run-1".to_owned(),
+                mode: IndexPublicationMode::Full,
+                published_at_epoch_ms: 1,
+            },
+            project_id: project_identity_v3(&root).project_id,
+        }
+    }
+
+    fn source_callable(store: &Store, terminal_name: &str) -> Node {
+        let nodes = store.get_nodes().unwrap();
+        let mut matches = nodes
+            .iter()
+            .filter(|node| {
+                is_callable(node.kind)
+                    && (node.serialized_name == terminal_name
+                        || node.qualified_name.as_deref().is_some_and(|qualified| {
+                            qualified.rsplit("::").next() == Some(terminal_name)
+                        }))
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        assert_eq!(
+            matches.len(),
+            1,
+            "source fixture must have one exact callable named {terminal_name}: matches={matches:?}, nodes={nodes:?}"
+        );
+        matches.remove(0)
+    }
+
+    fn canonical_id(node: &Node) -> &str {
+        node.canonical_id
+            .as_deref()
+            .expect("source-built callable has a canonical ID")
+    }
+
+    fn source_built_census(store: &Store) -> (usize, usize) {
+        let call_rows = store
+            .get_edges()
+            .unwrap()
+            .into_iter()
+            .filter(|edge| edge.kind == EdgeKind::CALL)
+            .collect::<Vec<_>>();
+        let admitted = call_rows
+            .iter()
+            .filter(|edge| {
+                matches!(
+                    admit_raw_call_edge(edge, edge.effective_source(), edge.effective_target()),
+                    RawCallEdgeAdmission::Admitted(_)
+                )
+            })
+            .count();
+        (call_rows.len(), admitted)
+    }
+
+    #[test]
+    fn source_built_one_and_six_step_paths_integrate_exact_receipts_and_stable_census() {
+        let one = source_built_fixture(
+            "pub fn callee() -> i32 { 1 }\npub fn caller() -> i32 { callee(); 1 }\n",
+        );
+        let caller = source_callable(&one.store, "caller");
+        let callee = source_callable(&one.store, "callee");
+        let (one_contract, one_hashes, _) =
+            validated_contract(canonical_id(&caller), &[canonical_id(&callee)]);
+        let one_result = evaluate_from_store(
+            &one.store,
+            &one.root,
+            &one.project_id,
+            &one.publication,
+            &one_contract,
+            &one_hashes,
+            |path| fs::read(path),
+        )
+        .unwrap();
+
+        assert_eq!(source_built_census(&one.store), (1, 1));
+        eprintln!("source-built admission census: raw_call_rows=1 admitted_rows=1");
+        assert_eq!(one_result.built.facts.len(), 1);
+        assert_eq!(one_result.built.receipts.len(), 1);
+        assert!(one_result.built.gaps.is_empty());
+        assert!(one_result.built.unavailable.is_empty());
+        let receipt = &one_result.built.receipts[0];
+        let raw_edge = one
+            .store
+            .get_edges()
+            .unwrap()
+            .into_iter()
+            .find(|edge| edge.kind == EdgeKind::CALL)
+            .expect("one source-built raw call edge");
+        assert_eq!(receipt.source.pinned.node_id, caller.id.0.to_string());
+        assert_eq!(receipt.target.pinned.node_id, callee.id.0.to_string());
+        assert_eq!(receipt.receipt.edge_id, raw_edge.id.0.to_string());
+        assert_eq!(
+            receipt.callsite_identity,
+            raw_edge.callsite_identity.as_deref().unwrap()
+        );
+        assert_eq!(receipt.containment.owner_node_id, caller.id);
+        assert_eq!(
+            receipt.line_window.indexed_sha256,
+            sha256_hex(&fs::read(&one.source_path).unwrap())
+        );
+        assert_eq!(
+            receipt.line_window.observed_sha256,
+            receipt.line_window.indexed_sha256
+        );
+        assert_eq!(
+            receipt.line_window.text,
+            "pub fn caller() -> i32 { callee(); 1 }\n"
+        );
+        assert_eq!(
+            receipt
+                .callsite_identity
+                .split('|')
+                .next()
+                .unwrap()
+                .split(':')
+                .count(),
+            4
+        );
+        assert!(receipt.receipt.receipt_id.starts_with("indexed-call-edge:"));
+        assert_eq!(
+            one_result.disposition,
+            ProofDisposition::ContractProven {
+                contract_digest: one_hashes.contract_digest().to_owned(),
+                receipts: vec![receipt.receipt.clone()],
+            }
+        );
+
+        let six = source_built_fixture(
+            "pub fn step0() { step1(); }\n\
+             pub fn step1() { step2(); }\n\
+             pub fn step2() { step3(); }\n\
+             pub fn step3() { step4(); }\n\
+             pub fn step4() { step5(); }\n\
+             pub fn step5() { step6(); }\n\
+             pub fn step6() {}\n",
+        );
+        let nodes = (0..=6)
+            .map(|index| source_callable(&six.store, &format!("step{index}")))
+            .collect::<Vec<_>>();
+        let target_ids = nodes[1..].iter().map(canonical_id).collect::<Vec<_>>();
+        let (six_contract, six_hashes, _) =
+            validated_contract(canonical_id(&nodes[0]), &target_ids);
+        let six_result = evaluate_from_store(
+            &six.store,
+            &six.root,
+            &six.project_id,
+            &six.publication,
+            &six_contract,
+            &six_hashes,
+            |path| fs::read(path),
+        )
+        .unwrap();
+
+        assert_eq!(source_built_census(&six.store), (6, 6));
+        eprintln!("source-built admission census: raw_call_rows=6 admitted_rows=6");
+        assert_eq!(six_result.built.facts.len(), 6);
+        assert_eq!(six_result.built.receipts.len(), 6);
+        let receipt_ids = six_result
+            .built
+            .receipts
+            .iter()
+            .map(|receipt| receipt.receipt.receipt_id.as_str())
+            .collect::<BTreeSet<_>>();
+        let edge_ids = six_result
+            .built
+            .receipts
+            .iter()
+            .map(|receipt| receipt.receipt.edge_id.as_str())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(receipt_ids.len(), 6);
+        assert_eq!(edge_ids.len(), 6);
+        for (index, receipt) in six_result.built.receipts.iter().enumerate() {
+            assert_eq!(receipt.source.pinned.node_id, nodes[index].id.0.to_string());
+            assert_eq!(
+                receipt.target.pinned.node_id,
+                nodes[index + 1].id.0.to_string()
+            );
+            if let Some(next) = six_result.built.receipts.get(index + 1) {
+                assert_eq!(receipt.target, next.source);
+            }
+        }
+        assert!(matches!(
+            six_result.disposition,
+            ProofDisposition::ContractProven { ref receipts, .. } if receipts.len() == 6
+        ));
+    }
+
+    #[test]
+    fn source_built_hostile_mutations_never_preserve_a_proven_contract() {
+        let six = source_built_fixture(
+            "pub fn step0() { step1(); }\n\
+             pub fn step1() { step2(); }\n\
+             pub fn step2() { step3(); }\n\
+             pub fn step3() { step4(); }\n\
+             pub fn step4() { step5(); }\n\
+             pub fn step5() { step6(); }\n\
+             pub fn step6() {}\n",
+        );
+        let nodes = (0..=6)
+            .map(|index| source_callable(&six.store, &format!("step{index}")))
+            .collect::<Vec<_>>();
+        let targets = nodes[1..].iter().map(canonical_id).collect::<Vec<_>>();
+        let (contract, hashes, _) = validated_contract(canonical_id(&nodes[0]), &targets);
+        let integrated = evaluate_from_store(
+            &six.store,
+            &six.root,
+            &six.project_id,
+            &six.publication,
+            &contract,
+            &hashes,
+            |path| fs::read(path),
+        )
+        .unwrap();
+        assert!(matches!(
+            integrated.disposition,
+            ProofDisposition::ContractProven { .. }
+        ));
+
+        let mut reversed = integrated.built.facts.clone();
+        for fact in &mut reversed {
+            if let VerifiedProofFact::DirectCall(fact) = fact {
+                std::mem::swap(&mut fact.source, &mut fact.target);
+            }
+        }
+        let omitted = integrated.built.facts[..5].to_vec();
+        let mut changed_target = integrated.built.facts.clone();
+        let VerifiedProofFact::DirectCall(first_changed) = &mut changed_target[0] else {
+            panic!("source-built fact is direct")
+        };
+        first_changed.target = match &integrated.built.facts[1] {
+            VerifiedProofFact::DirectCall(next) => next.target.clone(),
+            _ => panic!("source-built fact is direct"),
+        };
+        let mut reused = integrated.built.facts.clone();
+        let first_receipt = match &reused[0] {
+            VerifiedProofFact::DirectCall(fact) => fact.receipt.clone(),
+            _ => panic!("source-built fact is direct"),
+        };
+        let VerifiedProofFact::DirectCall(last) = reused.last_mut().unwrap() else {
+            panic!("source-built fact is direct")
+        };
+        last.receipt = first_receipt;
+
+        for (mutation, facts) in [
+            ("reverse", reversed),
+            ("omit", omitted),
+            ("target", changed_target),
+            ("reuse", reused),
+        ] {
+            assert!(
+                !matches!(
+                    check_call_path(&contract, &hashes, &facts),
+                    ProofDisposition::ContractProven { .. }
+                ),
+                "{mutation} mutation must not preserve ContractProven"
+            );
+        }
+
+        let intermediate = source_built_fixture(
+            "pub fn callee() {}\npub fn middle() { callee(); }\npub fn caller() { middle(); }\n",
+        );
+        let caller = source_callable(&intermediate.store, "caller");
+        let middle = source_callable(&intermediate.store, "middle");
+        let callee = source_callable(&intermediate.store, "callee");
+        let (chain_contract, chain_hashes, _) = validated_contract(
+            canonical_id(&caller),
+            &[canonical_id(&middle), canonical_id(&callee)],
+        );
+        let chain = evaluate_from_store(
+            &intermediate.store,
+            &intermediate.root,
+            &intermediate.project_id,
+            &intermediate.publication,
+            &chain_contract,
+            &chain_hashes,
+            |path| fs::read(path),
+        )
+        .unwrap();
+        let (direct_contract, direct_hashes, _) =
+            validated_contract(canonical_id(&caller), &[canonical_id(&callee)]);
+        assert!(
+            !matches!(
+                check_call_path(&direct_contract, &direct_hashes, &chain.built.facts),
+                ProofDisposition::ContractProven { .. }
+            ),
+            "two source-built edges through an intermediate are not one direct fact"
+        );
+
+        let raw_edge = six
+            .store
+            .get_edges()
+            .unwrap()
+            .into_iter()
+            .find(|edge| edge.kind == EdgeKind::CALL)
+            .unwrap();
+        let mut uncertain = raw_edge.clone();
+        uncertain.certainty = Some(ResolutionCertainty::Uncertain);
+        let mut ambiguous = raw_edge.clone();
+        ambiguous.candidate_targets = vec![nodes[2].id];
+        for (mutation, edge) in [("uncertain", &uncertain), ("ambiguous", &ambiguous)] {
+            assert_eq!(
+                admit_raw_call_edge(edge, edge.effective_source(), edge.effective_target()),
+                RawCallEdgeAdmission::Rejected
+            );
+            let rejected_edge_id = edge.id.0.to_string();
+            let facts_after_admission = integrated
+                .built
+                .facts
+                .iter()
+                .filter(|fact| match fact {
+                    VerifiedProofFact::DirectCall(fact) => fact.receipt.edge_id != rejected_edge_id,
+                    _ => true,
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+            assert!(
+                !matches!(
+                    check_call_path(&contract, &hashes, &facts_after_admission),
+                    ProofDisposition::ContractProven { .. }
+                ),
+                "{mutation} source-built row is rejected before proof and cannot preserve ContractProven"
+            );
+        }
+
+        fs::write(&six.source_path, "pub fn changed() {}\n").unwrap();
+        let drifted = evaluate_from_store(
+            &six.store,
+            &six.root,
+            &six.project_id,
+            &six.publication,
+            &contract,
+            &hashes,
+            |path| fs::read(path),
+        )
+        .unwrap();
+        assert_eq!(
+            drifted.built.unavailable,
+            vec![UnavailableReason::SourceNotBoundToPublication]
+        );
+        assert!(!matches!(
+            drifted.disposition,
+            ProofDisposition::ContractProven { .. }
+        ));
+    }
+
+    #[test]
+    fn source_built_recursion_and_policy_closure_keep_exact_fail_closed_outcomes() {
+        // The alias keeps the call placeholder's source identity distinct from
+        // the declaration while resolution still targets the same callable.
+        // The producer then suppresses the self-edge, leaving the exact
+        // recursive step unrepresentable.
+        let recursive = source_built_fixture(
+            "use crate::recursive as again;\npub fn recursive() { again(); }\n",
+        );
+        let recursive_node = source_callable(&recursive.store, "recursive");
+        let (recursive_contract, recursive_hashes, _) = validated_contract(
+            canonical_id(&recursive_node),
+            &[canonical_id(&recursive_node)],
+        );
+        let recursive_result = evaluate_from_store(
+            &recursive.store,
+            &recursive.root,
+            &recursive.project_id,
+            &recursive.publication,
+            &recursive_contract,
+            &recursive_hashes,
+            |path| fs::read(path),
+        )
+        .unwrap();
+        assert_eq!(
+            recursive_result.built.gaps,
+            vec![FactBuildGap::RecursiveCallNotRepresentable { step_index: 0 }]
+        );
+        assert!(matches!(
+            recursive_result.disposition,
+            ProofDisposition::Unknown { .. }
+        ));
+
+        let fixture = source_built_fixture(
+            "pub fn step0() { step1(); }\n\
+             pub fn step1() { step2(); }\n\
+             pub fn step2() { step3(); }\n\
+             pub fn step3() {}\n",
+        );
+        let nodes = (0..=3)
+            .map(|index| source_callable(&fixture.store, &format!("step{index}")))
+            .collect::<Vec<_>>();
+        let targets = nodes[1..].iter().map(canonical_id).collect::<Vec<_>>();
+        let (prohibited, prohibited_hashes, prohibited_rendering) =
+            validated_contract_with_policies(
+                canonical_id(&nodes[0]),
+                &targets,
+                &[canonical_id(&nodes[2])],
+                &[],
+            );
+        let refuted = evaluate_from_store(
+            &fixture.store,
+            &fixture.root,
+            &fixture.project_id,
+            &fixture.publication,
+            &prohibited,
+            &prohibited_hashes,
+            |path| fs::read(path),
+        )
+        .unwrap();
+        let expected_chain = refuted.built.receipts[..2]
+            .iter()
+            .map(|receipt| receipt.receipt.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            refuted.disposition,
+            ProofDisposition::ContractRefuted {
+                contract_digest: prohibited_hashes.contract_digest().to_owned(),
+                refutation: codestory_agent::indexed_source_call_path_v1::Refutation::ProhibitedScopeTraversal {
+                    step_index: 1,
+                    prohibition_index: 0,
+                    connected_receipts: expected_chain.clone(),
+                },
+            }
+        );
+        let refuted_projection = project_internal_call_path_result(InternalProjectionInput {
+            contract: &prohibited,
+            hashes: &prohibited_hashes,
+            rendering: &prohibited_rendering,
+            publication: InternalCorePublicationIdentity {
+                project_id: fixture.project_id.clone(),
+                generation_id: fixture.publication.generation_id.clone(),
+                run_id: fixture.publication.run_id.clone(),
+            },
+            disposition: &refuted.disposition,
+            receipts: &refuted.built.receipts,
+        })
+        .unwrap();
+        let InternalProjection::Complete { root, .. } = refuted_projection else {
+            panic!("small positive contradiction projection fits")
+        };
+        assert_eq!(
+            root["disposition"]["refutation"]["connected_receipts"],
+            json!(
+                expected_chain
+                    .iter()
+                    .map(|receipt| json!({
+                        "receipt_id": receipt.receipt_id,
+                        "edge_id": receipt.edge_id,
+                    }))
+                    .collect::<Vec<_>>()
+            )
+        );
+
+        let (excluded, excluded_hashes, _) = validated_contract_with_policies(
+            canonical_id(&nodes[0]),
+            &targets,
+            &[],
+            &[canonical_id(&nodes[2])],
+        );
+        let excluded_result = evaluate_from_store(
+            &fixture.store,
+            &fixture.root,
+            &fixture.project_id,
+            &fixture.publication,
+            &excluded,
+            &excluded_hashes,
+            |path| fs::read(path),
+        )
+        .unwrap();
+        assert!(matches!(
+            excluded_result.disposition,
+            ProofDisposition::Unknown { ref gaps, .. }
+                if gaps == &[codestory_agent::indexed_source_call_path_v1::ProofGap::ProjectionExclusionConflictsWithRequiredReceipt { step_index: 1 }]
+        ));
+    }
+
+    #[test]
+    fn integrated_execution_uses_the_existing_core_pin_without_retrieval_or_inner_retry() {
+        let project = tempfile::tempdir().unwrap();
+        let source_path = project.path().join("src/lib.rs");
+        fs::create_dir_all(source_path.parent().unwrap()).unwrap();
+        let source = b"pub fn callee() -> i32 { 1 }\npub fn caller() -> i32 { callee(); 1 }\n";
+        fs::write(&source_path, source).unwrap();
+        let storage_path = project.path().join(".codestory-test/codestory.db");
+        let controller = AppController::new_with_config(crate::test_sidecar_runtime_from_env());
+        controller
+            .open_project_summary_with_storage_path(
+                project.path().to_path_buf(),
+                storage_path.clone(),
+            )
+            .unwrap();
+        controller
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+            .unwrap();
+        let store = Store::open(&storage_path).unwrap();
+        let caller = source_callable(&store, "caller");
+        let callee = source_callable(&store, "callee");
+        let (contract, hashes, rendering) =
+            validated_contract(canonical_id(&caller), &[canonical_id(&callee)]);
+        drop(store);
+
+        let retrieval_pin_calls = Rc::new(Cell::new(0));
+        let observed_retrieval_pin_calls = Rc::clone(&retrieval_pin_calls);
+        crate::set_before_retrieval_pin_test_hook(move || {
+            observed_retrieval_pin_calls.set(observed_retrieval_pin_calls.get() + 1);
+        });
+        let service = crate::services::PublicOperationService::new(controller.clone());
+        let operation = run_integrated_projected_public_operation(
+            &service,
+            &controller,
+            &contract,
+            &hashes,
+            &rendering,
+            Arc::new(AtomicBool::new(false)),
+        )
+        .unwrap();
+
+        assert_eq!(operation.attempt, 1);
+        assert!(operation.core_publication.is_some());
+        assert_eq!(operation.retrieval_publication, None);
+        assert_eq!(retrieval_pin_calls.get(), 0);
+        assert!(matches!(
+            operation.value.integrated.disposition,
+            ProofDisposition::ContractProven { .. }
+        ));
+        assert!(matches!(
+            operation.value.projection,
+            codestory_agent::indexed_source_call_path_v1::InternalProjection::Complete { .. }
+        ));
+        assert_eq!(
+            Store::open(&storage_path)
+                .unwrap()
+                .get_retrieval_index_publication(&project_identity_v3(project.path()).project_id)
+                .unwrap(),
+            None
+        );
+
+        let builds = Cell::new(0_usize);
+        let refusal = service
+            .run_with_cancel(PROOF_DOMAIN, Arc::new(AtomicBool::new(false)), || {
+                builds.set(builds.get() + 1);
+                let built = build_indexed_source_call_path_facts(&controller, &contract)?;
+                let mut changed = source.to_vec();
+                let byte = changed.iter().position(|byte| *byte == b'1').unwrap();
+                changed[byte] = b'2';
+                fs::write(&source_path, changed).unwrap();
+                Ok(built)
+            })
+            .expect_err("post-build source drift must consume the one bounded retry and refuse");
+        assert_eq!(refusal.code, "project_unavailable");
+        assert_eq!(builds.get(), 1);
     }
 
     #[test]

--- a/crates/codestory-runtime/src/indexed_source_call_path_v1.rs
+++ b/crates/codestory-runtime/src/indexed_source_call_path_v1.rs
@@ -19,11 +19,11 @@ use std::sync::atomic::AtomicBool;
 use codestory_agent::indexed_source_call_path_v1::{
     AdmittedRawCallEdge, BuiltCallPathFacts, CallableContainmentEvidence, ExactScopeSelector,
     ExactSymbolSelector, FactBuildGap, IndexedCallEdgeReceipt, IndexedLineWindow,
-    InternalCorePublicationIdentity, InternalProjection, InternalProjectionInput, PROOF_DOMAIN,
-    PinnedNodeIdentity, ProofDisposition, ProofHashes, RawCallEdgeAdmission, ReceiptRef,
-    ResolvedNodeIdentity, UnavailableProofFact, UnavailableReason, ValidatedCallPathContract,
-    ValidatedContractRendering, VerifiedDirectCallFact, VerifiedProofFact, admit_raw_call_edge,
-    check_call_path, project_internal_call_path_result,
+    InternalCorePublicationIdentity, InternalProjection, PROOF_DOMAIN, PinnedNodeIdentity,
+    ProofHashes, RawCallEdgeAdmission, ReceiptRef, ResolvedNodeIdentity, UnavailableReason,
+    ValidatedCallPathContract, ValidatedContractRendering, VerifiedDirectCallFact,
+    VerifiedProofFact, admit_raw_call_edge, check_built_call_path_integration,
+    project_internal_call_path_result,
 };
 use codestory_contracts::api::ApiError;
 use codestory_contracts::graph::{Node, NodeId, NodeKind, ResolutionCertainty};
@@ -74,6 +74,11 @@ fn build_from_store<R>(
 where
     R: FnMut(&Path) -> io::Result<Vec<u8>>,
 {
+    let proof_publication = InternalCorePublicationIdentity {
+        project_id: project_id.to_owned(),
+        generation_id: publication.generation_id.clone(),
+        run_id: publication.run_id.clone(),
+    };
     let files = store.files().inventory().map_err(store_error)?;
     let file_rows = store.files().get_files().map_err(store_error)?;
     let mut path_identities = OperationPathIdentityResolver::native();
@@ -138,6 +143,7 @@ where
         gaps.sort();
         gaps.dedup();
         return Ok(BuiltCallPathFacts {
+            publication: proof_publication,
             facts: Vec::new(),
             receipts: Vec::new(),
             gaps,
@@ -314,6 +320,7 @@ where
     unavailable.sort();
     unavailable.dedup();
     Ok(BuiltCallPathFacts {
+        publication: proof_publication,
         facts,
         receipts,
         gaps,
@@ -322,14 +329,8 @@ where
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct IntegratedCallPathResult {
-    pub built: BuiltCallPathFacts,
-    pub disposition: ProofDisposition,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct IntegratedProjectedCallPathResult {
-    pub integrated: IntegratedCallPathResult,
+    pub integration: codestory_agent::indexed_source_call_path_v1::CheckedBuiltCallPathIntegration,
     pub projection: InternalProjection,
 }
 
@@ -342,34 +343,29 @@ pub(crate) fn run_integrated_projected_public_operation(
     cancelled: Arc<AtomicBool>,
 ) -> Result<PublicOperation<IntegratedProjectedCallPathResult>, ApiError> {
     service.run_with_cancel(PROOF_DOMAIN, cancelled, || {
-        let publication = controller.active_core_publication().ok_or_else(|| {
-            ApiError::internal("indexed call-path projection requires an active core publication")
-        })?;
-        let project_root = controller.require_project_root()?;
         let built = build_indexed_source_call_path_facts(controller, contract)?;
-        let integrated = integrate_built_facts(contract, hashes, built);
-        let projection = project_internal_call_path_result(InternalProjectionInput {
-            contract,
-            hashes,
-            rendering,
-            publication: InternalCorePublicationIdentity {
-                project_id: project_identity_v3(&project_root).project_id,
-                generation_id: publication.generation_id,
-                run_id: publication.run_id,
-            },
-            disposition: &integrated.disposition,
-            receipts: &integrated.built.receipts,
-        })
-        .map_err(|error| {
+        let integration = check_built_call_path_integration(contract, hashes, rendering, built)
+            .map_err(|error| {
+                ApiError::internal(format!(
+                    "indexed call-path checked integration failed: {error:?}"
+                ))
+            })?;
+        let projection = project_internal_call_path_result(&integration).map_err(|error| {
             ApiError::internal(format!(
                 "indexed call-path projection construction failed: {error:?}"
             ))
         })?;
         Ok(IntegratedProjectedCallPathResult {
-            integrated,
+            integration,
             projection,
         })
     })
+}
+
+struct CheckedIntegrationInputs<'a> {
+    contract: &'a ValidatedCallPathContract,
+    hashes: &'a ProofHashes,
+    rendering: &'a ValidatedContractRendering,
 }
 
 fn evaluate_from_store<R>(
@@ -377,10 +373,9 @@ fn evaluate_from_store<R>(
     project_root: &Path,
     project_id: &str,
     publication: &IndexPublicationRecord,
-    contract: &ValidatedCallPathContract,
-    hashes: &ProofHashes,
+    inputs: CheckedIntegrationInputs<'_>,
     read_source: R,
-) -> Result<IntegratedCallPathResult, ApiError>
+) -> Result<codestory_agent::indexed_source_call_path_v1::CheckedBuiltCallPathIntegration, ApiError>
 where
     R: FnMut(&Path) -> io::Result<Vec<u8>>,
 {
@@ -389,27 +384,15 @@ where
         project_root,
         project_id,
         publication,
-        contract,
+        inputs.contract,
         read_source,
     )?;
-    Ok(integrate_built_facts(contract, hashes, built))
-}
-
-fn integrate_built_facts(
-    contract: &ValidatedCallPathContract,
-    hashes: &ProofHashes,
-    built: BuiltCallPathFacts,
-) -> IntegratedCallPathResult {
-    let mut facts = built.facts.clone();
-    facts.extend(
-        built
-            .unavailable
-            .iter()
-            .cloned()
-            .map(|reason| VerifiedProofFact::Unavailable(UnavailableProofFact { reason })),
-    );
-    let disposition = check_call_path(contract, hashes, &facts);
-    IntegratedCallPathResult { built, disposition }
+    check_built_call_path_integration(inputs.contract, inputs.hashes, inputs.rendering, built)
+        .map_err(|error| {
+            ApiError::internal(format!(
+                "indexed call-path checked integration failed: {error:?}"
+            ))
+        })
 }
 
 #[derive(Debug)]
@@ -868,10 +851,10 @@ mod tests {
     use std::sync::atomic::AtomicBool;
 
     use codestory_agent::indexed_source_call_path_v1::{
-        ClauseAnchor, ClauseClassification, ProofContractField, UnvalidatedCallPathContract,
-        UnvalidatedCallPathSpec, UnvalidatedDirectCallStep, UnvalidatedExactScopeSelector,
-        UnvalidatedExactSymbolSelector, ValidatedContractRendering, ValidationOutcome,
-        validate_contract,
+        ClauseAnchor, ClauseClassification, ProofContractField, ProofDisposition,
+        UnvalidatedCallPathContract, UnvalidatedCallPathSpec, UnvalidatedDirectCallStep,
+        UnvalidatedExactScopeSelector, UnvalidatedExactSymbolSelector, ValidatedContractRendering,
+        ValidationOutcome, check_call_path, validate_contract,
     };
     use codestory_contracts::api::IndexMode;
     use codestory_contracts::events::EventBus;
@@ -1229,26 +1212,30 @@ mod tests {
         );
         let caller = source_callable(&one.store, "caller");
         let callee = source_callable(&one.store, "callee");
-        let (one_contract, one_hashes, _) =
+        let (one_contract, one_hashes, one_rendering) =
             validated_contract(canonical_id(&caller), &[canonical_id(&callee)]);
         let one_result = evaluate_from_store(
             &one.store,
             &one.root,
             &one.project_id,
             &one.publication,
-            &one_contract,
-            &one_hashes,
+            CheckedIntegrationInputs {
+                contract: &one_contract,
+                hashes: &one_hashes,
+                rendering: &one_rendering,
+            },
             |path| fs::read(path),
         )
         .unwrap();
 
         assert_eq!(source_built_census(&one.store), (1, 1));
         eprintln!("source-built admission census: raw_call_rows=1 admitted_rows=1");
-        assert_eq!(one_result.built.facts.len(), 1);
-        assert_eq!(one_result.built.receipts.len(), 1);
-        assert!(one_result.built.gaps.is_empty());
-        assert!(one_result.built.unavailable.is_empty());
-        let receipt = &one_result.built.receipts[0];
+        let one_built = one_result.built_facts();
+        assert_eq!(one_built.facts.len(), 1);
+        assert_eq!(one_built.receipts.len(), 1);
+        assert!(one_built.gaps.is_empty());
+        assert!(one_built.unavailable.is_empty());
+        let receipt = &one_built.receipts[0];
         let raw_edge = one
             .store
             .get_edges()
@@ -1288,8 +1275,8 @@ mod tests {
         );
         assert!(receipt.receipt.receipt_id.starts_with("indexed-call-edge:"));
         assert_eq!(
-            one_result.disposition,
-            ProofDisposition::ContractProven {
+            one_result.disposition(),
+            &ProofDisposition::ContractProven {
                 contract_digest: one_hashes.contract_digest().to_owned(),
                 receipts: vec![receipt.receipt.clone()],
             }
@@ -1308,50 +1295,52 @@ mod tests {
             .map(|index| source_callable(&six.store, &format!("step{index}")))
             .collect::<Vec<_>>();
         let target_ids = nodes[1..].iter().map(canonical_id).collect::<Vec<_>>();
-        let (six_contract, six_hashes, _) =
+        let (six_contract, six_hashes, six_rendering) =
             validated_contract(canonical_id(&nodes[0]), &target_ids);
         let six_result = evaluate_from_store(
             &six.store,
             &six.root,
             &six.project_id,
             &six.publication,
-            &six_contract,
-            &six_hashes,
+            CheckedIntegrationInputs {
+                contract: &six_contract,
+                hashes: &six_hashes,
+                rendering: &six_rendering,
+            },
             |path| fs::read(path),
         )
         .unwrap();
 
         assert_eq!(source_built_census(&six.store), (6, 6));
         eprintln!("source-built admission census: raw_call_rows=6 admitted_rows=6");
-        assert_eq!(six_result.built.facts.len(), 6);
-        assert_eq!(six_result.built.receipts.len(), 6);
-        let receipt_ids = six_result
-            .built
+        let six_built = six_result.built_facts();
+        assert_eq!(six_built.facts.len(), 6);
+        assert_eq!(six_built.receipts.len(), 6);
+        let receipt_ids = six_built
             .receipts
             .iter()
             .map(|receipt| receipt.receipt.receipt_id.as_str())
             .collect::<BTreeSet<_>>();
-        let edge_ids = six_result
-            .built
+        let edge_ids = six_built
             .receipts
             .iter()
             .map(|receipt| receipt.receipt.edge_id.as_str())
             .collect::<BTreeSet<_>>();
         assert_eq!(receipt_ids.len(), 6);
         assert_eq!(edge_ids.len(), 6);
-        for (index, receipt) in six_result.built.receipts.iter().enumerate() {
+        for (index, receipt) in six_built.receipts.iter().enumerate() {
             assert_eq!(receipt.source.pinned.node_id, nodes[index].id.0.to_string());
             assert_eq!(
                 receipt.target.pinned.node_id,
                 nodes[index + 1].id.0.to_string()
             );
-            if let Some(next) = six_result.built.receipts.get(index + 1) {
+            if let Some(next) = six_built.receipts.get(index + 1) {
                 assert_eq!(receipt.target, next.source);
             }
         }
         assert!(matches!(
-            six_result.disposition,
-            ProofDisposition::ContractProven { ref receipts, .. } if receipts.len() == 6
+            six_result.disposition(),
+            ProofDisposition::ContractProven { receipts, .. } if receipts.len() == 6
         ));
     }
 
@@ -1370,38 +1359,42 @@ mod tests {
             .map(|index| source_callable(&six.store, &format!("step{index}")))
             .collect::<Vec<_>>();
         let targets = nodes[1..].iter().map(canonical_id).collect::<Vec<_>>();
-        let (contract, hashes, _) = validated_contract(canonical_id(&nodes[0]), &targets);
+        let (contract, hashes, rendering) = validated_contract(canonical_id(&nodes[0]), &targets);
         let integrated = evaluate_from_store(
             &six.store,
             &six.root,
             &six.project_id,
             &six.publication,
-            &contract,
-            &hashes,
+            CheckedIntegrationInputs {
+                contract: &contract,
+                hashes: &hashes,
+                rendering: &rendering,
+            },
             |path| fs::read(path),
         )
         .unwrap();
         assert!(matches!(
-            integrated.disposition,
+            integrated.disposition(),
             ProofDisposition::ContractProven { .. }
         ));
 
-        let mut reversed = integrated.built.facts.clone();
+        let built = integrated.built_facts();
+        let mut reversed = built.facts.clone();
         for fact in &mut reversed {
             if let VerifiedProofFact::DirectCall(fact) = fact {
                 std::mem::swap(&mut fact.source, &mut fact.target);
             }
         }
-        let omitted = integrated.built.facts[..5].to_vec();
-        let mut changed_target = integrated.built.facts.clone();
+        let omitted = built.facts[..5].to_vec();
+        let mut changed_target = built.facts.clone();
         let VerifiedProofFact::DirectCall(first_changed) = &mut changed_target[0] else {
             panic!("source-built fact is direct")
         };
-        first_changed.target = match &integrated.built.facts[1] {
+        first_changed.target = match &built.facts[1] {
             VerifiedProofFact::DirectCall(next) => next.target.clone(),
             _ => panic!("source-built fact is direct"),
         };
-        let mut reused = integrated.built.facts.clone();
+        let mut reused = built.facts.clone();
         let first_receipt = match &reused[0] {
             VerifiedProofFact::DirectCall(fact) => fact.receipt.clone(),
             _ => panic!("source-built fact is direct"),
@@ -1432,7 +1425,7 @@ mod tests {
         let caller = source_callable(&intermediate.store, "caller");
         let middle = source_callable(&intermediate.store, "middle");
         let callee = source_callable(&intermediate.store, "callee");
-        let (chain_contract, chain_hashes, _) = validated_contract(
+        let (chain_contract, chain_hashes, chain_rendering) = validated_contract(
             canonical_id(&caller),
             &[canonical_id(&middle), canonical_id(&callee)],
         );
@@ -1441,8 +1434,11 @@ mod tests {
             &intermediate.root,
             &intermediate.project_id,
             &intermediate.publication,
-            &chain_contract,
-            &chain_hashes,
+            CheckedIntegrationInputs {
+                contract: &chain_contract,
+                hashes: &chain_hashes,
+                rendering: &chain_rendering,
+            },
             |path| fs::read(path),
         )
         .unwrap();
@@ -1450,7 +1446,7 @@ mod tests {
             validated_contract(canonical_id(&caller), &[canonical_id(&callee)]);
         assert!(
             !matches!(
-                check_call_path(&direct_contract, &direct_hashes, &chain.built.facts),
+                check_call_path(&direct_contract, &direct_hashes, &chain.built_facts().facts,),
                 ProofDisposition::ContractProven { .. }
             ),
             "two source-built edges through an intermediate are not one direct fact"
@@ -1474,7 +1470,7 @@ mod tests {
             );
             let rejected_edge_id = edge.id.0.to_string();
             let facts_after_admission = integrated
-                .built
+                .built_facts()
                 .facts
                 .iter()
                 .filter(|fact| match fact {
@@ -1498,17 +1494,20 @@ mod tests {
             &six.root,
             &six.project_id,
             &six.publication,
-            &contract,
-            &hashes,
+            CheckedIntegrationInputs {
+                contract: &contract,
+                hashes: &hashes,
+                rendering: &rendering,
+            },
             |path| fs::read(path),
         )
         .unwrap();
         assert_eq!(
-            drifted.built.unavailable,
+            drifted.built_facts().unavailable,
             vec![UnavailableReason::SourceNotBoundToPublication]
         );
         assert!(!matches!(
-            drifted.disposition,
+            drifted.disposition(),
             ProofDisposition::ContractProven { .. }
         ));
     }
@@ -1523,7 +1522,7 @@ mod tests {
             "use crate::recursive as again;\npub fn recursive() { again(); }\n",
         );
         let recursive_node = source_callable(&recursive.store, "recursive");
-        let (recursive_contract, recursive_hashes, _) = validated_contract(
+        let (recursive_contract, recursive_hashes, recursive_rendering) = validated_contract(
             canonical_id(&recursive_node),
             &[canonical_id(&recursive_node)],
         );
@@ -1532,17 +1531,20 @@ mod tests {
             &recursive.root,
             &recursive.project_id,
             &recursive.publication,
-            &recursive_contract,
-            &recursive_hashes,
+            CheckedIntegrationInputs {
+                contract: &recursive_contract,
+                hashes: &recursive_hashes,
+                rendering: &recursive_rendering,
+            },
             |path| fs::read(path),
         )
         .unwrap();
         assert_eq!(
-            recursive_result.built.gaps,
+            recursive_result.built_facts().gaps,
             vec![FactBuildGap::RecursiveCallNotRepresentable { step_index: 0 }]
         );
         assert!(matches!(
-            recursive_result.disposition,
+            recursive_result.disposition(),
             ProofDisposition::Unknown { .. }
         ));
 
@@ -1568,18 +1570,21 @@ mod tests {
             &fixture.root,
             &fixture.project_id,
             &fixture.publication,
-            &prohibited,
-            &prohibited_hashes,
+            CheckedIntegrationInputs {
+                contract: &prohibited,
+                hashes: &prohibited_hashes,
+                rendering: &prohibited_rendering,
+            },
             |path| fs::read(path),
         )
         .unwrap();
-        let expected_chain = refuted.built.receipts[..2]
+        let expected_chain = refuted.built_facts().receipts[..2]
             .iter()
             .map(|receipt| receipt.receipt.clone())
             .collect::<Vec<_>>();
         assert_eq!(
-            refuted.disposition,
-            ProofDisposition::ContractRefuted {
+            refuted.disposition(),
+            &ProofDisposition::ContractRefuted {
                 contract_digest: prohibited_hashes.contract_digest().to_owned(),
                 refutation: codestory_agent::indexed_source_call_path_v1::Refutation::ProhibitedScopeTraversal {
                     step_index: 1,
@@ -1588,19 +1593,7 @@ mod tests {
                 },
             }
         );
-        let refuted_projection = project_internal_call_path_result(InternalProjectionInput {
-            contract: &prohibited,
-            hashes: &prohibited_hashes,
-            rendering: &prohibited_rendering,
-            publication: InternalCorePublicationIdentity {
-                project_id: fixture.project_id.clone(),
-                generation_id: fixture.publication.generation_id.clone(),
-                run_id: fixture.publication.run_id.clone(),
-            },
-            disposition: &refuted.disposition,
-            receipts: &refuted.built.receipts,
-        })
-        .unwrap();
+        let refuted_projection = project_internal_call_path_result(&refuted).unwrap();
         let InternalProjection::Complete { root, .. } = refuted_projection else {
             panic!("small positive contradiction projection fits")
         };
@@ -1617,7 +1610,7 @@ mod tests {
             )
         );
 
-        let (excluded, excluded_hashes, _) = validated_contract_with_policies(
+        let (excluded, excluded_hashes, excluded_rendering) = validated_contract_with_policies(
             canonical_id(&nodes[0]),
             &targets,
             &[],
@@ -1628,16 +1621,110 @@ mod tests {
             &fixture.root,
             &fixture.project_id,
             &fixture.publication,
-            &excluded,
-            &excluded_hashes,
+            CheckedIntegrationInputs {
+                contract: &excluded,
+                hashes: &excluded_hashes,
+                rendering: &excluded_rendering,
+            },
             |path| fs::read(path),
         )
         .unwrap();
         assert!(matches!(
-            excluded_result.disposition,
-            ProofDisposition::Unknown { ref gaps, .. }
+            excluded_result.disposition(),
+            ProofDisposition::Unknown { gaps, .. }
                 if gaps == &[codestory_agent::indexed_source_call_path_v1::ProofGap::ProjectionExclusionConflictsWithRequiredReceipt { step_index: 1 }]
         ));
+    }
+
+    #[test]
+    fn source_built_partial_and_recursive_results_project_exact_builder_gaps() {
+        let recursive = source_built_fixture(
+            "use crate::recursive as again;\npub fn recursive() { again(); }\n",
+        );
+        let recursive_node = source_callable(&recursive.store, "recursive");
+        let (recursive_contract, recursive_hashes, recursive_rendering) = validated_contract(
+            canonical_id(&recursive_node),
+            &[canonical_id(&recursive_node)],
+        );
+        let recursive_result = evaluate_from_store(
+            &recursive.store,
+            &recursive.root,
+            &recursive.project_id,
+            &recursive.publication,
+            CheckedIntegrationInputs {
+                contract: &recursive_contract,
+                hashes: &recursive_hashes,
+                rendering: &recursive_rendering,
+            },
+            |path| fs::read(path),
+        )
+        .unwrap();
+        assert!(matches!(
+            recursive_result.disposition(),
+            ProofDisposition::Unknown { gaps, .. }
+                if gaps == &[codestory_agent::indexed_source_call_path_v1::ProofGap::FactBuild(
+                    FactBuildGap::RecursiveCallNotRepresentable { step_index: 0 }
+                )]
+        ));
+        let InternalProjection::Complete { root, .. } =
+            project_internal_call_path_result(&recursive_result).unwrap()
+        else {
+            panic!("small recursive Unknown projection fits")
+        };
+        assert_eq!(
+            root["disposition"]["gaps"],
+            json!([{ "kind": "recursive_call_not_representable", "step_index": 0 }])
+        );
+        assert!(root["receipts"].as_array().unwrap().is_empty());
+
+        let partial = source_built_fixture(
+            "pub fn step0() { step1(); }\npub fn step1() {}\npub fn step2() {}\n",
+        );
+        let step0 = source_callable(&partial.store, "step0");
+        let step1 = source_callable(&partial.store, "step1");
+        let step2 = source_callable(&partial.store, "step2");
+        let (partial_contract, partial_hashes, partial_rendering) = validated_contract(
+            canonical_id(&step0),
+            &[canonical_id(&step1), canonical_id(&step2)],
+        );
+        let partial_result = evaluate_from_store(
+            &partial.store,
+            &partial.root,
+            &partial.project_id,
+            &partial.publication,
+            CheckedIntegrationInputs {
+                contract: &partial_contract,
+                hashes: &partial_hashes,
+                rendering: &partial_rendering,
+            },
+            |path| fs::read(path),
+        )
+        .unwrap();
+        assert!(matches!(
+            partial_result.disposition(),
+            ProofDisposition::Unknown {
+                gaps,
+                connected_receipts,
+                ..
+            } if gaps == &[codestory_agent::indexed_source_call_path_v1::ProofGap::FactBuild(
+                FactBuildGap::DirectCallMissing { step_index: 1 }
+            )] && connected_receipts.len() == 1
+        ));
+        let InternalProjection::Complete { root, .. } =
+            project_internal_call_path_result(&partial_result).unwrap()
+        else {
+            panic!("small partial Unknown projection fits")
+        };
+        assert_eq!(
+            root["steps"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|step| step["status"].as_str().unwrap())
+                .collect::<Vec<_>>(),
+            ["proven", "unknown"]
+        );
+        assert_eq!(root["receipts"].as_array().unwrap().len(), 1);
     }
 
     #[test]
@@ -1686,7 +1773,7 @@ mod tests {
         assert_eq!(operation.retrieval_publication, None);
         assert_eq!(retrieval_pin_calls.get(), 0);
         assert!(matches!(
-            operation.value.integrated.disposition,
+            operation.value.integration.disposition(),
             ProofDisposition::ContractProven { .. }
         ));
         assert!(matches!(

--- a/crates/codestory-runtime/src/indexed_source_call_path_v1.rs
+++ b/crates/codestory-runtime/src/indexed_source_call_path_v1.rs
@@ -601,7 +601,7 @@ struct BoundSource {
 enum SourceObservation {
     Bound(BoundSource),
     Unavailable,
-    InvalidUtf8,
+    InvalidUtf8 { observed_sha256: String },
 }
 
 enum BindSourceError {
@@ -633,22 +633,25 @@ where
     if !cache.contains_key(&identity) {
         let observation = match read_source(&absolute) {
             Err(_) => SourceObservation::Unavailable,
-            Ok(bytes) if std::str::from_utf8(&bytes).is_err() => SourceObservation::InvalidUtf8,
             Ok(bytes) => {
                 let observed_sha256 = sha256_hex(&bytes);
-                let Some(project_file_components) = relative
-                    .iter()
-                    .map(|part| part.to_str().map(str::to_owned))
-                    .collect::<Option<Vec<_>>>()
-                else {
-                    cache.insert(identity.clone(), SourceObservation::Unavailable);
-                    return Err(BindSourceError::Unavailable);
-                };
-                SourceObservation::Bound(BoundSource {
-                    bytes,
-                    observed_sha256,
-                    project_file_components,
-                })
+                if std::str::from_utf8(&bytes).is_err() {
+                    SourceObservation::InvalidUtf8 { observed_sha256 }
+                } else {
+                    let Some(project_file_components) = relative
+                        .iter()
+                        .map(|part| part.to_str().map(str::to_owned))
+                        .collect::<Option<Vec<_>>>()
+                    else {
+                        cache.insert(identity.clone(), SourceObservation::Unavailable);
+                        return Err(BindSourceError::Unavailable);
+                    };
+                    SourceObservation::Bound(BoundSource {
+                        bytes,
+                        observed_sha256,
+                        project_file_components,
+                    })
+                }
             }
         };
         cache.insert(identity.clone(), observation);
@@ -661,7 +664,10 @@ where
         SourceObservation::Bound(_) | SourceObservation::Unavailable => {
             Err(BindSourceError::Unavailable)
         }
-        SourceObservation::InvalidUtf8 => Err(BindSourceError::InvalidUtf8),
+        SourceObservation::InvalidUtf8 { observed_sha256 } if observed_sha256 != indexed_hash => {
+            Err(BindSourceError::Unavailable)
+        }
+        SourceObservation::InvalidUtf8 { .. } => Err(BindSourceError::InvalidUtf8),
     }
 }
 
@@ -1112,6 +1118,51 @@ mod tests {
             vec![FactBuildGap::InvalidUtf8 { step_index: 0 }]
         );
         assert!(utf8_result.facts.is_empty());
+    }
+
+    #[test]
+    fn hash_mismatch_precedes_invalid_utf8_and_is_cached_without_reread() {
+        let fixture = fixture(b"fn source() { target(); }\nfn target() {}\n");
+        fixture
+            .store
+            .insert_edge(&Edge {
+                id: EdgeId(15),
+                source: NodeId(2),
+                target: NodeId(3),
+                kind: EdgeKind::CALL,
+                file_node_id: Some(NodeId(1)),
+                line: Some(1),
+                resolved_source: Some(NodeId(2)),
+                resolved_target: Some(NodeId(3)),
+                confidence: Some(1.0),
+                certainty: Some(ResolutionCertainty::Certain),
+                callsite_identity: Some("1:1:1:3|second-callsite".to_owned()),
+                candidate_targets: Vec::new(),
+            })
+            .unwrap();
+        fs::write(&fixture.source_path, [0xff, b'\n']).unwrap();
+        let reads = Cell::new(0);
+
+        let built = build_from_store(
+            &fixture.store,
+            &fixture.root,
+            &fixture.project_id,
+            &fixture.publication,
+            &fixture.contract,
+            |path| {
+                reads.set(reads.get() + 1);
+                fs::read(path)
+            },
+        )
+        .unwrap();
+
+        assert_eq!(reads.get(), 1);
+        assert_eq!(
+            built.unavailable,
+            vec![UnavailableReason::SourceNotBoundToPublication]
+        );
+        assert!(built.gaps.is_empty());
+        assert!(built.facts.is_empty());
     }
 
     #[test]

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -71,6 +71,8 @@ mod index_freshness;
 mod index_full;
 mod index_incremental;
 mod index_timings;
+#[cfg(any(test, feature = "test-support"))]
+mod indexed_source_call_path_v1;
 mod publication;
 mod repo_text;
 mod root_rank;

--- a/crates/codestory-runtime/src/services.rs
+++ b/crates/codestory-runtime/src/services.rs
@@ -2772,6 +2772,16 @@ mod embedding_start_classification_tests {
 mod freshness_gate_tests {
     use super::*;
 
+    #[test]
+    fn dark_indexed_call_path_builder_remains_core_only() {
+        assert!(!operation_requires_retrieval(
+            codestory_agent::indexed_source_call_path_v1::PROOF_DOMAIN
+        ));
+        for operation in ["packet", "search", "context", "drill"] {
+            assert!(operation_requires_retrieval(operation));
+        }
+    }
+
     fn freshness(
         status: IndexFreshnessStatusDto,
         cause: Option<IndexFreshnessNotCheckedCauseDto>,


### PR DESCRIPTION
## Context

CodeStory currently lets broad packet retrieval carry answer-level support language. The v3 program separates that retrieval product from a narrow structural proof product. This PR builds the proof kernel and pinned fact path behind test-only gates; it deliberately changes no public v2 route or serialized contract.

Base: `d9e20f045ef4bce2a704c7b6182cb71e52576b68`  
Head: `c1964f4e1b3f2e6d55cd2766b1d34656c4343078`  
Tree: `446d15bbb8dc3e13818c81c951a8f6167e981f50`

## What changed

- Added the validated `indexed_source_call_path_v1` domain: whole-input typed anchors, exact selectors and component paths, RFC 8785/domain-separated contract digests, and one-to-six connected direct-call trail semantics.
- Added strict raw `CALL` edge admission from persisted graph rows. Certain, exact resolved endpoints, empty candidate alternatives, canonical callsite identity, callable/file containment, and edge-distinct receipts are required.
- Added the pinned runtime fact builder. It binds one working-tree byte buffer to the pinned file SHA before UTF-8 decoding, derives a complete untruncated line window, and fails closed on publication, source, containment, selector, recursion, and line-window gaps.
- Added the pure checker and opaque checked integration boundary. Positive prohibited traversal is receipt-backed; production absence remains `Unknown`; certified absence remains fixture-only.
- Added complete and whole-object budget-fallback projections. The projector can consume only the digest/publication/fact/receipt-bound integration and serializes only disposition-authoritative receipts.
- Added deterministic real-index fixtures through `WorkspaceIndexer`: the one-step census is 1 raw / 1 admitted and the six-step census is 6 raw / 6 admitted.
- Added architecture ratchets proving the entire implementation remains production-unreachable and that `source_text` cannot enter search, ranking, target resolution, graph traversal, or source matching.

## How to review

The semantic center is split across:

- `crates/codestory-agent/src/indexed_source_call_path_v1.rs`: validation, digest, pure admission/checking, checked integration, and projection.
- `crates/codestory-runtime/src/indexed_source_call_path_v1.rs`: exact Store resolution, hash-bound source receipts, containment, real-index fixtures, and the existing pinned public-operation wrapper.
- `crates/codestory-cli/tests/architecture_contracts.rs`: production-darkness and source-text dependency fences.

The highest-risk boundaries are raw-edge admission, hash-before-decode ordering, exact builder-gap preservation, positive contradiction versus absence, and the opaque projection input. Each has hostile regression coverage.

## Verification

- `cargo test --locked -p codestory-agent indexed_source_call_path_v1` — 43 passed
- `cargo test --locked -p codestory-runtime --lib indexed_source_call_path_v1 -- --nocapture` — 15 passed; census 1/1 and 6/6
- `cargo test --locked -p codestory-cli --test architecture_contracts dark_call_path` — 3 passed
- `cargo test --locked -p codestory-agent` — 404 passed; doc tests 0
- scoped normal and `test-support` checks for agent/runtime — passed
- agent/runtime all-target `test-support` clippy with `-D warnings` — passed
- scoped fmt, generated catalog check, catalog diff, and `git diff --check` — passed
- v2 generated catalog SHA-256 remains `e96a7049922552198cc65270aeb7d4ee1c8d3d8b6974224f3c8305398bb6b7b6`
- independent full-range review of the immutable 320,440-byte package — approved with no Critical or Important finding

## Risk and non-claims

This PR adds 6.8K lines, mostly adversarial and source-built tests, but its shipping blast radius is intentionally zero: the modules compile only for tests or the explicit non-shipping `test-support` feature. It registers no DTO, tool, CLI command, HTTP route, runtime facade, MCP profile, packet behavior, Store/indexer migration, or production completeness provider. Public activation happens only in the final schema-v3 integration PR.

Closes #1976
Refs #1973
