### PR TITLE
[codex] add dark v3 packet projections

### DIFF
--- a/crates/codestory-agent/src/lib.rs
+++ b/crates/codestory-agent/src/lib.rs
@@ -30,6 +30,9 @@ pub mod packet_evidence;
 pub mod packet_evidence_carriers;
 pub mod packet_evidence_roles;
 pub mod packet_execution_graphs;
+#[cfg(any(test, feature = "test-support"))]
+#[doc(hidden)]
+pub mod packet_execution_plan_v3;
 pub mod packet_flow_requirements;
 pub mod packet_freshness;
 pub mod packet_obligations;

--- a/crates/codestory-agent/src/packet_execution_plan_v3.rs
+++ b/crates/codestory-agent/src/packet_execution_plan_v3.rs
@@ -1,0 +1,1046 @@
+//! Dark, pure v3 packet evidence planning.
+//!
+//! The module is compiled only for unit tests and the internal `test-support`
+//! feature. It translates the narrow historical inputs needed by the v3
+//! compatibility proof and evaluates an execution ledger without performing
+//! retrieval or changing the current packet compiler.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use codestory_contracts::api::{PacketClaimObligationDto, PacketClaimObligationKindDto};
+
+pub const PACKET_EXECUTION_PLAN_VERSION_V3: u32 = 3;
+
+macro_rules! stable_id {
+    ($name:ident) => {
+        #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        pub struct $name(String);
+
+        impl From<&str> for $name {
+            fn from(value: &str) -> Self {
+                Self(value.to_owned())
+            }
+        }
+
+        impl From<String> for $name {
+            fn from(value: String) -> Self {
+                Self(value)
+            }
+        }
+
+        impl $name {
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+    };
+}
+
+stable_id!(DiscoveryLeadIdV3);
+stable_id!(ClaimIdV3);
+stable_id!(RequirementIdV3);
+stable_id!(QueryIdV3);
+stable_id!(ReceiptIdV3);
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ReceiptRequirementKindV3 {
+    TypedProbeBinding {
+        input_index: u32,
+        path: Option<String>,
+        symbol_id: Option<String>,
+    },
+    SourceSpan {
+        path: String,
+        start_byte: u32,
+        end_byte: u32,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReceiptRequirementV3 {
+    pub id: RequirementIdV3,
+    pub kind: ReceiptRequirementKindV3,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscoveryLeadV3 {
+    pub id: DiscoveryLeadIdV3,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MaterialClaimV3 {
+    pub id: ClaimIdV3,
+    pub requirements: Vec<ReceiptRequirementV3>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PlanningSubjectV3 {
+    DiscoveryLead(DiscoveryLeadV3),
+    MaterialClaim(MaterialClaimV3),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceSpannedMaterialInputV3 {
+    pub claim_id: ClaimIdV3,
+    pub path: String,
+    pub start_byte: u32,
+    pub end_byte: u32,
+}
+
+pub enum ExistingObligationInputV3<'a> {
+    Legacy(&'a PacketClaimObligationDto),
+    SourceSpanned(SourceSpannedMaterialInputV3),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClassifierErrorV3 {
+    UnsupportedLegacyObligation,
+    InvalidSourceSpan,
+}
+
+pub fn classify_existing_obligation_v3(
+    input: ExistingObligationInputV3<'_>,
+) -> Result<PlanningSubjectV3, ClassifierErrorV3> {
+    match input {
+        ExistingObligationInputV3::Legacy(obligation) => {
+            if obligation.kind != PacketClaimObligationKindDto::ExactProbe {
+                return Err(ClassifierErrorV3::UnsupportedLegacyObligation);
+            }
+            let Some(binding) = obligation.probe_binding.as_ref() else {
+                return Ok(PlanningSubjectV3::DiscoveryLead(DiscoveryLeadV3 {
+                    id: DiscoveryLeadIdV3::from(obligation.id.clone()),
+                }));
+            };
+            Ok(PlanningSubjectV3::MaterialClaim(MaterialClaimV3 {
+                id: ClaimIdV3::from(obligation.id.clone()),
+                requirements: vec![ReceiptRequirementV3 {
+                    id: RequirementIdV3::from(format!(
+                        "typed_probe_binding:{}",
+                        binding.input_index
+                    )),
+                    kind: ReceiptRequirementKindV3::TypedProbeBinding {
+                        input_index: binding.input_index,
+                        path: binding.path.clone(),
+                        symbol_id: binding.symbol_id.clone(),
+                    },
+                }],
+            }))
+        }
+        ExistingObligationInputV3::SourceSpanned(source) => {
+            if source.path.is_empty() || source.start_byte >= source.end_byte {
+                return Err(ClassifierErrorV3::InvalidSourceSpan);
+            }
+            Ok(PlanningSubjectV3::MaterialClaim(MaterialClaimV3 {
+                id: source.claim_id,
+                requirements: vec![ReceiptRequirementV3 {
+                    id: RequirementIdV3::from("source_span"),
+                    kind: ReceiptRequirementKindV3::SourceSpan {
+                        path: source.path,
+                        start_byte: source.start_byte,
+                        end_byte: source.end_byte,
+                    },
+                }],
+            }))
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReceiptOwnerV3 {
+    DiscoveryLead(DiscoveryLeadIdV3),
+    MaterialClaim(ClaimIdV3),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AdmittedReceiptV3 {
+    pub id: ReceiptIdV3,
+    pub owner: ReceiptOwnerV3,
+    pub requirement_id: RequirementIdV3,
+    pub kind: ReceiptRequirementKindV3,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QuerySubjectV3 {
+    DiscoveryLead(DiscoveryLeadIdV3),
+    MaterialClaim(ClaimIdV3),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlannedQueryV3 {
+    pub id: QueryIdV3,
+    pub subject: QuerySubjectV3,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum QueryFailureGapV3 {
+    RetrievalUnavailable,
+    SourceUnavailable,
+    BudgetUnavailable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QueryOutcomeV3 {
+    Completed {
+        receipt_ids: Vec<ReceiptIdV3>,
+    },
+    SkippedBecauseDischarged {
+        claim_id: ClaimIdV3,
+        receipt_ids: Vec<ReceiptIdV3>,
+    },
+    NotDispatched,
+    Failed {
+        gap: QueryFailureGapV3,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueryExecutionV3 {
+    pub query_id: QueryIdV3,
+    pub outcome: QueryOutcomeV3,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PacketExecutionPlanV3 {
+    pub version: u32,
+    pub leads: Vec<DiscoveryLeadV3>,
+    pub claims: Vec<MaterialClaimV3>,
+    pub queries: Vec<PlannedQueryV3>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClaimDispositionV3 {
+    Discharged {
+        receipt_ids: Vec<ReceiptIdV3>,
+    },
+    Gap {
+        missing_requirement_ids: Vec<RequirementIdV3>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClaimResultV3 {
+    pub claim_id: ClaimIdV3,
+    pub disposition: ClaimDispositionV3,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueryResultV3 {
+    pub query_id: QueryIdV3,
+    pub outcome: QueryOutcomeV3,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum QueryGapV3 {
+    NotDispatched {
+        query_id: QueryIdV3,
+    },
+    Failed {
+        query_id: QueryIdV3,
+        gap: QueryFailureGapV3,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PacketExecutionLedgerV3 {
+    pub claim_results: Vec<ClaimResultV3>,
+    pub query_results: Vec<QueryResultV3>,
+    pub query_gaps: Vec<QueryGapV3>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PlanValidationErrorV3 {
+    WrongPlanVersion(u32),
+    DuplicateLeadId(DiscoveryLeadIdV3),
+    DuplicateClaimId(ClaimIdV3),
+    DuplicateRequirementId {
+        claim_id: ClaimIdV3,
+        requirement_id: RequirementIdV3,
+    },
+    EmptyMaterialClaimRequirements(ClaimIdV3),
+    DuplicateQueryId(QueryIdV3),
+    UnknownQuerySubject(QueryIdV3),
+    DuplicateReceiptId(ReceiptIdV3),
+    UnknownReceiptOwner(ReceiptIdV3),
+    DuplicateQueryExecution(QueryIdV3),
+    UnknownQueryExecution(QueryIdV3),
+    MissingQueryExecution(QueryIdV3),
+    DuplicateOutcomeReceiptId {
+        query_id: QueryIdV3,
+        receipt_id: ReceiptIdV3,
+    },
+    EmptySkipReceiptSet {
+        query_id: QueryIdV3,
+    },
+    SkipClaimDoesNotMatchQuery {
+        query_id: QueryIdV3,
+        claim_id: ClaimIdV3,
+    },
+    UnknownSkipReceipt {
+        query_id: QueryIdV3,
+        receipt_id: ReceiptIdV3,
+    },
+    ForeignSkipReceipt {
+        query_id: QueryIdV3,
+        receipt_id: ReceiptIdV3,
+        claim_id: ClaimIdV3,
+    },
+    NonDischargingSkipReceiptSet {
+        query_id: QueryIdV3,
+        claim_id: ClaimIdV3,
+    },
+}
+
+pub fn evaluate_execution_plan_v3(
+    mut plan: PacketExecutionPlanV3,
+    mut admitted_receipts: Vec<AdmittedReceiptV3>,
+    executions: Vec<QueryExecutionV3>,
+) -> Result<PacketExecutionLedgerV3, PlanValidationErrorV3> {
+    if plan.version != PACKET_EXECUTION_PLAN_VERSION_V3 {
+        return Err(PlanValidationErrorV3::WrongPlanVersion(plan.version));
+    }
+
+    plan.leads.sort_by(|left, right| left.id.cmp(&right.id));
+    reject_adjacent_duplicate(&plan.leads, |lead| &lead.id)
+        .map_err(PlanValidationErrorV3::DuplicateLeadId)?;
+    plan.claims.sort_by(|left, right| left.id.cmp(&right.id));
+    reject_adjacent_duplicate(&plan.claims, |claim| &claim.id)
+        .map_err(PlanValidationErrorV3::DuplicateClaimId)?;
+    for claim in &mut plan.claims {
+        if claim.requirements.is_empty() {
+            return Err(PlanValidationErrorV3::EmptyMaterialClaimRequirements(
+                claim.id.clone(),
+            ));
+        }
+        claim
+            .requirements
+            .sort_by(|left, right| left.id.cmp(&right.id));
+        if let Err(requirement_id) =
+            reject_adjacent_duplicate(&claim.requirements, |requirement| &requirement.id)
+        {
+            return Err(PlanValidationErrorV3::DuplicateRequirementId {
+                claim_id: claim.id.clone(),
+                requirement_id,
+            });
+        }
+    }
+    plan.queries.sort_by(|left, right| left.id.cmp(&right.id));
+    reject_adjacent_duplicate(&plan.queries, |query| &query.id)
+        .map_err(PlanValidationErrorV3::DuplicateQueryId)?;
+
+    let lead_ids = plan
+        .leads
+        .iter()
+        .map(|lead| lead.id.clone())
+        .collect::<BTreeSet<_>>();
+    let claims = plan
+        .claims
+        .iter()
+        .map(|claim| (claim.id.clone(), claim))
+        .collect::<BTreeMap<_, _>>();
+    for query in &plan.queries {
+        let subject_exists = match &query.subject {
+            QuerySubjectV3::DiscoveryLead(id) => lead_ids.contains(id),
+            QuerySubjectV3::MaterialClaim(id) => claims.contains_key(id),
+        };
+        if !subject_exists {
+            return Err(PlanValidationErrorV3::UnknownQuerySubject(query.id.clone()));
+        }
+    }
+
+    admitted_receipts.sort_by(|left, right| left.id.cmp(&right.id));
+    reject_adjacent_duplicate(&admitted_receipts, |receipt| &receipt.id)
+        .map_err(PlanValidationErrorV3::DuplicateReceiptId)?;
+    for receipt in &admitted_receipts {
+        let owner_exists = match &receipt.owner {
+            ReceiptOwnerV3::DiscoveryLead(id) => lead_ids.contains(id),
+            ReceiptOwnerV3::MaterialClaim(id) => claims.contains_key(id),
+        };
+        if !owner_exists {
+            return Err(PlanValidationErrorV3::UnknownReceiptOwner(
+                receipt.id.clone(),
+            ));
+        }
+    }
+    let receipts_by_id = admitted_receipts
+        .iter()
+        .map(|receipt| (receipt.id.clone(), receipt))
+        .collect::<BTreeMap<_, _>>();
+
+    let planned_queries = plan
+        .queries
+        .iter()
+        .map(|query| (query.id.clone(), query))
+        .collect::<BTreeMap<_, _>>();
+    let mut executions_by_id = BTreeMap::new();
+    for mut execution in executions {
+        let Some(query) = planned_queries.get(&execution.query_id) else {
+            return Err(PlanValidationErrorV3::UnknownQueryExecution(
+                execution.query_id,
+            ));
+        };
+        if let Err(receipt_id) = normalize_receipt_ids(&mut execution.outcome) {
+            return Err(PlanValidationErrorV3::DuplicateOutcomeReceiptId {
+                query_id: execution.query_id,
+                receipt_id,
+            });
+        }
+        if executions_by_id
+            .insert(execution.query_id.clone(), execution)
+            .is_some()
+        {
+            return Err(PlanValidationErrorV3::DuplicateQueryExecution(
+                query.id.clone(),
+            ));
+        }
+    }
+    for query in &plan.queries {
+        if !executions_by_id.contains_key(&query.id) {
+            return Err(PlanValidationErrorV3::MissingQueryExecution(
+                query.id.clone(),
+            ));
+        }
+    }
+
+    for execution in executions_by_id.values() {
+        let QueryOutcomeV3::SkippedBecauseDischarged {
+            claim_id,
+            receipt_ids,
+        } = &execution.outcome
+        else {
+            continue;
+        };
+        if receipt_ids.is_empty() {
+            return Err(PlanValidationErrorV3::EmptySkipReceiptSet {
+                query_id: execution.query_id.clone(),
+            });
+        }
+        let query = planned_queries
+            .get(&execution.query_id)
+            .expect("executions were checked against planned queries");
+        if query.subject != QuerySubjectV3::MaterialClaim(claim_id.clone()) {
+            return Err(PlanValidationErrorV3::SkipClaimDoesNotMatchQuery {
+                query_id: execution.query_id.clone(),
+                claim_id: claim_id.clone(),
+            });
+        }
+        let claim = claims
+            .get(claim_id)
+            .expect("a planned material query references an existing claim");
+        let mut skip_receipts = Vec::with_capacity(receipt_ids.len());
+        for receipt_id in receipt_ids {
+            let Some(receipt) = receipts_by_id.get(receipt_id) else {
+                return Err(PlanValidationErrorV3::UnknownSkipReceipt {
+                    query_id: execution.query_id.clone(),
+                    receipt_id: receipt_id.clone(),
+                });
+            };
+            if receipt.owner != ReceiptOwnerV3::MaterialClaim(claim_id.clone()) {
+                return Err(PlanValidationErrorV3::ForeignSkipReceipt {
+                    query_id: execution.query_id.clone(),
+                    receipt_id: receipt_id.clone(),
+                    claim_id: claim_id.clone(),
+                });
+            }
+            skip_receipts.push(*receipt);
+        }
+        if !receipts_discharge_claim(claim, skip_receipts.into_iter()) {
+            return Err(PlanValidationErrorV3::NonDischargingSkipReceiptSet {
+                query_id: execution.query_id.clone(),
+                claim_id: claim_id.clone(),
+            });
+        }
+    }
+
+    let claim_results = plan
+        .claims
+        .iter()
+        .map(|claim| {
+            let exact_receipts = admitted_receipts
+                .iter()
+                .filter(|receipt| receipt.owner == ReceiptOwnerV3::MaterialClaim(claim.id.clone()));
+            let disposition = claim_disposition(claim, exact_receipts);
+            ClaimResultV3 {
+                claim_id: claim.id.clone(),
+                disposition,
+            }
+        })
+        .collect();
+    let query_results = executions_by_id
+        .into_values()
+        .map(|execution| QueryResultV3 {
+            query_id: execution.query_id,
+            outcome: execution.outcome,
+        })
+        .collect::<Vec<_>>();
+    let mut query_gaps = query_results
+        .iter()
+        .filter_map(|result| match &result.outcome {
+            QueryOutcomeV3::NotDispatched => Some(QueryGapV3::NotDispatched {
+                query_id: result.query_id.clone(),
+            }),
+            QueryOutcomeV3::Failed { gap } => Some(QueryGapV3::Failed {
+                query_id: result.query_id.clone(),
+                gap: gap.clone(),
+            }),
+            QueryOutcomeV3::Completed { .. } | QueryOutcomeV3::SkippedBecauseDischarged { .. } => {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+    query_gaps.sort();
+
+    Ok(PacketExecutionLedgerV3 {
+        claim_results,
+        query_results,
+        query_gaps,
+    })
+}
+
+fn reject_adjacent_duplicate<T, I, F>(values: &[T], identity: F) -> Result<(), I>
+where
+    I: Clone + Eq,
+    F: Fn(&T) -> &I,
+{
+    for pair in values.windows(2) {
+        if identity(&pair[0]) == identity(&pair[1]) {
+            return Err(identity(&pair[0]).clone());
+        }
+    }
+    Ok(())
+}
+
+fn normalize_receipt_ids(outcome: &mut QueryOutcomeV3) -> Result<(), ReceiptIdV3> {
+    let receipt_ids = match outcome {
+        QueryOutcomeV3::Completed { receipt_ids }
+        | QueryOutcomeV3::SkippedBecauseDischarged { receipt_ids, .. } => receipt_ids,
+        QueryOutcomeV3::NotDispatched | QueryOutcomeV3::Failed { .. } => return Ok(()),
+    };
+    receipt_ids.sort();
+    reject_adjacent_duplicate(receipt_ids, |receipt_id| receipt_id)
+}
+
+fn receipts_discharge_claim<'a>(
+    claim: &MaterialClaimV3,
+    receipts: impl Iterator<Item = &'a AdmittedReceiptV3> + Clone,
+) -> bool {
+    claim.requirements.iter().all(|requirement| {
+        receipts.clone().any(|receipt| {
+            receipt.requirement_id == requirement.id && receipt.kind == requirement.kind
+        })
+    })
+}
+
+fn claim_disposition<'a>(
+    claim: &MaterialClaimV3,
+    receipts: impl Iterator<Item = &'a AdmittedReceiptV3> + Clone,
+) -> ClaimDispositionV3 {
+    let missing_requirement_ids = claim
+        .requirements
+        .iter()
+        .filter(|requirement| {
+            !receipts.clone().any(|receipt| {
+                receipt.requirement_id == requirement.id && receipt.kind == requirement.kind
+            })
+        })
+        .map(|requirement| requirement.id.clone())
+        .collect::<Vec<_>>();
+    if missing_requirement_ids.is_empty() {
+        ClaimDispositionV3::Discharged {
+            receipt_ids: receipts
+                .filter(|receipt| {
+                    claim.requirements.iter().any(|requirement| {
+                        receipt.requirement_id == requirement.id && receipt.kind == requirement.kind
+                    })
+                })
+                .map(|receipt| receipt.id.clone())
+                .collect::<Vec<_>>(),
+        }
+    } else {
+        ClaimDispositionV3::Gap {
+            missing_requirement_ids,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use codestory_contracts::api::{
+        PACKET_OBLIGATION_PLAN_VERSION, PacketClaimObligationDto, PacketClaimObligationKindDto,
+        PacketObligationProofStatusDto, PacketProbeDto, PacketProbeResolutionDto,
+        PacketProbeResolutionStatusDto,
+    };
+
+    use super::*;
+
+    fn legacy_exact(probe_binding: Option<PacketProbeResolutionDto>) -> PacketClaimObligationDto {
+        PacketClaimObligationDto {
+            id: "exact:entry".to_owned(),
+            kind: PacketClaimObligationKindDto::ExactProbe,
+            binding_terms: vec!["entry".to_owned()],
+            probe_binding,
+            material: true,
+            allowed_node_kinds: Vec::new(),
+            required_edge_kind: None,
+            requires_complete_discovery: false,
+            proof_status: PacketObligationProofStatusDto::Planned,
+            reason: None,
+            carrier_node_ids: Vec::new(),
+            carrier_paths: Vec::new(),
+            carrier_edge_proofs: Vec::new(),
+            open_next_candidates: vec!["entry".to_owned()],
+        }
+    }
+
+    fn binding() -> PacketProbeResolutionDto {
+        PacketProbeResolutionDto {
+            input_index: 0,
+            probe: PacketProbeDto::FileSymbol {
+                path: "src/lib.rs".to_owned(),
+                symbol: "entry".to_owned(),
+            },
+            status: PacketProbeResolutionStatusDto::IndexedSymbol,
+            normalized_query: Some("entry".to_owned()),
+            path: Some("src/lib.rs".to_owned()),
+            symbol_id: Some("crate::entry".to_owned()),
+            candidates: Vec::new(),
+            rejection: None,
+        }
+    }
+
+    fn requirement(id: &str) -> ReceiptRequirementV3 {
+        ReceiptRequirementV3 {
+            id: RequirementIdV3::from(id),
+            kind: ReceiptRequirementKindV3::TypedProbeBinding {
+                input_index: 0,
+                path: Some("src/lib.rs".to_owned()),
+                symbol_id: Some("crate::entry".to_owned()),
+            },
+        }
+    }
+
+    fn claim(id: &str, requirement_ids: &[&str]) -> MaterialClaimV3 {
+        MaterialClaimV3 {
+            id: ClaimIdV3::from(id),
+            requirements: requirement_ids.iter().map(|id| requirement(id)).collect(),
+        }
+    }
+
+    fn lead(id: &str) -> DiscoveryLeadV3 {
+        DiscoveryLeadV3 {
+            id: DiscoveryLeadIdV3::from(id),
+        }
+    }
+
+    fn receipt(id: &str, claim_id: &str, requirement_id: &str) -> AdmittedReceiptV3 {
+        AdmittedReceiptV3 {
+            id: ReceiptIdV3::from(id),
+            owner: ReceiptOwnerV3::MaterialClaim(ClaimIdV3::from(claim_id)),
+            requirement_id: RequirementIdV3::from(requirement_id),
+            kind: requirement(requirement_id).kind,
+        }
+    }
+
+    fn query(id: &str, claim_id: &str) -> PlannedQueryV3 {
+        PlannedQueryV3 {
+            id: QueryIdV3::from(id),
+            subject: QuerySubjectV3::MaterialClaim(ClaimIdV3::from(claim_id)),
+        }
+    }
+
+    fn execution(id: &str, outcome: QueryOutcomeV3) -> QueryExecutionV3 {
+        QueryExecutionV3 {
+            query_id: QueryIdV3::from(id),
+            outcome,
+        }
+    }
+
+    fn plan(
+        leads: Vec<DiscoveryLeadV3>,
+        claims: Vec<MaterialClaimV3>,
+        queries: Vec<PlannedQueryV3>,
+    ) -> PacketExecutionPlanV3 {
+        PacketExecutionPlanV3 {
+            version: PACKET_EXECUTION_PLAN_VERSION_V3,
+            leads,
+            claims,
+            queries,
+        }
+    }
+
+    #[test]
+    fn packet_execution_plan_v3_classifies_historical_inputs_without_legacy_authority() {
+        assert_eq!(PACKET_OBLIGATION_PLAN_VERSION, 1);
+        assert_ne!(
+            PACKET_EXECUTION_PLAN_VERSION_V3,
+            PACKET_OBLIGATION_PLAN_VERSION
+        );
+
+        let unbound = legacy_exact(None);
+        assert_eq!(
+            classify_existing_obligation_v3(ExistingObligationInputV3::Legacy(&unbound))
+                .expect("classify generated exact probe"),
+            PlanningSubjectV3::DiscoveryLead(lead("exact:entry"))
+        );
+
+        let bound = legacy_exact(Some(binding()));
+        let PlanningSubjectV3::MaterialClaim(bound_claim) =
+            classify_existing_obligation_v3(ExistingObligationInputV3::Legacy(&bound))
+                .expect("classify bound probe")
+        else {
+            panic!("bound typed probe must be material");
+        };
+        assert_eq!(bound_claim.id, ClaimIdV3::from("exact:entry"));
+        assert_eq!(bound_claim.requirements.len(), 1);
+
+        let PlanningSubjectV3::MaterialClaim(source_claim) = classify_existing_obligation_v3(
+            ExistingObligationInputV3::SourceSpanned(SourceSpannedMaterialInputV3 {
+                claim_id: ClaimIdV3::from("source:entry"),
+                path: "src/lib.rs".to_owned(),
+                start_byte: 12,
+                end_byte: 44,
+            }),
+        )
+        .expect("classify source-spanned claim") else {
+            panic!("source-spanned language must be material");
+        };
+        assert_eq!(source_claim.requirements.len(), 1);
+        assert!(matches!(
+            source_claim.requirements[0].kind,
+            ReceiptRequirementKindV3::SourceSpan { .. }
+        ));
+    }
+
+    #[test]
+    fn packet_execution_plan_v3_discharge_requires_separately_admitted_exact_receipts() {
+        let material = claim("claim-a", &["requirement-a"]);
+        let planned = plan(
+            Vec::new(),
+            vec![material],
+            vec![query("query-a", "claim-a")],
+        );
+
+        for receipt_ids in [Vec::new(), vec![ReceiptIdV3::from("receipt-a")]] {
+            let ledger = evaluate_execution_plan_v3(
+                planned.clone(),
+                Vec::new(),
+                vec![execution(
+                    "query-a",
+                    QueryOutcomeV3::Completed { receipt_ids },
+                )],
+            )
+            .expect("completed query is a valid execution record");
+            assert_eq!(
+                ledger.claim_results[0].disposition,
+                ClaimDispositionV3::Gap {
+                    missing_requirement_ids: vec![RequirementIdV3::from("requirement-a")],
+                }
+            );
+        }
+
+        let discovery_receipt = AdmittedReceiptV3 {
+            id: ReceiptIdV3::from("receipt-a"),
+            owner: ReceiptOwnerV3::DiscoveryLead(DiscoveryLeadIdV3::from("lead-a")),
+            requirement_id: RequirementIdV3::from("requirement-a"),
+            kind: requirement("requirement-a").kind,
+        };
+        let ledger = evaluate_execution_plan_v3(
+            plan(
+                vec![lead("lead-a")],
+                vec![claim("claim-a", &["requirement-a"])],
+                vec![query("query-a", "claim-a")],
+            ),
+            vec![discovery_receipt],
+            vec![execution(
+                "query-a",
+                QueryOutcomeV3::Completed {
+                    receipt_ids: vec![ReceiptIdV3::from("receipt-a")],
+                },
+            )],
+        )
+        .expect("discovery evidence remains admissible as evidence");
+        assert!(matches!(
+            ledger.claim_results[0].disposition,
+            ClaimDispositionV3::Gap { .. }
+        ));
+    }
+
+    #[test]
+    fn packet_execution_plan_v3_discharge_retains_only_matching_receipts() {
+        let ledger = evaluate_execution_plan_v3(
+            plan(
+                Vec::new(),
+                vec![claim("claim-a", &["requirement-a"])],
+                vec![query("query-a", "claim-a")],
+            ),
+            vec![
+                receipt("receipt-unused", "claim-a", "other-requirement"),
+                receipt("receipt-exact", "claim-a", "requirement-a"),
+            ],
+            vec![execution(
+                "query-a",
+                QueryOutcomeV3::Completed {
+                    receipt_ids: vec![ReceiptIdV3::from("receipt-exact")],
+                },
+            )],
+        )
+        .expect("evaluate exact receipt retention");
+
+        assert_eq!(
+            ledger.claim_results[0].disposition,
+            ClaimDispositionV3::Discharged {
+                receipt_ids: vec![ReceiptIdV3::from("receipt-exact")],
+            }
+        );
+    }
+
+    #[test]
+    fn packet_execution_plan_v3_not_dispatched_and_failed_are_exact_gaps() {
+        let ledger = evaluate_execution_plan_v3(
+            plan(
+                Vec::new(),
+                vec![claim("claim-a", &["requirement-a"])],
+                vec![query("query-b", "claim-a"), query("query-a", "claim-a")],
+            ),
+            vec![receipt("receipt-a", "claim-a", "requirement-a")],
+            vec![
+                execution(
+                    "query-b",
+                    QueryOutcomeV3::Failed {
+                        gap: QueryFailureGapV3::RetrievalUnavailable,
+                    },
+                ),
+                execution("query-a", QueryOutcomeV3::NotDispatched),
+            ],
+        )
+        .expect("evaluate query gaps");
+
+        assert_eq!(
+            ledger.query_gaps,
+            vec![
+                QueryGapV3::NotDispatched {
+                    query_id: QueryIdV3::from("query-a"),
+                },
+                QueryGapV3::Failed {
+                    query_id: QueryIdV3::from("query-b"),
+                    gap: QueryFailureGapV3::RetrievalUnavailable,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn packet_execution_plan_v3_receipt_backed_skip_fails_closed() {
+        let base_plan = || {
+            plan(
+                Vec::new(),
+                vec![
+                    claim("claim-a", &["requirement-a"]),
+                    claim("claim-b", &["requirement-b"]),
+                ],
+                vec![query("query-a", "claim-a")],
+            )
+        };
+        let skip = |claim_id: &str, receipt_ids: Vec<ReceiptIdV3>| {
+            vec![execution(
+                "query-a",
+                QueryOutcomeV3::SkippedBecauseDischarged {
+                    claim_id: ClaimIdV3::from(claim_id),
+                    receipt_ids,
+                },
+            )]
+        };
+
+        assert_eq!(
+            evaluate_execution_plan_v3(base_plan(), Vec::new(), skip("claim-a", Vec::new())),
+            Err(PlanValidationErrorV3::EmptySkipReceiptSet {
+                query_id: QueryIdV3::from("query-a")
+            })
+        );
+        assert_eq!(
+            evaluate_execution_plan_v3(
+                base_plan(),
+                Vec::new(),
+                skip("claim-a", vec![ReceiptIdV3::from("unknown")])
+            ),
+            Err(PlanValidationErrorV3::UnknownSkipReceipt {
+                query_id: QueryIdV3::from("query-a"),
+                receipt_id: ReceiptIdV3::from("unknown"),
+            })
+        );
+        assert_eq!(
+            evaluate_execution_plan_v3(
+                base_plan(),
+                vec![receipt("receipt-b", "claim-b", "requirement-b")],
+                skip("claim-a", vec![ReceiptIdV3::from("receipt-b")])
+            ),
+            Err(PlanValidationErrorV3::ForeignSkipReceipt {
+                query_id: QueryIdV3::from("query-a"),
+                receipt_id: ReceiptIdV3::from("receipt-b"),
+                claim_id: ClaimIdV3::from("claim-a"),
+            })
+        );
+        assert_eq!(
+            evaluate_execution_plan_v3(
+                base_plan(),
+                vec![receipt("receipt-a", "claim-a", "wrong-requirement")],
+                skip("claim-a", vec![ReceiptIdV3::from("receipt-a")])
+            ),
+            Err(PlanValidationErrorV3::NonDischargingSkipReceiptSet {
+                query_id: QueryIdV3::from("query-a"),
+                claim_id: ClaimIdV3::from("claim-a"),
+            })
+        );
+        assert_eq!(
+            evaluate_execution_plan_v3(
+                base_plan(),
+                vec![receipt("receipt-a", "claim-a", "requirement-a")],
+                skip("claim-b", vec![ReceiptIdV3::from("receipt-a")])
+            ),
+            Err(PlanValidationErrorV3::SkipClaimDoesNotMatchQuery {
+                query_id: QueryIdV3::from("query-a"),
+                claim_id: ClaimIdV3::from("claim-b"),
+            })
+        );
+
+        let ledger = evaluate_execution_plan_v3(
+            base_plan(),
+            vec![receipt("receipt-a", "claim-a", "requirement-a")],
+            skip("claim-a", vec![ReceiptIdV3::from("receipt-a")]),
+        )
+        .expect("exact admitted discharging skip");
+        assert_eq!(
+            ledger.query_results[0].outcome,
+            QueryOutcomeV3::SkippedBecauseDischarged {
+                claim_id: ClaimIdV3::from("claim-a"),
+                receipt_ids: vec![ReceiptIdV3::from("receipt-a")],
+            }
+        );
+    }
+
+    #[test]
+    fn packet_execution_plan_v3_duplicate_identities_fail_closed() {
+        let duplicate_claim = claim("claim-a", &["requirement-a"]);
+        assert_eq!(
+            evaluate_execution_plan_v3(
+                plan(
+                    Vec::new(),
+                    vec![duplicate_claim.clone(), duplicate_claim],
+                    Vec::new()
+                ),
+                Vec::new(),
+                Vec::new()
+            ),
+            Err(PlanValidationErrorV3::DuplicateClaimId(ClaimIdV3::from(
+                "claim-a"
+            )))
+        );
+        assert_eq!(
+            evaluate_execution_plan_v3(
+                plan(
+                    Vec::new(),
+                    vec![claim("claim-a", &["requirement-a"])],
+                    vec![query("query-a", "claim-a"), query("query-a", "claim-a")]
+                ),
+                Vec::new(),
+                Vec::new()
+            ),
+            Err(PlanValidationErrorV3::DuplicateQueryId(QueryIdV3::from(
+                "query-a"
+            )))
+        );
+        let duplicate_receipt = receipt("receipt-a", "claim-a", "requirement-a");
+        assert_eq!(
+            evaluate_execution_plan_v3(
+                plan(
+                    Vec::new(),
+                    vec![claim("claim-a", &["requirement-a"])],
+                    Vec::new()
+                ),
+                vec![duplicate_receipt.clone(), duplicate_receipt],
+                Vec::new()
+            ),
+            Err(PlanValidationErrorV3::DuplicateReceiptId(
+                ReceiptIdV3::from("receipt-a")
+            ))
+        );
+        assert_eq!(
+            evaluate_execution_plan_v3(
+                plan(
+                    Vec::new(),
+                    vec![claim("claim-a", &["requirement-a"])],
+                    vec![query("query-a", "claim-a")]
+                ),
+                vec![receipt("receipt-a", "claim-a", "requirement-a")],
+                vec![execution(
+                    "query-a",
+                    QueryOutcomeV3::Completed {
+                        receipt_ids: vec![
+                            ReceiptIdV3::from("receipt-a"),
+                            ReceiptIdV3::from("receipt-a"),
+                        ],
+                    },
+                )]
+            ),
+            Err(PlanValidationErrorV3::DuplicateOutcomeReceiptId {
+                query_id: QueryIdV3::from("query-a"),
+                receipt_id: ReceiptIdV3::from("receipt-a"),
+            })
+        );
+    }
+
+    #[test]
+    fn packet_execution_plan_v3_ordering_is_identity_stable() {
+        let first = evaluate_execution_plan_v3(
+            plan(
+                Vec::new(),
+                vec![
+                    claim("claim-b", &["requirement-b"]),
+                    claim("claim-a", &["requirement-a"]),
+                ],
+                vec![query("query-b", "claim-b"), query("query-a", "claim-a")],
+            ),
+            vec![
+                receipt("receipt-b", "claim-b", "requirement-b"),
+                receipt("receipt-a", "claim-a", "requirement-a"),
+            ],
+            vec![
+                execution("query-b", QueryOutcomeV3::NotDispatched),
+                execution(
+                    "query-a",
+                    QueryOutcomeV3::Completed {
+                        receipt_ids: vec![ReceiptIdV3::from("receipt-a")],
+                    },
+                ),
+            ],
+        )
+        .expect("evaluate first ordering");
+        let second = evaluate_execution_plan_v3(
+            plan(
+                Vec::new(),
+                vec![
+                    claim("claim-a", &["requirement-a"]),
+                    claim("claim-b", &["requirement-b"]),
+                ],
+                vec![query("query-a", "claim-a"), query("query-b", "claim-b")],
+            ),
+            vec![
+                receipt("receipt-a", "claim-a", "requirement-a"),
+                receipt("receipt-b", "claim-b", "requirement-b"),
+            ],
+            vec![
+                execution(
+                    "query-a",
+                    QueryOutcomeV3::Completed {
+                        receipt_ids: vec![ReceiptIdV3::from("receipt-a")],
+                    },
+                ),
+                execution("query-b", QueryOutcomeV3::NotDispatched),
+            ],
+        )
+        .expect("evaluate second ordering");
+
+        assert_eq!(first, second);
+        assert_eq!(first.claim_results[0].claim_id, ClaimIdV3::from("claim-a"));
+        assert_eq!(first.query_results[0].query_id, QueryIdV3::from("query-a"));
+    }
+}

--- a/crates/codestory-agent/src/packet_execution_plan_v3.rs
+++ b/crates/codestory-agent/src/packet_execution_plan_v3.rs
@@ -8,8 +8,15 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use codestory_contracts::api::{PacketClaimObligationDto, PacketClaimObligationKindDto};
+use serde::Serialize;
 
 pub const PACKET_EXECUTION_PLAN_VERSION_V3: u32 = 3;
+
+/// Canonicalize a closed v3 input with the RFC 8785 implementation already
+/// pinned behind this dark module's test-support gate.
+pub fn canonical_json_bytes_v3<T: Serialize>(value: &T) -> Result<Vec<u8>, String> {
+    serde_json_canonicalizer::to_vec(value).map_err(|error| error.to_string())
+}
 
 macro_rules! stable_id {
     ($name:ident) => {

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -7011,6 +7011,108 @@ mod tests {
     use serde_json::json;
     use std::process::Command;
 
+    fn fixture_json_sha256(value: &serde_json::Value) -> String {
+        format!(
+            "{:x}",
+            Sha256::digest(serde_json::to_vec(value).expect("serialize v2 fixture"))
+        )
+    }
+
+    #[test]
+    fn v2_packet_context_search_projection_bytes() {
+        let packet = stdio_packet_tool_call_success(
+            json!({
+                "packet_id": "packet-v2-fixture",
+                "question": "Explain dispatch.",
+                "answer": {"sections": [], "citations": [], "graphs": []},
+                "support": [],
+                "disposition": {"kind": "supported", "reason": "grounded"},
+                "budget": {
+                    "requested": "compact",
+                    "truncated": false,
+                    "omitted_sections": []
+                }
+            }),
+            &json!(["packet_stdio_phase label=fixture duration_ms=7"]),
+            &json!({
+                "operation": {"operation_id": "operation-v2-fixture"},
+                "core_publication": {
+                    "generation_id": "core-v2-fixture",
+                    "run_id": "run-v2-fixture"
+                }
+            }),
+        );
+
+        let context_answer = codestory_contracts::api::AgentAnswerDto {
+            answer_id: "context-v2-fixture".to_string(),
+            prompt: "AppController".to_string(),
+            summary: "Dispatch context.".to_string(),
+            freshness: None,
+            source_coverage: Vec::new(),
+            sections: Vec::new(),
+            citations: Vec::new(),
+            subgraph_ids: Vec::new(),
+            retrieval_version: "v2-fixture".to_string(),
+            graphs: Vec::new(),
+            retrieval_trace: serde_json::from_value(json!({
+                "request_id": "request-v2-fixture",
+                "resolved_profile": "architecture",
+                "policy_mode": "latency_first",
+                "total_latency_ms": 0,
+                "steps": []
+            }))
+            .expect("minimal context retrieval trace"),
+        };
+        let context = stdio_tool_call_success("context", context_packet_json(&context_answer));
+
+        let search_result = codestory_contracts::api::SearchResultsDto {
+            query: "AppController".to_string(),
+            retrieval_publication: None,
+            retrieval: codestory_contracts::api::RetrievalStateDto {
+                mode: codestory_contracts::api::RetrievalModeDto::Hybrid,
+                hybrid_configured: true,
+                semantic_ready: true,
+                semantic_mode: codestory_contracts::api::SemanticModeDto::Enabled,
+                semantic_doc_count: 1,
+                embedding_model: None,
+                current_embedding: None,
+                stored_embedding: None,
+                fallback_reason: None,
+                fallback_message: None,
+            },
+            retrieval_shadow: None,
+            freshness: None,
+            limit_per_source: 5,
+            repo_text_mode: SearchRepoTextMode::Off,
+            repo_text_enabled: false,
+            query_assessment: None,
+            search_plan: None,
+            repo_text_stats: None,
+            suggestions: Vec::new(),
+            indexed_symbol_hits: Vec::new(),
+            repo_text_hits: Vec::new(),
+            hits: Vec::new(),
+        };
+        let search = stdio_tool_call_success(
+            "search",
+            enrich_stdio_search_result(search_result, "project-v2-fixture", Path::new("/repo")),
+        );
+
+        let hashes = [
+            fixture_json_sha256(&packet),
+            fixture_json_sha256(&context),
+            fixture_json_sha256(&search),
+        ];
+        assert_eq!(
+            hashes,
+            [
+                "52f98c63f1a321bee9031cb7a990c58abf23859c73cde25c6948af1a4becdd5d".to_string(),
+                "b30f84585275d2423f7b3cca8350a7ed226bc5d8db2e647e2338cc1d7f711630".to_string(),
+                "07cf60cf7eed630b4d95b99ca1eec407ca025c64de76e219e9fcc2b061e1f4ee".to_string(),
+            ]
+        );
+    }
+
     #[test]
     fn published_guidance_calls_satisfy_the_generated_catalog() {
         fn walk(value: &serde_json::Value, checked: &mut usize) {

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -605,8 +605,66 @@ const AGENT_PLANNING_MODULES: [&str; 27] = [
 ///   import-DAG guard a file no product build links.
 /// - `indexed_source_call_path_v1.rs` is the dark v3 proof kernel. Task 2 keeps
 ///   it behind the same test-support gate until the atomic public v3 cut.
-const AGENT_MODULE_ALLOWLIST_EXCLUSIONS: [&str; 3] =
-    ["lib.rs", "eval_probes.rs", "indexed_source_call_path_v1.rs"];
+/// - `packet_execution_plan_v3.rs` is the dark v3 evidence-planning ledger.
+///   Task 3A keeps its callable surface behind the same test-support gate; it
+///   is not one of the 27 production packet-planning modules.
+const AGENT_MODULE_ALLOWLIST_EXCLUSIONS: [&str; 4] = [
+    "lib.rs",
+    "eval_probes.rs",
+    "indexed_source_call_path_v1.rs",
+    "packet_execution_plan_v3.rs",
+];
+
+#[test]
+fn dark_packet_execution_plan_v3_stays_inert_and_unshipped() {
+    let agent_lib = read("crates/codestory-agent/src/lib.rs");
+    assert!(
+        agent_lib.contains(
+            "#[cfg(any(test, feature = \"test-support\"))]\n#[doc(hidden)]\npub mod packet_execution_plan_v3;"
+        ),
+        "the v3 evidence planner must remain test-support-only until the atomic v3 cut"
+    );
+    assert!(
+        AGENT_MODULE_ALLOWLIST_EXCLUSIONS.contains(&"packet_execution_plan_v3.rs"),
+        "the dark v3 evidence planner must not count as a production planning module"
+    );
+
+    let surfaces = [
+        (
+            "runtime source",
+            read_source_tree("crates/codestory-runtime/src"),
+        ),
+        ("CLI source", read_source_tree("crates/codestory-cli/src")),
+        (
+            "current public API DTO source",
+            format!(
+                "{}\n{}",
+                read("crates/codestory-contracts/src/api.rs"),
+                read_source_tree("crates/codestory-contracts/src/api")
+            ),
+        ),
+        (
+            "current wire source",
+            read("crates/codestory-contracts/src/wire.rs"),
+        ),
+        (
+            "generated MCP catalog",
+            read("plugins/codestory/generated-mcp-catalog.json"),
+        ),
+    ];
+    for (surface, source) in surfaces {
+        for forbidden in [
+            "packet_execution_plan_v3",
+            "PacketExecutionPlanV3",
+            "PacketProjectionV3Dto",
+        ] {
+            assert!(
+                !source.contains(forbidden),
+                "{surface} references dark Task-3A vocabulary via {forbidden}"
+            );
+        }
+    }
+}
 
 #[test]
 fn dark_call_path_kernel_stays_on_the_test_support_side_of_the_crate_root() {

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -179,7 +179,7 @@ fn read_source_tree(dir: &str) -> String {
         .join("\n")
 }
 
-fn read_source_tree_excluding(dir: &str, excluded_suffix: &str) -> String {
+fn read_source_tree_excluding_many(dir: &str, excluded_suffixes: &[&str]) -> String {
     let root = repo_root().join(dir);
     let mut files = Vec::new();
     collect_rs_files(&root, &mut files);
@@ -187,11 +187,13 @@ fn read_source_tree_excluding(dir: &str, excluded_suffix: &str) -> String {
     files
         .into_iter()
         .filter(|path| {
-            !path
+            let relative = path
                 .strip_prefix(&root)
                 .expect("source file stays below source root")
-                .to_string_lossy()
-                .ends_with(excluded_suffix)
+                .to_string_lossy();
+            !excluded_suffixes
+                .iter()
+                .any(|suffix| relative.ends_with(suffix))
         })
         .map(|path| fs::read_to_string(path).expect("read source"))
         .collect::<Vec<_>>()
@@ -651,9 +653,12 @@ fn dark_packet_execution_plan_v3_stays_inert_and_unshipped() {
     let surfaces = [
         (
             "runtime source",
-            read_source_tree_excluding(
+            read_source_tree_excluding_many(
                 "crates/codestory-runtime/src",
-                "agent/packet_execution_record_v3.rs",
+                &[
+                    "agent/packet_execution_record_v3.rs",
+                    "agent/packet_projection_v3.rs",
+                ],
             ),
         ),
         ("CLI source", read_source_tree("crates/codestory-cli/src")),
@@ -697,6 +702,12 @@ fn dark_packet_v3_preparation_stays_inert_and_unshipped() {
         ),
         "the runtime-owned v3 record must remain test-support-only until the atomic v3 cut"
     );
+    assert!(
+        runtime_agent_modules.contains(
+            "#[cfg(any(test, feature = \"test-support\"))]\npub(crate) mod packet_projection_v3;"
+        ),
+        "the runtime-owned v3 projector must remain test-support-only until the atomic v3 cut"
+    );
 
     let record_path = "crates/codestory-runtime/src/agent/packet_execution_record_v3.rs";
     let record = production_source(&read(record_path));
@@ -731,14 +742,51 @@ fn dark_packet_v3_preparation_stays_inert_and_unshipped() {
         );
     }
 
+    let projector_path = "crates/codestory-runtime/src/agent/packet_projection_v3.rs";
+    let projector = production_source(&read(projector_path));
+    for forbidden in [
+        "AgentPacketDto",
+        "AgentAnswerDto",
+        "SearchResultsDto",
+        "ToolSpec",
+        "run_with_cancel",
+        ".active_publication()",
+        "with_pinned_retrieval",
+        "retrieval_primary",
+        "include_evidence",
+        "operation_id",
+        "published_at_epoch_ms",
+        "capability_uri",
+        "session_secret",
+        "Hmac",
+        "SystemTime",
+        "Instant",
+        ".question()",
+        "source_text",
+        "ClaimDisposition",
+        "CompleteQueryNegative",
+        "Supported",
+        "Proven",
+        "eligible_for_sufficiency",
+    ] {
+        assert!(
+            !projector.contains(forbidden),
+            "the dark projector source crosses a forbidden execution/authority boundary via {forbidden}"
+        );
+    }
+
     let surfaces = [
         (
-            "runtime source outside the gated record and its module declaration",
-            read_source_tree_excluding(
+            "runtime source outside the gated record/projector and their module declarations",
+            read_source_tree_excluding_many(
                 "crates/codestory-runtime/src",
-                "agent/packet_execution_record_v3.rs",
+                &[
+                    "agent/packet_execution_record_v3.rs",
+                    "agent/packet_projection_v3.rs",
+                ],
             )
-            .replace("pub(crate) mod packet_execution_record_v3;", ""),
+            .replace("pub(crate) mod packet_execution_record_v3;", "")
+            .replace("pub(crate) mod packet_projection_v3;", ""),
         ),
         ("CLI source", read_source_tree("crates/codestory-cli/src")),
         (
@@ -757,12 +805,30 @@ fn dark_packet_v3_preparation_stays_inert_and_unshipped() {
             "generated MCP catalog",
             read("plugins/codestory/generated-mcp-catalog.json"),
         ),
+        (
+            "generated grounding syntax",
+            read("plugins/codestory/skills/codestory-grounding/references/generated-mcp-syntax.md"),
+        ),
+        (
+            "plugin launcher",
+            format!(
+                "{}\n{}",
+                read("plugins/codestory/scripts/codestory-mcp.cjs"),
+                read("plugins/codestory/hooks/codestory-runtime.cjs")
+            ),
+        ),
     ];
     for (surface, source) in surfaces {
         for forbidden in [
             "PacketExecutionRecordV3",
             "PacketRequestFingerprintV3",
             "build_packet_execution_record_v3",
+            "packet_projection_v3",
+            "build_packet_projection_v3",
+            "build_context_projection_v3",
+            "build_search_projection_v3",
+            "build_diagnostic_artifact_v3",
+            "DiagnosticArtifactBuildV3",
         ] {
             assert!(
                 !source.contains(forbidden),
@@ -770,6 +836,16 @@ fn dark_packet_v3_preparation_stays_inert_and_unshipped() {
             );
         }
     }
+
+    let current_dto = read("crates/codestory-contracts/src/api/dto.rs");
+    assert!(
+        current_dto.contains("pub include_evidence: bool"),
+        "current packet include_evidence must remain present throughout PR 3"
+    );
+    assert!(
+        current_dto.contains("pub const PACKET_OBLIGATION_PLAN_VERSION: u32 = 1;"),
+        "the current packet obligation plan must remain version 1 throughout PR 3"
+    );
 }
 
 #[test]

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -179,6 +179,25 @@ fn read_source_tree(dir: &str) -> String {
         .join("\n")
 }
 
+fn read_source_tree_excluding(dir: &str, excluded_suffix: &str) -> String {
+    let root = repo_root().join(dir);
+    let mut files = Vec::new();
+    collect_rs_files(&root, &mut files);
+    files.sort();
+    files
+        .into_iter()
+        .filter(|path| {
+            !path
+                .strip_prefix(&root)
+                .expect("source file stays below source root")
+                .to_string_lossy()
+                .ends_with(excluded_suffix)
+        })
+        .map(|path| fs::read_to_string(path).expect("read source"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 fn production_source_prefix(source: &str) -> &str {
     source
         .split_once("#[cfg(test)]\nmod tests {")
@@ -632,7 +651,10 @@ fn dark_packet_execution_plan_v3_stays_inert_and_unshipped() {
     let surfaces = [
         (
             "runtime source",
-            read_source_tree("crates/codestory-runtime/src"),
+            read_source_tree_excluding(
+                "crates/codestory-runtime/src",
+                "agent/packet_execution_record_v3.rs",
+            ),
         ),
         ("CLI source", read_source_tree("crates/codestory-cli/src")),
         (
@@ -661,6 +683,90 @@ fn dark_packet_execution_plan_v3_stays_inert_and_unshipped() {
             assert!(
                 !source.contains(forbidden),
                 "{surface} references dark Task-3A vocabulary via {forbidden}"
+            );
+        }
+    }
+}
+
+#[test]
+fn dark_packet_v3_preparation_stays_inert_and_unshipped() {
+    let runtime_agent_modules = read("crates/codestory-runtime/src/agent/mod.rs");
+    assert!(
+        runtime_agent_modules.contains(
+            "#[cfg(any(test, feature = \"test-support\"))]\npub(crate) mod packet_execution_record_v3;"
+        ),
+        "the runtime-owned v3 record must remain test-support-only until the atomic v3 cut"
+    );
+
+    let record_path = "crates/codestory-runtime/src/agent/packet_execution_record_v3.rs";
+    let record = production_source(&read(record_path));
+    assert_eq!(
+        record.matches(".active_publication()").count(),
+        1,
+        "the record builder must capture the already-active publication exactly once"
+    );
+    for forbidden in [
+        "AgentPacketDto",
+        "enforce_packet_output_budget",
+        "serde_json::Value",
+        "ToolSpec",
+        "run_with_cancel",
+        "with_pinned_retrieval",
+        "retrieval_primary",
+        "DiagnosticsCapabilityV3Dto",
+        "SystemTime",
+        "Instant",
+        "include_evidence",
+        "operation_id",
+        "published_at_epoch_ms",
+        "capability_uri",
+        "session_secret",
+        "ClaimDisposition",
+        "evaluate_execution_plan_v3",
+        "Supported",
+    ] {
+        assert!(
+            !record.contains(forbidden),
+            "the dark record source crosses a forbidden execution/serialization boundary via {forbidden}"
+        );
+    }
+
+    let surfaces = [
+        (
+            "runtime source outside the gated record and its module declaration",
+            read_source_tree_excluding(
+                "crates/codestory-runtime/src",
+                "agent/packet_execution_record_v3.rs",
+            )
+            .replace("pub(crate) mod packet_execution_record_v3;", ""),
+        ),
+        ("CLI source", read_source_tree("crates/codestory-cli/src")),
+        (
+            "current public API DTO source",
+            format!(
+                "{}\n{}",
+                read("crates/codestory-contracts/src/api.rs"),
+                read_source_tree("crates/codestory-contracts/src/api")
+            ),
+        ),
+        (
+            "current wire source",
+            read("crates/codestory-contracts/src/wire.rs"),
+        ),
+        (
+            "generated MCP catalog",
+            read("plugins/codestory/generated-mcp-catalog.json"),
+        ),
+    ];
+    for (surface, source) in surfaces {
+        for forbidden in [
+            "PacketExecutionRecordV3",
+            "PacketRequestFingerprintV3",
+            "build_packet_execution_record_v3",
+        ] {
+            assert!(
+                !source.contains(forbidden),
+                "{surface} references dark Task-3B vocabulary via {forbidden}"
             );
         }
     }

--- a/crates/codestory-contracts/src/lib.rs
+++ b/crates/codestory-contracts/src/lib.rs
@@ -18,6 +18,7 @@ pub mod graph;
 pub mod grounding;
 pub mod language_support;
 pub mod owned_artifacts;
+pub mod packet_projection_v3;
 pub mod query;
 pub mod trail;
 pub mod validation_receipts;

--- a/crates/codestory-contracts/src/packet_projection_v3.rs
+++ b/crates/codestory-contracts/src/packet_projection_v3.rs
@@ -258,12 +258,68 @@ pub struct ProjectionGapRowV3Dto {
     pub message: Option<MessageTextV3>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ContinuationStateV3Dto {
     pub continuation_id: IdentityTextV3,
     pub remaining_rounds: u16,
     pub gap_ids: BoundedVecV3<GapIdentityV3Dto, REFERENCE_ROWS_MAX_V3>,
+}
+
+impl ContinuationStateV3Dto {
+    pub fn new(
+        continuation_id: IdentityTextV3,
+        remaining_rounds: u16,
+        gap_ids: BoundedVecV3<GapIdentityV3Dto, REFERENCE_ROWS_MAX_V3>,
+    ) -> Result<Self, ContinuationStateViolationV3> {
+        let value = Self {
+            continuation_id,
+            remaining_rounds,
+            gap_ids,
+        };
+        value.validate()?;
+        Ok(value)
+    }
+
+    pub fn validate(&self) -> Result<(), ContinuationStateViolationV3> {
+        if self.remaining_rounds == 0 {
+            return Err(ContinuationStateViolationV3::ZeroRemainingRounds);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContinuationStateViolationV3 {
+    ZeroRemainingRounds,
+}
+
+impl fmt::Display for ContinuationStateViolationV3 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ZeroRemainingRounds => {
+                formatter.write_str("continuation remaining_rounds must be positive")
+            }
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ContinuationStateV3DtoWire {
+    continuation_id: IdentityTextV3,
+    remaining_rounds: u16,
+    gap_ids: BoundedVecV3<GapIdentityV3Dto, REFERENCE_ROWS_MAX_V3>,
+}
+
+impl<'de> Deserialize<'de> for ContinuationStateV3Dto {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = ContinuationStateV3DtoWire::deserialize(deserializer)?;
+        Self::new(wire.continuation_id, wire.remaining_rounds, wire.gap_ids)
+            .map_err(D::Error::custom)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -571,6 +627,69 @@ mod tests {
         assert!(Sha256DigestV3Dto::new("d".repeat(63)).is_err());
         assert!(Sha256DigestV3Dto::new(format!("{}z", "d".repeat(63))).is_err());
         assert!(serde_json::from_value::<Sha256DigestV3Dto>(json!("not-a-digest")).is_err());
+    }
+
+    #[test]
+    fn packet_projection_v3_rejects_zero_round_continuations_everywhere() {
+        assert_eq!(
+            ContinuationStateV3Dto::new(
+                text("continuation-1"),
+                0,
+                list(vec![gap_identity("gap-1")])
+            ),
+            Err(ContinuationStateViolationV3::ZeroRemainingRounds)
+        );
+
+        let packet = PacketProjectionV3Dto::Complete {
+            schema_version: PACKET_PROJECTION_V3_SCHEMA_VERSION,
+            identity: identity(),
+            publication: publication(),
+            status: EvidenceAvailabilityV3Dto::ContinuationAvailable,
+            retrieval: retrieval(RetrievalStateV3Dto::Full),
+            evidence: list(Vec::new()),
+            gaps: list(vec![gap(GapKindV3Dto::ContinuationRequired)]),
+            continuation: Some(continuation()),
+            diagnostics: diagnostics(),
+        };
+        let context = ContextProjectionV3Dto {
+            kind: ContextProjectionKindV3Dto::Complete,
+            schema_version: PACKET_PROJECTION_V3_SCHEMA_VERSION,
+            identity: identity(),
+            publication: publication(),
+            status: EvidenceAvailabilityV3Dto::ContinuationAvailable,
+            target: ContextTargetV3Dto {
+                path: Some(text("src/lib.rs")),
+                symbol_id: None,
+            },
+            evidence: list(Vec::new()),
+            gaps: list(vec![gap(GapKindV3Dto::ContinuationRequired)]),
+            continuation: Some(continuation()),
+            diagnostics: diagnostics(),
+        };
+        let search = SearchProjectionV3Dto {
+            kind: SearchProjectionKindV3Dto::Complete,
+            schema_version: PACKET_PROJECTION_V3_SCHEMA_VERSION,
+            identity: identity(),
+            publication: publication(),
+            status: EvidenceAvailabilityV3Dto::ContinuationAvailable,
+            evidence: list(Vec::new()),
+            gaps: list(vec![gap(GapKindV3Dto::ContinuationRequired)]),
+            continuation: Some(continuation()),
+            retrieval: retrieval(RetrievalStateV3Dto::Full),
+            diagnostics: diagnostics(),
+        };
+
+        let mut packet_json = serde_json::to_value(packet).expect("serialize packet");
+        packet_json["continuation"]["remaining_rounds"] = json!(0);
+        assert!(serde_json::from_value::<PacketProjectionV3Dto>(packet_json).is_err());
+
+        let mut context_json = serde_json::to_value(context).expect("serialize context");
+        context_json["continuation"]["remaining_rounds"] = json!(0);
+        assert!(serde_json::from_value::<ContextProjectionV3Dto>(context_json).is_err());
+
+        let mut search_json = serde_json::to_value(search).expect("serialize search");
+        search_json["continuation"]["remaining_rounds"] = json!(0);
+        assert!(serde_json::from_value::<SearchProjectionV3Dto>(search_json).is_err());
     }
 
     #[test]

--- a/crates/codestory-contracts/src/packet_projection_v3.rs
+++ b/crates/codestory-contracts/src/packet_projection_v3.rs
@@ -1,0 +1,721 @@
+//! Inert, closed DTO vocabulary for future v3 evidence projections.
+//!
+//! These types deliberately carry rendered evidence availability, not the
+//! internal planning or proof state that produced it. No production adapter
+//! references this module in the v3 preparation slices.
+
+use std::fmt;
+
+use serde::{Deserialize, Deserializer, Serialize, de::Error as _};
+
+pub const PACKET_PROJECTION_V3_SCHEMA_VERSION: u16 = 3;
+
+pub const IDENTITY_MAX_BYTES_V3: usize = 256;
+pub const PATH_MAX_BYTES_V3: usize = 4_096;
+pub const SYMBOL_ID_MAX_BYTES_V3: usize = 1_024;
+pub const SUMMARY_MAX_BYTES_V3: usize = 8_192;
+pub const MESSAGE_MAX_BYTES_V3: usize = 4_096;
+pub const EXCERPT_MAX_BYTES_V3: usize = 8_192;
+pub const DIAGNOSTIC_CODE_MAX_BYTES_V3: usize = 128;
+pub const EVIDENCE_ROWS_MAX_V3: usize = 256;
+pub const GAP_ROWS_MAX_V3: usize = 256;
+pub const REFERENCE_ROWS_MAX_V3: usize = 256;
+pub const DIAGNOSTIC_ROWS_MAX_V3: usize = 256;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(transparent)]
+pub struct BoundedTextV3<const MAX: usize>(String);
+
+impl<const MAX: usize> BoundedTextV3<MAX> {
+    pub fn new(value: impl Into<String>) -> Result<Self, BoundViolationV3> {
+        let value = value.into();
+        if value.len() > MAX {
+            return Err(BoundViolationV3::TooManyBytes {
+                maximum: MAX,
+                actual: value.len(),
+            });
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl<'de, const MAX: usize> Deserialize<'de> for BoundedTextV3<MAX> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value).map_err(D::Error::custom)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(transparent)]
+pub struct BoundedVecV3<T, const MAX: usize>(Vec<T>);
+
+impl<T, const MAX: usize> BoundedVecV3<T, MAX> {
+    pub fn new(value: Vec<T>) -> Result<Self, BoundViolationV3> {
+        if value.len() > MAX {
+            return Err(BoundViolationV3::TooManyItems {
+                maximum: MAX,
+                actual: value.len(),
+            });
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_slice(&self) -> &[T] {
+        &self.0
+    }
+}
+
+impl<'de, T, const MAX: usize> Deserialize<'de> for BoundedVecV3<T, MAX>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = Vec::<T>::deserialize(deserializer)?;
+        Self::new(value).map_err(D::Error::custom)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BoundViolationV3 {
+    TooManyBytes { maximum: usize, actual: usize },
+    TooManyItems { maximum: usize, actual: usize },
+}
+
+impl fmt::Display for BoundViolationV3 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::TooManyBytes { maximum, actual } => {
+                write!(formatter, "maximum {maximum} bytes, got {actual}")
+            }
+            Self::TooManyItems { maximum, actual } => {
+                write!(formatter, "maximum {maximum} items, got {actual}")
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(transparent)]
+pub struct Sha256DigestV3Dto(String);
+
+impl Sha256DigestV3Dto {
+    pub fn new(value: impl Into<String>) -> Result<Self, InvalidSha256DigestV3> {
+        let value = value.into();
+        if value.len() != 64 || !value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            return Err(InvalidSha256DigestV3);
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for Sha256DigestV3Dto {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value).map_err(D::Error::custom)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InvalidSha256DigestV3;
+
+impl fmt::Display for InvalidSha256DigestV3 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("expected a 64-character hexadecimal SHA-256 digest")
+    }
+}
+
+pub type IdentityTextV3 = BoundedTextV3<IDENTITY_MAX_BYTES_V3>;
+pub type PathTextV3 = BoundedTextV3<PATH_MAX_BYTES_V3>;
+pub type SymbolIdTextV3 = BoundedTextV3<SYMBOL_ID_MAX_BYTES_V3>;
+pub type SummaryTextV3 = BoundedTextV3<SUMMARY_MAX_BYTES_V3>;
+pub type MessageTextV3 = BoundedTextV3<MESSAGE_MAX_BYTES_V3>;
+pub type ExcerptTextV3 = BoundedTextV3<EXCERPT_MAX_BYTES_V3>;
+pub type DiagnosticCodeTextV3 = BoundedTextV3<DIAGNOSTIC_CODE_MAX_BYTES_V3>;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PacketRequestIdentityV3Dto {
+    pub packet_id: IdentityTextV3,
+    pub request_id: IdentityTextV3,
+    pub question_sha256: Sha256DigestV3Dto,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CorePublicationIdentityV3Dto {
+    pub project_id: IdentityTextV3,
+    pub generation_id: IdentityTextV3,
+    pub run_id: IdentityTextV3,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RetrievalPublicationIdentityV3Dto {
+    pub core_generation_id: IdentityTextV3,
+    pub core_run_id: IdentityTextV3,
+    pub retrieval_generation: IdentityTextV3,
+    pub retrieval_input_sha256: Sha256DigestV3Dto,
+    pub semantic_generation: IdentityTextV3,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PublicationIdentityV3Dto {
+    pub core: CorePublicationIdentityV3Dto,
+    pub retrieval: Option<RetrievalPublicationIdentityV3Dto>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvidenceIdentityV3Dto {
+    pub evidence_id: IdentityTextV3,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GapIdentityV3Dto {
+    pub gap_id: IdentityTextV3,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceAvailabilityV3Dto {
+    Available,
+    ContinuationAvailable,
+    NoUsefulEvidence,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RetrievalStateV3Dto {
+    Full,
+    Degraded,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RetrievalStateDescriptorV3Dto {
+    pub state: RetrievalStateV3Dto,
+    pub generation_id: Option<IdentityTextV3>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceKindV3Dto {
+    ExactSource,
+    StructuralSource,
+    GraphRelation,
+    RetrievalExcerpt,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GapKindV3Dto {
+    EvidenceMissing,
+    RetrievalUnavailable,
+    SourceUnavailable,
+    ContinuationRequired,
+    OutputBudgetExceeded,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PacketEvidenceRowV3Dto {
+    pub identity: EvidenceIdentityV3Dto,
+    pub kind: EvidenceKindV3Dto,
+    pub path: Option<PathTextV3>,
+    pub symbol_id: Option<SymbolIdTextV3>,
+    pub start_line: Option<u32>,
+    pub end_line: Option<u32>,
+    pub summary: Option<SummaryTextV3>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectionGapRowV3Dto {
+    pub identity: GapIdentityV3Dto,
+    pub kind: GapKindV3Dto,
+    pub message: Option<MessageTextV3>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ContinuationStateV3Dto {
+    pub continuation_id: IdentityTextV3,
+    pub remaining_rounds: u16,
+    pub gap_ids: BoundedVecV3<GapIdentityV3Dto, REFERENCE_ROWS_MAX_V3>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiagnosticReferenceV3Dto {
+    pub artifact_id: IdentityTextV3,
+    pub sha256: Sha256DigestV3Dto,
+    pub byte_length: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "availability", rename_all = "snake_case", deny_unknown_fields)]
+pub enum DiagnosticsCapabilityV3Dto {
+    Unavailable,
+    Available { reference: DiagnosticReferenceV3Dto },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum PacketProjectionV3Dto {
+    Complete {
+        schema_version: u16,
+        identity: PacketRequestIdentityV3Dto,
+        publication: PublicationIdentityV3Dto,
+        status: EvidenceAvailabilityV3Dto,
+        retrieval: RetrievalStateDescriptorV3Dto,
+        evidence: BoundedVecV3<PacketEvidenceRowV3Dto, EVIDENCE_ROWS_MAX_V3>,
+        gaps: BoundedVecV3<ProjectionGapRowV3Dto, GAP_ROWS_MAX_V3>,
+        continuation: Option<ContinuationStateV3Dto>,
+        diagnostics: DiagnosticsCapabilityV3Dto,
+    },
+    BudgetExceeded {
+        schema_version: u16,
+        identity: PacketRequestIdentityV3Dto,
+        publication: PublicationIdentityV3Dto,
+        status: EvidenceAvailabilityV3Dto,
+        retrieval: RetrievalStateDescriptorV3Dto,
+        diagnostics: DiagnosticsCapabilityV3Dto,
+        maximum_bytes: u64,
+        required_complete_bytes: u64,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ContextProjectionKindV3Dto {
+    Complete,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ContextTargetV3Dto {
+    pub path: Option<PathTextV3>,
+    pub symbol_id: Option<SymbolIdTextV3>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ContextEvidenceRowV3Dto {
+    pub identity: EvidenceIdentityV3Dto,
+    pub path: PathTextV3,
+    pub symbol_id: Option<SymbolIdTextV3>,
+    pub start_line: u32,
+    pub end_line: u32,
+    pub excerpt: Option<ExcerptTextV3>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ContextProjectionV3Dto {
+    pub kind: ContextProjectionKindV3Dto,
+    pub schema_version: u16,
+    pub identity: PacketRequestIdentityV3Dto,
+    pub publication: PublicationIdentityV3Dto,
+    pub status: EvidenceAvailabilityV3Dto,
+    pub target: ContextTargetV3Dto,
+    pub evidence: BoundedVecV3<ContextEvidenceRowV3Dto, EVIDENCE_ROWS_MAX_V3>,
+    pub gaps: BoundedVecV3<ProjectionGapRowV3Dto, GAP_ROWS_MAX_V3>,
+    pub continuation: Option<ContinuationStateV3Dto>,
+    pub diagnostics: DiagnosticsCapabilityV3Dto,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SearchProjectionKindV3Dto {
+    Complete,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SearchEvidenceRowV3Dto {
+    pub identity: EvidenceIdentityV3Dto,
+    pub path: PathTextV3,
+    pub symbol_id: Option<SymbolIdTextV3>,
+    pub start_line: Option<u32>,
+    pub end_line: Option<u32>,
+    pub excerpt: Option<ExcerptTextV3>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SearchProjectionV3Dto {
+    pub kind: SearchProjectionKindV3Dto,
+    pub schema_version: u16,
+    pub identity: PacketRequestIdentityV3Dto,
+    pub publication: PublicationIdentityV3Dto,
+    pub status: EvidenceAvailabilityV3Dto,
+    pub evidence: BoundedVecV3<SearchEvidenceRowV3Dto, EVIDENCE_ROWS_MAX_V3>,
+    pub gaps: BoundedVecV3<ProjectionGapRowV3Dto, GAP_ROWS_MAX_V3>,
+    pub continuation: Option<ContinuationStateV3Dto>,
+    pub retrieval: RetrievalStateDescriptorV3Dto,
+    pub diagnostics: DiagnosticsCapabilityV3Dto,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiagnosticArtifactKindV3Dto {
+    Complete,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiagnosticCategoryV3Dto {
+    Retrieval,
+    Freshness,
+    Coverage,
+    Budget,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiagnosticRowV3Dto {
+    pub category: DiagnosticCategoryV3Dto,
+    pub code: DiagnosticCodeTextV3,
+    pub evidence_ids: BoundedVecV3<EvidenceIdentityV3Dto, REFERENCE_ROWS_MAX_V3>,
+    pub gap_ids: BoundedVecV3<GapIdentityV3Dto, REFERENCE_ROWS_MAX_V3>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiagnosticArtifactV3Dto {
+    pub kind: DiagnosticArtifactKindV3Dto,
+    pub schema_version: u16,
+    pub artifact_id: IdentityTextV3,
+    pub packet_id: IdentityTextV3,
+    pub publication: PublicationIdentityV3Dto,
+    pub rows: BoundedVecV3<DiagnosticRowV3Dto, DIAGNOSTIC_ROWS_MAX_V3>,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{Value, json};
+
+    use super::*;
+
+    fn text<const MAX: usize>(value: &str) -> BoundedTextV3<MAX> {
+        BoundedTextV3::new(value).expect("bounded fixture text")
+    }
+
+    fn list<T, const MAX: usize>(values: Vec<T>) -> BoundedVecV3<T, MAX> {
+        BoundedVecV3::new(values).expect("bounded fixture list")
+    }
+
+    fn identity() -> PacketRequestIdentityV3Dto {
+        PacketRequestIdentityV3Dto {
+            packet_id: text("packet-1"),
+            request_id: text("request-1"),
+            question_sha256: Sha256DigestV3Dto::new("a".repeat(64)).expect("question digest"),
+        }
+    }
+
+    fn publication() -> PublicationIdentityV3Dto {
+        PublicationIdentityV3Dto {
+            core: CorePublicationIdentityV3Dto {
+                project_id: text("project-1"),
+                generation_id: text("core-generation-1"),
+                run_id: text("core-run-1"),
+            },
+            retrieval: Some(RetrievalPublicationIdentityV3Dto {
+                core_generation_id: text("core-generation-1"),
+                core_run_id: text("core-run-1"),
+                retrieval_generation: text("retrieval-generation-1"),
+                retrieval_input_sha256: Sha256DigestV3Dto::new("b".repeat(64))
+                    .expect("retrieval digest"),
+                semantic_generation: text("semantic-generation-1"),
+            }),
+        }
+    }
+
+    fn evidence_identity(value: &str) -> EvidenceIdentityV3Dto {
+        EvidenceIdentityV3Dto {
+            evidence_id: text(value),
+        }
+    }
+
+    fn gap_identity(value: &str) -> GapIdentityV3Dto {
+        GapIdentityV3Dto {
+            gap_id: text(value),
+        }
+    }
+
+    fn diagnostic_reference() -> DiagnosticReferenceV3Dto {
+        DiagnosticReferenceV3Dto {
+            artifact_id: text("diagnostic-1"),
+            sha256: Sha256DigestV3Dto::new("c".repeat(64)).expect("artifact digest"),
+            byte_length: 512,
+        }
+    }
+
+    fn diagnostics() -> DiagnosticsCapabilityV3Dto {
+        DiagnosticsCapabilityV3Dto::Available {
+            reference: diagnostic_reference(),
+        }
+    }
+
+    fn packet_evidence(kind: EvidenceKindV3Dto) -> PacketEvidenceRowV3Dto {
+        PacketEvidenceRowV3Dto {
+            identity: evidence_identity("evidence-1"),
+            kind,
+            path: Some(text("src/lib.rs")),
+            symbol_id: Some(text("crate::entry")),
+            start_line: Some(4),
+            end_line: Some(9),
+            summary: Some(text("The entry calls the runtime boundary.")),
+        }
+    }
+
+    fn gap(kind: GapKindV3Dto) -> ProjectionGapRowV3Dto {
+        ProjectionGapRowV3Dto {
+            identity: gap_identity("gap-1"),
+            kind,
+            message: Some(text("Additional evidence is required.")),
+        }
+    }
+
+    fn retrieval(state: RetrievalStateV3Dto) -> RetrievalStateDescriptorV3Dto {
+        RetrievalStateDescriptorV3Dto {
+            state,
+            generation_id: Some(text("retrieval-generation-1")),
+        }
+    }
+
+    fn continuation() -> ContinuationStateV3Dto {
+        ContinuationStateV3Dto {
+            continuation_id: text("continuation-1"),
+            remaining_rounds: 1,
+            gap_ids: list(vec![gap_identity("gap-1")]),
+        }
+    }
+
+    fn assert_no_prohibited_keys(value: &Value) {
+        const PROHIBITED: &[&str] = &[
+            "supported",
+            "proof_disposition",
+            "claim_discharge",
+            "eligible_for_sufficiency",
+            "complete_query_negative",
+            "plan",
+            "obligation",
+            "query_trace",
+            "score",
+            "ranking",
+            "local_executable_path",
+            "capability_token",
+        ];
+        match value {
+            Value::Object(object) => {
+                for (key, value) in object {
+                    assert!(!PROHIBITED.contains(&key.as_str()), "prohibited key: {key}");
+                    assert_no_prohibited_keys(value);
+                }
+            }
+            Value::Array(values) => values.iter().for_each(assert_no_prohibited_keys),
+            _ => {}
+        }
+    }
+
+    #[test]
+    fn packet_projection_v3_bounds_hold_at_construction_and_deserialization() {
+        let exact_text = "x".repeat(IDENTITY_MAX_BYTES_V3);
+        assert!(IdentityTextV3::new(exact_text.clone()).is_ok());
+        assert!(IdentityTextV3::new(format!("{exact_text}x")).is_err());
+        assert!(serde_json::from_value::<IdentityTextV3>(json!(format!("{exact_text}x"))).is_err());
+
+        let exact_items = vec![gap_identity("gap"); REFERENCE_ROWS_MAX_V3];
+        assert!(
+            BoundedVecV3::<GapIdentityV3Dto, REFERENCE_ROWS_MAX_V3>::new(exact_items.clone())
+                .is_ok()
+        );
+        let mut excess_items = exact_items;
+        excess_items.push(gap_identity("excess"));
+        assert!(
+            BoundedVecV3::<GapIdentityV3Dto, REFERENCE_ROWS_MAX_V3>::new(excess_items.clone())
+                .is_err()
+        );
+        assert!(
+            serde_json::from_value::<BoundedVecV3<GapIdentityV3Dto, REFERENCE_ROWS_MAX_V3>>(
+                serde_json::to_value(excess_items).expect("serialize excess fixture")
+            )
+            .is_err()
+        );
+
+        assert!(Sha256DigestV3Dto::new("d".repeat(64)).is_ok());
+        assert!(Sha256DigestV3Dto::new("d".repeat(63)).is_err());
+        assert!(Sha256DigestV3Dto::new(format!("{}z", "d".repeat(63))).is_err());
+        assert!(serde_json::from_value::<Sha256DigestV3Dto>(json!("not-a-digest")).is_err());
+    }
+
+    #[test]
+    fn packet_projection_v3_maximal_fixtures_are_closed_and_authority_free() {
+        let complete = PacketProjectionV3Dto::Complete {
+            schema_version: PACKET_PROJECTION_V3_SCHEMA_VERSION,
+            identity: identity(),
+            publication: publication(),
+            status: EvidenceAvailabilityV3Dto::ContinuationAvailable,
+            retrieval: retrieval(RetrievalStateV3Dto::Full),
+            evidence: list(vec![packet_evidence(EvidenceKindV3Dto::ExactSource)]),
+            gaps: list(vec![gap(GapKindV3Dto::ContinuationRequired)]),
+            continuation: Some(continuation()),
+            diagnostics: diagnostics(),
+        };
+        let budget_exceeded = PacketProjectionV3Dto::BudgetExceeded {
+            schema_version: PACKET_PROJECTION_V3_SCHEMA_VERSION,
+            identity: identity(),
+            publication: publication(),
+            status: EvidenceAvailabilityV3Dto::Unavailable,
+            retrieval: retrieval(RetrievalStateV3Dto::Degraded),
+            diagnostics: diagnostics(),
+            maximum_bytes: 16_384,
+            required_complete_bytes: 16_385,
+        };
+        let context = ContextProjectionV3Dto {
+            kind: ContextProjectionKindV3Dto::Complete,
+            schema_version: PACKET_PROJECTION_V3_SCHEMA_VERSION,
+            identity: identity(),
+            publication: publication(),
+            status: EvidenceAvailabilityV3Dto::Available,
+            target: ContextTargetV3Dto {
+                path: Some(text("src/lib.rs")),
+                symbol_id: Some(text("crate::entry")),
+            },
+            evidence: list(vec![ContextEvidenceRowV3Dto {
+                identity: evidence_identity("context-evidence-1"),
+                path: text("src/lib.rs"),
+                symbol_id: Some(text("crate::entry")),
+                start_line: 4,
+                end_line: 9,
+                excerpt: Some(text("pub fn entry() { runtime(); }")),
+            }]),
+            gaps: list(vec![gap(GapKindV3Dto::EvidenceMissing)]),
+            continuation: Some(continuation()),
+            diagnostics: diagnostics(),
+        };
+        let search = SearchProjectionV3Dto {
+            kind: SearchProjectionKindV3Dto::Complete,
+            schema_version: PACKET_PROJECTION_V3_SCHEMA_VERSION,
+            identity: identity(),
+            publication: publication(),
+            status: EvidenceAvailabilityV3Dto::NoUsefulEvidence,
+            evidence: list(vec![SearchEvidenceRowV3Dto {
+                identity: evidence_identity("search-evidence-1"),
+                path: text("src/lib.rs"),
+                symbol_id: Some(text("crate::entry")),
+                start_line: Some(4),
+                end_line: Some(9),
+                excerpt: Some(text("pub fn entry() { runtime(); }")),
+            }]),
+            gaps: list(vec![gap(GapKindV3Dto::RetrievalUnavailable)]),
+            continuation: Some(continuation()),
+            retrieval: retrieval(RetrievalStateV3Dto::Unavailable),
+            diagnostics: diagnostics(),
+        };
+        let artifact = DiagnosticArtifactV3Dto {
+            kind: DiagnosticArtifactKindV3Dto::Complete,
+            schema_version: PACKET_PROJECTION_V3_SCHEMA_VERSION,
+            artifact_id: text("diagnostic-1"),
+            packet_id: text("packet-1"),
+            publication: publication(),
+            rows: list(vec![DiagnosticRowV3Dto {
+                category: DiagnosticCategoryV3Dto::Coverage,
+                code: text("coverage_gap"),
+                evidence_ids: list(vec![evidence_identity("evidence-1")]),
+                gap_ids: list(vec![gap_identity("gap-1")]),
+            }]),
+        };
+
+        let maximal = json!({
+            "packet_variants": [complete, budget_exceeded],
+            "context": context,
+            "search": search,
+            "diagnostic_artifact": artifact,
+            "diagnostics_capabilities": [DiagnosticsCapabilityV3Dto::Unavailable, diagnostics()],
+            "availability_variants": [
+                EvidenceAvailabilityV3Dto::Available,
+                EvidenceAvailabilityV3Dto::ContinuationAvailable,
+                EvidenceAvailabilityV3Dto::NoUsefulEvidence,
+                EvidenceAvailabilityV3Dto::Unavailable,
+            ],
+            "retrieval_variants": [
+                RetrievalStateV3Dto::Full,
+                RetrievalStateV3Dto::Degraded,
+                RetrievalStateV3Dto::Unavailable,
+            ],
+            "evidence_variants": [
+                EvidenceKindV3Dto::ExactSource,
+                EvidenceKindV3Dto::StructuralSource,
+                EvidenceKindV3Dto::GraphRelation,
+                EvidenceKindV3Dto::RetrievalExcerpt,
+            ],
+            "gap_variants": [
+                GapKindV3Dto::EvidenceMissing,
+                GapKindV3Dto::RetrievalUnavailable,
+                GapKindV3Dto::SourceUnavailable,
+                GapKindV3Dto::ContinuationRequired,
+                GapKindV3Dto::OutputBudgetExceeded,
+            ],
+            "diagnostic_categories": [
+                DiagnosticCategoryV3Dto::Retrieval,
+                DiagnosticCategoryV3Dto::Freshness,
+                DiagnosticCategoryV3Dto::Coverage,
+                DiagnosticCategoryV3Dto::Budget,
+            ],
+        });
+        assert_no_prohibited_keys(&maximal);
+
+        let packet_json = serde_json::to_value(PacketProjectionV3Dto::Complete {
+            schema_version: PACKET_PROJECTION_V3_SCHEMA_VERSION,
+            identity: identity(),
+            publication: publication(),
+            status: EvidenceAvailabilityV3Dto::Available,
+            retrieval: retrieval(RetrievalStateV3Dto::Full),
+            evidence: list(vec![packet_evidence(EvidenceKindV3Dto::GraphRelation)]),
+            gaps: list(Vec::new()),
+            continuation: Some(continuation()),
+            diagnostics: diagnostics(),
+        })
+        .expect("serialize packet root");
+        assert_eq!(packet_json["kind"], "complete");
+        assert!(packet_json.is_object());
+
+        let mut unknown_root = packet_json.clone();
+        unknown_root
+            .as_object_mut()
+            .expect("packet object")
+            .insert("supported".to_owned(), json!(true));
+        assert!(serde_json::from_value::<PacketProjectionV3Dto>(unknown_root).is_err());
+
+        let mut unknown_row = packet_json;
+        unknown_row["evidence"][0]
+            .as_object_mut()
+            .expect("evidence row")
+            .insert("score".to_owned(), json!(0.99));
+        assert!(serde_json::from_value::<PacketProjectionV3Dto>(unknown_row).is_err());
+    }
+}

--- a/crates/codestory-contracts/src/packet_projection_v3.rs
+++ b/crates/codestory-contracts/src/packet_projection_v3.rs
@@ -396,6 +396,7 @@ pub enum DiagnosticCategoryV3Dto {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiagnosticRowV3Dto {
+    pub diagnostic_id: IdentityTextV3,
     pub category: DiagnosticCategoryV3Dto,
     pub code: DiagnosticCodeTextV3,
     pub evidence_ids: BoundedVecV3<EvidenceIdentityV3Dto, REFERENCE_ROWS_MAX_V3>,
@@ -643,6 +644,7 @@ mod tests {
             packet_id: text("packet-1"),
             publication: publication(),
             rows: list(vec![DiagnosticRowV3Dto {
+                diagnostic_id: text("diagnostic-row-1"),
                 category: DiagnosticCategoryV3Dto::Coverage,
                 code: text("coverage_gap"),
                 evidence_ids: list(vec![evidence_identity("evidence-1")]),

--- a/crates/codestory-runtime/src/agent/mod.rs
+++ b/crates/codestory-runtime/src/agent/mod.rs
@@ -44,6 +44,9 @@ pub(crate) mod packet_follow_up;
 #[cfg(any(test, feature = "test-support"))]
 pub(crate) mod packet_execution_record_v3;
 
+#[cfg(any(test, feature = "test-support"))]
+pub(crate) mod packet_projection_v3;
+
 pub(crate) mod packet_probe;
 pub(crate) mod packet_search;
 pub(crate) mod packet_trace;

--- a/crates/codestory-runtime/src/agent/mod.rs
+++ b/crates/codestory-runtime/src/agent/mod.rs
@@ -41,6 +41,9 @@ pub(crate) mod packet_capping;
 pub(crate) mod packet_compiler;
 pub(crate) mod packet_follow_up;
 
+#[cfg(any(test, feature = "test-support"))]
+pub(crate) mod packet_execution_record_v3;
+
 pub(crate) mod packet_probe;
 pub(crate) mod packet_search;
 pub(crate) mod packet_trace;

--- a/crates/codestory-runtime/src/agent/packet_execution_record_v3.rs
+++ b/crates/codestory-runtime/src/agent/packet_execution_record_v3.rs
@@ -782,6 +782,48 @@ fn digest_v3(bytes: &[u8]) -> Result<Sha256DigestV3Dto, RecordValidationErrorV3>
 }
 
 #[cfg(test)]
+pub(crate) fn build_packet_execution_record_fixture_v3(
+    input: &FinalizedPacketExecutionInputV3,
+    with_retrieval_publication: bool,
+) -> Result<PacketExecutionRecordV3, RecordValidationErrorV3> {
+    struct FixedPacketIdSourceV3;
+
+    impl PacketIdSourceV3 for FixedPacketIdSourceV3 {
+        fn next_packet_id(&mut self) -> String {
+            "00000000-0000-4000-8000-000000000001".to_owned()
+        }
+    }
+
+    let project = ProjectIdentityV3 {
+        project_identity_schema_version: 3,
+        project_id: "project-1".to_owned(),
+        workspace_id: "workspace-1".to_owned(),
+        artifact_scope_id: "artifact-1".to_owned(),
+        canonical_repository_id: Some("repository-1".to_owned()),
+        legacy_canonical_repository_id: None,
+        legacy_raw_root_project_id: None,
+        normalized_root_project_id_alias: None,
+        portable_reuse_eligible: true,
+        portable_reuse_reason: "test fixture".to_owned(),
+    };
+    let capture = CapturedPacketPublicationV3 {
+        core_project_id: project.project_id.clone(),
+        core_generation_id: "core-generation-1".to_owned(),
+        core_run_id: "core-run-1".to_owned(),
+        project,
+        retrieval: with_retrieval_publication.then(|| EmbeddingVectorPublicationIdentityDto {
+            core_generation_id: "core-generation-1".to_owned(),
+            core_run_id: "core-run-1".to_owned(),
+            retrieval_generation: "retrieval-generation-1".to_owned(),
+            retrieval_input_hash:
+                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_owned(),
+            semantic_generation: "semantic-generation-1".to_owned(),
+        }),
+    };
+    build_record_from_captured_v3(&capture, input, &mut FixedPacketIdSourceV3)
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use std::collections::VecDeque;

--- a/crates/codestory-runtime/src/agent/packet_execution_record_v3.rs
+++ b/crates/codestory-runtime/src/agent/packet_execution_record_v3.rs
@@ -1,0 +1,1467 @@
+//! Dark, immutable v3 packet execution capture.
+
+// The record remains intentionally unreachable from production until the
+// atomic v3 surface cut. `test-support` consumers exercise the callable seam.
+#![allow(dead_code)]
+
+use std::collections::BTreeSet;
+
+use codestory_contracts::{
+    api::{
+        AgentPacketRequestDto, ApiError, EmbeddingVectorPublicationIdentityDto,
+        PacketBudgetModeDto, PacketProbeDto, PacketTaskClassDto,
+    },
+    packet_projection_v3::{
+        ContinuationStateV3Dto, CorePublicationIdentityV3Dto, DIAGNOSTIC_ROWS_MAX_V3,
+        DiagnosticCategoryV3Dto, DiagnosticCodeTextV3, EVIDENCE_ROWS_MAX_V3, EvidenceIdentityV3Dto,
+        GAP_ROWS_MAX_V3, GapIdentityV3Dto, IdentityTextV3, PacketEvidenceRowV3Dto,
+        ProjectionGapRowV3Dto, REFERENCE_ROWS_MAX_V3, RetrievalPublicationIdentityV3Dto,
+        RetrievalStateDescriptorV3Dto, RetrievalStateV3Dto, Sha256DigestV3Dto,
+    },
+};
+use codestory_workspace::ProjectIdentityV3;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use uuid::{Uuid, Variant};
+
+use crate::services::PublicOperationService;
+
+const REQUEST_DIGEST_DOMAIN_V3: &[u8] = b"codestory.packet_execution_record_v3.request\0";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum PacketProfileV3 {
+    Auto,
+    Architecture,
+    Callflow,
+    Impact,
+    Inheritance,
+    Investigate,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PacketRequestFingerprintV3 {
+    question: String,
+    budget: PacketBudgetModeDto,
+    profile: PacketProfileV3,
+    task_class: Option<PacketTaskClassDto>,
+    typed_probes: Vec<PacketProbeDto>,
+    extra_probes: Vec<String>,
+    latency_budget_ms: Option<u32>,
+    parent_packet_id: Option<String>,
+    option_ids: Vec<String>,
+    core_generation_id: Option<String>,
+    retrieval_generation: Option<String>,
+}
+
+impl PacketRequestFingerprintV3 {
+    pub(crate) fn from_current_request(
+        request: &AgentPacketRequestDto,
+        profile: PacketProfileV3,
+    ) -> Self {
+        Self {
+            question: request.question.clone(),
+            budget: request.budget,
+            profile,
+            task_class: request.task_class,
+            typed_probes: request.probes.clone(),
+            extra_probes: request.extra_probes.clone(),
+            latency_budget_ms: request.latency_budget_ms,
+            parent_packet_id: request.parent_packet_id.clone(),
+            option_ids: request.option_ids.clone(),
+            core_generation_id: request.core_generation_id.clone(),
+            retrieval_generation: request.retrieval_generation.clone(),
+        }
+    }
+
+    pub(crate) fn question(&self) -> &str {
+        &self.question
+    }
+
+    pub(crate) fn budget(&self) -> PacketBudgetModeDto {
+        self.budget
+    }
+
+    pub(crate) fn profile(&self) -> PacketProfileV3 {
+        self.profile
+    }
+
+    pub(crate) fn task_class(&self) -> Option<PacketTaskClassDto> {
+        self.task_class
+    }
+
+    pub(crate) fn typed_probes(&self) -> &[PacketProbeDto] {
+        &self.typed_probes
+    }
+
+    pub(crate) fn extra_probes(&self) -> &[String] {
+        &self.extra_probes
+    }
+
+    pub(crate) fn latency_budget_ms(&self) -> Option<u32> {
+        self.latency_budget_ms
+    }
+
+    pub(crate) fn parent_packet_id(&self) -> Option<&str> {
+        self.parent_packet_id.as_deref()
+    }
+
+    pub(crate) fn option_ids(&self) -> &[String] {
+        &self.option_ids
+    }
+
+    pub(crate) fn core_generation_id(&self) -> Option<&str> {
+        self.core_generation_id.as_deref()
+    }
+
+    pub(crate) fn retrieval_generation(&self) -> Option<&str> {
+        self.retrieval_generation.as_deref()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RequestHashesV3 {
+    question_sha256: Sha256DigestV3Dto,
+    request_sha256: Sha256DigestV3Dto,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RecordValidationErrorV3 {
+    CanonicalJson(String),
+    InvalidDigest,
+    NoActiveCorePin,
+    ProjectIdentityUnavailable,
+    EmptyQuestion,
+    EmptyIdentity(&'static str),
+    IdentityTooLong(&'static str, usize),
+    ProjectMismatch,
+    InvalidRequest(String),
+    RequestedCoreGenerationMismatch,
+    RequestedRetrievalGenerationMismatch,
+    RetrievalCoreSkew,
+    InvalidRetrievalHash,
+    FullRetrievalWithoutPublication,
+    RetrievalStateMismatch,
+    InvalidPacketId,
+    TooManyEvidenceRows(usize),
+    TooManyGapRows(usize),
+    TooManyDiagnosticRows(usize),
+    TooManyDiagnosticReferences(usize),
+    DuplicateEvidenceIdentity(String),
+    DuplicateGapIdentity(String),
+    DuplicateDiagnosticIdentity(String),
+    DuplicateContinuationGapReference(String),
+    UnknownContinuationGap(String),
+    DuplicateDiagnosticEvidenceReference(String),
+    DuplicateDiagnosticGapReference(String),
+    UnknownDiagnosticEvidence(String),
+    UnknownDiagnosticGap(String),
+}
+
+impl RecordValidationErrorV3 {
+    fn into_api_error(self) -> ApiError {
+        ApiError::new("invalid_packet_execution_record_v3", format!("{self:?}"))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FinalizedDiagnosticSourceRowV3 {
+    diagnostic_id: IdentityTextV3,
+    category: DiagnosticCategoryV3Dto,
+    code: DiagnosticCodeTextV3,
+    evidence_ids: Vec<EvidenceIdentityV3Dto>,
+    gap_ids: Vec<GapIdentityV3Dto>,
+}
+
+impl FinalizedDiagnosticSourceRowV3 {
+    pub(crate) fn new(
+        diagnostic_id: IdentityTextV3,
+        category: DiagnosticCategoryV3Dto,
+        code: DiagnosticCodeTextV3,
+        evidence_ids: Vec<EvidenceIdentityV3Dto>,
+        gap_ids: Vec<GapIdentityV3Dto>,
+    ) -> Self {
+        Self {
+            diagnostic_id,
+            category,
+            code,
+            evidence_ids,
+            gap_ids,
+        }
+    }
+
+    pub(crate) fn diagnostic_id(&self) -> &IdentityTextV3 {
+        &self.diagnostic_id
+    }
+
+    pub(crate) fn category(&self) -> DiagnosticCategoryV3Dto {
+        self.category
+    }
+
+    pub(crate) fn code(&self) -> &DiagnosticCodeTextV3 {
+        &self.code
+    }
+
+    pub(crate) fn evidence_ids(&self) -> &[EvidenceIdentityV3Dto] {
+        &self.evidence_ids
+    }
+
+    pub(crate) fn gap_ids(&self) -> &[GapIdentityV3Dto] {
+        &self.gap_ids
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FinalizedPacketExecutionInputV3 {
+    caller_id: IdentityTextV3,
+    request_id: IdentityTextV3,
+    request: PacketRequestFingerprintV3,
+    evidence: Vec<PacketEvidenceRowV3Dto>,
+    gaps: Vec<ProjectionGapRowV3Dto>,
+    continuation: Option<ContinuationStateV3Dto>,
+    retrieval: RetrievalStateDescriptorV3Dto,
+    diagnostics: Vec<FinalizedDiagnosticSourceRowV3>,
+}
+
+impl FinalizedPacketExecutionInputV3 {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        caller_id: IdentityTextV3,
+        request_id: IdentityTextV3,
+        request: PacketRequestFingerprintV3,
+        evidence: Vec<PacketEvidenceRowV3Dto>,
+        gaps: Vec<ProjectionGapRowV3Dto>,
+        continuation: Option<ContinuationStateV3Dto>,
+        retrieval: RetrievalStateDescriptorV3Dto,
+        diagnostics: Vec<FinalizedDiagnosticSourceRowV3>,
+    ) -> Self {
+        Self {
+            caller_id,
+            request_id,
+            request,
+            evidence,
+            gaps,
+            continuation,
+            retrieval,
+            diagnostics,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CapturedPacketPublicationV3 {
+    project: ProjectIdentityV3,
+    core_project_id: String,
+    core_generation_id: String,
+    core_run_id: String,
+    retrieval: Option<EmbeddingVectorPublicationIdentityDto>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PacketExecutionRecordV3 {
+    packet_id: IdentityTextV3,
+    caller_id: IdentityTextV3,
+    request_id: IdentityTextV3,
+    question_sha256: Sha256DigestV3Dto,
+    request_sha256: Sha256DigestV3Dto,
+    plan_version: u32,
+    project: ProjectIdentityV3,
+    core_publication: CorePublicationIdentityV3Dto,
+    retrieval_publication: Option<RetrievalPublicationIdentityV3Dto>,
+    request: PacketRequestFingerprintV3,
+    evidence: Vec<PacketEvidenceRowV3Dto>,
+    gaps: Vec<ProjectionGapRowV3Dto>,
+    continuation: Option<ContinuationStateV3Dto>,
+    retrieval: RetrievalStateDescriptorV3Dto,
+    diagnostics: Vec<FinalizedDiagnosticSourceRowV3>,
+}
+
+impl PacketExecutionRecordV3 {
+    pub(crate) fn packet_id(&self) -> &IdentityTextV3 {
+        &self.packet_id
+    }
+
+    pub(crate) fn caller_id(&self) -> &IdentityTextV3 {
+        &self.caller_id
+    }
+
+    pub(crate) fn request_id(&self) -> &IdentityTextV3 {
+        &self.request_id
+    }
+
+    pub(crate) fn question_sha256(&self) -> &Sha256DigestV3Dto {
+        &self.question_sha256
+    }
+
+    pub(crate) fn request_sha256(&self) -> &Sha256DigestV3Dto {
+        &self.request_sha256
+    }
+
+    pub(crate) fn plan_version(&self) -> u32 {
+        self.plan_version
+    }
+
+    pub(crate) fn project(&self) -> &ProjectIdentityV3 {
+        &self.project
+    }
+
+    pub(crate) fn core_publication(&self) -> &CorePublicationIdentityV3Dto {
+        &self.core_publication
+    }
+
+    pub(crate) fn retrieval_publication(&self) -> Option<&RetrievalPublicationIdentityV3Dto> {
+        self.retrieval_publication.as_ref()
+    }
+
+    pub(crate) fn request(&self) -> &PacketRequestFingerprintV3 {
+        &self.request
+    }
+
+    pub(crate) fn evidence(&self) -> &[PacketEvidenceRowV3Dto] {
+        &self.evidence
+    }
+
+    pub(crate) fn gaps(&self) -> &[ProjectionGapRowV3Dto] {
+        &self.gaps
+    }
+
+    pub(crate) fn continuation(&self) -> Option<&ContinuationStateV3Dto> {
+        self.continuation.as_ref()
+    }
+
+    pub(crate) fn diagnostics(&self) -> &[FinalizedDiagnosticSourceRowV3] {
+        &self.diagnostics
+    }
+
+    pub(crate) fn retrieval(&self) -> &RetrievalStateDescriptorV3Dto {
+        &self.retrieval
+    }
+}
+
+trait PacketIdSourceV3 {
+    fn next_packet_id(&mut self) -> String;
+}
+
+struct OsPacketIdSourceV3;
+
+impl PacketIdSourceV3 for OsPacketIdSourceV3 {
+    fn next_packet_id(&mut self) -> String {
+        Uuid::new_v4().to_string()
+    }
+}
+
+pub(crate) fn build_packet_execution_record_v3(
+    service: &PublicOperationService,
+    input: &FinalizedPacketExecutionInputV3,
+) -> Result<PacketExecutionRecordV3, RecordValidationErrorV3> {
+    let active = service
+        .active_publication()
+        .ok_or(RecordValidationErrorV3::NoActiveCorePin)?;
+    let project = service
+        .active_project_identity_v3()
+        .map_err(|_| RecordValidationErrorV3::ProjectIdentityUnavailable)?;
+    let capture = CapturedPacketPublicationV3 {
+        core_project_id: project.project_id.clone(),
+        core_generation_id: active.core_publication.generation_id,
+        core_run_id: active.core_publication.run_id,
+        project,
+        retrieval: active.retrieval_publication,
+    };
+    build_record_from_captured_product_v3(&capture, input)
+}
+
+fn build_record_from_captured_product_v3(
+    capture: &CapturedPacketPublicationV3,
+    input: &FinalizedPacketExecutionInputV3,
+) -> Result<PacketExecutionRecordV3, RecordValidationErrorV3> {
+    build_record_from_captured_v3(capture, input, &mut OsPacketIdSourceV3)
+}
+
+fn build_record_from_captured_v3(
+    capture: &CapturedPacketPublicationV3,
+    input: &FinalizedPacketExecutionInputV3,
+    packet_ids: &mut impl PacketIdSourceV3,
+) -> Result<PacketExecutionRecordV3, RecordValidationErrorV3> {
+    validate_required_identity("caller_id", input.caller_id.as_str())?;
+    validate_required_identity("request_id", input.request_id.as_str())?;
+    validate_request(&input.request)?;
+    validate_project(&capture.project)?;
+    validate_required_identity("core_project_id", &capture.core_project_id)?;
+    validate_required_identity("core_generation_id", &capture.core_generation_id)?;
+    validate_required_identity("core_run_id", &capture.core_run_id)?;
+    if capture.core_project_id != capture.project.project_id {
+        return Err(RecordValidationErrorV3::ProjectMismatch);
+    }
+    if input
+        .request
+        .core_generation_id
+        .as_deref()
+        .is_some_and(|requested| requested != capture.core_generation_id)
+    {
+        return Err(RecordValidationErrorV3::RequestedCoreGenerationMismatch);
+    }
+    if let Some(requested) = input.request.retrieval_generation.as_deref()
+        && capture
+            .retrieval
+            .as_ref()
+            .is_none_or(|retrieval| retrieval.retrieval_generation != requested)
+    {
+        return Err(RecordValidationErrorV3::RequestedRetrievalGenerationMismatch);
+    }
+
+    let retrieval_publication = capture
+        .retrieval
+        .as_ref()
+        .map(|retrieval| validate_retrieval(retrieval, capture))
+        .transpose()?;
+    validate_retrieval_state(&input.retrieval, retrieval_publication.as_ref())?;
+
+    if input.evidence.len() > EVIDENCE_ROWS_MAX_V3 {
+        return Err(RecordValidationErrorV3::TooManyEvidenceRows(
+            input.evidence.len(),
+        ));
+    }
+    if input.gaps.len() > GAP_ROWS_MAX_V3 {
+        return Err(RecordValidationErrorV3::TooManyGapRows(input.gaps.len()));
+    }
+    if input.diagnostics.len() > DIAGNOSTIC_ROWS_MAX_V3 {
+        return Err(RecordValidationErrorV3::TooManyDiagnosticRows(
+            input.diagnostics.len(),
+        ));
+    }
+
+    let mut evidence = input.evidence.clone();
+    evidence.sort_by(|left, right| left.identity.cmp(&right.identity));
+    for row in &evidence {
+        validate_required_identity("evidence_id", row.identity.evidence_id.as_str())?;
+    }
+    reject_duplicate_by(
+        &evidence,
+        |row| row.identity.evidence_id.as_str(),
+        RecordValidationErrorV3::DuplicateEvidenceIdentity,
+    )?;
+    let evidence_ids = evidence
+        .iter()
+        .map(|row| row.identity.evidence_id.as_str())
+        .collect::<BTreeSet<_>>();
+
+    let mut gaps = input.gaps.clone();
+    gaps.sort_by(|left, right| left.identity.cmp(&right.identity));
+    for row in &gaps {
+        validate_required_identity("gap_id", row.identity.gap_id.as_str())?;
+    }
+    reject_duplicate_by(
+        &gaps,
+        |row| row.identity.gap_id.as_str(),
+        RecordValidationErrorV3::DuplicateGapIdentity,
+    )?;
+    let gap_ids = gaps
+        .iter()
+        .map(|row| row.identity.gap_id.as_str())
+        .collect::<BTreeSet<_>>();
+
+    let continuation = input
+        .continuation
+        .as_ref()
+        .map(|continuation| canonical_continuation(continuation, &gap_ids))
+        .transpose()?;
+    let diagnostics = canonical_diagnostics(&input.diagnostics, &evidence_ids, &gap_ids)?;
+    let hashes = fingerprint_request_v3(&input.request)?;
+    let packet_id = packet_ids.next_packet_id();
+    let parsed_packet_id =
+        Uuid::parse_str(&packet_id).map_err(|_| RecordValidationErrorV3::InvalidPacketId)?;
+    if parsed_packet_id.get_version_num() != 4 || parsed_packet_id.get_variant() != Variant::RFC4122
+    {
+        return Err(RecordValidationErrorV3::InvalidPacketId);
+    }
+
+    Ok(PacketExecutionRecordV3 {
+        packet_id: identity_from_required("packet_id", packet_id)?,
+        caller_id: input.caller_id.clone(),
+        request_id: input.request_id.clone(),
+        question_sha256: hashes.question_sha256,
+        request_sha256: hashes.request_sha256,
+        plan_version: codestory_agent::packet_execution_plan_v3::PACKET_EXECUTION_PLAN_VERSION_V3,
+        project: capture.project.clone(),
+        core_publication: CorePublicationIdentityV3Dto {
+            project_id: identity_from_required("core_project_id", capture.core_project_id.clone())?,
+            generation_id: identity_from_required(
+                "core_generation_id",
+                capture.core_generation_id.clone(),
+            )?,
+            run_id: identity_from_required("core_run_id", capture.core_run_id.clone())?,
+        },
+        retrieval_publication,
+        request: input.request.clone(),
+        evidence,
+        gaps,
+        continuation,
+        retrieval: input.retrieval.clone(),
+        diagnostics,
+    })
+}
+
+fn validate_project(project: &ProjectIdentityV3) -> Result<(), RecordValidationErrorV3> {
+    validate_required_identity("project_id", &project.project_id)?;
+    validate_required_identity("workspace_id", &project.workspace_id)?;
+    validate_required_identity("artifact_scope_id", &project.artifact_scope_id)?;
+    for (field, value) in [
+        (
+            "canonical_repository_id",
+            project.canonical_repository_id.as_deref(),
+        ),
+        (
+            "legacy_canonical_repository_id",
+            project.legacy_canonical_repository_id.as_deref(),
+        ),
+        (
+            "legacy_raw_root_project_id",
+            project.legacy_raw_root_project_id.as_deref(),
+        ),
+        (
+            "normalized_root_project_id_alias",
+            project.normalized_root_project_id_alias.as_deref(),
+        ),
+    ] {
+        if let Some(value) = value {
+            validate_required_identity(field, value)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_request(request: &PacketRequestFingerprintV3) -> Result<(), RecordValidationErrorV3> {
+    if request.question.trim().is_empty() {
+        return Err(RecordValidationErrorV3::EmptyQuestion);
+    }
+    codestory_contracts::api::validate_packet_probe_request(
+        &request.typed_probes,
+        &request.extra_probes,
+    )
+    .map_err(RecordValidationErrorV3::InvalidRequest)?;
+    for (field, value) in [
+        ("parent_packet_id", request.parent_packet_id.as_deref()),
+        (
+            "requested_core_generation_id",
+            request.core_generation_id.as_deref(),
+        ),
+        (
+            "requested_retrieval_generation",
+            request.retrieval_generation.as_deref(),
+        ),
+    ] {
+        if let Some(value) = value {
+            validate_required_identity(field, value)?;
+        }
+    }
+    for option_id in &request.option_ids {
+        validate_required_identity("option_id", option_id)?;
+    }
+    Ok(())
+}
+
+fn validate_retrieval(
+    retrieval: &EmbeddingVectorPublicationIdentityDto,
+    capture: &CapturedPacketPublicationV3,
+) -> Result<RetrievalPublicationIdentityV3Dto, RecordValidationErrorV3> {
+    for (field, value) in [
+        (
+            "retrieval_core_generation_id",
+            retrieval.core_generation_id.as_str(),
+        ),
+        ("retrieval_core_run_id", retrieval.core_run_id.as_str()),
+        (
+            "retrieval_generation",
+            retrieval.retrieval_generation.as_str(),
+        ),
+        (
+            "semantic_generation",
+            retrieval.semantic_generation.as_str(),
+        ),
+    ] {
+        validate_required_identity(field, value)?;
+    }
+    if retrieval.core_generation_id != capture.core_generation_id
+        || retrieval.core_run_id != capture.core_run_id
+    {
+        return Err(RecordValidationErrorV3::RetrievalCoreSkew);
+    }
+    let retrieval_input_sha256 = Sha256DigestV3Dto::new(retrieval.retrieval_input_hash.clone())
+        .map_err(|_| RecordValidationErrorV3::InvalidRetrievalHash)?;
+    Ok(RetrievalPublicationIdentityV3Dto {
+        core_generation_id: identity_from_required(
+            "retrieval_core_generation_id",
+            retrieval.core_generation_id.clone(),
+        )?,
+        core_run_id: identity_from_required(
+            "retrieval_core_run_id",
+            retrieval.core_run_id.clone(),
+        )?,
+        retrieval_generation: identity_from_required(
+            "retrieval_generation",
+            retrieval.retrieval_generation.clone(),
+        )?,
+        retrieval_input_sha256,
+        semantic_generation: identity_from_required(
+            "semantic_generation",
+            retrieval.semantic_generation.clone(),
+        )?,
+    })
+}
+
+fn validate_retrieval_state(
+    state: &RetrievalStateDescriptorV3Dto,
+    publication: Option<&RetrievalPublicationIdentityV3Dto>,
+) -> Result<(), RecordValidationErrorV3> {
+    if let Some(generation) = &state.generation_id {
+        validate_required_identity("retrieval_state_generation_id", generation.as_str())?;
+    }
+    match (&state.state, publication, state.generation_id.as_ref()) {
+        (RetrievalStateV3Dto::Full, None, _) => {
+            Err(RecordValidationErrorV3::FullRetrievalWithoutPublication)
+        }
+        (RetrievalStateV3Dto::Full, Some(publication), Some(generation))
+            if generation.as_str() == publication.retrieval_generation.as_str() =>
+        {
+            Ok(())
+        }
+        (RetrievalStateV3Dto::Degraded, None, None)
+        | (RetrievalStateV3Dto::Unavailable, None, None) => Ok(()),
+        (RetrievalStateV3Dto::Degraded, Some(publication), Some(generation))
+            if generation.as_str() == publication.retrieval_generation.as_str() =>
+        {
+            Ok(())
+        }
+        _ => Err(RecordValidationErrorV3::RetrievalStateMismatch),
+    }
+}
+
+fn canonical_continuation(
+    continuation: &ContinuationStateV3Dto,
+    gap_ids: &BTreeSet<&str>,
+) -> Result<ContinuationStateV3Dto, RecordValidationErrorV3> {
+    validate_required_identity("continuation_id", continuation.continuation_id.as_str())?;
+    let mut references = continuation.gap_ids.as_slice().to_vec();
+    references.sort();
+    for pair in references.windows(2) {
+        if pair[0] == pair[1] {
+            return Err(RecordValidationErrorV3::DuplicateContinuationGapReference(
+                pair[0].gap_id.as_str().to_owned(),
+            ));
+        }
+    }
+    for reference in &references {
+        if !gap_ids.contains(reference.gap_id.as_str()) {
+            return Err(RecordValidationErrorV3::UnknownContinuationGap(
+                reference.gap_id.as_str().to_owned(),
+            ));
+        }
+    }
+    Ok(ContinuationStateV3Dto {
+        continuation_id: continuation.continuation_id.clone(),
+        remaining_rounds: continuation.remaining_rounds,
+        gap_ids: codestory_contracts::packet_projection_v3::BoundedVecV3::new(references)
+            .expect("the source bounded vector remains bounded after sorting"),
+    })
+}
+
+fn canonical_diagnostics(
+    source: &[FinalizedDiagnosticSourceRowV3],
+    evidence_ids: &BTreeSet<&str>,
+    gap_ids: &BTreeSet<&str>,
+) -> Result<Vec<FinalizedDiagnosticSourceRowV3>, RecordValidationErrorV3> {
+    let mut diagnostics = source.to_vec();
+    diagnostics.sort_by(|left, right| left.diagnostic_id.cmp(&right.diagnostic_id));
+    reject_duplicate_by(
+        &diagnostics,
+        |row| row.diagnostic_id.as_str(),
+        RecordValidationErrorV3::DuplicateDiagnosticIdentity,
+    )?;
+    for diagnostic in &mut diagnostics {
+        validate_required_identity("diagnostic_id", diagnostic.diagnostic_id.as_str())?;
+        validate_required_identity("diagnostic_code", diagnostic.code.as_str())?;
+        if diagnostic.evidence_ids.len() > REFERENCE_ROWS_MAX_V3 {
+            return Err(RecordValidationErrorV3::TooManyDiagnosticReferences(
+                diagnostic.evidence_ids.len(),
+            ));
+        }
+        if diagnostic.gap_ids.len() > REFERENCE_ROWS_MAX_V3 {
+            return Err(RecordValidationErrorV3::TooManyDiagnosticReferences(
+                diagnostic.gap_ids.len(),
+            ));
+        }
+        diagnostic.evidence_ids.sort();
+        for pair in diagnostic.evidence_ids.windows(2) {
+            if pair[0] == pair[1] {
+                return Err(
+                    RecordValidationErrorV3::DuplicateDiagnosticEvidenceReference(
+                        pair[0].evidence_id.as_str().to_owned(),
+                    ),
+                );
+            }
+        }
+        for reference in &diagnostic.evidence_ids {
+            if !evidence_ids.contains(reference.evidence_id.as_str()) {
+                return Err(RecordValidationErrorV3::UnknownDiagnosticEvidence(
+                    reference.evidence_id.as_str().to_owned(),
+                ));
+            }
+        }
+        diagnostic.gap_ids.sort();
+        for pair in diagnostic.gap_ids.windows(2) {
+            if pair[0] == pair[1] {
+                return Err(RecordValidationErrorV3::DuplicateDiagnosticGapReference(
+                    pair[0].gap_id.as_str().to_owned(),
+                ));
+            }
+        }
+        for reference in &diagnostic.gap_ids {
+            if !gap_ids.contains(reference.gap_id.as_str()) {
+                return Err(RecordValidationErrorV3::UnknownDiagnosticGap(
+                    reference.gap_id.as_str().to_owned(),
+                ));
+            }
+        }
+    }
+    Ok(diagnostics)
+}
+
+fn reject_duplicate_by<T>(
+    rows: &[T],
+    identity: impl Fn(&T) -> &str,
+    error: impl Fn(String) -> RecordValidationErrorV3,
+) -> Result<(), RecordValidationErrorV3> {
+    for pair in rows.windows(2) {
+        if identity(&pair[0]) == identity(&pair[1]) {
+            return Err(error(identity(&pair[0]).to_owned()));
+        }
+    }
+    Ok(())
+}
+
+fn validate_required_identity(
+    field: &'static str,
+    value: &str,
+) -> Result<(), RecordValidationErrorV3> {
+    if value.is_empty() {
+        return Err(RecordValidationErrorV3::EmptyIdentity(field));
+    }
+    if value.len() > codestory_contracts::packet_projection_v3::IDENTITY_MAX_BYTES_V3 {
+        return Err(RecordValidationErrorV3::IdentityTooLong(field, value.len()));
+    }
+    Ok(())
+}
+
+fn identity_from_required(
+    field: &'static str,
+    value: String,
+) -> Result<IdentityTextV3, RecordValidationErrorV3> {
+    validate_required_identity(field, &value)?;
+    let length = value.len();
+    IdentityTextV3::new(value).map_err(|_| RecordValidationErrorV3::IdentityTooLong(field, length))
+}
+
+fn fingerprint_request_v3(
+    request: &PacketRequestFingerprintV3,
+) -> Result<RequestHashesV3, RecordValidationErrorV3> {
+    let canonical = codestory_agent::packet_execution_plan_v3::canonical_json_bytes_v3(request)
+        .map_err(RecordValidationErrorV3::CanonicalJson)?;
+    let mut request_bytes = Vec::with_capacity(REQUEST_DIGEST_DOMAIN_V3.len() + canonical.len());
+    request_bytes.extend_from_slice(REQUEST_DIGEST_DOMAIN_V3);
+    request_bytes.extend_from_slice(&canonical);
+    Ok(RequestHashesV3 {
+        question_sha256: digest_v3(request.question.as_bytes())?,
+        request_sha256: digest_v3(&request_bytes)?,
+    })
+}
+
+fn digest_v3(bytes: &[u8]) -> Result<Sha256DigestV3Dto, RecordValidationErrorV3> {
+    Sha256DigestV3Dto::new(format!("{:x}", Sha256::digest(bytes)))
+        .map_err(|_| RecordValidationErrorV3::InvalidDigest)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::VecDeque;
+    use std::fs;
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicBool;
+
+    use codestory_contracts::api::{
+        AgentPacketRequestDto, EmbeddingVectorPublicationIdentityDto, PacketProbeDto,
+        PacketTaskClassDto,
+    };
+    use codestory_contracts::packet_projection_v3::{
+        BoundedVecV3, ContinuationStateV3Dto, DiagnosticCategoryV3Dto, DiagnosticCodeTextV3,
+        EvidenceIdentityV3Dto, EvidenceKindV3Dto, GapIdentityV3Dto, GapKindV3Dto, IdentityTextV3,
+        PacketEvidenceRowV3Dto, ProjectionGapRowV3Dto, RetrievalStateDescriptorV3Dto,
+        RetrievalStateV3Dto, Sha256DigestV3Dto, SummaryTextV3,
+    };
+    use codestory_workspace::ProjectIdentityV3;
+
+    use crate::services::activation_tests::ready_activation_fixture;
+
+    fn identity(value: &str) -> IdentityTextV3 {
+        IdentityTextV3::new(value).expect("bounded identity")
+    }
+
+    fn sha(value: &str) -> Sha256DigestV3Dto {
+        Sha256DigestV3Dto::new(value).expect("sha-256")
+    }
+
+    fn request_fixture() -> PacketRequestFingerprintV3 {
+        PacketRequestFingerprintV3 {
+            question: "hello".to_owned(),
+            budget: PacketBudgetModeDto::Standard,
+            profile: PacketProfileV3::Auto,
+            task_class: None,
+            typed_probes: Vec::new(),
+            extra_probes: Vec::new(),
+            latency_budget_ms: None,
+            parent_packet_id: None,
+            option_ids: Vec::new(),
+            core_generation_id: None,
+            retrieval_generation: None,
+        }
+    }
+
+    fn project_fixture() -> ProjectIdentityV3 {
+        ProjectIdentityV3 {
+            project_identity_schema_version: 3,
+            project_id: "project-1".to_owned(),
+            workspace_id: "workspace-1".to_owned(),
+            artifact_scope_id: "artifact-1".to_owned(),
+            canonical_repository_id: Some("repository-1".to_owned()),
+            legacy_canonical_repository_id: None,
+            legacy_raw_root_project_id: Some("legacy-root-1".to_owned()),
+            normalized_root_project_id_alias: Some("root-alias-1".to_owned()),
+            portable_reuse_eligible: true,
+            portable_reuse_reason: "clean tree".to_owned(),
+        }
+    }
+
+    fn capture_fixture() -> CapturedPacketPublicationV3 {
+        CapturedPacketPublicationV3 {
+            project: project_fixture(),
+            core_project_id: "project-1".to_owned(),
+            core_generation_id: "core-generation-1".to_owned(),
+            core_run_id: "core-run-1".to_owned(),
+            retrieval: Some(EmbeddingVectorPublicationIdentityDto {
+                core_generation_id: "core-generation-1".to_owned(),
+                core_run_id: "core-run-1".to_owned(),
+                retrieval_generation: "retrieval-generation-1".to_owned(),
+                retrieval_input_hash:
+                    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_owned(),
+                semantic_generation: "semantic-generation-1".to_owned(),
+            }),
+        }
+    }
+
+    fn evidence(id: &str) -> PacketEvidenceRowV3Dto {
+        PacketEvidenceRowV3Dto {
+            identity: EvidenceIdentityV3Dto {
+                evidence_id: identity(id),
+            },
+            kind: EvidenceKindV3Dto::ExactSource,
+            path: None,
+            symbol_id: None,
+            start_line: Some(1),
+            end_line: Some(1),
+            summary: Some(SummaryTextV3::new(format!("summary {id}")).unwrap()),
+        }
+    }
+
+    fn gap(id: &str) -> ProjectionGapRowV3Dto {
+        ProjectionGapRowV3Dto {
+            identity: GapIdentityV3Dto {
+                gap_id: identity(id),
+            },
+            kind: GapKindV3Dto::EvidenceMissing,
+            message: None,
+        }
+    }
+
+    fn diagnostic(
+        id: &str,
+        evidence_ids: &[&str],
+        gap_ids: &[&str],
+    ) -> FinalizedDiagnosticSourceRowV3 {
+        FinalizedDiagnosticSourceRowV3 {
+            diagnostic_id: identity(id),
+            category: DiagnosticCategoryV3Dto::Coverage,
+            code: DiagnosticCodeTextV3::new("source_gap").unwrap(),
+            evidence_ids: evidence_ids
+                .iter()
+                .map(|id| EvidenceIdentityV3Dto {
+                    evidence_id: identity(id),
+                })
+                .collect(),
+            gap_ids: gap_ids
+                .iter()
+                .map(|id| GapIdentityV3Dto {
+                    gap_id: identity(id),
+                })
+                .collect(),
+        }
+    }
+
+    fn finalized_fixture() -> FinalizedPacketExecutionInputV3 {
+        FinalizedPacketExecutionInputV3 {
+            caller_id: identity("caller-1"),
+            request_id: identity("request-1"),
+            request: request_fixture(),
+            evidence: vec![evidence("evidence-b"), evidence("evidence-a")],
+            gaps: vec![gap("gap-b"), gap("gap-a")],
+            continuation: Some(ContinuationStateV3Dto {
+                continuation_id: identity("continuation-1"),
+                remaining_rounds: 1,
+                gap_ids: BoundedVecV3::new(vec![
+                    GapIdentityV3Dto {
+                        gap_id: identity("gap-b"),
+                    },
+                    GapIdentityV3Dto {
+                        gap_id: identity("gap-a"),
+                    },
+                ])
+                .unwrap(),
+            }),
+            retrieval: RetrievalStateDescriptorV3Dto {
+                state: RetrievalStateV3Dto::Full,
+                generation_id: Some(identity("retrieval-generation-1")),
+            },
+            diagnostics: vec![
+                diagnostic("diagnostic-b", &["evidence-b"], &["gap-b"]),
+                diagnostic("diagnostic-a", &["evidence-a"], &["gap-a"]),
+            ],
+        }
+    }
+
+    struct SequencePacketIdSourceV3 {
+        ids: VecDeque<String>,
+    }
+
+    impl PacketIdSourceV3 for SequencePacketIdSourceV3 {
+        fn next_packet_id(&mut self) -> String {
+            self.ids.pop_front().expect("enough packet ids")
+        }
+    }
+
+    fn deterministic_id_source() -> SequencePacketIdSourceV3 {
+        SequencePacketIdSourceV3 {
+            ids: VecDeque::from([
+                "00000000-0000-4000-8000-000000000001".to_owned(),
+                "00000000-0000-4000-8000-000000000002".to_owned(),
+            ]),
+        }
+    }
+
+    #[test]
+    fn packet_execution_record_v3_hashes_exact_question_and_canonical_request() {
+        let request = request_fixture();
+
+        let hashes = fingerprint_request_v3(&request).expect("valid closed request");
+
+        assert_eq!(
+            hashes.question_sha256.as_str(),
+            "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        );
+        assert_eq!(
+            hashes.request_sha256.as_str(),
+            "154ea7d1090d6679591d96117cbdebdd160fac2782f8569300fa46ba39507de9"
+        );
+    }
+
+    #[test]
+    fn packet_execution_record_v3_fingerprints_every_semantic_request_dimension() {
+        let base = request_fixture();
+        let base_digest = fingerprint_request_v3(&base).unwrap().request_sha256;
+        let mut mutations = Vec::new();
+
+        let mut value = base.clone();
+        value.question.push('!');
+        mutations.push(value);
+        let mut value = base.clone();
+        value.budget = PacketBudgetModeDto::Deep;
+        mutations.push(value);
+        let mut value = base.clone();
+        value.profile = PacketProfileV3::Callflow;
+        mutations.push(value);
+        let mut value = base.clone();
+        value.task_class = Some(PacketTaskClassDto::RouteTracing);
+        mutations.push(value);
+        let mut value = base.clone();
+        value.typed_probes = vec![PacketProbeDto::ExactPath {
+            path: "src/lib.rs".to_owned(),
+        }];
+        mutations.push(value);
+        let mut value = base.clone();
+        value.extra_probes = vec!["Router::run".to_owned()];
+        mutations.push(value);
+        let mut value = base.clone();
+        value.latency_budget_ms = Some(5_000);
+        mutations.push(value);
+        let mut value = base.clone();
+        value.parent_packet_id = Some("parent-1".to_owned());
+        mutations.push(value);
+        let mut value = base.clone();
+        value.option_ids = vec!["option-1".to_owned()];
+        mutations.push(value);
+        let mut value = base.clone();
+        value.core_generation_id = Some("core-generation-1".to_owned());
+        mutations.push(value);
+        let mut value = base;
+        value.retrieval_generation = Some("retrieval-generation-1".to_owned());
+        mutations.push(value);
+
+        for mutation in mutations {
+            assert_ne!(
+                fingerprint_request_v3(&mutation).unwrap().request_sha256,
+                base_digest
+            );
+        }
+
+        let mut ordered = request_fixture();
+        ordered.option_ids = vec!["first".to_owned(), "second".to_owned()];
+        ordered.typed_probes = vec![
+            PacketProbeDto::ExactPath {
+                path: "src/first.rs".to_owned(),
+            },
+            PacketProbeDto::ExactPath {
+                path: "src/second.rs".to_owned(),
+            },
+        ];
+        let ordered_digest = fingerprint_request_v3(&ordered).unwrap().request_sha256;
+        ordered.option_ids.reverse();
+        assert_ne!(
+            fingerprint_request_v3(&ordered).unwrap().request_sha256,
+            ordered_digest,
+            "ordered option semantics must survive canonicalization"
+        );
+        ordered.option_ids.reverse();
+        ordered.typed_probes.reverse();
+        assert_ne!(
+            fingerprint_request_v3(&ordered).unwrap().request_sha256,
+            ordered_digest,
+            "ordered probe semantics must survive canonicalization"
+        );
+
+        let mut current_request = AgentPacketRequestDto {
+            question: "hello".to_owned(),
+            budget: PacketBudgetModeDto::Standard,
+            task_class: None,
+            probes: Vec::new(),
+            extra_probes: Vec::new(),
+            include_evidence: true,
+            latency_budget_ms: None,
+            parent_packet_id: None,
+            option_ids: Vec::new(),
+            core_generation_id: None,
+            retrieval_generation: None,
+        };
+        let with_evidence = PacketRequestFingerprintV3::from_current_request(
+            &current_request,
+            PacketProfileV3::Auto,
+        );
+        current_request.include_evidence = false;
+        let without_evidence = PacketRequestFingerprintV3::from_current_request(
+            &current_request,
+            PacketProfileV3::Auto,
+        );
+        assert_eq!(
+            fingerprint_request_v3(&with_evidence).unwrap(),
+            fingerprint_request_v3(&without_evidence).unwrap(),
+            "the removed include_evidence flag is outside the v3 request fingerprint"
+        );
+    }
+
+    #[test]
+    fn packet_execution_record_v3_is_canonical_owned_and_immutable() {
+        let mut input = finalized_fixture();
+        let mut ids = deterministic_id_source();
+        let record = build_record_from_captured_v3(&capture_fixture(), &input, &mut ids).unwrap();
+        let before_borrow = record.clone();
+
+        assert_eq!(
+            record.packet_id().as_str(),
+            "00000000-0000-4000-8000-000000000001"
+        );
+        assert_eq!(record.caller_id().as_str(), "caller-1");
+        assert_eq!(record.request_id().as_str(), "request-1");
+        assert_eq!(
+            record.plan_version(),
+            codestory_agent::packet_execution_plan_v3::PACKET_EXECUTION_PLAN_VERSION_V3
+        );
+        assert_eq!(record.project().project_id, "project-1");
+        assert_eq!(record.project().workspace_id, "workspace-1");
+        assert_eq!(record.project().artifact_scope_id, "artifact-1");
+        assert_eq!(
+            record.evidence()[0].identity.evidence_id.as_str(),
+            "evidence-a"
+        );
+        assert_eq!(record.gaps()[0].identity.gap_id.as_str(), "gap-a");
+        assert_eq!(
+            record.diagnostics()[0].diagnostic_id.as_str(),
+            "diagnostic-a"
+        );
+        assert_eq!(
+            record.continuation().unwrap().gap_ids.as_slice()[0]
+                .gap_id
+                .as_str(),
+            "gap-a"
+        );
+
+        input.request.question = "caller-mutated".to_owned();
+        input.evidence[0].summary = Some(SummaryTextV3::new("caller-mutated").unwrap());
+        input.diagnostics[0].code = DiagnosticCodeTextV3::new("caller_mutated").unwrap();
+        assert_eq!(record, before_borrow);
+        assert_eq!(record.request().question(), "hello");
+        assert_eq!(record.retrieval().state, RetrievalStateV3Dto::Full);
+        assert_eq!(
+            record.diagnostics()[0].category(),
+            DiagnosticCategoryV3Dto::Coverage
+        );
+        assert_eq!(record.diagnostics()[0].code().as_str(), "source_gap");
+        assert_eq!(record, record.clone());
+
+        let mut reordered = finalized_fixture();
+        reordered.evidence.reverse();
+        reordered.gaps.reverse();
+        reordered.diagnostics.reverse();
+        let mut gap_references = reordered
+            .continuation
+            .as_ref()
+            .unwrap()
+            .gap_ids
+            .as_slice()
+            .to_vec();
+        gap_references.reverse();
+        reordered.continuation.as_mut().unwrap().gap_ids =
+            BoundedVecV3::new(gap_references).unwrap();
+        let mut reordered_ids = deterministic_id_source();
+        assert_eq!(
+            build_record_from_captured_v3(&capture_fixture(), &reordered, &mut reordered_ids)
+                .unwrap(),
+            before_borrow,
+            "canonical row ordering must not depend on caller vector order"
+        );
+    }
+
+    #[test]
+    fn packet_execution_record_v3_rejects_hostile_publication_and_identity_shapes() {
+        let input = finalized_fixture();
+        let mut ids = deterministic_id_source();
+
+        let mut capture = capture_fixture();
+        capture.core_project_id = "other-project".to_owned();
+        assert_eq!(
+            build_record_from_captured_v3(&capture, &input, &mut ids),
+            Err(RecordValidationErrorV3::ProjectMismatch)
+        );
+
+        let mut capture = capture_fixture();
+        capture.core_generation_id.clear();
+        assert!(matches!(
+            build_record_from_captured_v3(&capture, &input, &mut ids),
+            Err(RecordValidationErrorV3::EmptyIdentity("core_generation_id"))
+        ));
+
+        let mut capture = capture_fixture();
+        capture.core_run_id = "x".repeat(257);
+        assert!(matches!(
+            build_record_from_captured_v3(&capture, &input, &mut ids),
+            Err(RecordValidationErrorV3::IdentityTooLong("core_run_id", 257))
+        ));
+
+        let mut capture = capture_fixture();
+        capture.retrieval.as_mut().unwrap().core_run_id = "wrong-run".to_owned();
+        assert_eq!(
+            build_record_from_captured_v3(&capture, &input, &mut ids),
+            Err(RecordValidationErrorV3::RetrievalCoreSkew)
+        );
+
+        let mut capture = capture_fixture();
+        capture.retrieval.as_mut().unwrap().retrieval_input_hash = "not-a-hash".to_owned();
+        assert_eq!(
+            build_record_from_captured_v3(&capture, &input, &mut ids),
+            Err(RecordValidationErrorV3::InvalidRetrievalHash)
+        );
+
+        let mut capture = capture_fixture();
+        capture.retrieval = None;
+        assert_eq!(
+            build_record_from_captured_v3(&capture, &input, &mut ids),
+            Err(RecordValidationErrorV3::FullRetrievalWithoutPublication)
+        );
+
+        let mut unavailable = finalized_fixture();
+        unavailable.retrieval = RetrievalStateDescriptorV3Dto {
+            state: RetrievalStateV3Dto::Unavailable,
+            generation_id: None,
+        };
+        assert_eq!(
+            build_record_from_captured_v3(&capture_fixture(), &unavailable, &mut ids),
+            Err(RecordValidationErrorV3::RetrievalStateMismatch)
+        );
+
+        let mut capture = capture_fixture();
+        capture.project.workspace_id.clear();
+        assert!(matches!(
+            build_record_from_captured_v3(&capture, &input, &mut ids),
+            Err(RecordValidationErrorV3::EmptyIdentity("workspace_id"))
+        ));
+
+        let mut input = finalized_fixture();
+        input.request.core_generation_id = Some("wrong-core".to_owned());
+        assert_eq!(
+            build_record_from_captured_v3(&capture_fixture(), &input, &mut ids),
+            Err(RecordValidationErrorV3::RequestedCoreGenerationMismatch)
+        );
+
+        let mut input = finalized_fixture();
+        input.request.retrieval_generation = Some("wrong-retrieval".to_owned());
+        assert_eq!(
+            build_record_from_captured_v3(&capture_fixture(), &input, &mut ids),
+            Err(RecordValidationErrorV3::RequestedRetrievalGenerationMismatch)
+        );
+    }
+
+    #[test]
+    fn packet_execution_record_v3_rejects_duplicate_and_dangling_finalized_rows() {
+        let capture = capture_fixture();
+        let mut ids = deterministic_id_source();
+
+        let mut input = finalized_fixture();
+        input.evidence.push(evidence("evidence-a"));
+        assert!(matches!(
+            build_record_from_captured_v3(&capture, &input, &mut ids),
+            Err(RecordValidationErrorV3::DuplicateEvidenceIdentity(_))
+        ));
+
+        let mut input = finalized_fixture();
+        input.evidence = (0..=EVIDENCE_ROWS_MAX_V3)
+            .map(|index| evidence(&format!("evidence-{index:03}")))
+            .collect();
+        assert_eq!(
+            build_record_from_captured_v3(&capture, &input, &mut ids),
+            Err(RecordValidationErrorV3::TooManyEvidenceRows(
+                EVIDENCE_ROWS_MAX_V3 + 1
+            ))
+        );
+
+        let mut input = finalized_fixture();
+        input.gaps.push(gap("gap-a"));
+        assert!(matches!(
+            build_record_from_captured_v3(&capture, &input, &mut ids),
+            Err(RecordValidationErrorV3::DuplicateGapIdentity(_))
+        ));
+
+        let mut input = finalized_fixture();
+        input.diagnostics.push(diagnostic("diagnostic-a", &[], &[]));
+        assert!(matches!(
+            build_record_from_captured_v3(&capture, &input, &mut ids),
+            Err(RecordValidationErrorV3::DuplicateDiagnosticIdentity(_))
+        ));
+
+        let mut input = finalized_fixture();
+        input.continuation.as_mut().unwrap().gap_ids = BoundedVecV3::new(vec![GapIdentityV3Dto {
+            gap_id: identity("missing-gap"),
+        }])
+        .unwrap();
+        assert!(matches!(
+            build_record_from_captured_v3(&capture, &input, &mut ids),
+            Err(RecordValidationErrorV3::UnknownContinuationGap(_))
+        ));
+
+        let mut input = finalized_fixture();
+        input.diagnostics[0].evidence_ids = vec![EvidenceIdentityV3Dto {
+            evidence_id: identity("missing-evidence"),
+        }];
+        assert!(matches!(
+            build_record_from_captured_v3(&capture, &input, &mut ids),
+            Err(RecordValidationErrorV3::UnknownDiagnosticEvidence(_))
+        ));
+
+        let mut input = finalized_fixture();
+        input.diagnostics[0].gap_ids = vec![
+            GapIdentityV3Dto {
+                gap_id: identity("gap-a"),
+            },
+            GapIdentityV3Dto {
+                gap_id: identity("gap-a"),
+            },
+        ];
+        assert!(matches!(
+            build_record_from_captured_v3(&capture, &input, &mut ids),
+            Err(RecordValidationErrorV3::DuplicateDiagnosticGapReference(_))
+        ));
+
+        let mut input = finalized_fixture();
+        input.continuation.as_mut().unwrap().gap_ids = BoundedVecV3::new(vec![
+            GapIdentityV3Dto {
+                gap_id: identity("gap-a"),
+            },
+            GapIdentityV3Dto {
+                gap_id: identity("gap-a"),
+            },
+        ])
+        .unwrap();
+        assert!(matches!(
+            build_record_from_captured_v3(&capture, &input, &mut ids),
+            Err(RecordValidationErrorV3::DuplicateContinuationGapReference(
+                _
+            ))
+        ));
+
+        let mut input = finalized_fixture();
+        input.diagnostics[0].evidence_ids = vec![
+            EvidenceIdentityV3Dto {
+                evidence_id: identity("evidence-a"),
+            },
+            EvidenceIdentityV3Dto {
+                evidence_id: identity("evidence-a"),
+            },
+        ];
+        assert!(matches!(
+            build_record_from_captured_v3(&capture, &input, &mut ids),
+            Err(RecordValidationErrorV3::DuplicateDiagnosticEvidenceReference(_))
+        ));
+
+        let mut input = finalized_fixture();
+        input.diagnostics[0].gap_ids = vec![GapIdentityV3Dto {
+            gap_id: identity("missing-gap"),
+        }];
+        assert!(matches!(
+            build_record_from_captured_v3(&capture, &input, &mut ids),
+            Err(RecordValidationErrorV3::UnknownDiagnosticGap(_))
+        ));
+    }
+
+    #[test]
+    fn packet_execution_record_v3_product_ids_are_independent_uuid_v4_values() {
+        let capture = capture_fixture();
+        let input = finalized_fixture();
+        let first = build_record_from_captured_product_v3(&capture, &input).unwrap();
+        let second = build_record_from_captured_product_v3(&capture, &input).unwrap();
+
+        assert_ne!(first.packet_id(), second.packet_id());
+        for packet_id in [first.packet_id(), second.packet_id()] {
+            let decoded = uuid::Uuid::parse_str(packet_id.as_str()).expect("UUID packet id");
+            assert_eq!(decoded.get_version_num(), 4);
+            assert_eq!(decoded.get_variant(), uuid::Variant::RFC4122);
+        }
+        assert_eq!(first.question_sha256(), second.question_sha256());
+        assert_eq!(first.request_sha256(), second.request_sha256());
+    }
+
+    #[test]
+    fn packet_execution_record_v3_captures_one_ready_public_operation_pin() {
+        let fixture = ready_activation_fixture();
+        let service = fixture.runtime.public_operation_service();
+        let mut records = None;
+
+        let operation = service
+            .run_with_cancel("packet", Arc::new(AtomicBool::new(false)), || {
+                let input = finalized_fixture_for_active_pin(&service, finalized_fixture());
+                let first = build_packet_execution_record_v3(&service, &input)
+                    .map_err(RecordValidationErrorV3::into_api_error)?;
+                let second = build_packet_execution_record_v3(&service, &input)
+                    .map_err(RecordValidationErrorV3::into_api_error)?;
+                records = Some((first.clone(), second));
+                Ok(first)
+            })
+            .expect("ready pinned capture");
+
+        assert_eq!(operation.attempt, 1);
+        let core = operation.core_publication.as_ref().unwrap();
+        assert_eq!(
+            operation.value.core_publication().generation_id.as_str(),
+            core.generation_id
+        );
+        assert_eq!(
+            operation.value.core_publication().run_id.as_str(),
+            core.run_id
+        );
+        let retrieval = operation.retrieval_publication.as_ref().unwrap();
+        assert_eq!(
+            operation
+                .value
+                .retrieval_publication()
+                .unwrap()
+                .retrieval_generation
+                .as_str(),
+            retrieval.retrieval_generation
+        );
+        assert_eq!(
+            operation
+                .value
+                .retrieval_publication()
+                .unwrap()
+                .retrieval_input_sha256
+                .as_str(),
+            retrieval.retrieval_input_hash
+        );
+        assert_eq!(
+            operation
+                .value
+                .retrieval_publication()
+                .unwrap()
+                .semantic_generation
+                .as_str(),
+            retrieval.semantic_generation
+        );
+        assert_eq!(retrieval.core_generation_id, core.generation_id);
+        assert_eq!(retrieval.core_run_id, core.run_id);
+        let (first, second) = records.unwrap();
+        assert_ne!(first.packet_id(), second.packet_id());
+        assert_eq!(first.question_sha256(), second.question_sha256());
+        assert_eq!(first.request_sha256(), second.request_sha256());
+    }
+
+    #[test]
+    fn packet_execution_record_v3_cannot_capture_without_an_active_pin() {
+        let fixture = ready_activation_fixture();
+        let service = fixture.runtime.public_operation_service();
+        assert_eq!(
+            build_packet_execution_record_v3(&service, &finalized_fixture()),
+            Err(RecordValidationErrorV3::NoActiveCorePin)
+        );
+    }
+
+    #[test]
+    fn packet_execution_record_v3_does_not_bypass_mid_operation_freshness_refusal() {
+        let fixture = ready_activation_fixture();
+        let service = fixture.runtime.public_operation_service();
+        let source = fixture.project.path().join("metadata.rs");
+        let mut builds = 0;
+
+        let refusal = service
+            .run_with_cancel("packet", Arc::new(AtomicBool::new(false)), || {
+                builds += 1;
+                let input = finalized_fixture_for_active_pin(&service, finalized_fixture());
+                let record = build_packet_execution_record_v3(&service, &input)
+                    .map_err(RecordValidationErrorV3::into_api_error)?;
+                fs::write(&source, "// CHANGED_PACKET_RECORD_SOURCE\n")
+                    .expect("mutate source during capture");
+                Ok(record)
+            })
+            .expect_err("the existing post-operation fence must reject source drift");
+
+        assert_eq!(builds, 1);
+        assert_eq!(refusal.code, "project_unavailable");
+    }
+
+    fn finalized_fixture_for_active_pin(
+        service: &crate::services::PublicOperationService,
+        mut input: FinalizedPacketExecutionInputV3,
+    ) -> FinalizedPacketExecutionInputV3 {
+        let retrieval = service
+            .active_publication()
+            .expect("active core publication")
+            .retrieval_publication
+            .expect("active retrieval publication");
+        input.retrieval.generation_id = Some(identity(&retrieval.retrieval_generation));
+        input
+    }
+}

--- a/crates/codestory-runtime/src/agent/packet_execution_record_v3.rs
+++ b/crates/codestory-runtime/src/agent/packet_execution_record_v3.rs
@@ -151,6 +151,7 @@ pub(crate) enum RecordValidationErrorV3 {
     DuplicateEvidenceIdentity(String),
     DuplicateGapIdentity(String),
     DuplicateDiagnosticIdentity(String),
+    ZeroContinuationRounds,
     DuplicateContinuationGapReference(String),
     UnknownContinuationGap(String),
     DuplicateDiagnosticEvidenceReference(String),
@@ -642,6 +643,9 @@ fn canonical_continuation(
     gap_ids: &BTreeSet<&str>,
 ) -> Result<ContinuationStateV3Dto, RecordValidationErrorV3> {
     validate_required_identity("continuation_id", continuation.continuation_id.as_str())?;
+    continuation
+        .validate()
+        .map_err(|_| RecordValidationErrorV3::ZeroContinuationRounds)?;
     let mut references = continuation.gap_ids.as_slice().to_vec();
     references.sort();
     for pair in references.windows(2) {
@@ -658,12 +662,13 @@ fn canonical_continuation(
             ));
         }
     }
-    Ok(ContinuationStateV3Dto {
-        continuation_id: continuation.continuation_id.clone(),
-        remaining_rounds: continuation.remaining_rounds,
-        gap_ids: codestory_contracts::packet_projection_v3::BoundedVecV3::new(references)
+    Ok(ContinuationStateV3Dto::new(
+        continuation.continuation_id.clone(),
+        continuation.remaining_rounds,
+        codestory_contracts::packet_projection_v3::BoundedVecV3::new(references)
             .expect("the source bounded vector remains bounded after sorting"),
-    })
+    )
+    .expect("validated continuation remains positive"))
 }
 
 fn canonical_diagnostics(
@@ -1266,6 +1271,13 @@ mod tests {
         assert_eq!(
             build_record_from_captured_v3(&capture_fixture(), &input, &mut ids),
             Err(RecordValidationErrorV3::RequestedRetrievalGenerationMismatch)
+        );
+
+        let mut input = finalized_fixture();
+        input.continuation.as_mut().unwrap().remaining_rounds = 0;
+        assert_eq!(
+            build_record_from_captured_v3(&capture_fixture(), &input, &mut ids),
+            Err(RecordValidationErrorV3::ZeroContinuationRounds)
         );
     }
 

--- a/crates/codestory-runtime/src/agent/packet_projection_v3.rs
+++ b/crates/codestory-runtime/src/agent/packet_projection_v3.rs
@@ -39,6 +39,7 @@ pub(crate) enum ProjectionInputErrorV3 {
     DuplicateEvidenceIdentity(String),
     DuplicateGapIdentity(String),
     DuplicateDiagnosticIdentity(String),
+    ZeroContinuationRounds,
     DuplicateContinuationGapReference(String),
     UnknownContinuationGap(String),
     DuplicateDiagnosticEvidenceReference(String),
@@ -223,12 +224,13 @@ fn packet_complete_candidate_v3(
             row.message = None;
         }
     }
+    let continuation = canonical_continuation_v3(record.continuation(), &gaps)?;
     Ok(PacketProjectionV3Dto::Complete {
         schema_version: PACKET_PROJECTION_V3_SCHEMA_VERSION,
         identity: identity_from_record(record),
         publication: publication_from_record(record),
         status: evidence_availability_v3(
-            record.continuation().is_some(),
+            continuation.is_some(),
             !evidence.is_empty(),
             record.retrieval(),
             &gaps,
@@ -236,7 +238,7 @@ fn packet_complete_candidate_v3(
         retrieval: record.retrieval().clone(),
         evidence: BoundedVecV3::new(evidence).map_err(ProjectionBuildErrorV3::BoundViolation)?,
         gaps: BoundedVecV3::new(gaps).map_err(ProjectionBuildErrorV3::BoundViolation)?,
-        continuation: record.continuation().cloned(),
+        continuation,
         diagnostics,
     })
 }
@@ -357,6 +359,9 @@ fn canonical_continuation_v3(
     let Some(source) = source else {
         return Ok(None);
     };
+    source.validate().map_err(|_| {
+        ProjectionBuildErrorV3::InvalidInput(ProjectionInputErrorV3::ZeroContinuationRounds)
+    })?;
     let gap_ids = gaps
         .iter()
         .map(|gap| gap.identity.gap_id.as_str())
@@ -382,11 +387,12 @@ fn canonical_continuation_v3(
         }
     }
     Ok(Some(
-        codestory_contracts::packet_projection_v3::ContinuationStateV3Dto {
-            continuation_id: source.continuation_id.clone(),
-            remaining_rounds: source.remaining_rounds,
-            gap_ids: BoundedVecV3::new(references).expect("bounded references remain bounded"),
-        },
+        codestory_contracts::packet_projection_v3::ContinuationStateV3Dto::new(
+            source.continuation_id.clone(),
+            source.remaining_rounds,
+            BoundedVecV3::new(references).expect("bounded references remain bounded"),
+        )
+        .expect("validated continuation remains positive"),
     ))
 }
 
@@ -1321,6 +1327,19 @@ mod tests {
             ))
         ));
 
+        let mut zero_round_continuation = context_input.clone();
+        zero_round_continuation
+            .continuation
+            .as_mut()
+            .unwrap()
+            .remaining_rounds = 0;
+        assert_eq!(
+            build_context_projection_v3(&zero_round_continuation),
+            Err(ProjectionBuildErrorV3::InvalidInput(
+                ProjectionInputErrorV3::ZeroContinuationRounds
+            ))
+        );
+
         let mut dangling_diagnostic = context_input.clone();
         dangling_diagnostic.diagnostic_rows[0].evidence_ids =
             BoundedVecV3::new(vec![EvidenceIdentityV3Dto {
@@ -1385,6 +1404,19 @@ mod tests {
                 .map(|row| row.identity.evidence_id.as_str())
                 .collect::<Vec<_>>(),
             ["evidence-a", "evidence-b"]
+        );
+
+        let mut zero_round_continuation = search_input.clone();
+        zero_round_continuation
+            .continuation
+            .as_mut()
+            .unwrap()
+            .remaining_rounds = 0;
+        assert_eq!(
+            build_search_projection_v3(&zero_round_continuation),
+            Err(ProjectionBuildErrorV3::InvalidInput(
+                ProjectionInputErrorV3::ZeroContinuationRounds
+            ))
         );
 
         let mut duplicate_diagnostic_reference = search_input;

--- a/crates/codestory-runtime/src/agent/packet_projection_v3.rs
+++ b/crates/codestory-runtime/src/agent/packet_projection_v3.rs
@@ -1,0 +1,1553 @@
+//! Dark, pure v3 packet/context/search projection builders.
+
+#![allow(dead_code)]
+
+use std::collections::BTreeSet;
+
+use codestory_contracts::packet_projection_v3::{
+    BoundViolationV3, BoundedVecV3, ContextEvidenceRowV3Dto, ContextProjectionKindV3Dto,
+    ContextProjectionV3Dto, ContextTargetV3Dto, DIAGNOSTIC_ROWS_MAX_V3,
+    DiagnosticArtifactKindV3Dto, DiagnosticArtifactV3Dto, DiagnosticReferenceV3Dto,
+    DiagnosticRowV3Dto, DiagnosticsCapabilityV3Dto, EvidenceAvailabilityV3Dto, GapKindV3Dto,
+    IdentityTextV3, PACKET_PROJECTION_V3_SCHEMA_VERSION, PacketProjectionV3Dto,
+    PacketRequestIdentityV3Dto, ProjectionGapRowV3Dto, PublicationIdentityV3Dto,
+    RetrievalStateDescriptorV3Dto, RetrievalStateV3Dto, SearchEvidenceRowV3Dto,
+    SearchProjectionKindV3Dto, SearchProjectionV3Dto, Sha256DigestV3Dto,
+};
+use sha2::{Digest, Sha256};
+
+use super::packet_execution_record_v3::PacketExecutionRecordV3;
+
+pub(crate) const PACKET_PUBLIC_RESULT_MAX_BYTES_V3: usize = 16 * 1024;
+pub(crate) const DIAGNOSTIC_ARTIFACT_MAX_BYTES_V3: usize = 1024 * 1024;
+
+const DIAGNOSTIC_ARTIFACT_ID_DOMAIN_V3: &[u8] = b"codestory.packet_diagnostic_v3.id\0";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ProjectionBuildErrorV3 {
+    MeasurementFailed,
+    FallbackTooLarge { required_bytes: usize },
+    InvalidInput(ProjectionInputErrorV3),
+    BoundViolation(BoundViolationV3),
+    CanonicalJson(String),
+    InvalidDigest,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ProjectionInputErrorV3 {
+    EmptyContextTarget,
+    DuplicateEvidenceIdentity(String),
+    DuplicateGapIdentity(String),
+    DuplicateDiagnosticIdentity(String),
+    DuplicateContinuationGapReference(String),
+    UnknownContinuationGap(String),
+    DuplicateDiagnosticEvidenceReference(String),
+    DuplicateDiagnosticGapReference(String),
+    UnknownDiagnosticEvidence(String),
+    UnknownDiagnosticGap(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DiagnosticArtifactBuildV3 {
+    Complete {
+        artifact: Box<DiagnosticArtifactV3Dto>,
+        bytes: DiagnosticArtifactBytesV3,
+        reference: DiagnosticReferenceV3Dto,
+    },
+    TooLarge {
+        required_bytes: u64,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DiagnosticArtifactBytesV3(Box<[u8]>);
+
+impl DiagnosticArtifactBytesV3 {
+    pub(crate) fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FinalizedContextProjectionInputV3 {
+    identity: PacketRequestIdentityV3Dto,
+    publication: PublicationIdentityV3Dto,
+    retrieval: RetrievalStateDescriptorV3Dto,
+    target: ContextTargetV3Dto,
+    evidence: Vec<ContextEvidenceRowV3Dto>,
+    gaps: Vec<ProjectionGapRowV3Dto>,
+    continuation: Option<codestory_contracts::packet_projection_v3::ContinuationStateV3Dto>,
+    diagnostics: DiagnosticsCapabilityV3Dto,
+    diagnostic_rows: Vec<DiagnosticRowV3Dto>,
+}
+
+impl FinalizedContextProjectionInputV3 {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        identity: PacketRequestIdentityV3Dto,
+        publication: PublicationIdentityV3Dto,
+        retrieval: RetrievalStateDescriptorV3Dto,
+        target: ContextTargetV3Dto,
+        evidence: Vec<ContextEvidenceRowV3Dto>,
+        gaps: Vec<ProjectionGapRowV3Dto>,
+        continuation: Option<codestory_contracts::packet_projection_v3::ContinuationStateV3Dto>,
+        diagnostics: DiagnosticsCapabilityV3Dto,
+        diagnostic_rows: Vec<DiagnosticRowV3Dto>,
+    ) -> Self {
+        Self {
+            identity,
+            publication,
+            retrieval,
+            target,
+            evidence,
+            gaps,
+            continuation,
+            diagnostics,
+            diagnostic_rows,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FinalizedSearchProjectionInputV3 {
+    identity: PacketRequestIdentityV3Dto,
+    publication: PublicationIdentityV3Dto,
+    retrieval: RetrievalStateDescriptorV3Dto,
+    evidence: Vec<SearchEvidenceRowV3Dto>,
+    gaps: Vec<ProjectionGapRowV3Dto>,
+    continuation: Option<codestory_contracts::packet_projection_v3::ContinuationStateV3Dto>,
+    diagnostics: DiagnosticsCapabilityV3Dto,
+    diagnostic_rows: Vec<DiagnosticRowV3Dto>,
+}
+
+impl FinalizedSearchProjectionInputV3 {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        identity: PacketRequestIdentityV3Dto,
+        publication: PublicationIdentityV3Dto,
+        retrieval: RetrievalStateDescriptorV3Dto,
+        evidence: Vec<SearchEvidenceRowV3Dto>,
+        gaps: Vec<ProjectionGapRowV3Dto>,
+        continuation: Option<codestory_contracts::packet_projection_v3::ContinuationStateV3Dto>,
+        diagnostics: DiagnosticsCapabilityV3Dto,
+        diagnostic_rows: Vec<DiagnosticRowV3Dto>,
+    ) -> Self {
+        Self {
+            identity,
+            publication,
+            retrieval,
+            evidence,
+            gaps,
+            continuation,
+            diagnostics,
+            diagnostic_rows,
+        }
+    }
+}
+
+pub(crate) fn build_packet_projection_v3(
+    record: &PacketExecutionRecordV3,
+    diagnostics: DiagnosticsCapabilityV3Dto,
+    mut measure: impl FnMut(&PacketProjectionV3Dto) -> Result<usize, ()>,
+) -> Result<PacketProjectionV3Dto, ProjectionBuildErrorV3> {
+    let mut candidate = packet_complete_candidate_v3(record, diagnostics.clone(), false, false)?;
+    let mut required_complete_bytes =
+        measure(&candidate).map_err(|_| ProjectionBuildErrorV3::MeasurementFailed)?;
+    if required_complete_bytes <= PACKET_PUBLIC_RESULT_MAX_BYTES_V3 {
+        return Ok(candidate);
+    }
+
+    if record.evidence().iter().any(|row| row.summary.is_some()) {
+        candidate = packet_complete_candidate_v3(record, diagnostics.clone(), true, false)?;
+        required_complete_bytes =
+            measure(&candidate).map_err(|_| ProjectionBuildErrorV3::MeasurementFailed)?;
+        if required_complete_bytes <= PACKET_PUBLIC_RESULT_MAX_BYTES_V3 {
+            return Ok(candidate);
+        }
+    }
+
+    if record.gaps().iter().any(|row| row.message.is_some()) {
+        candidate = packet_complete_candidate_v3(record, diagnostics.clone(), true, true)?;
+        required_complete_bytes =
+            measure(&candidate).map_err(|_| ProjectionBuildErrorV3::MeasurementFailed)?;
+        if required_complete_bytes <= PACKET_PUBLIC_RESULT_MAX_BYTES_V3 {
+            return Ok(candidate);
+        }
+    }
+
+    let fallback = PacketProjectionV3Dto::BudgetExceeded {
+        schema_version: PACKET_PROJECTION_V3_SCHEMA_VERSION,
+        identity: identity_from_record(record),
+        publication: publication_from_record(record),
+        status: EvidenceAvailabilityV3Dto::Unavailable,
+        retrieval: record.retrieval().clone(),
+        diagnostics,
+        maximum_bytes: PACKET_PUBLIC_RESULT_MAX_BYTES_V3 as u64,
+        required_complete_bytes: required_complete_bytes as u64,
+    };
+    let fallback_bytes =
+        measure(&fallback).map_err(|_| ProjectionBuildErrorV3::MeasurementFailed)?;
+    if fallback_bytes > PACKET_PUBLIC_RESULT_MAX_BYTES_V3 {
+        return Err(ProjectionBuildErrorV3::FallbackTooLarge {
+            required_bytes: fallback_bytes,
+        });
+    }
+    Ok(fallback)
+}
+
+fn packet_complete_candidate_v3(
+    record: &PacketExecutionRecordV3,
+    diagnostics: DiagnosticsCapabilityV3Dto,
+    remove_summaries: bool,
+    remove_messages: bool,
+) -> Result<PacketProjectionV3Dto, ProjectionBuildErrorV3> {
+    let mut evidence = record.evidence().to_vec();
+    let mut gaps = record.gaps().to_vec();
+    evidence.sort_by(|left, right| left.identity.cmp(&right.identity));
+    gaps.sort_by(|left, right| left.identity.cmp(&right.identity));
+    if remove_summaries {
+        for row in &mut evidence {
+            row.summary = None;
+        }
+    }
+    if remove_messages {
+        for row in &mut gaps {
+            row.message = None;
+        }
+    }
+    Ok(PacketProjectionV3Dto::Complete {
+        schema_version: PACKET_PROJECTION_V3_SCHEMA_VERSION,
+        identity: identity_from_record(record),
+        publication: publication_from_record(record),
+        status: evidence_availability_v3(
+            record.continuation().is_some(),
+            !evidence.is_empty(),
+            record.retrieval(),
+            &gaps,
+        ),
+        retrieval: record.retrieval().clone(),
+        evidence: BoundedVecV3::new(evidence).map_err(ProjectionBuildErrorV3::BoundViolation)?,
+        gaps: BoundedVecV3::new(gaps).map_err(ProjectionBuildErrorV3::BoundViolation)?,
+        continuation: record.continuation().cloned(),
+        diagnostics,
+    })
+}
+
+pub(crate) fn build_context_projection_v3(
+    input: &FinalizedContextProjectionInputV3,
+) -> Result<ContextProjectionV3Dto, ProjectionBuildErrorV3> {
+    if input.target.path.is_none() && input.target.symbol_id.is_none() {
+        return Err(ProjectionBuildErrorV3::InvalidInput(
+            ProjectionInputErrorV3::EmptyContextTarget,
+        ));
+    }
+    let mut evidence = input.evidence.clone();
+    evidence.sort_by(|left, right| left.identity.cmp(&right.identity));
+    reject_duplicate_evidence_v3(&evidence, |row| &row.identity)?;
+    let gaps = canonical_gaps_v3(&input.gaps)?;
+    let continuation = canonical_continuation_v3(input.continuation.as_ref(), &gaps)?;
+    let diagnostic_rows =
+        BoundedVecV3::<_, DIAGNOSTIC_ROWS_MAX_V3>::new(input.diagnostic_rows.clone())
+            .map_err(ProjectionBuildErrorV3::BoundViolation)?;
+    validate_diagnostic_references_v3(diagnostic_rows.as_slice(), &evidence, &gaps, |row| {
+        &row.identity
+    })?;
+    Ok(ContextProjectionV3Dto {
+        kind: ContextProjectionKindV3Dto::Complete,
+        schema_version: PACKET_PROJECTION_V3_SCHEMA_VERSION,
+        identity: input.identity.clone(),
+        publication: input.publication.clone(),
+        status: evidence_availability_v3(
+            input.continuation.is_some(),
+            !evidence.is_empty(),
+            &input.retrieval,
+            &gaps,
+        ),
+        target: input.target.clone(),
+        evidence: BoundedVecV3::new(evidence).map_err(ProjectionBuildErrorV3::BoundViolation)?,
+        gaps: BoundedVecV3::new(gaps).map_err(ProjectionBuildErrorV3::BoundViolation)?,
+        continuation,
+        diagnostics: input.diagnostics.clone(),
+    })
+}
+
+pub(crate) fn build_search_projection_v3(
+    input: &FinalizedSearchProjectionInputV3,
+) -> Result<SearchProjectionV3Dto, ProjectionBuildErrorV3> {
+    let mut evidence = input.evidence.clone();
+    evidence.sort_by(|left, right| left.identity.cmp(&right.identity));
+    reject_duplicate_evidence_v3(&evidence, |row| &row.identity)?;
+    let gaps = canonical_gaps_v3(&input.gaps)?;
+    let continuation = canonical_continuation_v3(input.continuation.as_ref(), &gaps)?;
+    let diagnostic_rows =
+        BoundedVecV3::<_, DIAGNOSTIC_ROWS_MAX_V3>::new(input.diagnostic_rows.clone())
+            .map_err(ProjectionBuildErrorV3::BoundViolation)?;
+    validate_diagnostic_references_v3(diagnostic_rows.as_slice(), &evidence, &gaps, |row| {
+        &row.identity
+    })?;
+    Ok(SearchProjectionV3Dto {
+        kind: SearchProjectionKindV3Dto::Complete,
+        schema_version: PACKET_PROJECTION_V3_SCHEMA_VERSION,
+        identity: input.identity.clone(),
+        publication: input.publication.clone(),
+        status: evidence_availability_v3(
+            input.continuation.is_some(),
+            !evidence.is_empty(),
+            &input.retrieval,
+            &gaps,
+        ),
+        evidence: BoundedVecV3::new(evidence).map_err(ProjectionBuildErrorV3::BoundViolation)?,
+        gaps: BoundedVecV3::new(gaps).map_err(ProjectionBuildErrorV3::BoundViolation)?,
+        continuation,
+        retrieval: input.retrieval.clone(),
+        diagnostics: input.diagnostics.clone(),
+    })
+}
+
+fn reject_duplicate_evidence_v3<T>(
+    evidence: &[T],
+    identity: impl Fn(&T) -> &codestory_contracts::packet_projection_v3::EvidenceIdentityV3Dto,
+) -> Result<(), ProjectionBuildErrorV3> {
+    for pair in evidence.windows(2) {
+        let left = identity(&pair[0]);
+        let right = identity(&pair[1]);
+        if left == right {
+            return Err(ProjectionBuildErrorV3::InvalidInput(
+                ProjectionInputErrorV3::DuplicateEvidenceIdentity(
+                    left.evidence_id.as_str().to_owned(),
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn canonical_gaps_v3(
+    source: &[ProjectionGapRowV3Dto],
+) -> Result<Vec<ProjectionGapRowV3Dto>, ProjectionBuildErrorV3> {
+    let mut gaps = source.to_vec();
+    gaps.sort_by(|left, right| left.identity.cmp(&right.identity));
+    for pair in gaps.windows(2) {
+        if pair[0].identity == pair[1].identity {
+            return Err(ProjectionBuildErrorV3::InvalidInput(
+                ProjectionInputErrorV3::DuplicateGapIdentity(
+                    pair[0].identity.gap_id.as_str().to_owned(),
+                ),
+            ));
+        }
+    }
+    Ok(gaps)
+}
+
+fn canonical_continuation_v3(
+    source: Option<&codestory_contracts::packet_projection_v3::ContinuationStateV3Dto>,
+    gaps: &[ProjectionGapRowV3Dto],
+) -> Result<
+    Option<codestory_contracts::packet_projection_v3::ContinuationStateV3Dto>,
+    ProjectionBuildErrorV3,
+> {
+    let Some(source) = source else {
+        return Ok(None);
+    };
+    let gap_ids = gaps
+        .iter()
+        .map(|gap| gap.identity.gap_id.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut references = source.gap_ids.as_slice().to_vec();
+    references.sort();
+    for pair in references.windows(2) {
+        if pair[0] == pair[1] {
+            return Err(ProjectionBuildErrorV3::InvalidInput(
+                ProjectionInputErrorV3::DuplicateContinuationGapReference(
+                    pair[0].gap_id.as_str().to_owned(),
+                ),
+            ));
+        }
+    }
+    for reference in &references {
+        if !gap_ids.contains(reference.gap_id.as_str()) {
+            return Err(ProjectionBuildErrorV3::InvalidInput(
+                ProjectionInputErrorV3::UnknownContinuationGap(
+                    reference.gap_id.as_str().to_owned(),
+                ),
+            ));
+        }
+    }
+    Ok(Some(
+        codestory_contracts::packet_projection_v3::ContinuationStateV3Dto {
+            continuation_id: source.continuation_id.clone(),
+            remaining_rounds: source.remaining_rounds,
+            gap_ids: BoundedVecV3::new(references).expect("bounded references remain bounded"),
+        },
+    ))
+}
+
+fn validate_diagnostic_references_v3<T>(
+    diagnostics: &[DiagnosticRowV3Dto],
+    evidence: &[T],
+    gaps: &[ProjectionGapRowV3Dto],
+    identity: impl Fn(&T) -> &codestory_contracts::packet_projection_v3::EvidenceIdentityV3Dto,
+) -> Result<(), ProjectionBuildErrorV3> {
+    let mut ordered_diagnostics = diagnostics.iter().collect::<Vec<_>>();
+    ordered_diagnostics.sort_by(|left, right| left.diagnostic_id.cmp(&right.diagnostic_id));
+    for pair in ordered_diagnostics.windows(2) {
+        if pair[0].diagnostic_id == pair[1].diagnostic_id {
+            return Err(ProjectionBuildErrorV3::InvalidInput(
+                ProjectionInputErrorV3::DuplicateDiagnosticIdentity(
+                    pair[0].diagnostic_id.as_str().to_owned(),
+                ),
+            ));
+        }
+    }
+    let evidence_ids = evidence
+        .iter()
+        .map(|row| identity(row).evidence_id.as_str())
+        .collect::<BTreeSet<_>>();
+    let gap_ids = gaps
+        .iter()
+        .map(|gap| gap.identity.gap_id.as_str())
+        .collect::<BTreeSet<_>>();
+    for diagnostic in ordered_diagnostics {
+        let mut evidence_references = diagnostic.evidence_ids.as_slice().to_vec();
+        evidence_references.sort();
+        for pair in evidence_references.windows(2) {
+            if pair[0] == pair[1] {
+                return Err(ProjectionBuildErrorV3::InvalidInput(
+                    ProjectionInputErrorV3::DuplicateDiagnosticEvidenceReference(
+                        pair[0].evidence_id.as_str().to_owned(),
+                    ),
+                ));
+            }
+        }
+        for reference in &evidence_references {
+            if !evidence_ids.contains(reference.evidence_id.as_str()) {
+                return Err(ProjectionBuildErrorV3::InvalidInput(
+                    ProjectionInputErrorV3::UnknownDiagnosticEvidence(
+                        reference.evidence_id.as_str().to_owned(),
+                    ),
+                ));
+            }
+        }
+
+        let mut gap_references = diagnostic.gap_ids.as_slice().to_vec();
+        gap_references.sort();
+        for pair in gap_references.windows(2) {
+            if pair[0] == pair[1] {
+                return Err(ProjectionBuildErrorV3::InvalidInput(
+                    ProjectionInputErrorV3::DuplicateDiagnosticGapReference(
+                        pair[0].gap_id.as_str().to_owned(),
+                    ),
+                ));
+            }
+        }
+        for reference in &gap_references {
+            if !gap_ids.contains(reference.gap_id.as_str()) {
+                return Err(ProjectionBuildErrorV3::InvalidInput(
+                    ProjectionInputErrorV3::UnknownDiagnosticGap(
+                        reference.gap_id.as_str().to_owned(),
+                    ),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn build_diagnostic_artifact_v3(
+    record: &PacketExecutionRecordV3,
+) -> Result<DiagnosticArtifactBuildV3, ProjectionBuildErrorV3> {
+    let artifact_id = diagnostic_artifact_id_v3(record)?;
+    let mut rows = record
+        .diagnostics()
+        .iter()
+        .map(|row| {
+            let mut evidence_ids = row.evidence_ids().to_vec();
+            evidence_ids.sort();
+            let mut gap_ids = row.gap_ids().to_vec();
+            gap_ids.sort();
+            DiagnosticRowV3Dto {
+                diagnostic_id: row.diagnostic_id().clone(),
+                category: row.category(),
+                code: row.code().clone(),
+                evidence_ids: BoundedVecV3::new(evidence_ids)
+                    .expect("validated record reference bound"),
+                gap_ids: BoundedVecV3::new(gap_ids).expect("validated record reference bound"),
+            }
+        })
+        .collect::<Vec<_>>();
+    rows.sort_by(|left, right| left.diagnostic_id.cmp(&right.diagnostic_id));
+    let artifact = DiagnosticArtifactV3Dto {
+        kind: DiagnosticArtifactKindV3Dto::Complete,
+        schema_version: PACKET_PROJECTION_V3_SCHEMA_VERSION,
+        artifact_id: artifact_id.clone(),
+        packet_id: record.packet_id().clone(),
+        publication: publication_from_record(record),
+        rows: BoundedVecV3::<_, DIAGNOSTIC_ROWS_MAX_V3>::new(rows)
+            .expect("validated record diagnostic bound"),
+    };
+    let bytes = codestory_agent::packet_execution_plan_v3::canonical_json_bytes_v3(&artifact)
+        .map_err(ProjectionBuildErrorV3::CanonicalJson)?;
+    if bytes.len() > DIAGNOSTIC_ARTIFACT_MAX_BYTES_V3 {
+        return Ok(DiagnosticArtifactBuildV3::TooLarge {
+            required_bytes: bytes.len() as u64,
+        });
+    }
+    let sha256 = Sha256DigestV3Dto::new(format!("{:x}", Sha256::digest(&bytes)))
+        .map_err(|_| ProjectionBuildErrorV3::InvalidDigest)?;
+    let reference = DiagnosticReferenceV3Dto {
+        artifact_id,
+        sha256,
+        byte_length: bytes.len() as u64,
+    };
+    Ok(DiagnosticArtifactBuildV3::Complete {
+        artifact: Box::new(artifact),
+        bytes: DiagnosticArtifactBytesV3(bytes.into_boxed_slice()),
+        reference,
+    })
+}
+
+fn identity_from_record(record: &PacketExecutionRecordV3) -> PacketRequestIdentityV3Dto {
+    PacketRequestIdentityV3Dto {
+        packet_id: record.packet_id().clone(),
+        request_id: record.request_id().clone(),
+        question_sha256: record.question_sha256().clone(),
+    }
+}
+
+fn publication_from_record(record: &PacketExecutionRecordV3) -> PublicationIdentityV3Dto {
+    PublicationIdentityV3Dto {
+        core: record.core_publication().clone(),
+        retrieval: record.retrieval_publication().cloned(),
+    }
+}
+
+/// Classify only whether evidence can be consumed or continued.
+///
+/// Continuation wins, then an existing evidence row, then a typed unavailable
+/// retrieval/source state. With none of those, the projection has no useful
+/// evidence. This helper deliberately has no request, score, claim, or query
+/// input from which it could infer answer authority.
+fn evidence_availability_v3(
+    has_continuation: bool,
+    has_evidence: bool,
+    retrieval: &RetrievalStateDescriptorV3Dto,
+    gaps: &[ProjectionGapRowV3Dto],
+) -> EvidenceAvailabilityV3Dto {
+    if has_continuation {
+        EvidenceAvailabilityV3Dto::ContinuationAvailable
+    } else if has_evidence {
+        EvidenceAvailabilityV3Dto::Available
+    } else if retrieval.state == RetrievalStateV3Dto::Unavailable
+        || gaps.iter().any(|gap| {
+            matches!(
+                gap.kind,
+                GapKindV3Dto::RetrievalUnavailable | GapKindV3Dto::SourceUnavailable
+            )
+        })
+    {
+        EvidenceAvailabilityV3Dto::Unavailable
+    } else {
+        EvidenceAvailabilityV3Dto::NoUsefulEvidence
+    }
+}
+
+fn diagnostic_artifact_id_v3(
+    record: &PacketExecutionRecordV3,
+) -> Result<IdentityTextV3, ProjectionBuildErrorV3> {
+    let publication = publication_from_record(record);
+    let publication_bytes =
+        codestory_agent::packet_execution_plan_v3::canonical_json_bytes_v3(&publication)
+            .map_err(ProjectionBuildErrorV3::CanonicalJson)?;
+    let mut hasher = Sha256::new();
+    hasher.update(DIAGNOSTIC_ARTIFACT_ID_DOMAIN_V3);
+    for field in [
+        record.packet_id().as_str().as_bytes(),
+        record.request_id().as_str().as_bytes(),
+        record.request_sha256().as_str().as_bytes(),
+        publication_bytes.as_slice(),
+    ] {
+        hasher.update((field.len() as u64).to_be_bytes());
+        hasher.update(field);
+    }
+    IdentityTextV3::new(format!("diagnostic-{:x}", hasher.finalize()))
+        .map_err(ProjectionBuildErrorV3::BoundViolation)
+}
+
+#[cfg(test)]
+mod tests {
+    use codestory_contracts::{
+        api::{AgentPacketRequestDto, PacketBudgetModeDto},
+        packet_projection_v3::{
+            BoundedVecV3, ContextEvidenceRowV3Dto, ContextProjectionKindV3Dto, ContextTargetV3Dto,
+            ContinuationStateV3Dto, DiagnosticArtifactKindV3Dto, DiagnosticArtifactV3Dto,
+            DiagnosticCategoryV3Dto, DiagnosticCodeTextV3, DiagnosticRowV3Dto,
+            DiagnosticsCapabilityV3Dto, EvidenceAvailabilityV3Dto, EvidenceIdentityV3Dto,
+            EvidenceKindV3Dto, GapIdentityV3Dto, GapKindV3Dto, IdentityTextV3, MessageTextV3,
+            PacketEvidenceRowV3Dto, PacketProjectionV3Dto, PathTextV3, ProjectionGapRowV3Dto,
+            PublicationIdentityV3Dto, RetrievalStateDescriptorV3Dto, RetrievalStateV3Dto,
+            SearchEvidenceRowV3Dto, SearchProjectionKindV3Dto, SummaryTextV3,
+        },
+    };
+    use sha2::Digest as _;
+
+    use super::*;
+    use crate::agent::packet_execution_record_v3::{
+        FinalizedDiagnosticSourceRowV3, FinalizedPacketExecutionInputV3, PacketProfileV3,
+        PacketRequestFingerprintV3, build_packet_execution_record_fixture_v3,
+    };
+
+    fn identity(value: &str) -> IdentityTextV3 {
+        IdentityTextV3::new(value).expect("bounded identity")
+    }
+
+    fn record_fixture(
+        question: &str,
+    ) -> crate::agent::packet_execution_record_v3::PacketExecutionRecordV3 {
+        record_fixture_with(
+            question,
+            PacketBudgetModeDto::Standard,
+            PacketProfileV3::Auto,
+            vec![packet_evidence("evidence-1", Some("dispatches once"))],
+            Vec::new(),
+            None,
+            RetrievalStateDescriptorV3Dto {
+                state: RetrievalStateV3Dto::Full,
+                generation_id: Some(identity("retrieval-generation-1")),
+            },
+            Vec::new(),
+            true,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn record_fixture_with(
+        question: &str,
+        budget: PacketBudgetModeDto,
+        profile: PacketProfileV3,
+        evidence: Vec<PacketEvidenceRowV3Dto>,
+        gaps: Vec<ProjectionGapRowV3Dto>,
+        continuation: Option<ContinuationStateV3Dto>,
+        retrieval: RetrievalStateDescriptorV3Dto,
+        diagnostics: Vec<FinalizedDiagnosticSourceRowV3>,
+        with_retrieval_publication: bool,
+    ) -> crate::agent::packet_execution_record_v3::PacketExecutionRecordV3 {
+        let request = AgentPacketRequestDto {
+            question: question.to_owned(),
+            budget,
+            task_class: None,
+            probes: Vec::new(),
+            extra_probes: Vec::new(),
+            include_evidence: true,
+            latency_budget_ms: None,
+            parent_packet_id: None,
+            option_ids: Vec::new(),
+            core_generation_id: None,
+            retrieval_generation: None,
+        };
+        let input = FinalizedPacketExecutionInputV3::new(
+            identity("caller-1"),
+            identity("request-1"),
+            PacketRequestFingerprintV3::from_current_request(&request, profile),
+            evidence,
+            gaps,
+            continuation,
+            retrieval,
+            diagnostics,
+        );
+        build_packet_execution_record_fixture_v3(&input, with_retrieval_publication)
+            .expect("valid record fixture")
+    }
+
+    fn packet_evidence(id: &str, summary: Option<&str>) -> PacketEvidenceRowV3Dto {
+        PacketEvidenceRowV3Dto {
+            identity: EvidenceIdentityV3Dto {
+                evidence_id: identity(id),
+            },
+            kind: EvidenceKindV3Dto::ExactSource,
+            path: None,
+            symbol_id: None,
+            start_line: Some(7),
+            end_line: Some(7),
+            summary: summary.map(|summary| SummaryTextV3::new(summary).unwrap()),
+        }
+    }
+
+    fn projection_gap(
+        id: &str,
+        kind: GapKindV3Dto,
+        message: Option<&str>,
+    ) -> ProjectionGapRowV3Dto {
+        ProjectionGapRowV3Dto {
+            identity: GapIdentityV3Dto {
+                gap_id: identity(id),
+            },
+            kind,
+            message: message.map(|message| MessageTextV3::new(message).unwrap()),
+        }
+    }
+
+    fn diagnostic_source(
+        id: &str,
+        evidence_ids: &[&str],
+        gap_ids: &[&str],
+    ) -> FinalizedDiagnosticSourceRowV3 {
+        FinalizedDiagnosticSourceRowV3::new(
+            identity(id),
+            DiagnosticCategoryV3Dto::Coverage,
+            DiagnosticCodeTextV3::new("coverage_gap").unwrap(),
+            evidence_ids
+                .iter()
+                .map(|id| EvidenceIdentityV3Dto {
+                    evidence_id: identity(id),
+                })
+                .collect(),
+            gap_ids
+                .iter()
+                .map(|id| GapIdentityV3Dto {
+                    gap_id: identity(id),
+                })
+                .collect(),
+        )
+    }
+
+    fn diagnostics_capability_fixture() -> DiagnosticsCapabilityV3Dto {
+        DiagnosticsCapabilityV3Dto::Available {
+            reference: DiagnosticReferenceV3Dto {
+                artifact_id: identity("diagnostic-artifact-1"),
+                sha256: Sha256DigestV3Dto::new("d".repeat(64)).unwrap(),
+                byte_length: 512,
+            },
+        }
+    }
+
+    fn fixed_length_identity(prefix: &str, index: usize, length: usize) -> String {
+        let base = format!("{prefix}-{index:03}-");
+        assert!(base.len() <= length);
+        format!("{base}{}", "x".repeat(length - base.len()))
+    }
+
+    fn diagnostic_cap_record(
+        final_code_length: usize,
+    ) -> crate::agent::packet_execution_record_v3::PacketExecutionRecordV3 {
+        let evidence_ids = (0..256)
+            .map(|index| fixed_length_identity("evidence", index, 128))
+            .collect::<Vec<_>>();
+        let evidence = evidence_ids
+            .iter()
+            .map(|id| packet_evidence(id, None))
+            .collect::<Vec<_>>();
+        let all_evidence_references = evidence_ids
+            .iter()
+            .map(|id| EvidenceIdentityV3Dto {
+                evidence_id: identity(id),
+            })
+            .collect::<Vec<_>>();
+        let mut diagnostics = (0..27)
+            .map(|index| {
+                FinalizedDiagnosticSourceRowV3::new(
+                    identity(&fixed_length_identity("diagnostic", index, 32)),
+                    DiagnosticCategoryV3Dto::Coverage,
+                    DiagnosticCodeTextV3::new("c".repeat(12)).unwrap(),
+                    all_evidence_references.clone(),
+                    Vec::new(),
+                )
+            })
+            .collect::<Vec<_>>();
+        diagnostics.push(FinalizedDiagnosticSourceRowV3::new(
+            identity(&fixed_length_identity("diagnostic", 27, 32)),
+            DiagnosticCategoryV3Dto::Coverage,
+            DiagnosticCodeTextV3::new("c".repeat(final_code_length)).unwrap(),
+            all_evidence_references[..193].to_vec(),
+            Vec::new(),
+        ));
+
+        record_fixture_with(
+            "diagnostic cap fixture",
+            PacketBudgetModeDto::Standard,
+            PacketProfileV3::Auto,
+            evidence,
+            Vec::new(),
+            None,
+            RetrievalStateDescriptorV3Dto {
+                state: RetrievalStateV3Dto::Full,
+                generation_id: Some(identity("retrieval-generation-1")),
+            },
+            diagnostics,
+            true,
+        )
+    }
+
+    fn packet_identity(
+        record: &crate::agent::packet_execution_record_v3::PacketExecutionRecordV3,
+    ) -> codestory_contracts::packet_projection_v3::PacketRequestIdentityV3Dto {
+        codestory_contracts::packet_projection_v3::PacketRequestIdentityV3Dto {
+            packet_id: record.packet_id().clone(),
+            request_id: record.request_id().clone(),
+            question_sha256: record.question_sha256().clone(),
+        }
+    }
+
+    fn publication(
+        record: &crate::agent::packet_execution_record_v3::PacketExecutionRecordV3,
+    ) -> PublicationIdentityV3Dto {
+        PublicationIdentityV3Dto {
+            core: record.core_publication().clone(),
+            retrieval: record.retrieval_publication().cloned(),
+        }
+    }
+
+    #[test]
+    fn packet_projection_v3_builds_from_the_immutable_record_without_raw_question() {
+        let question = "escape-heavy \"question\" \\ with 控制\n\t\u{0001}";
+        let record = record_fixture(question);
+        let before = record.clone();
+
+        let projection =
+            build_packet_projection_v3(&record, DiagnosticsCapabilityV3Dto::Unavailable, |_| Ok(1))
+                .expect("complete packet projection");
+
+        let PacketProjectionV3Dto::Complete {
+            status,
+            evidence,
+            gaps,
+            ..
+        } = &projection
+        else {
+            panic!("one evidence row should fit the complete projection");
+        };
+        assert_eq!(status, &EvidenceAvailabilityV3Dto::Available);
+        assert_eq!(evidence.as_slice().len(), 1);
+        assert!(gaps.as_slice().is_empty());
+        assert_eq!(record, before, "projection must not mutate the record");
+        assert!(
+            !serde_json::to_string(&projection)
+                .expect("serialize projection")
+                .contains(question),
+            "raw question must stay out of the packet projection"
+        );
+    }
+
+    #[test]
+    fn packet_projection_v3_availability_is_evidence_only_and_ordered() {
+        let full = RetrievalStateDescriptorV3Dto {
+            state: RetrievalStateV3Dto::Full,
+            generation_id: Some(identity("retrieval-generation-1")),
+        };
+        let unavailable = RetrievalStateDescriptorV3Dto {
+            state: RetrievalStateV3Dto::Unavailable,
+            generation_id: None,
+        };
+        let source_gap = projection_gap("gap-source", GapKindV3Dto::SourceUnavailable, None);
+
+        assert_eq!(
+            evidence_availability_v3(true, true, &unavailable, std::slice::from_ref(&source_gap)),
+            EvidenceAvailabilityV3Dto::ContinuationAvailable
+        );
+        assert_eq!(
+            evidence_availability_v3(false, true, &unavailable, std::slice::from_ref(&source_gap),),
+            EvidenceAvailabilityV3Dto::Available
+        );
+        assert_eq!(
+            evidence_availability_v3(false, false, &unavailable, &[]),
+            EvidenceAvailabilityV3Dto::Unavailable
+        );
+        assert_eq!(
+            evidence_availability_v3(false, false, &full, &[source_gap]),
+            EvidenceAvailabilityV3Dto::Unavailable
+        );
+        assert_eq!(
+            evidence_availability_v3(false, false, &full, &[]),
+            EvidenceAvailabilityV3Dto::NoUsefulEvidence
+        );
+    }
+
+    #[test]
+    fn packet_projection_v3_trims_only_optional_text_and_retains_every_identity() {
+        let gaps = vec![
+            projection_gap("gap-b", GapKindV3Dto::EvidenceMissing, Some("second gap")),
+            projection_gap(
+                "gap-a",
+                GapKindV3Dto::ContinuationRequired,
+                Some("first gap"),
+            ),
+        ];
+        let continuation = ContinuationStateV3Dto {
+            continuation_id: identity("continuation-1"),
+            remaining_rounds: 1,
+            gap_ids: BoundedVecV3::new(vec![GapIdentityV3Dto {
+                gap_id: identity("gap-a"),
+            }])
+            .unwrap(),
+        };
+        let record = record_fixture_with(
+            "trim only display text",
+            PacketBudgetModeDto::Compact,
+            PacketProfileV3::Callflow,
+            vec![
+                packet_evidence("evidence-b", Some("second summary")),
+                packet_evidence("evidence-a", Some("first summary")),
+            ],
+            gaps,
+            Some(continuation.clone()),
+            RetrievalStateDescriptorV3Dto {
+                state: RetrievalStateV3Dto::Full,
+                generation_id: Some(identity("retrieval-generation-1")),
+            },
+            Vec::new(),
+            true,
+        );
+        let before = record.clone();
+        let mut measurements = 0;
+        let diagnostics = diagnostics_capability_fixture();
+        let projection = build_packet_projection_v3(&record, diagnostics.clone(), |candidate| {
+            measurements += 1;
+            let PacketProjectionV3Dto::Complete { evidence, gaps, .. } = candidate else {
+                return Ok(PACKET_PUBLIC_RESULT_MAX_BYTES_V3);
+            };
+            if evidence.as_slice().iter().any(|row| row.summary.is_some()) {
+                Ok(PACKET_PUBLIC_RESULT_MAX_BYTES_V3 + 2)
+            } else if gaps.as_slice().iter().any(|row| row.message.is_some()) {
+                Ok(PACKET_PUBLIC_RESULT_MAX_BYTES_V3 + 1)
+            } else {
+                Ok(PACKET_PUBLIC_RESULT_MAX_BYTES_V3)
+            }
+        })
+        .expect("optional text stages should fit");
+
+        let PacketProjectionV3Dto::Complete {
+            evidence,
+            gaps,
+            continuation: projected_continuation,
+            diagnostics: projected_diagnostics,
+            ..
+        } = projection
+        else {
+            panic!("text-only trimming should retain a complete projection");
+        };
+        assert_eq!(
+            measurements, 3,
+            "measure complete, summary-free, then message-free"
+        );
+        assert_eq!(
+            evidence
+                .as_slice()
+                .iter()
+                .map(|row| row.identity.evidence_id.as_str())
+                .collect::<Vec<_>>(),
+            ["evidence-a", "evidence-b"]
+        );
+        assert!(evidence.as_slice().iter().all(|row| row.summary.is_none()));
+        assert_eq!(
+            gaps.as_slice()
+                .iter()
+                .map(|row| row.identity.gap_id.as_str())
+                .collect::<Vec<_>>(),
+            ["gap-a", "gap-b"]
+        );
+        assert!(gaps.as_slice().iter().all(|row| row.message.is_none()));
+        assert_eq!(projected_continuation, Some(continuation));
+        assert_eq!(projected_diagnostics, diagnostics);
+        assert_eq!(
+            record, before,
+            "budget projection must not mutate its record"
+        );
+    }
+
+    #[derive(Clone, Copy)]
+    enum PlannedTransportShape {
+        November2024,
+        March2025,
+        June2025,
+        November2025,
+    }
+
+    fn planned_transport_size(
+        shape: PlannedTransportShape,
+        projection: &PacketProjectionV3Dto,
+    ) -> usize {
+        let text = serde_json::to_string(projection).expect("compact mirrored projection");
+        let result = match shape {
+            PlannedTransportShape::November2024 | PlannedTransportShape::March2025 => {
+                serde_json::json!({"content": [{"type": "text", "text": text}]})
+            }
+            PlannedTransportShape::June2025 | PlannedTransportShape::November2025 => {
+                serde_json::json!({
+                    "content": [{"type": "text", "text": text}],
+                    "structuredContent": projection
+                })
+            }
+        };
+        serde_json::to_vec(&result)
+            .expect("planned transport fixture")
+            .len()
+    }
+
+    #[test]
+    fn packet_projection_v3_accepts_exactly_16_kib_for_all_planned_transport_shapes() {
+        let record = record_fixture("all four planned transport shapes");
+        for shape in [
+            PlannedTransportShape::November2024,
+            PlannedTransportShape::March2025,
+            PlannedTransportShape::June2025,
+            PlannedTransportShape::November2025,
+        ] {
+            let probe = build_packet_projection_v3(
+                &record,
+                DiagnosticsCapabilityV3Dto::Unavailable,
+                |_| Ok(0),
+            )
+            .unwrap();
+            let shape_bytes = planned_transport_size(shape, &probe);
+            assert!(shape_bytes < PACKET_PUBLIC_RESULT_MAX_BYTES_V3);
+            let fixed_envelope_bytes = PACKET_PUBLIC_RESULT_MAX_BYTES_V3 - shape_bytes;
+
+            let exact = build_packet_projection_v3(
+                &record,
+                DiagnosticsCapabilityV3Dto::Unavailable,
+                |candidate| Ok(planned_transport_size(shape, candidate) + fixed_envelope_bytes),
+            )
+            .expect("exact cap is admitted");
+            assert!(matches!(exact, PacketProjectionV3Dto::Complete { .. }));
+        }
+    }
+
+    #[test]
+    fn packet_projection_v3_cap_plus_one_is_a_whole_budget_fallback_for_every_mode() {
+        for budget in [
+            PacketBudgetModeDto::Tiny,
+            PacketBudgetModeDto::Compact,
+            PacketBudgetModeDto::Standard,
+            PacketBudgetModeDto::Deep,
+        ] {
+            for profile in [
+                PacketProfileV3::Auto,
+                PacketProfileV3::Architecture,
+                PacketProfileV3::Callflow,
+                PacketProfileV3::Impact,
+                PacketProfileV3::Inheritance,
+                PacketProfileV3::Investigate,
+            ] {
+                let record = record_fixture_with(
+                    "one cap for every current request mode",
+                    budget,
+                    profile,
+                    vec![packet_evidence("evidence-1", None)],
+                    Vec::new(),
+                    None,
+                    RetrievalStateDescriptorV3Dto {
+                        state: RetrievalStateV3Dto::Full,
+                        generation_id: Some(identity("retrieval-generation-1")),
+                    },
+                    Vec::new(),
+                    true,
+                );
+                let projection = build_packet_projection_v3(
+                    &record,
+                    diagnostics_capability_fixture(),
+                    |candidate| match candidate {
+                        PacketProjectionV3Dto::Complete { .. } => {
+                            Ok(PACKET_PUBLIC_RESULT_MAX_BYTES_V3 + 1)
+                        }
+                        PacketProjectionV3Dto::BudgetExceeded { .. } => {
+                            Ok(PACKET_PUBLIC_RESULT_MAX_BYTES_V3)
+                        }
+                    },
+                )
+                .expect("whole budget fallback fits");
+                let PacketProjectionV3Dto::BudgetExceeded {
+                    status,
+                    diagnostics,
+                    maximum_bytes,
+                    required_complete_bytes,
+                    ..
+                } = projection
+                else {
+                    panic!("cap plus one must discard the complete projection");
+                };
+                assert_eq!(status, EvidenceAvailabilityV3Dto::Unavailable);
+                assert_eq!(diagnostics, diagnostics_capability_fixture());
+                assert_eq!(maximum_bytes, PACKET_PUBLIC_RESULT_MAX_BYTES_V3 as u64);
+                assert_eq!(
+                    required_complete_bytes,
+                    (PACKET_PUBLIC_RESULT_MAX_BYTES_V3 + 1) as u64
+                );
+                let serialized = serde_json::to_value(PacketProjectionV3Dto::BudgetExceeded {
+                    schema_version: PACKET_PROJECTION_V3_SCHEMA_VERSION,
+                    identity: packet_identity(&record),
+                    publication: publication(&record),
+                    status,
+                    retrieval: record.retrieval().clone(),
+                    diagnostics,
+                    maximum_bytes,
+                    required_complete_bytes,
+                })
+                .unwrap();
+                for absent in ["evidence", "gaps", "continuation", "summary", "message"] {
+                    assert!(serialized.get(absent).is_none(), "fallback leaked {absent}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn packet_projection_v3_measurement_failures_and_oversized_fallback_return_no_dto() {
+        let record = record_fixture("measurement failures");
+        assert_eq!(
+            build_packet_projection_v3(&record, DiagnosticsCapabilityV3Dto::Unavailable, |_| Err(
+                ()
+            )),
+            Err(ProjectionBuildErrorV3::MeasurementFailed)
+        );
+
+        assert_eq!(
+            build_packet_projection_v3(
+                &record,
+                DiagnosticsCapabilityV3Dto::Unavailable,
+                |candidate| match candidate {
+                    PacketProjectionV3Dto::Complete { .. } => {
+                        Ok(PACKET_PUBLIC_RESULT_MAX_BYTES_V3 + 1)
+                    }
+                    PacketProjectionV3Dto::BudgetExceeded { .. } => Err(()),
+                }
+            ),
+            Err(ProjectionBuildErrorV3::MeasurementFailed)
+        );
+
+        assert_eq!(
+            build_packet_projection_v3(&record, DiagnosticsCapabilityV3Dto::Unavailable, |_| Ok(
+                PACKET_PUBLIC_RESULT_MAX_BYTES_V3 + 1
+            )),
+            Err(ProjectionBuildErrorV3::FallbackTooLarge {
+                required_bytes: PACKET_PUBLIC_RESULT_MAX_BYTES_V3 + 1
+            })
+        );
+    }
+
+    #[test]
+    fn packet_projection_v3_exposes_separate_context_and_search_builders() {
+        let record = record_fixture("typed target only");
+        let context_input = FinalizedContextProjectionInputV3::new(
+            packet_identity(&record),
+            publication(&record),
+            record.retrieval().clone(),
+            ContextTargetV3Dto {
+                path: Some(PathTextV3::new("src/lib.rs").unwrap()),
+                symbol_id: None,
+            },
+            vec![ContextEvidenceRowV3Dto {
+                identity: EvidenceIdentityV3Dto {
+                    evidence_id: identity("evidence-context"),
+                },
+                path: PathTextV3::new("src/lib.rs").unwrap(),
+                symbol_id: None,
+                start_line: 3,
+                end_line: 5,
+                excerpt: None,
+            }],
+            Vec::new(),
+            None,
+            DiagnosticsCapabilityV3Dto::Unavailable,
+            Vec::new(),
+        );
+        let context = build_context_projection_v3(&context_input).expect("context projection");
+        assert_eq!(context.kind, ContextProjectionKindV3Dto::Complete);
+        assert_eq!(context.status, EvidenceAvailabilityV3Dto::Available);
+
+        let search_input = FinalizedSearchProjectionInputV3::new(
+            packet_identity(&record),
+            publication(&record),
+            record.retrieval().clone(),
+            vec![SearchEvidenceRowV3Dto {
+                identity: EvidenceIdentityV3Dto {
+                    evidence_id: identity("evidence-search"),
+                },
+                path: PathTextV3::new("src/search.rs").unwrap(),
+                symbol_id: None,
+                start_line: Some(8),
+                end_line: Some(9),
+                excerpt: None,
+            }],
+            Vec::new(),
+            None,
+            DiagnosticsCapabilityV3Dto::Unavailable,
+            Vec::new(),
+        );
+        let search = build_search_projection_v3(&search_input).expect("search projection");
+        assert_eq!(search.kind, SearchProjectionKindV3Dto::Complete);
+        assert_eq!(search.status, EvidenceAvailabilityV3Dto::Available);
+
+        let context_keys = serde_json::to_value(&context).unwrap();
+        let search_keys = serde_json::to_value(&search).unwrap();
+        for forbidden in ["supported", "proof_disposition", "eligible_for_sufficiency"] {
+            assert!(!context_keys.to_string().contains(forbidden));
+            assert!(!search_keys.to_string().contains(forbidden));
+        }
+    }
+
+    fn context_input_fixture(
+        record: &crate::agent::packet_execution_record_v3::PacketExecutionRecordV3,
+    ) -> FinalizedContextProjectionInputV3 {
+        FinalizedContextProjectionInputV3::new(
+            packet_identity(record),
+            publication(record),
+            record.retrieval().clone(),
+            ContextTargetV3Dto {
+                path: Some(PathTextV3::new("src/lib.rs").unwrap()),
+                symbol_id: None,
+            },
+            vec![
+                ContextEvidenceRowV3Dto {
+                    identity: EvidenceIdentityV3Dto {
+                        evidence_id: identity("evidence-b"),
+                    },
+                    path: PathTextV3::new("src/b.rs").unwrap(),
+                    symbol_id: None,
+                    start_line: 7,
+                    end_line: 8,
+                    excerpt: None,
+                },
+                ContextEvidenceRowV3Dto {
+                    identity: EvidenceIdentityV3Dto {
+                        evidence_id: identity("evidence-a"),
+                    },
+                    path: PathTextV3::new("src/a.rs").unwrap(),
+                    symbol_id: None,
+                    start_line: 3,
+                    end_line: 4,
+                    excerpt: None,
+                },
+            ],
+            vec![
+                projection_gap("gap-b", GapKindV3Dto::EvidenceMissing, None),
+                projection_gap("gap-a", GapKindV3Dto::ContinuationRequired, None),
+            ],
+            Some(ContinuationStateV3Dto {
+                continuation_id: identity("continuation-1"),
+                remaining_rounds: 1,
+                gap_ids: BoundedVecV3::new(vec![GapIdentityV3Dto {
+                    gap_id: identity("gap-b"),
+                }])
+                .unwrap(),
+            }),
+            DiagnosticsCapabilityV3Dto::Unavailable,
+            vec![DiagnosticRowV3Dto {
+                diagnostic_id: identity("diagnostic-context"),
+                category: DiagnosticCategoryV3Dto::Coverage,
+                code: DiagnosticCodeTextV3::new("coverage_gap").unwrap(),
+                evidence_ids: BoundedVecV3::new(vec![EvidenceIdentityV3Dto {
+                    evidence_id: identity("evidence-a"),
+                }])
+                .unwrap(),
+                gap_ids: BoundedVecV3::new(vec![GapIdentityV3Dto {
+                    gap_id: identity("gap-a"),
+                }])
+                .unwrap(),
+            }],
+        )
+    }
+
+    #[test]
+    fn packet_projection_v3_context_and_search_canonicalize_and_reject_dangling_references() {
+        let record = record_fixture("finalized typed context and search");
+        let context_input = context_input_fixture(&record);
+        let context = build_context_projection_v3(&context_input).expect("canonical context");
+        assert_eq!(
+            context
+                .evidence
+                .as_slice()
+                .iter()
+                .map(|row| row.identity.evidence_id.as_str())
+                .collect::<Vec<_>>(),
+            ["evidence-a", "evidence-b"]
+        );
+        assert_eq!(
+            context
+                .gaps
+                .as_slice()
+                .iter()
+                .map(|row| row.identity.gap_id.as_str())
+                .collect::<Vec<_>>(),
+            ["gap-a", "gap-b"]
+        );
+
+        let mut duplicate_evidence = context_input.clone();
+        duplicate_evidence.evidence[1].identity = duplicate_evidence.evidence[0].identity.clone();
+        assert!(matches!(
+            build_context_projection_v3(&duplicate_evidence),
+            Err(ProjectionBuildErrorV3::InvalidInput(
+                ProjectionInputErrorV3::DuplicateEvidenceIdentity(_)
+            ))
+        ));
+
+        let mut empty_target = context_input.clone();
+        empty_target.target = ContextTargetV3Dto {
+            path: None,
+            symbol_id: None,
+        };
+        assert_eq!(
+            build_context_projection_v3(&empty_target),
+            Err(ProjectionBuildErrorV3::InvalidInput(
+                ProjectionInputErrorV3::EmptyContextTarget
+            ))
+        );
+
+        let mut duplicate_gap = context_input.clone();
+        duplicate_gap.gaps[1].identity = duplicate_gap.gaps[0].identity.clone();
+        assert!(matches!(
+            build_context_projection_v3(&duplicate_gap),
+            Err(ProjectionBuildErrorV3::InvalidInput(
+                ProjectionInputErrorV3::DuplicateGapIdentity(_)
+            ))
+        ));
+
+        let mut dangling_continuation = context_input.clone();
+        dangling_continuation.continuation.as_mut().unwrap().gap_ids =
+            BoundedVecV3::new(vec![GapIdentityV3Dto {
+                gap_id: identity("gap-missing"),
+            }])
+            .unwrap();
+        assert!(matches!(
+            build_context_projection_v3(&dangling_continuation),
+            Err(ProjectionBuildErrorV3::InvalidInput(
+                ProjectionInputErrorV3::UnknownContinuationGap(_)
+            ))
+        ));
+
+        let mut dangling_diagnostic = context_input.clone();
+        dangling_diagnostic.diagnostic_rows[0].evidence_ids =
+            BoundedVecV3::new(vec![EvidenceIdentityV3Dto {
+                evidence_id: identity("evidence-missing"),
+            }])
+            .unwrap();
+        assert!(matches!(
+            build_context_projection_v3(&dangling_diagnostic),
+            Err(ProjectionBuildErrorV3::InvalidInput(
+                ProjectionInputErrorV3::UnknownDiagnosticEvidence(_)
+            ))
+        ));
+
+        let mut duplicate_diagnostic = context_input.clone();
+        duplicate_diagnostic
+            .diagnostic_rows
+            .push(duplicate_diagnostic.diagnostic_rows[0].clone());
+        assert!(matches!(
+            build_context_projection_v3(&duplicate_diagnostic),
+            Err(ProjectionBuildErrorV3::InvalidInput(
+                ProjectionInputErrorV3::DuplicateDiagnosticIdentity(_)
+            ))
+        ));
+
+        let search_input = FinalizedSearchProjectionInputV3::new(
+            packet_identity(&record),
+            publication(&record),
+            record.retrieval().clone(),
+            vec![
+                SearchEvidenceRowV3Dto {
+                    identity: EvidenceIdentityV3Dto {
+                        evidence_id: identity("evidence-b"),
+                    },
+                    path: PathTextV3::new("src/b.rs").unwrap(),
+                    symbol_id: None,
+                    start_line: Some(7),
+                    end_line: Some(8),
+                    excerpt: None,
+                },
+                SearchEvidenceRowV3Dto {
+                    identity: EvidenceIdentityV3Dto {
+                        evidence_id: identity("evidence-a"),
+                    },
+                    path: PathTextV3::new("src/a.rs").unwrap(),
+                    symbol_id: None,
+                    start_line: Some(3),
+                    end_line: Some(4),
+                    excerpt: None,
+                },
+            ],
+            context_input.gaps.clone(),
+            context_input.continuation.clone(),
+            DiagnosticsCapabilityV3Dto::Unavailable,
+            context_input.diagnostic_rows.clone(),
+        );
+        let search = build_search_projection_v3(&search_input).expect("canonical search");
+        assert_eq!(
+            search
+                .evidence
+                .as_slice()
+                .iter()
+                .map(|row| row.identity.evidence_id.as_str())
+                .collect::<Vec<_>>(),
+            ["evidence-a", "evidence-b"]
+        );
+
+        let mut duplicate_diagnostic_reference = search_input;
+        duplicate_diagnostic_reference.diagnostic_rows[0].gap_ids = BoundedVecV3::new(vec![
+            GapIdentityV3Dto {
+                gap_id: identity("gap-a"),
+            },
+            GapIdentityV3Dto {
+                gap_id: identity("gap-a"),
+            },
+        ])
+        .unwrap();
+        assert!(matches!(
+            build_search_projection_v3(&duplicate_diagnostic_reference),
+            Err(ProjectionBuildErrorV3::InvalidInput(
+                ProjectionInputErrorV3::DuplicateDiagnosticGapReference(_)
+            ))
+        ));
+    }
+
+    #[test]
+    fn packet_projection_v3_materializes_one_exact_diagnostic_artifact() {
+        let record = record_fixture("diagnostic identity");
+
+        let built = build_diagnostic_artifact_v3(&record).expect("diagnostic artifact build");
+        let DiagnosticArtifactBuildV3::Complete {
+            artifact,
+            bytes,
+            reference,
+        } = built
+        else {
+            panic!("small diagnostic artifact should fit");
+        };
+        assert_eq!(artifact.kind, DiagnosticArtifactKindV3Dto::Complete);
+        assert_eq!(reference.byte_length, bytes.len() as u64);
+        assert_eq!(
+            reference.sha256.as_str(),
+            format!("{:x}", sha2::Sha256::digest(bytes.as_slice()))
+        );
+        assert_eq!(
+            serde_json::from_slice::<DiagnosticArtifactV3Dto>(bytes.as_slice()).unwrap(),
+            *artifact
+        );
+    }
+
+    #[test]
+    fn packet_projection_v3_diagnostic_rows_retain_typed_identity_and_are_repeatable() {
+        let record = record_fixture_with(
+            "canonical diagnostics",
+            PacketBudgetModeDto::Standard,
+            PacketProfileV3::Auto,
+            vec![
+                packet_evidence("evidence-b", None),
+                packet_evidence("evidence-a", None),
+            ],
+            vec![
+                projection_gap("gap-b", GapKindV3Dto::EvidenceMissing, None),
+                projection_gap("gap-a", GapKindV3Dto::EvidenceMissing, None),
+            ],
+            None,
+            RetrievalStateDescriptorV3Dto {
+                state: RetrievalStateV3Dto::Full,
+                generation_id: Some(identity("retrieval-generation-1")),
+            },
+            vec![
+                diagnostic_source("diagnostic-b", &["evidence-b"], &["gap-b"]),
+                diagnostic_source(
+                    "diagnostic-a",
+                    &["evidence-b", "evidence-a"],
+                    &["gap-b", "gap-a"],
+                ),
+            ],
+            true,
+        );
+        let before = record.clone();
+        let first = build_diagnostic_artifact_v3(&record).unwrap();
+        let second = build_diagnostic_artifact_v3(&record).unwrap();
+        assert_eq!(
+            first, second,
+            "one frozen record must produce exact repeatable bytes"
+        );
+        assert_eq!(
+            record, before,
+            "diagnostic projection must not mutate the record"
+        );
+
+        let DiagnosticArtifactBuildV3::Complete {
+            artifact, bytes, ..
+        } = first
+        else {
+            panic!("small diagnostic artifact should fit");
+        };
+        assert_eq!(
+            artifact
+                .rows
+                .as_slice()
+                .iter()
+                .map(|row| row.diagnostic_id.as_str())
+                .collect::<Vec<_>>(),
+            ["diagnostic-a", "diagnostic-b"]
+        );
+        assert_eq!(
+            artifact.rows.as_slice()[0]
+                .evidence_ids
+                .as_slice()
+                .iter()
+                .map(|reference| reference.evidence_id.as_str())
+                .collect::<Vec<_>>(),
+            ["evidence-a", "evidence-b"]
+        );
+        assert_eq!(
+            artifact.rows.as_slice()[0]
+                .gap_ids
+                .as_slice()
+                .iter()
+                .map(|reference| reference.gap_id.as_str())
+                .collect::<Vec<_>>(),
+            ["gap-a", "gap-b"]
+        );
+        let text = String::from_utf8(bytes.as_slice().to_vec()).unwrap();
+        for forbidden in [
+            "capability_uri",
+            "token",
+            "session_secret",
+            "hmac",
+            "expiry",
+            "cache_path",
+            "executable_path",
+            "source_text",
+            "/Users/",
+        ] {
+            assert!(
+                !text.contains(forbidden),
+                "diagnostic bytes leaked {forbidden}: {text}"
+            );
+        }
+    }
+
+    #[test]
+    fn packet_projection_v3_diagnostic_artifact_is_whole_at_one_mib_and_absent_at_cap_plus_one() {
+        let exact = diagnostic_cap_record(31);
+        let DiagnosticArtifactBuildV3::Complete {
+            artifact,
+            bytes,
+            reference,
+        } = build_diagnostic_artifact_v3(&exact).expect("exact-cap diagnostic build")
+        else {
+            panic!("exactly one MiB must be admitted");
+        };
+        assert_eq!(bytes.len(), DIAGNOSTIC_ARTIFACT_MAX_BYTES_V3);
+        assert_eq!(
+            reference.byte_length,
+            DIAGNOSTIC_ARTIFACT_MAX_BYTES_V3 as u64
+        );
+        assert_eq!(artifact.rows.as_slice().len(), 28);
+
+        let over = diagnostic_cap_record(32);
+        assert_eq!(
+            build_diagnostic_artifact_v3(&over).expect("typed over-cap result"),
+            DiagnosticArtifactBuildV3::TooLarge {
+                required_bytes: (DIAGNOSTIC_ARTIFACT_MAX_BYTES_V3 + 1) as u64
+            },
+            "over-cap diagnostics must return no bytes, reference, or partial DTO"
+        );
+    }
+}

--- a/crates/codestory-runtime/src/services.rs
+++ b/crates/codestory-runtime/src/services.rs
@@ -1898,6 +1898,14 @@ impl PublicOperationService {
         })
     }
 
+    #[cfg(any(test, feature = "test-support"))]
+    pub(crate) fn active_project_identity_v3(
+        &self,
+    ) -> Result<codestory_workspace::ProjectIdentityV3, ApiError> {
+        let project_root = self.controller.require_project_root()?;
+        Ok(codestory_workspace::project_identity_v3(&project_root))
+    }
+
     /// Read the project summary from the core snapshot pinned by the current
     /// public operation. This deliberately rejects calls outside a pin so a
     /// response cannot mix a pre-operation summary with pinned graph reads.
@@ -2868,7 +2876,7 @@ mod freshness_gate_tests {
 }
 
 #[cfg(test)]
-mod activation_tests {
+pub(crate) mod activation_tests {
     use super::*;
     use crate::Runtime;
     use crate::search_publication::{
@@ -2877,16 +2885,16 @@ mod activation_tests {
     use crate::test_support::git;
     use std::fs;
 
-    struct ReadyActivationFixture {
-        project: tempfile::TempDir,
+    pub(crate) struct ReadyActivationFixture {
+        pub(crate) project: tempfile::TempDir,
         _cache: tempfile::TempDir,
-        runtime: Runtime,
+        pub(crate) runtime: Runtime,
         storage_path: PathBuf,
         lease: ReadyLease,
         sidecar: codestory_retrieval::SidecarRuntimeConfig,
     }
 
-    fn ready_activation_fixture() -> ReadyActivationFixture {
+    pub(crate) fn ready_activation_fixture() -> ReadyActivationFixture {
         let project = tempfile::tempdir().expect("project");
         let cache = tempfile::tempdir().expect("cache");
         let storage_path = cache.path().join("codestory.db");


### PR DESCRIPTION
Closes #1974
Refs #1968
Refs #1973

## What changed

Adds an inert v3 packet-execution record and explicit packet, context, search, and diagnostic-artifact projection builders. The new code is test/test-support only and is not registered by the current runtime, CLI, HTTP, MCP, plugin, or generated catalog surfaces.

Zero-round continuation descriptors are rejected at DTO, record, and projection admission, so a continuation is advertised only when at least one round remains.

## Review notes

The v3 path carries evidence availability only. It does not expose legacy `Supported`, claim truth, proof authority, scoring, packet-route behavior, or public serialization. Current v2 packet/context/search bytes and the generated MCP catalog remain frozen.

## Verification

- focused projector, record, planner, and contract suites: 11 + 9 + 7 + 3 passing tests
- frozen-v2 serializer and dark-architecture ratchet: 1 + 1 passing tests
- runtime `test-support` check and clippy: passed
- `git diff --check` and direct changed-file `rustfmt --check`: passed
- independent review: one continuation invariant defect found, fixed, and scoped re-review passed

The worktree-wide `cargo fmt --all` invocation encounters the repository's nested-worktree vendored-workspace resolution error before formatting; direct `rustfmt --check` passes on every changed Rust file.

## Non-claim

Proof availability remains unqualified. There is no public v3 route or production selection path in this PR.
