### PR TITLE
[codex] remove repository-shaped packet rank bias

### DIFF
--- a/crates/codestory-agent/src/packet_scoring.rs
+++ b/crates/codestory-agent/src/packet_scoring.rs
@@ -146,13 +146,6 @@ pub fn packet_citation_rank(
     if path.contains("/server/") && !packet_terms_contain(terms, "server") {
         score -= 12.0;
     }
-    if path.contains("/collections/")
-        && terms
-            .iter()
-            .any(|term| term.contains("collection") || term.contains("payload"))
-    {
-        score += 4.0;
-    }
     #[cfg(any(test, feature = "test-support"))]
     {
         score = eval_citation_rank_adjustment(&normalized_display, &path, score);
@@ -190,7 +183,6 @@ pub fn packet_citation_rank(
             terms,
         );
         score += packet_runtime_formatting_core_symbol_rank_bonus(&normalized_display, terms);
-        score += packet_unrequested_python_source_rank_bonus(&path, terms);
         score +=
             packet_unrequested_windows_formatting_rank_bonus(&normalized_display, &path, terms);
         score += packet_unrequested_client_adapter_rank_bonus(&path, terms);
@@ -1183,17 +1175,6 @@ fn packet_keyframe_stem_is_named(citation: &AgentCitationDto, named_stems: &[Str
 fn packet_citation_is_markdown_source(citation: &AgentCitationDto) -> bool {
     let path = packet_citation_display_path(citation);
     path.ends_with(".md") || path.ends_with(".markdown") || path.ends_with(".mdx")
-}
-
-fn packet_unrequested_python_source_rank_bonus(path: &str, terms: &[String]) -> f32 {
-    if packet_question_wants_python(terms) {
-        return 0.0;
-    }
-    if path.ends_with(".py") || path.ends_with(".pyi") || path.ends_with(".pyx") {
-        -100.0
-    } else {
-        0.0
-    }
 }
 
 fn packet_runtime_formatting_core_symbol_rank_bonus(
@@ -2418,6 +2399,30 @@ mod tests {
         );
     }
 
+    #[test]
+    fn python_sources_are_not_globally_demoted_without_a_language_term() {
+        let terms = vec!["request".to_string(), "flow".to_string()];
+        let python = test_rank_citation("handle_request", "src/routes/request.py", 1.0);
+        let native = test_rank_citation("handle_request", "src/routes/request.rs", 1.0);
+
+        assert_eq!(
+            packet_citation_rank(&python, &terms, false),
+            packet_citation_rank(&native, &terms, false)
+        );
+    }
+
+    #[test]
+    fn collections_path_alone_has_no_rank_authority() {
+        let terms = vec!["payload".to_string()];
+        let collection = test_rank_citation("record", "src/collections/record.ts", 1.0);
+        let source = test_rank_citation("record", "src/content/record.ts", 1.0);
+
+        assert_eq!(
+            packet_citation_rank(&collection, &terms, false),
+            packet_citation_rank(&source, &terms, false)
+        );
+    }
+
     fn test_rank_citation(display_name: &str, file_path: &str, score: f32) -> AgentCitationDto {
         AgentCitationDto {
             node_id: NodeId(display_name.to_string()),
@@ -3308,7 +3313,6 @@ mod tests {
                 &terms,
             ) < 0.0
         );
-        assert!(packet_unrequested_python_source_rank_bonus("docs/cli/docopt.py", &terms) < 0.0);
     }
 
     #[test]

--- a/crates/codestory-agent/src/packet_scoring.rs
+++ b/crates/codestory-agent/src/packet_scoring.rs
@@ -2399,30 +2399,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn python_sources_are_not_globally_demoted_without_a_language_term() {
-        let terms = vec!["request".to_string(), "flow".to_string()];
-        let python = test_rank_citation("handle_request", "src/routes/request.py", 1.0);
-        let native = test_rank_citation("handle_request", "src/routes/request.rs", 1.0);
-
-        assert_eq!(
-            packet_citation_rank(&python, &terms, false),
-            packet_citation_rank(&native, &terms, false)
-        );
-    }
-
-    #[test]
-    fn collections_path_alone_has_no_rank_authority() {
-        let terms = vec!["payload".to_string()];
-        let collection = test_rank_citation("record", "src/collections/record.ts", 1.0);
-        let source = test_rank_citation("record", "src/content/record.ts", 1.0);
-
-        assert_eq!(
-            packet_citation_rank(&collection, &terms, false),
-            packet_citation_rank(&source, &terms, false)
-        );
-    }
-
     fn test_rank_citation(display_name: &str, file_path: &str, score: f32) -> AgentCitationDto {
         AgentCitationDto {
             node_id: NodeId(display_name.to_string()),

--- a/crates/codestory-agent/tests/packet_scoring_production.rs
+++ b/crates/codestory-agent/tests/packet_scoring_production.rs
@@ -1,0 +1,50 @@
+use codestory_agent::packet_scoring::packet_citation_rank;
+use codestory_contracts::api::{AgentCitationDto, NodeId, NodeKind, SearchHitOrigin};
+
+fn citation(display_name: &str, file_path: &str) -> AgentCitationDto {
+    AgentCitationDto {
+        node_id: NodeId(display_name.to_string()),
+        display_name: display_name.to_string(),
+        kind: NodeKind::METHOD,
+        file_path: Some(file_path.to_string()),
+        line: Some(1),
+        score: 1.0,
+        origin: SearchHitOrigin::IndexedSymbol,
+        target: None,
+        resolvable: true,
+        subgraph_id: None,
+        evidence_edge_ids: Vec::new(),
+        retrieval_score_breakdown: None,
+        evidence_tier: None,
+        evidence_producer: None,
+        resolution_status: None,
+        loss_reason: None,
+        coverage_role: None,
+        eligible_for_sufficiency: None,
+        source_excerpt: None,
+    }
+}
+
+#[test]
+fn python_sources_are_not_globally_demoted_without_a_language_term() {
+    let terms = vec!["request".to_string(), "flow".to_string()];
+    let python = citation("handle_request", "src/routes/request.py");
+    let native = citation("handle_request", "src/routes/request.rs");
+
+    assert_eq!(
+        packet_citation_rank(&python, &terms, false),
+        packet_citation_rank(&native, &terms, false)
+    );
+}
+
+#[test]
+fn collections_path_alone_has_no_rank_authority() {
+    let terms = vec!["payload".to_string()];
+    let collection = citation("record", "src/collections/record.ts");
+    let source = citation("record", "src/content/record.ts");
+
+    assert_eq!(
+        packet_citation_rank(&collection, &terms, false),
+        packet_citation_rank(&source, &terms, false)
+    );
+}

--- a/crates/codestory-runtime/src/agent/orchestrator.rs
+++ b/crates/codestory-runtime/src/agent/orchestrator.rs
@@ -12485,6 +12485,65 @@ mod tests {
     }
 
     #[test]
+    fn flask_shaped_request_path_survives_production_packet_ranking() {
+        let question = "Trace request handling through the application.";
+        let mut answer = packet_answer_fixture(
+            question,
+            vec![
+                test_packet_citation("FlaskApp.handle_request", "src/flask/app.py", 0.8),
+                test_packet_citation("NativeApp.handle_request", "src/native/app.rs", 0.8),
+            ],
+        );
+
+        rank_packet_evidence(question, &mut answer);
+
+        assert_eq!(
+            answer.citations[0].file_path.as_deref(),
+            Some("src/flask/app.py")
+        );
+    }
+
+    #[test]
+    fn mixed_language_formatting_suppression_requires_a_replacement() {
+        let question = "Explain how formatting arguments reach output.";
+        let mut without_replacement = packet_answer_fixture(
+            question,
+            vec![test_packet_citation(
+                "format_arguments",
+                "src/formatting.py",
+                0.8,
+            )],
+        );
+
+        rank_packet_evidence(question, &mut without_replacement);
+
+        assert_eq!(without_replacement.citations.len(), 1);
+        assert_eq!(
+            without_replacement.citations[0].file_path.as_deref(),
+            Some("src/formatting.py")
+        );
+
+        let mut with_replacement = packet_answer_fixture(
+            question,
+            vec![
+                test_packet_citation("format_arguments", "src/formatting.py", 0.8),
+                test_packet_citation("format_arguments", "src/formatting.rs", 0.8),
+            ],
+        );
+
+        rank_packet_evidence(question, &mut with_replacement);
+
+        assert_eq!(
+            with_replacement
+                .citations
+                .iter()
+                .filter_map(|citation| citation.file_path.as_deref())
+                .collect::<Vec<_>>(),
+            vec!["src/formatting.rs"]
+        );
+    }
+
+    #[test]
     fn packet_follow_up_commands_single_quote_shell_sensitive_questions() {
         let question = "Inspect $env:SECRET and $(Get-ChildItem) and 'literal'";
         let quoted = quote_packet_command_value(question);


### PR DESCRIPTION
Closes #1983
Refs #1968
Refs #1977

## What changed

Removes the two global packet-ranking rules that treated Python sources and `collections/` paths as rank authority. Typed evidence roles, request terms, and the guarded mixed-language formatting suppression remain unchanged.

Production-configuration integration tests now compare equivalent Python/non-Python and `collections/`/neutral citations through the public scorer. Runtime regressions cover the actual packet-ordering path and require a replacement before formatting suppression may drop a Python sibling.

## Review notes

The first review found that the original in-module agent regression compiled under `cfg(test)` and therefore could not exercise the production adjustment block. Fix commit `56065df8` moved both regressions into a Cargo integration target; scoped re-review confirmed the finding is addressed.

This PR changes ranking only. It does not change packet truth authority, proof qualification, v3 registration, transport schemas, release versions, or marketplace state.

## Verification

- production-built agent neutrality regressions: 1 passed each
- agent packet-scoring suite: 42 passed
- requested runtime production-ordering regressions: 1 passed each
- agent all-target clippy with `-D warnings`: passed
- direct changed-file rustfmt and `git diff --check`: passed
- independent review: one Important test-boundary defect found, fixed, and re-reviewed clean

The nested-worktree `cargo fmt --all` command encounters the repository's existing vendored-workspace resolution error before formatting; direct `rustfmt --check` passes on all changed Rust files.
