### PR TITLE
[codex] prepare CodeStory 0.17.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.17.4
+
 Cursor marketplace MCP tool results match the schemas Cursor validates. After the server started, Cursor rejected `status`, `packet`, and `files` because the advertised output schema forbade extra compact-status fields, typed packet `support` as an object, and omitted `files.coverage_gaps`.
 
 Cursor marketplace installs start CodeStory's MCP server. 0.17.3 found the installed launcher, then loaded it as a library, so the process exited immediately and Cursor reported `Connection closed`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-agent"
-version = "0.17.1"
+version = "0.17.4"
 dependencies = [
  "codestory-contracts",
  "serde",
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-bench"
-version = "0.17.1"
+version = "0.17.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.17.1"
+version = "0.17.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -588,7 +588,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.17.1"
+version = "0.17.4"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.17.1"
+version = "0.17.4"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -647,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-llama-sys"
-version = "0.17.1"
+version = "0.17.4"
 dependencies = [
  "codestory-contracts",
  "crossbeam-channel",
@@ -662,7 +662,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.17.1"
+version = "0.17.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.17.1"
+version = "0.17.4"
 dependencies = [
  "anyhow",
  "codestory-agent",
@@ -711,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.17.1"
+version = "0.17.4"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.17.1"
+version = "0.17.4"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-agent/Cargo.toml
+++ b/crates/codestory-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-agent"
-version = "0.17.1"
+version = "0.17.4"
 edition = "2024"
 
 [features]

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.17.1"
+version = "0.17.4"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.17.1"
+version = "0.17.4"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.17.1"
+version = "0.17.4"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.17.1"
+version = "0.17.4"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-llama-sys/Cargo.toml
+++ b/crates/codestory-llama-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-llama-sys"
-version = "0.17.1"
+version = "0.17.4"
 edition = "2024"
 build = "build.rs"
 

--- a/crates/codestory-llama-sys/model-contract.json
+++ b/crates/codestory-llama-sys/model-contract.json
@@ -37,7 +37,7 @@
   "producer": {
     "name": "codestory-llama-sys",
     "embedding_revision": "0.16.1",
-    "version": "0.17.1"
+    "version": "0.17.4"
   },
   "license": {
     "spdx_id": "MIT",

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.17.1"
+version = "0.17.4"
 edition = "2024"
 
 [features]

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.17.1"
+version = "0.17.4"
 edition = "2024"
 
 [features]

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.17.1"
+version = "0.17.4"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.17.1"
+version = "0.17.4"
 edition = "2024"
 
 [features]

--- a/plugins/codestory/.claude-plugin/plugin.json
+++ b/plugins/codestory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.cursor-plugin/plugin.json
+++ b/plugins/codestory/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "description": "CodeStory grounding for Cursor over the local codestory-cli runtime.",
   "author": {
     "name": "The Green Cedar"

--- a/plugins/codestory/.github/plugin/plugin.json
+++ b/plugins/codestory/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codestory",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "author": {
     "name": "The Green Cedar",
     "url": "https://github.com/TheGreenCedar"

--- a/plugins/codestory/cli-version.json
+++ b/plugins/codestory/cli-version.json
@@ -1,10 +1,5 @@
 {
   "schema_version": 1,
-  "cli_version": "0.17.1",
-  "release_tag": "v0.17.1",
-  "archives": {
-    "macos-arm64": "a71d58b9fdb1ca87f0835bf4d0459c4702e41fba599dd2eed556aec51dea7be2",
-    "windows-x64": "c3537ce8c4f4443bfa9655a50c6667763bc0afeb52664863a56106cc3df7aa73",
-    "linux-x64": "4ee46d990edd32d9066cf9f173a1d9cf087cd065529cade0eba5d0c132a0c6ce"
-  }
+  "cli_version": "0.17.4",
+  "release_tag": "v0.17.4"
 }

--- a/plugins/codestory/plugin.json
+++ b/plugins/codestory/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "codestory",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "description": "CodeStory grounding for coding agents over a local managed runtime.",
   "author": {
     "name": "The Green Cedar",


### PR DESCRIPTION
## Context

The current dev head contains the Cursor launcher and output-schema fixes recorded under Unreleased. This forms the native 0.17.4 candidate with every release surface synchronized.

## What changed

- promotes the existing Unreleased notes to 0.17.4
- updates all ten codestory workspace crates and Cargo.lock to 0.17.4
- updates the embedded-model producer version and every host plugin manifest to 0.17.4
- advances the managed CLI pin to v0.17.4 and removes prior archive digests, which cannot exist until this native release builds them

## How to review

The diff is the canonical native version bump only. The Cursor and dark v3 source changes were already reviewed and merged into dev in their owning PRs.

## Verification

- canonical native bump validation: passed
- check-codestory-release.py --version 0.17.4: passed
- check-workflow-policy.mjs: passed
- plugin-static.test.mjs: 134 passed, 1 skipped, 0 failed
- git diff --check: passed

## Risk

This commit forms the bumped source candidate. It does not itself claim source stabilization, calibration, qualification, publication, marketplace delivery, or completion of the unfinished v3 epic; those remain separate exact-head gates.

Closes #1982.
Refs #1973.
Refs #1974.
Refs #1977.
Refs #1978.