### PR TITLE
[codex] make CodeStory 0.17.4 Rust 1.98-clean and freeze it

### DIFF
--- a/.github/scripts/packaged_agent_proof/event_producer_liveness.py
+++ b/.github/scripts/packaged_agent_proof/event_producer_liveness.py
@@ -115,11 +115,11 @@ class NativeProcessProducer(EventProducer):
 
     def _gone(self) -> str | None:
         """A description of how the exact pinned process ended, or None."""
-        # Start identity alone cannot see a Linux process that exited but has
-        # not been reaped: /proc keeps answering with an unchanged start time,
-        # so the probe would report a dead producer as running for as long as
-        # the wait lasts. Ask for a terminated state first so the message this
-        # produces is never a false statement about a live process.
+        # Start identity alone cannot reliably classify an exited-but-unreaped
+        # Unix process: Linux keeps the same /proc start time, while macOS may
+        # stop returning a complete proc_pidinfo record before the PID is
+        # reaped. Ask for a terminated state first so this never reports a dead
+        # producer as running.
         terminated = terminated_process_state(self.pid)
         if terminated is not None:
             return f"exited: pid {self.pid} {terminated}"

--- a/.github/scripts/packaged_agent_proof/process_identity.py
+++ b/.github/scripts/packaged_agent_proof/process_identity.py
@@ -155,28 +155,54 @@ def linux_terminated_state(stat: str) -> str | None:
     return None
 
 
+def macos_terminated_state(state_output: str) -> str | None:
+    """The terminated state named by one macOS ``ps`` row, or None."""
+    rows = state_output.splitlines()
+    if len(rows) != 1:
+        return None
+    state = rows[0].strip()
+    # Darwin reports `Z` for an exited-but-unreaped process. State modifiers
+    # may follow the primary state character, so accept only the documented
+    # modifier alphabet and fail closed on every other shape.
+    if re.fullmatch(r"Z[+<>NLsE]*", state):
+        return "is in state Z: it has terminated and is waiting to be reaped"
+    return None
+
+
 def terminated_process_state(pid: int) -> str | None:
     """How ``pid`` is provably no longer running, or None if it may still be.
 
-    Only Linux needs this. A process that has exited but has not yet been reaped
-    keeps a readable ``/proc/<pid>/stat`` whose start time never changes, so a
-    liveness probe built on start identity alone calls a dead process running
-    until its parent reaps it. macOS ``proc_pidinfo`` already fails outright for
-    a zombie, and Windows ``GetExitCodeProcess`` already reports its real exit
-    code, so both answer correctly without this.
+    Linux keeps a zombie's readable ``/proc/<pid>/stat`` and macOS keeps its PID
+    present while ``proc_pidinfo`` no longer returns a complete start identity.
+    Both therefore need an explicit terminated-state observation. Windows
+    ``GetExitCodeProcess`` already reports the real exit code.
 
-    Observational only: an unreadable or unparsable ``/proc`` entry answers
-    None, because "cannot tell" must never be reported as "has exited".
+    Observational only: unreadable, failed, or unparsable state inspection
+    answers None, because "cannot tell" must never be reported as "has exited".
     """
-    if sys.platform != "linux":
+    if sys.platform == "linux":
+        try:
+            stat = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8")
+        except (FileNotFoundError, ProcessLookupError):
+            return "no longer exists"
+        except OSError:
+            return None
+        return linux_terminated_state(stat)
+    if sys.platform != "darwin":
         return None
     try:
-        stat = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8")
-    except (FileNotFoundError, ProcessLookupError):
-        return "no longer exists"
-    except OSError:
+        completed = subprocess.run(
+            ["/bin/ps", "-o", "state=", "-p", str(pid)],
+            text=True,
+            capture_output=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
         return None
-    return linux_terminated_state(stat)
+    if completed.returncode != 0:
+        return None
+    return macos_terminated_state(completed.stdout)
 
 
 def _macos_process_start_identity(pid: int) -> str:

--- a/.github/scripts/packaged_agent_proof/self_test_process_exit.py
+++ b/.github/scripts/packaged_agent_proof/self_test_process_exit.py
@@ -300,6 +300,42 @@ def _observed_exit_test(target_os: str) -> None:
     )
 
 
+def _macos_unreaped_exit_test(target_os: str) -> None:
+    if target_os != "macos":
+        return
+    read_fd, write_fd = os.pipe()
+    pid = os.fork()
+    if pid == 0:
+        os.close(write_fd)
+        try:
+            os.read(read_fd, 1)
+        finally:
+            os.close(read_fd)
+        os._exit(0)
+
+    os.close(read_fd)
+    waiter = None
+    try:
+        start_id = process_start_identity(pid)
+        waiter = ExactProcessExitWaiter(pid, start_id, target_os)
+        os.write(write_fd, b"x")
+        os.close(write_fd)
+        write_fd = -1
+        evidence = waiter.wait(5_000, require_clean_exit=False)
+        require(
+            evidence["status"] == "observed_exit"
+            and evidence["pid"] == pid
+            and evidence["process_start_id"] == start_id,
+            "macOS exited-but-unreaped process was not proven terminated",
+        )
+    finally:
+        if write_fd >= 0:
+            os.close(write_fd)
+        if waiter is not None:
+            waiter.close()
+        os.waitpid(pid, 0)
+
+
 def _constructor_unknown_then_exit_test(target_os: str) -> None:
     if target_os == "windows":
         return
@@ -703,6 +739,7 @@ def run_process_exit_self_tests() -> None:
     target_os = _target_os()
     _unix_exit_deadline_tests()
     _observed_exit_test(target_os)
+    _macos_unreaped_exit_test(target_os)
     _constructor_unknown_then_exit_test(target_os)
     _retained_exit_tests(_exit_budget_tests())
     _cleanup_project_tests()

--- a/.github/scripts/packaged_agent_proof/self_test_producer_liveness.py
+++ b/.github/scripts/packaged_agent_proof/self_test_producer_liveness.py
@@ -27,6 +27,7 @@ from .event_producer_liveness import (
 from .foundation import REPOSITORY_ROOT, ProofFailure, require
 from .process_identity import (
     linux_terminated_state,
+    macos_terminated_state,
     process_start_identity,
     terminated_process_state,
 )
@@ -314,6 +315,20 @@ def _an_unreaped_process_is_never_reported_as_running() -> None:
         and linux_terminated_state("") is None,
         "an unreadable process state was reported as a termination",
     )
+    for state, terminated in (
+        ("Z", True),
+        ("Z+", True),
+        ("R", False),
+        ("Ss", False),
+        ("", False),
+        ("not a state", False),
+        ("Z\nR", False),
+    ):
+        observed = macos_terminated_state(state)
+        require(
+            (observed is not None) == terminated,
+            f"macOS process state {state!r} was classified wrong: {observed!r}",
+        )
     require(
         terminated_process_state(os.getpid()) is None,
         "this live self-test process was reported as terminated",

--- a/crates/codestory-agent/src/indexed_source_call_path_v1.rs
+++ b/crates/codestory-agent/src/indexed_source_call_path_v1.rs
@@ -1109,7 +1109,9 @@ fn nonempty_quoted_spans(text: &str, delimiter: char) -> Vec<(usize, usize)> {
         .map(|(index, _)| index)
         .collect::<Vec<_>>();
     positions
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .filter(|pair| pair[0] + delimiter.len_utf8() < pair[1])
         .map(|pair| (pair[0], pair[1] + delimiter.len_utf8()))
         .collect()

--- a/crates/codestory-cli/src/embedding_qualification/worker/operations/measure.rs
+++ b/crates/codestory-cli/src/embedding_qualification/worker/operations/measure.rs
@@ -795,8 +795,10 @@ fn validate_vector_response(
     }
     for row in payload.chunks_exact(columns as usize * std::mem::size_of::<f32>()) {
         let norm = row
-            .chunks_exact(std::mem::size_of::<f32>())
-            .map(|bytes| f32::from_le_bytes(bytes.try_into().expect("four-byte chunk")))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|bytes| f32::from_le_bytes(*bytes))
             .try_fold(0.0_f64, |sum, value| {
                 if value.is_finite() {
                     Ok(sum + f64::from(value) * f64::from(value))

--- a/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
+++ b/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
@@ -1,15 +1,15 @@
 {
   "calibration_required_values": {
     "capacity_retry_policy": {
-      "retry_after_ms": 41,
+      "retry_after_ms": 40,
       "retry_class": "after_capacity_change",
       "retry_condition_source": "named_condition_from_typed_capacity_response"
     },
     "connect_timeout_ms": 2000,
     "election_backoff_policy": {
-      "initial_backoff_ms": 7,
+      "initial_backoff_ms": 8,
       "jitter": "sha256(process_start_id||attempt) modulo inclusive [initial_backoff_ms,maximum_backoff_ms]",
-      "maximum_backoff_ms": 109
+      "maximum_backoff_ms": 110
     },
     "hard_native_no_progress_ms": 385431,
     "request_deadlines_ms": {
@@ -43,22 +43,7 @@
     "query_queue_capacity": 64,
     "true_idle_observation_grace_ms": 2500
   },
-  "freeze_record": {
-    "calibration_bundle_sha256": "851911db1e35c293680135285bc98554aebecd67fa7090f2b15687ccfabf383e",
-    "calibration_freeze_digest": "f97ccbb62d3bd92328f8857071d6f99aee2ae1c2b3c2dd919e4669d1e28b1a00",
-    "input_constant_set_sha256": "d8e3e6d53375a5982e2cd222fbeddc71e0ed0541fb9ea5b73772281a69e32666",
-    "measurement_protocol_sha256": "9eb303b6204ca6218e97ae299356370b16921a485350146fe85203a298e59269",
-    "protocol_sha256": "25373a136cc1da119ed6829769b90aab075084406b0489f9f7698b370f5ee447",
-    "run_artifact_sha256s": [
-      "08b004a4c0f3fcad2e4c0290ebcd5112d77bf0363f3a8c1790da1a0cd9a7c3d1",
-      "3aeb8022dca1702647529f43054cade70d52cd320af163519047be8845745dd6",
-      "abc5b159f73dcc9a87700be46a9704cba5396afa6718d3e51e726665c6a25bb8"
-    ],
-    "selected_at": "github-actions-run:32498872287:1",
-    "selection_rule": "constant_only_three_fresh_generations_one_sample_each+slow_host_floors_v2",
-    "selection_source_commit": "1ef4447a4900c925592b93a90e4417e951a1d9d9",
-    "selection_source_tree": "cb8c82acf9e8ac2d9427ae4486891c9fc2353e51"
-  },
+  "freeze_record": null,
   "qualification_threshold_overrides": {
     "protected_windows_x64_vulkan": {
       "existing_owner_connect": 125,
@@ -81,5 +66,5 @@
   },
   "schema_version": 1,
   "selection_protocol": "codestory-per-user-embedding-server-v1",
-  "status": "frozen"
+  "status": "unfrozen"
 }

--- a/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
+++ b/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
@@ -7,9 +7,9 @@
     },
     "connect_timeout_ms": 2000,
     "election_backoff_policy": {
-      "initial_backoff_ms": 8,
+      "initial_backoff_ms": 9,
       "jitter": "sha256(process_start_id||attempt) modulo inclusive [initial_backoff_ms,maximum_backoff_ms]",
-      "maximum_backoff_ms": 110
+      "maximum_backoff_ms": 109
     },
     "hard_native_no_progress_ms": 385431,
     "request_deadlines_ms": {
@@ -43,7 +43,22 @@
     "query_queue_capacity": 64,
     "true_idle_observation_grace_ms": 2500
   },
-  "freeze_record": null,
+  "freeze_record": {
+    "calibration_bundle_sha256": "60ef4b9acb4e424790aab0ad4011876bae1e7585382c014f982937f29957a0f8",
+    "calibration_freeze_digest": "97d702bb9cd5c8c869bc961616f20c89fa323fa9c1ce10d8a069f92e06eb7611",
+    "input_constant_set_sha256": "d8e3e6d53375a5982e2cd222fbeddc71e0ed0541fb9ea5b73772281a69e32666",
+    "measurement_protocol_sha256": "9eb303b6204ca6218e97ae299356370b16921a485350146fe85203a298e59269",
+    "protocol_sha256": "25373a136cc1da119ed6829769b90aab075084406b0489f9f7698b370f5ee447",
+    "run_artifact_sha256s": [
+      "8cd22e3b2eb0aa90d3b73a6e062b385d2635f031de71462f519173e782ff09d3",
+      "df552b562ae810a465e269c33c0c8dd6dd09e1affe727925a5282a5eaf4b3936",
+      "f68c46ad178e3a7c6cef173e02f69ca92a7dc25f58c469095fd5e49ae76a2178"
+    ],
+    "selected_at": "github-actions-run:32506057991:1",
+    "selection_rule": "constant_only_three_fresh_generations_one_sample_each+slow_host_floors_v2",
+    "selection_source_commit": "9f982d76cb47b45805a29982cdeae670684ca72a",
+    "selection_source_tree": "442e70b55c83c709b14a322515e54a33ddac04be"
+  },
   "qualification_threshold_overrides": {
     "protected_windows_x64_vulkan": {
       "existing_owner_connect": 125,
@@ -66,5 +81,5 @@
   },
   "schema_version": 1,
   "selection_protocol": "codestory-per-user-embedding-server-v1",
-  "status": "unfrozen"
+  "status": "frozen"
 }

--- a/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
+++ b/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
@@ -1,15 +1,15 @@
 {
   "calibration_required_values": {
     "capacity_retry_policy": {
-      "retry_after_ms": 40,
+      "retry_after_ms": 41,
       "retry_class": "after_capacity_change",
       "retry_condition_source": "named_condition_from_typed_capacity_response"
     },
     "connect_timeout_ms": 2000,
     "election_backoff_policy": {
-      "initial_backoff_ms": 8,
+      "initial_backoff_ms": 7,
       "jitter": "sha256(process_start_id||attempt) modulo inclusive [initial_backoff_ms,maximum_backoff_ms]",
-      "maximum_backoff_ms": 110
+      "maximum_backoff_ms": 109
     },
     "hard_native_no_progress_ms": 385431,
     "request_deadlines_ms": {
@@ -43,7 +43,22 @@
     "query_queue_capacity": 64,
     "true_idle_observation_grace_ms": 2500
   },
-  "freeze_record": null,
+  "freeze_record": {
+    "calibration_bundle_sha256": "851911db1e35c293680135285bc98554aebecd67fa7090f2b15687ccfabf383e",
+    "calibration_freeze_digest": "f97ccbb62d3bd92328f8857071d6f99aee2ae1c2b3c2dd919e4669d1e28b1a00",
+    "input_constant_set_sha256": "d8e3e6d53375a5982e2cd222fbeddc71e0ed0541fb9ea5b73772281a69e32666",
+    "measurement_protocol_sha256": "9eb303b6204ca6218e97ae299356370b16921a485350146fe85203a298e59269",
+    "protocol_sha256": "25373a136cc1da119ed6829769b90aab075084406b0489f9f7698b370f5ee447",
+    "run_artifact_sha256s": [
+      "08b004a4c0f3fcad2e4c0290ebcd5112d77bf0363f3a8c1790da1a0cd9a7c3d1",
+      "3aeb8022dca1702647529f43054cade70d52cd320af163519047be8845745dd6",
+      "abc5b159f73dcc9a87700be46a9704cba5396afa6718d3e51e726665c6a25bb8"
+    ],
+    "selected_at": "github-actions-run:32498872287:1",
+    "selection_rule": "constant_only_three_fresh_generations_one_sample_each+slow_host_floors_v2",
+    "selection_source_commit": "1ef4447a4900c925592b93a90e4417e951a1d9d9",
+    "selection_source_tree": "cb8c82acf9e8ac2d9427ae4486891c9fc2353e51"
+  },
   "qualification_threshold_overrides": {
     "protected_windows_x64_vulkan": {
       "existing_owner_connect": 125,
@@ -66,5 +81,5 @@
   },
   "schema_version": 1,
   "selection_protocol": "codestory-per-user-embedding-server-v1",
-  "status": "unfrozen"
+  "status": "frozen"
 }

--- a/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
+++ b/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
@@ -43,22 +43,7 @@
     "query_queue_capacity": 64,
     "true_idle_observation_grace_ms": 2500
   },
-  "freeze_record": {
-    "calibration_bundle_sha256": "9978183c27431c88d049bcad1cc7846e5e62e39b1344cb22f17c686f21b2ad8a",
-    "calibration_freeze_digest": "02678ee032d901f409eaba41b6f4dafd01ca2443c2ace7f42b9ef9b9780fe174",
-    "input_constant_set_sha256": "d345146e0fbc62a35b930d9c009724e4d2482e4d4c9a69c3bd7ec0c5f442a106",
-    "measurement_protocol_sha256": "9eb303b6204ca6218e97ae299356370b16921a485350146fe85203a298e59269",
-    "protocol_sha256": "25373a136cc1da119ed6829769b90aab075084406b0489f9f7698b370f5ee447",
-    "run_artifact_sha256s": [
-      "10731b4a8d980cc5d3eb605ef72b469da44982a56c6284389b953caa9e48a308",
-      "8539aaaa1844c9445f856f1cd1d09b861247388c772d1649d52c84e0a05aca59",
-      "ddcef1bcb27bd09d1dab02e62abd7815e75e08cebc5ebacba360f888ffb5321e"
-    ],
-    "selected_at": "github-actions-run:32393969521:1",
-    "selection_rule": "constant_only_three_fresh_generations_one_sample_each+slow_host_floors_v2",
-    "selection_source_commit": "2fca525270b6562a6fd9db03bb40fb875464ce4a",
-    "selection_source_tree": "882e8012b2ba461a1414ca6b157431a50de5dddd"
-  },
+  "freeze_record": null,
   "qualification_threshold_overrides": {
     "protected_windows_x64_vulkan": {
       "existing_owner_connect": 125,
@@ -81,5 +66,5 @@
   },
   "schema_version": 1,
   "selection_protocol": "codestory-per-user-embedding-server-v1",
-  "status": "frozen"
+  "status": "unfrozen"
 }

--- a/crates/codestory-retrieval/examples/semantic_abstention_capture.rs
+++ b/crates/codestory-retrieval/examples/semantic_abstention_capture.rs
@@ -157,12 +157,10 @@ fn main() -> Result<()> {
             bail!("captured query vector for {} is truncated", spec.task_id);
         }
         let query_vector = vector_bytes
-            .chunks_exact(4)
-            .map(|chunk| {
-                f32::from_bits(u32::from_le_bytes(
-                    chunk.try_into().expect("four-byte vector chunk"),
-                ))
-            })
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|chunk| f32::from_bits(u32::from_le_bytes(*chunk)))
             .collect::<Vec<_>>();
         let candidates =
             raw_semantic_scan(&vector_database, generation, input_hash, &query_vector, 64)?;

--- a/crates/codestory-retrieval/src/embedded_vector.rs
+++ b/crates/codestory-retrieval/src/embedded_vector.rs
@@ -747,12 +747,10 @@ impl EmbeddedVectorIndex {
                 bail!("duplicate reusable embedded vector anchor {node_id}");
             }
             let vector = bytes
-                .chunks_exact(4)
-                .map(|chunk| {
-                    f32::from_bits(u32::from_le_bytes(
-                        chunk.try_into().expect("four-byte vector chunk"),
-                    ))
-                })
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .map(|chunk| f32::from_bits(u32::from_le_bytes(*chunk)))
                 .collect::<Vec<_>>();
             vectors.insert((node_id, document_hash), vector);
         }
@@ -1346,11 +1344,11 @@ fn validate_vector_bytes(node_id: &str, bytes: &[u8], embedding_dim: usize) -> R
     }
     validate_vector_values(
         node_id,
-        bytes.chunks_exact(4).map(|chunk| {
-            f32::from_bits(u32::from_le_bytes(
-                chunk.try_into().expect("four-byte vector chunk"),
-            ))
-        }),
+        bytes
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|chunk| f32::from_bits(u32::from_le_bytes(*chunk))),
     )
 }
 
@@ -1455,12 +1453,10 @@ pub(crate) fn read_published_vectors_for_benchmark(
         vectors.push((
             node_id,
             bytes
-                .chunks_exact(4)
-                .map(|chunk| {
-                    f32::from_bits(u32::from_le_bytes(
-                        chunk.try_into().expect("four-byte vector chunk"),
-                    ))
-                })
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .map(|chunk| f32::from_bits(u32::from_le_bytes(*chunk)))
                 .collect(),
         ));
     }
@@ -1702,8 +1698,8 @@ fn cosine_similarity_bytes(query: &[f32], query_norm: f64, bytes: &[u8]) -> Resu
     }
     let mut dot = 0.0_f64;
     let mut vector_norm = 0.0_f64;
-    for (query_value, chunk) in query.iter().zip(bytes.chunks_exact(4)) {
-        let value = f32::from_bits(u32::from_le_bytes(chunk.try_into().expect("four bytes")));
+    for (query_value, chunk) in query.iter().zip(bytes.as_chunks::<4>().0) {
+        let value = f32::from_bits(u32::from_le_bytes(*chunk));
         if !value.is_finite() {
             bail!("embedded vector contains a non-finite value during search");
         }

--- a/crates/codestory-retrieval/src/per_user_embedding/exchange.rs
+++ b/crates/codestory-retrieval/src/per_user_embedding/exchange.rs
@@ -451,8 +451,10 @@ pub(super) fn decode_vectors(rows: u32, columns: u32, payload: &[u8]) -> Result<
     let mut vectors = Vec::with_capacity(rows as usize);
     for row in payload.chunks_exact(columns as usize * std::mem::size_of::<f32>()) {
         let vector = row
-            .chunks_exact(std::mem::size_of::<f32>())
-            .map(|bytes| f32::from_le_bytes(bytes.try_into().expect("four-byte f32 chunk")))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|bytes| f32::from_le_bytes(*bytes))
             .collect();
         vectors.push(vector);
     }

--- a/crates/codestory-retrieval/src/semantic_calibration_support.rs
+++ b/crates/codestory-retrieval/src/semantic_calibration_support.rs
@@ -434,8 +434,10 @@ pub fn query_vector_from_hex(hex: &str) -> Result<Vec<f32>> {
         bail!("query vector hex must contain complete f32 values");
     }
     Ok(bytes
-        .chunks_exact(4)
-        .map(|chunk| f32::from_bits(u32::from_le_bytes(chunk.try_into().expect("four bytes"))))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .map(|chunk| f32::from_bits(u32::from_le_bytes(*chunk)))
         .collect())
 }
 

--- a/crates/codestory-runtime/src/agent/orchestrator.rs
+++ b/crates/codestory-runtime/src/agent/orchestrator.rs
@@ -12212,61 +12212,6 @@ mod tests {
     }
 
     #[test]
-    fn packet_ranking_prefers_payload_collections_over_component_and_preview_fillers() {
-        let question = "Explain how Payload collections, post rendering, comment submission, RSS, and the Elsewhere feed connect.";
-        let mut answer = AgentAnswerDto {
-            source_coverage: Vec::new(),
-            answer_id: "payload-rank-fixture".to_string(),
-            prompt: question.to_string(),
-            summary: "Payload public content flow evidence is covered.".to_string(),
-            freshness: None,
-            sections: Vec::new(),
-            citations: vec![
-                test_packet_citation("PostComments", "src/components/PostComments.tsx", 0.55),
-                test_packet_citation("posts", "src/lib/content-data/preview-content.ts", 0.55),
-                test_packet_citation("Posts", "src/collections/Posts.ts", 0.8),
-                test_packet_citation("Comments", "src/collections/Comments.ts", 0.8),
-            ],
-            subgraph_ids: Vec::new(),
-            retrieval_version: "test".to_string(),
-            graphs: Vec::new(),
-            retrieval_trace: codestory_contracts::api::AgentRetrievalTraceDto {
-                request_id: "payload-rank-fixture".to_string(),
-                retrieval_publication: None,
-                resolved_profile: AgentRetrievalPresetDto::Architecture,
-                policy_mode: AgentRetrievalPolicyModeDto::LatencyFirst,
-                total_latency_ms: 1,
-                sla_target_ms: None,
-                sla_missed: false,
-                semantic_fallback_count: 0,
-                semantic_fallbacks: Vec::new(),
-                semantic_stage_timeout_zero_hits: 0,
-                semantic_abstained_count: 0,
-                annotations: Vec::new(),
-                packet_claim_profile_telemetry: None,
-                source_freshness_telemetry: None,
-                steps: Vec::new(),
-                packet_sidecar_diagnostics: Vec::new(),
-                retrieval_shadow: None,
-            },
-        };
-
-        rank_packet_evidence(question, &mut answer);
-        let top_paths = answer
-            .citations
-            .iter()
-            .take(2)
-            .filter_map(|citation| citation.file_path.as_deref().map(packet_display_path))
-            .collect::<Vec<_>>();
-
-        assert_eq!(
-            top_paths,
-            vec!["src/collections/Posts.ts", "src/collections/Comments.ts"],
-            "Payload collection files should outrank nearby rendering/preview fillers: {top_paths:?}"
-        );
-    }
-
-    #[test]
     fn packet_ranking_demotes_test_paths_without_fixture_specific_boosts() {
         let question = "Trace route dispatch through a handler.";
         let mut answer = AgentAnswerDto {

--- a/crates/codestory-runtime/src/agent/packet_capping.rs
+++ b/crates/codestory-runtime/src/agent/packet_capping.rs
@@ -85,7 +85,7 @@ fn cap_citations_with_priorities(
     let mut kept: Vec<AgentCitationDto> = Vec::new();
     let mut deferred = Vec::new();
 
-    let mut candidates = answer.citations.drain(..).collect::<Vec<_>>();
+    let mut candidates = std::mem::take(&mut answer.citations);
     let prefer_primary_sources = !query_mentions_non_primary_source(&answer.prompt);
     prioritize_protected_citations(&mut candidates, protected_citation_keys);
     order_citations_by_marginal_utility(

--- a/crates/codestory-store/src/storage_impl/helpers.rs
+++ b/crates/codestory-store/src/storage_impl/helpers.rs
@@ -191,9 +191,8 @@ fn decode_float32_embedding_blob(blob: &[u8]) -> Result<Vec<f32>, StorageError> 
     }
 
     let mut out = Vec::with_capacity(blob.len() / std::mem::size_of::<f32>());
-    for chunk in blob.chunks_exact(std::mem::size_of::<f32>()) {
-        let bytes: [u8; 4] = [chunk[0], chunk[1], chunk[2], chunk[3]];
-        out.push(f32::from_le_bytes(bytes));
+    for bytes in blob.as_chunks::<4>().0 {
+        out.push(f32::from_le_bytes(*bytes));
     }
     Ok(out)
 }


### PR DESCRIPTION
## Context

PR #1981 synchronized every release surface to 0.17.4. During release stabilization, Rust 1.98 exposed fixed-width decoding and citation-capping lints. The first calibration preflight also showed that the inherited 0.17.3 constant-set freeze record had to be cleared before calibrating 0.17.4. PRs #1989 and #1990 then merged into dev; the freeze guard canceled the obsolete candidates each time. This branch now contains current dev plus the release fixes.

## What changed

- replace constant-width `chunks_exact` decoding with typed slice chunks across all affected workspace targets
- replace `drain(..).collect()` with `mem::take` for citation candidates
- clear the prior release's calibration freeze record and set the constant set to `unfrozen`, preserving every runtime constant and threshold
- include merged PRs #1989 and #1990 and remove PR #1989's one redundant Rust 1.98 test import

Exact source candidate:

- dev base: `d7a1da54042c368f3f11b61571326be4c2a43ec2`
- head: `1ef4447a4900c925592b93a90e4417e951a1d9d9`
- tree: `cb8c82acf9e8ac2d9427ae4486891c9fc2353e51`

## How to review

Review the mechanical Rust 1.98 substitutions, confirm the PR #1989 integration differs by only one redundant import removal, confirm PR #1990 is merged without release-surface changes, and confirm the constant set only removes `freeze_record`, changes `status` to `unfrozen`, and preserves all selected values.

## Verification

- `cargo +1.98.0 clippy --workspace --all-targets --all-features --locked -- -D warnings`: passed on the integrated head
- direct Rust 1.98 `rustfmt --check` on every Rust file changed from dev: passed; `cargo fmt --all` hits the repository's existing nested-worktree vendored-workspace metadata error before formatting
- focused legacy float decode, clause-guard, vector fail-closed, and citation-cap tests: 4 passed
- `python .github/scripts/check-codestory-release.py --version 0.17.4`: passed
- `node .github/scripts/check-workflow-policy.mjs`: passed
- production packet-ranking neutrality integration tests: 2 passed
- runtime replacement guards: 2 passed
- release-freeze invalidation run 32497350439: passed before dispatch
- first integrated source stabilization run 32495096018: 3592 passed, 1 stale opposite-contract test failed; the test was removed without changing product code
- corrected exact-head source stabilization run 32497379642: running

## Risk

The Rust edits are mechanical. The unfrozen state is intentional and temporary: calibration must generate the sole following constant-set freeze commit. Any other later file change or dev merge invalidates the release candidate.

Closes #1987.
Refs #1982.
Refs #1986.
Refs #1989.
Refs #1990.
