### PR TITLE
[codex] add dark revision-native MCP v3 transport

### DIFF
--- a/crates/codestory-cli/src/lib.rs
+++ b/crates/codestory-cli/src/lib.rs
@@ -30,6 +30,8 @@ mod status_wire_test_support;
 mod stdio_arguments;
 mod stdio_catalog;
 mod stdio_transport;
+#[cfg(test)]
+mod stdio_v3;
 
 use anyhow::Result;
 

--- a/crates/codestory-cli/src/stdio_catalog.rs
+++ b/crates/codestory-cli/src/stdio_catalog.rs
@@ -2524,6 +2524,15 @@ pub(crate) fn tools_list_json() -> Value {
     })
 }
 
+/// Return the current declarative tool inputs to the test-only v3 projector.
+///
+/// The projector owns revision-native field selection; this accessor keeps it
+/// from copying the v2 schemas or reaching the live `tools/list` response.
+#[cfg(test)]
+pub(crate) fn v3_tool_source_json() -> Vec<Value> {
+    TOOLS.iter().map(|tool| tool.to_json()).collect()
+}
+
 /// Build the `resources/list` response.
 pub(crate) fn resources_list_json() -> Value {
     json!({

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -107,6 +107,13 @@ const STDIO_PANIC_EVICTION_BUDGET: Duration = Duration::from_millis(250);
 const STDIO_DETACHED_EVICTION_BUDGET: Duration = Duration::from_secs(30);
 const DIRTY_MARKER_SCHEMA_VERSION: u32 = 1;
 
+#[cfg(test)]
+pub(crate) fn v3_serialize_call_tool_result(
+    result: &serde_json::Value,
+) -> Result<Vec<u8>, serde_json::Error> {
+    serde_json::to_vec(result)
+}
+
 /// Run the stdio server until stdin closes or the host asks it to stop.
 ///
 /// The server is local, stateful only for small packet/search caches, and keeps

--- a/crates/codestory-cli/src/stdio_v3/catalog.rs
+++ b/crates/codestory-cli/src/stdio_v3/catalog.rs
@@ -3,6 +3,8 @@ use serde_json::{Map, Value, json};
 use super::profile::McpRevisionV3;
 
 const VENDOR_SAFETY_KEY: &str = "com.thegreencedar.codestory/safety";
+const PROJECTION_ROWS_MAX_V3: usize = 256;
+const PROJECTION_REFERENCES_MAX_V3: usize = 256;
 
 pub(crate) fn tools_for_revision_v3(revision: McpRevisionV3) -> Vec<Value> {
     let mut sources = crate::stdio_catalog::v3_tool_source_json();
@@ -133,7 +135,7 @@ fn project_tool_v3(revision: McpRevisionV3, source: &Value) -> Value {
             projected.insert("title".to_string(), json!(title_v3(name)));
             projected.insert(
                 "outputSchema".to_string(),
-                output_schema_for_tool_v3(name, source),
+                output_schema_for_tool_v3(name, source, activates),
             );
             projected.insert(
                 "_meta".to_string(),
@@ -156,29 +158,335 @@ fn project_tool_v3(revision: McpRevisionV3, source: &Value) -> Value {
     Value::Object(projected)
 }
 
-fn output_schema_for_tool_v3(name: &str, source: &Value) -> Value {
-    match name {
+fn output_schema_for_tool_v3(name: &str, source: &Value, activates: bool) -> Value {
+    let success = match name {
         "prove_call_path" => proof_output_schema_v3(),
-        "packet" => tagged_evidence_schema_v3(&["complete", "budget_exceeded"]),
-        "context" | "search" => tagged_evidence_schema_v3(&["complete"]),
+        "packet" => packet_output_schema_v3(),
+        "context" => context_output_schema_v3(),
+        "search" => search_output_schema_v3(),
         _ => source
             .get("outputSchema")
             .cloned()
             .unwrap_or_else(|| json!({"type":"object"})),
+    };
+    if activates {
+        successful_with_preparing_schema_v3(success)
+    } else {
+        success
     }
 }
 
-fn tagged_evidence_schema_v3(kinds: &[&str]) -> Value {
+fn packet_output_schema_v3() -> Value {
+    json!({
+        "type": "object",
+        "oneOf": [packet_complete_schema_v3(), packet_budget_exceeded_schema_v3()]
+    })
+}
+
+fn packet_complete_schema_v3() -> Value {
+    closed_object_schema_v3(vec![
+        ("kind", enum_schema_v3(&["complete"])),
+        ("schema_version", schema_version_v3()),
+        ("identity", packet_identity_schema_v3()),
+        ("publication", publication_schema_v3()),
+        ("status", evidence_availability_schema_v3()),
+        ("retrieval", retrieval_state_schema_v3()),
+        (
+            "evidence",
+            bounded_array_schema_v3(packet_evidence_schema_v3(), PROJECTION_ROWS_MAX_V3),
+        ),
+        (
+            "gaps",
+            bounded_array_schema_v3(projection_gap_schema_v3(), PROJECTION_ROWS_MAX_V3),
+        ),
+        ("continuation", nullable_schema_v3(continuation_schema_v3())),
+        ("diagnostics", diagnostics_capability_schema_v3()),
+    ])
+}
+
+fn packet_budget_exceeded_schema_v3() -> Value {
+    closed_object_schema_v3(vec![
+        ("kind", enum_schema_v3(&["budget_exceeded"])),
+        ("schema_version", schema_version_v3()),
+        ("identity", packet_identity_schema_v3()),
+        ("publication", publication_schema_v3()),
+        ("status", evidence_availability_schema_v3()),
+        ("retrieval", retrieval_state_schema_v3()),
+        ("diagnostics", diagnostics_capability_schema_v3()),
+        ("maximum_bytes", unsigned_integer_schema_v3()),
+        ("required_complete_bytes", unsigned_integer_schema_v3()),
+    ])
+}
+
+fn context_output_schema_v3() -> Value {
+    closed_object_schema_v3(vec![
+        ("kind", enum_schema_v3(&["complete"])),
+        ("schema_version", schema_version_v3()),
+        ("identity", packet_identity_schema_v3()),
+        ("publication", publication_schema_v3()),
+        ("status", evidence_availability_schema_v3()),
+        (
+            "target",
+            closed_object_schema_v3(vec![
+                ("path", nullable_schema_v3(string_schema_v3())),
+                ("symbol_id", nullable_schema_v3(string_schema_v3())),
+            ]),
+        ),
+        (
+            "evidence",
+            bounded_array_schema_v3(context_evidence_schema_v3(), PROJECTION_ROWS_MAX_V3),
+        ),
+        (
+            "gaps",
+            bounded_array_schema_v3(projection_gap_schema_v3(), PROJECTION_ROWS_MAX_V3),
+        ),
+        ("continuation", nullable_schema_v3(continuation_schema_v3())),
+        ("diagnostics", diagnostics_capability_schema_v3()),
+    ])
+}
+
+fn search_output_schema_v3() -> Value {
+    closed_object_schema_v3(vec![
+        ("kind", enum_schema_v3(&["complete"])),
+        ("schema_version", schema_version_v3()),
+        ("identity", packet_identity_schema_v3()),
+        ("publication", publication_schema_v3()),
+        ("status", evidence_availability_schema_v3()),
+        (
+            "evidence",
+            bounded_array_schema_v3(search_evidence_schema_v3(), PROJECTION_ROWS_MAX_V3),
+        ),
+        (
+            "gaps",
+            bounded_array_schema_v3(projection_gap_schema_v3(), PROJECTION_ROWS_MAX_V3),
+        ),
+        ("continuation", nullable_schema_v3(continuation_schema_v3())),
+        ("retrieval", retrieval_state_schema_v3()),
+        ("diagnostics", diagnostics_capability_schema_v3()),
+    ])
+}
+
+fn packet_identity_schema_v3() -> Value {
+    closed_object_schema_v3(vec![
+        ("packet_id", string_schema_v3()),
+        ("request_id", string_schema_v3()),
+        ("question_sha256", sha256_schema_v3()),
+    ])
+}
+
+fn publication_schema_v3() -> Value {
+    closed_object_schema_v3(vec![
+        (
+            "core",
+            closed_object_schema_v3(vec![
+                ("project_id", string_schema_v3()),
+                ("generation_id", string_schema_v3()),
+                ("run_id", string_schema_v3()),
+            ]),
+        ),
+        (
+            "retrieval",
+            nullable_schema_v3(closed_object_schema_v3(vec![
+                ("core_generation_id", string_schema_v3()),
+                ("core_run_id", string_schema_v3()),
+                ("retrieval_generation", string_schema_v3()),
+                ("retrieval_input_sha256", sha256_schema_v3()),
+                ("semantic_generation", string_schema_v3()),
+            ])),
+        ),
+    ])
+}
+
+fn retrieval_state_schema_v3() -> Value {
+    closed_object_schema_v3(vec![
+        (
+            "state",
+            enum_schema_v3(&["full", "degraded", "unavailable"]),
+        ),
+        ("generation_id", nullable_schema_v3(string_schema_v3())),
+    ])
+}
+
+fn evidence_availability_schema_v3() -> Value {
+    enum_schema_v3(&[
+        "available",
+        "continuation_available",
+        "no_useful_evidence",
+        "unavailable",
+    ])
+}
+
+fn evidence_identity_schema_v3() -> Value {
+    closed_object_schema_v3(vec![("evidence_id", string_schema_v3())])
+}
+
+fn gap_identity_schema_v3() -> Value {
+    closed_object_schema_v3(vec![("gap_id", string_schema_v3())])
+}
+
+fn packet_evidence_schema_v3() -> Value {
+    closed_object_schema_v3(vec![
+        ("identity", evidence_identity_schema_v3()),
+        (
+            "kind",
+            enum_schema_v3(&[
+                "exact_source",
+                "structural_source",
+                "graph_relation",
+                "retrieval_excerpt",
+            ]),
+        ),
+        ("path", nullable_schema_v3(string_schema_v3())),
+        ("symbol_id", nullable_schema_v3(string_schema_v3())),
+        (
+            "start_line",
+            nullable_schema_v3(unsigned_integer_schema_v3()),
+        ),
+        ("end_line", nullable_schema_v3(unsigned_integer_schema_v3())),
+        ("summary", nullable_schema_v3(string_schema_v3())),
+    ])
+}
+
+fn context_evidence_schema_v3() -> Value {
+    closed_object_schema_v3(vec![
+        ("identity", evidence_identity_schema_v3()),
+        ("path", string_schema_v3()),
+        ("symbol_id", nullable_schema_v3(string_schema_v3())),
+        ("start_line", unsigned_integer_schema_v3()),
+        ("end_line", unsigned_integer_schema_v3()),
+        ("excerpt", nullable_schema_v3(string_schema_v3())),
+    ])
+}
+
+fn search_evidence_schema_v3() -> Value {
+    closed_object_schema_v3(vec![
+        ("identity", evidence_identity_schema_v3()),
+        ("path", string_schema_v3()),
+        ("symbol_id", nullable_schema_v3(string_schema_v3())),
+        (
+            "start_line",
+            nullable_schema_v3(unsigned_integer_schema_v3()),
+        ),
+        ("end_line", nullable_schema_v3(unsigned_integer_schema_v3())),
+        ("excerpt", nullable_schema_v3(string_schema_v3())),
+    ])
+}
+
+fn projection_gap_schema_v3() -> Value {
+    closed_object_schema_v3(vec![
+        ("identity", gap_identity_schema_v3()),
+        (
+            "kind",
+            enum_schema_v3(&[
+                "evidence_missing",
+                "retrieval_unavailable",
+                "source_unavailable",
+                "continuation_required",
+                "output_budget_exceeded",
+            ]),
+        ),
+        ("message", nullable_schema_v3(string_schema_v3())),
+    ])
+}
+
+fn continuation_schema_v3() -> Value {
+    closed_object_schema_v3(vec![
+        ("continuation_id", string_schema_v3()),
+        (
+            "remaining_rounds",
+            json!({"type":"integer","minimum":1,"maximum":65535}),
+        ),
+        (
+            "gap_ids",
+            bounded_array_schema_v3(gap_identity_schema_v3(), PROJECTION_REFERENCES_MAX_V3),
+        ),
+    ])
+}
+
+fn diagnostics_capability_schema_v3() -> Value {
+    json!({
+        "type":"object",
+        "oneOf":[
+            closed_object_schema_v3(vec![("availability", enum_schema_v3(&["unavailable"]))]),
+            closed_object_schema_v3(vec![
+                ("availability", enum_schema_v3(&["available"])),
+                ("reference", closed_object_schema_v3(vec![
+                    ("artifact_id", string_schema_v3()),
+                    ("sha256", sha256_schema_v3()),
+                    ("byte_length", unsigned_integer_schema_v3()),
+                    ("uri", string_schema_v3()),
+                ])),
+            ]),
+        ]
+    })
+}
+
+fn closed_object_schema_v3(properties: Vec<(&str, Value)>) -> Value {
+    let required = properties
+        .iter()
+        .map(|(name, _)| Value::String((*name).to_string()))
+        .collect::<Vec<_>>();
+    let properties = properties
+        .into_iter()
+        .map(|(name, schema)| (name.to_string(), schema))
+        .collect::<Map<_, _>>();
+    json!({
+        "type":"object",
+        "properties":properties,
+        "required":required,
+        "additionalProperties":false
+    })
+}
+
+fn bounded_array_schema_v3(items: Value, maximum: usize) -> Value {
+    json!({"type":"array","items":items,"maxItems":maximum})
+}
+
+fn nullable_schema_v3(mut schema: Value) -> Value {
+    let object = schema
+        .as_object_mut()
+        .expect("v3 nullable schema must be an object");
+    let declared = object
+        .remove("type")
+        .expect("v3 nullable schema must declare its type");
+    let mut types = declared
+        .as_array()
+        .cloned()
+        .unwrap_or_else(|| vec![declared]);
+    types.push(json!("null"));
+    object.insert("type".to_string(), Value::Array(types));
+    schema
+}
+
+fn enum_schema_v3(values: &[&str]) -> Value {
+    json!({"type":"string","enum":values})
+}
+
+fn string_schema_v3() -> Value {
+    json!({"type":"string"})
+}
+
+fn sha256_schema_v3() -> Value {
+    json!({"type":"string","minLength":64,"maxLength":64})
+}
+
+fn schema_version_v3() -> Value {
+    json!({"type":"integer","enum":[3]})
+}
+
+fn unsigned_integer_schema_v3() -> Value {
+    json!({"type":"integer","minimum":0})
+}
+
+fn successful_with_preparing_schema_v3(success: Value) -> Value {
     json!({
         "type": "object",
         "oneOf": [
             {
-                "type": "object",
-                "properties": {
-                    "kind": {"type":"string","enum":kinds},
-                    "schema_version": {"type":"integer"}
-                },
-                "required": ["kind", "schema_version"]
+                "allOf": [
+                    success,
+                    {"not":{"type":"object","properties":{"kind":{"enum":["preparing"]}},"required":["kind"]}}
+                ]
             },
             {
                 "type": "object",
@@ -447,5 +755,120 @@ mod tests {
         let mut invalid = complete;
         invalid["kind"] = json!("supported");
         assert!(crate::stdio_arguments::validate_structured_content(&schema, &invalid).is_err());
+    }
+
+    #[test]
+    fn packet_context_and_search_schemas_reject_open_or_malformed_dto_shapes() {
+        let identity = json!({
+            "packet_id":"b96ac0cc-e552-4c35-a0ba-c83b9ead67de",
+            "request_id":"request-1",
+            "question_sha256":"a".repeat(64)
+        });
+        let publication = json!({
+            "core":{"project_id":"project-1","generation_id":"core-1","run_id":"run-1"},
+            "retrieval":null
+        });
+        let diagnostics = json!({"availability":"unavailable"});
+        let packet_complete = json!({
+            "kind":"complete","schema_version":3,"identity":identity,"publication":publication,
+            "status":"available","retrieval":{"state":"full","generation_id":null},
+            "evidence":[{
+                "identity":{"evidence_id":"evidence-1"},"kind":"exact_source",
+                "path":"src/lib.rs","symbol_id":null,"start_line":4,"end_line":9,"summary":null
+            }],
+            "gaps":[],"continuation":null,"diagnostics":diagnostics
+        });
+        let packet_budget = json!({
+            "kind":"budget_exceeded","schema_version":3,"identity":identity,"publication":publication,
+            "status":"unavailable","retrieval":{"state":"degraded","generation_id":null},
+            "diagnostics":diagnostics,"maximum_bytes":16384,"required_complete_bytes":16385
+        });
+        let context = json!({
+            "kind":"complete","schema_version":3,"identity":identity,"publication":publication,
+            "status":"available","target":{"path":"src/lib.rs","symbol_id":null},
+            "evidence":[{
+                "identity":{"evidence_id":"evidence-1"},"path":"src/lib.rs","symbol_id":null,
+                "start_line":4,"end_line":9,"excerpt":null
+            }],
+            "gaps":[],"continuation":null,"diagnostics":diagnostics
+        });
+        let search = json!({
+            "kind":"complete","schema_version":3,"identity":identity,"publication":publication,
+            "status":"no_useful_evidence","evidence":[{
+                "identity":{"evidence_id":"evidence-1"},"path":"src/lib.rs","symbol_id":null,
+                "start_line":null,"end_line":null,"excerpt":null
+            }],
+            "gaps":[],"continuation":null,"retrieval":{"state":"unavailable","generation_id":null},
+            "diagnostics":diagnostics
+        });
+        let tools = tools_for_revision_v3(McpRevisionV3::June2025);
+        let cases = [
+            (
+                "packet",
+                packet_complete,
+                "/identity/request_id",
+                "/evidence/0/start_line",
+            ),
+            (
+                "packet",
+                packet_budget,
+                "/identity/request_id",
+                "/maximum_bytes",
+            ),
+            ("context", context, "/target/path", "/evidence/0/start_line"),
+            (
+                "search",
+                search,
+                "/retrieval/generation_id",
+                "/evidence/0/path",
+            ),
+        ];
+        for (name, valid, required_pointer, typed_pointer) in cases {
+            let schema = &tool(&tools, name)["outputSchema"];
+            assert!(
+                crate::stdio_arguments::validate_structured_content(schema, &valid).is_ok(),
+                "closed {name} schema rejected its explicit DTO variant: {valid}"
+            );
+
+            let mut missing = valid.clone();
+            let (parent, field) = required_pointer.rsplit_once('/').unwrap();
+            missing
+                .pointer_mut(parent)
+                .and_then(Value::as_object_mut)
+                .unwrap()
+                .remove(field);
+            assert!(
+                crate::stdio_arguments::validate_structured_content(schema, &missing).is_err(),
+                "{name} accepted missing DTO field {required_pointer}: {missing}"
+            );
+
+            let mut unknown = valid.clone();
+            unknown
+                .as_object_mut()
+                .unwrap()
+                .insert("undeclared".into(), json!(true));
+            assert!(
+                crate::stdio_arguments::validate_structured_content(schema, &unknown).is_err(),
+                "{name} accepted an unknown root field: {unknown}"
+            );
+
+            let mut nested_unknown = valid.clone();
+            nested_unknown["identity"]
+                .as_object_mut()
+                .unwrap()
+                .insert("undeclared".into(), json!(true));
+            assert!(
+                crate::stdio_arguments::validate_structured_content(schema, &nested_unknown)
+                    .is_err(),
+                "{name} accepted an unknown nested field: {nested_unknown}"
+            );
+
+            let mut mistyped = valid;
+            *mistyped.pointer_mut(typed_pointer).unwrap() = json!(false);
+            assert!(
+                crate::stdio_arguments::validate_structured_content(schema, &mistyped).is_err(),
+                "{name} accepted mistyped DTO field {typed_pointer}: {mistyped}"
+            );
+        }
     }
 }

--- a/crates/codestory-cli/src/stdio_v3/catalog.rs
+++ b/crates/codestory-cli/src/stdio_v3/catalog.rs
@@ -1,0 +1,451 @@
+use serde_json::{Map, Value, json};
+
+use super::profile::McpRevisionV3;
+
+const VENDOR_SAFETY_KEY: &str = "com.thegreencedar.codestory/safety";
+
+pub(crate) fn tools_for_revision_v3(revision: McpRevisionV3) -> Vec<Value> {
+    let mut sources = crate::stdio_catalog::v3_tool_source_json();
+    sources.push(proof_tool_source_v3());
+    sources
+        .into_iter()
+        .map(|source| project_tool_v3(revision, &source))
+        .collect()
+}
+
+pub(crate) fn proof_output_schema_v3() -> Value {
+    let common = Map::from_iter([
+        ("kind".to_string(), json!({"type":"string"})),
+        ("schema_version".to_string(), json!({"type":"integer"})),
+        ("domain".to_string(), json!({"type":"string"})),
+        (
+            "contract_interpretation".to_string(),
+            json!({"type":"string","enum":["host_supplied"]}),
+        ),
+        ("guard_version".to_string(), json!({"type":"string"})),
+        (
+            "source_text_sha256".to_string(),
+            json!({"type":"string","minLength":64,"maxLength":64}),
+        ),
+        (
+            "contract_digest".to_string(),
+            json!({"type":"string","minLength":64,"maxLength":64}),
+        ),
+        ("core_publication".to_string(), json!({"type":"object"})),
+        ("disposition".to_string(), json!({"type":"object"})),
+    ]);
+    let variant = |kind: &str, additional: &[(&str, Value)], required: &[&str]| {
+        let mut properties = common.clone();
+        properties.insert("kind".to_string(), json!({"type":"string","enum":[kind]}));
+        properties.extend(
+            additional
+                .iter()
+                .map(|(name, schema)| ((*name).to_string(), schema.clone())),
+        );
+        let mut required_fields = vec![
+            "kind",
+            "schema_version",
+            "domain",
+            "contract_interpretation",
+            "guard_version",
+            "source_text_sha256",
+            "contract_digest",
+            "core_publication",
+            "disposition",
+        ];
+        required_fields.extend_from_slice(required);
+        json!({
+            "type": "object",
+            "properties": properties,
+            "required": required_fields,
+            "additionalProperties": false
+        })
+    };
+    json!({
+        "type": "object",
+        "oneOf": [
+            variant(
+                "complete",
+                &[
+                    ("spec", json!({"type":"object"})),
+                    ("clauses", json!({"type":"array"})),
+                    ("steps", json!({"type":"array"})),
+                    ("receipts", json!({"type":"array"})),
+                ],
+                &["spec", "clauses", "steps", "receipts"],
+            ),
+            variant(
+                "budget_exceeded",
+                &[
+                    ("cap_bytes", json!({"type":"integer","minimum":1})),
+                    (
+                        "required_complete_size",
+                        json!({"type":"integer","minimum":1}),
+                    ),
+                ],
+                &["cap_bytes", "required_complete_size"],
+            )
+        ]
+    })
+}
+
+fn project_tool_v3(revision: McpRevisionV3, source: &Value) -> Value {
+    let name = source["name"].as_str().expect("tool source name");
+    let activates = source
+        .pointer("/safety/activatesProject")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let base_description = source["description"]
+        .as_str()
+        .expect("tool source description");
+    let description = if revision < McpRevisionV3::June2025 {
+        format!(
+            "{base_description} CodeStory effect: {}.",
+            if activates {
+                "may activate project-local managed cache, indexing, or network-backed retrieval state"
+            } else {
+                "observational and does not activate managed state"
+            }
+        )
+    } else {
+        base_description.to_string()
+    };
+
+    let mut projected = Map::from_iter([
+        ("name".to_string(), json!(name)),
+        ("description".to_string(), json!(description)),
+        ("inputSchema".to_string(), source["inputSchema"].clone()),
+    ]);
+    match revision {
+        McpRevisionV3::November2024 => {}
+        McpRevisionV3::March2025 => {
+            let mut annotations = Map::from_iter([
+                ("destructiveHint".to_string(), json!(false)),
+                ("idempotentHint".to_string(), json!(true)),
+                ("openWorldHint".to_string(), json!(activates)),
+            ]);
+            if !activates {
+                annotations.insert("readOnlyHint".to_string(), json!(true));
+            }
+            projected.insert("annotations".to_string(), Value::Object(annotations));
+        }
+        McpRevisionV3::June2025 | McpRevisionV3::November2025 => {
+            projected.insert("title".to_string(), json!(title_v3(name)));
+            projected.insert(
+                "outputSchema".to_string(),
+                output_schema_for_tool_v3(name, source),
+            );
+            projected.insert(
+                "_meta".to_string(),
+                json!({
+                    VENDOR_SAFETY_KEY: {
+                        "effect": if activates { "managed_activation" } else { "read_only" },
+                        "sideEffects": activates,
+                        "activatesProject": activates,
+                        "writesRepository": false,
+                        "destructive": false,
+                        "idempotent": true,
+                        "requiresConfirmation": false,
+                        "localOnly": !activates,
+                        "openWorld": activates
+                    }
+                }),
+            );
+        }
+    }
+    Value::Object(projected)
+}
+
+fn output_schema_for_tool_v3(name: &str, source: &Value) -> Value {
+    match name {
+        "prove_call_path" => proof_output_schema_v3(),
+        "packet" => tagged_evidence_schema_v3(&["complete", "budget_exceeded"]),
+        "context" | "search" => tagged_evidence_schema_v3(&["complete"]),
+        _ => source
+            .get("outputSchema")
+            .cloned()
+            .unwrap_or_else(|| json!({"type":"object"})),
+    }
+}
+
+fn tagged_evidence_schema_v3(kinds: &[&str]) -> Value {
+    json!({
+        "type": "object",
+        "oneOf": [
+            {
+                "type": "object",
+                "properties": {
+                    "kind": {"type":"string","enum":kinds},
+                    "schema_version": {"type":"integer"}
+                },
+                "required": ["kind", "schema_version"]
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "kind": {"type":"string","enum":["preparing"]},
+                    "state": {"type":"string","enum":["preparing"]},
+                    "retry_after_ms": {"type":"integer","minimum":1},
+                    "operation": {"type":"object"}
+                },
+                "required": ["kind", "state", "retry_after_ms", "operation"],
+                "additionalProperties": false
+            }
+        ]
+    })
+}
+
+fn proof_tool_source_v3() -> Value {
+    json!({
+        "name": "prove_call_path",
+        "description": "Verify one host-translated exact indexed source call-path contract against a pinned publication.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "project": {"type":"string","minLength":1},
+                "source_text": {"type":"string","minLength":1},
+                "clauses": {"type":"array"},
+                "spec": {"type":"object"}
+            },
+            "required": ["project", "source_text", "clauses", "spec"],
+            "additionalProperties": false
+        },
+        "outputSchema": proof_output_schema_v3(),
+        "safety": {
+            "effect": "read_only",
+            "activatesProject": false,
+            "sideEffects": false
+        }
+    })
+}
+
+fn title_v3(name: &str) -> String {
+    name.split('_')
+        .map(|word| {
+            let mut characters = word.chars();
+            match characters.next() {
+                Some(first) => format!("{}{}", first.to_ascii_uppercase(), characters.as_str()),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use super::*;
+
+    fn field_names(tool: &Value) -> BTreeSet<&str> {
+        tool.as_object()
+            .expect("tool object")
+            .keys()
+            .map(String::as_str)
+            .collect()
+    }
+
+    fn tool<'a>(tools: &'a [Value], name: &str) -> &'a Value {
+        tools
+            .iter()
+            .find(|tool| tool["name"] == name)
+            .unwrap_or_else(|| panic!("missing v3 tool {name}"))
+    }
+
+    #[test]
+    fn discovery_tools_use_only_revision_native_fields_and_audited_annotations() {
+        for revision in McpRevisionV3::all() {
+            let tools = tools_for_revision_v3(*revision);
+            assert_eq!(
+                tools.len(),
+                21,
+                "{revision:?} should include the dark proof tool"
+            );
+            let expected = revision
+                .profile()
+                .tool_fields
+                .iter()
+                .copied()
+                .collect::<BTreeSet<_>>();
+            for projected in &tools {
+                assert_eq!(
+                    field_names(projected),
+                    expected,
+                    "{revision:?}: {projected}"
+                );
+                assert!(projected.get("safety").is_none());
+            }
+
+            if *revision == McpRevisionV3::March2025 {
+                assert_eq!(
+                    tool(&tools, "status").pointer("/annotations/readOnlyHint"),
+                    Some(&json!(true))
+                );
+                assert_eq!(
+                    tool(&tools, "prove_call_path").pointer("/annotations/readOnlyHint"),
+                    Some(&json!(true))
+                );
+                for activation_capable in ["packet", "search", "ground", "context"] {
+                    assert!(
+                        tool(&tools, activation_capable)
+                            .pointer("/annotations/readOnlyHint")
+                            .is_none(),
+                        "activation-capable {activation_capable} must omit readOnlyHint"
+                    );
+                }
+            }
+
+            if matches!(
+                revision,
+                McpRevisionV3::June2025 | McpRevisionV3::November2025
+            ) {
+                let status_safety = tool(&tools, "status")
+                    .pointer("/_meta/com.thegreencedar.codestory~1safety")
+                    .expect("vendor safety metadata");
+                assert_eq!(status_safety["effect"], "read_only");
+                let packet_safety = tool(&tools, "packet")
+                    .pointer("/_meta/com.thegreencedar.codestory~1safety")
+                    .expect("vendor safety metadata");
+                assert_eq!(packet_safety["effect"], "managed_activation");
+            }
+        }
+    }
+
+    #[test]
+    fn modern_output_schemas_are_root_objects_and_accept_maximal_projection_variants() {
+        let identity = json!({
+            "packet_id":"b96ac0cc-e552-4c35-a0ba-c83b9ead67de",
+            "request_id":"request-1",
+            "question_sha256":"a".repeat(64)
+        });
+        let publication = json!({
+            "core":{"project_id":"project-1","generation_id":"core-1","run_id":"run-1"},
+            "retrieval":{
+                "core_generation_id":"core-1",
+                "core_run_id":"run-1",
+                "retrieval_generation":"retrieval-1",
+                "retrieval_input_sha256":"b".repeat(64),
+                "semantic_generation":"semantic-1"
+            }
+        });
+        let diagnostics = json!({
+            "availability":"available",
+            "reference":{
+                "artifact_id":"diagnostic-1",
+                "sha256":"c".repeat(64),
+                "byte_length":128,
+                "uri":"codestory://packet-diagnostics/b96ac0cc-e552-4c35-a0ba-c83b9ead67de/".to_string() + &"d".repeat(64)
+            }
+        });
+        let maximal = [
+            (
+                "packet",
+                json!({
+                    "kind":"complete","schema_version":3,"identity":identity,"publication":publication,
+                    "status":"continuation_available","retrieval":{"state":"full","generation_id":"retrieval-1"},
+                    "evidence":[{"identity":{"evidence_id":"evidence-1"},"kind":"exact_source","path":"src/lib.rs","symbol_id":"crate::entry","start_line":4,"end_line":9,"summary":"entry calls runtime"}],
+                    "gaps":[{"identity":{"gap_id":"gap-1"},"kind":"continuation_required","message":"one round remains"}],
+                    "continuation":{"continuation_id":"continuation-1","remaining_rounds":1,"gap_ids":[{"gap_id":"gap-1"}]},
+                    "diagnostics":diagnostics
+                }),
+            ),
+            (
+                "packet",
+                json!({
+                    "kind":"budget_exceeded","schema_version":3,"identity":identity,"publication":publication,
+                    "status":"unavailable","retrieval":{"state":"degraded","generation_id":"retrieval-1"},
+                    "diagnostics":diagnostics,"maximum_bytes":16384,"required_complete_bytes":16385
+                }),
+            ),
+            (
+                "context",
+                json!({
+                    "kind":"complete","schema_version":3,"identity":identity,"publication":publication,
+                    "status":"available","target":{"path":"src/lib.rs","symbol_id":"crate::entry"},
+                    "evidence":[{"identity":{"evidence_id":"evidence-1"},"path":"src/lib.rs","symbol_id":"crate::entry","start_line":4,"end_line":9,"excerpt":"pub fn entry() { runtime(); }"}],
+                    "gaps":[],"continuation":null,"diagnostics":diagnostics
+                }),
+            ),
+            (
+                "search",
+                json!({
+                    "kind":"complete","schema_version":3,"identity":identity,"publication":publication,
+                    "status":"no_useful_evidence","evidence":[],"gaps":[{"identity":{"gap_id":"gap-1"},"kind":"retrieval_unavailable","message":"retrieval unavailable"}],
+                    "continuation":null,"retrieval":{"state":"unavailable","generation_id":null},"diagnostics":diagnostics
+                }),
+            ),
+        ];
+        for revision in [McpRevisionV3::June2025, McpRevisionV3::November2025] {
+            let tools = tools_for_revision_v3(revision);
+            for projected in &tools {
+                assert_eq!(
+                    projected.pointer("/outputSchema/type"),
+                    Some(&json!("object")),
+                    "modern output schema must be a root object: {projected}"
+                );
+            }
+            let preparing = json!({
+                "kind":"preparing",
+                "state":"preparing",
+                "retry_after_ms":250,
+                "operation":{"stage":"publication"}
+            });
+            for name in ["packet", "context", "search"] {
+                assert!(
+                    crate::stdio_arguments::validate_structured_content(
+                        &tool(&tools, name)["outputSchema"],
+                        &preparing,
+                    )
+                    .is_ok(),
+                    "{name} must admit the successful preparing variant"
+                );
+            }
+            for (name, projection) in &maximal {
+                assert!(
+                    crate::stdio_arguments::validate_structured_content(
+                        &tool(&tools, name)["outputSchema"],
+                        projection,
+                    )
+                    .is_ok(),
+                    "{name} must admit its maximal v3 projection: {projection}"
+                );
+            }
+        }
+
+        let complete = json!({
+            "kind": "complete",
+            "schema_version": 1,
+            "domain": "indexed_source_call_path_v1",
+            "contract_interpretation": "host_supplied",
+            "guard_version": "clause_guard_v1",
+            "source_text_sha256": "a".repeat(64),
+            "contract_digest": "b".repeat(64),
+            "core_publication": {"project_id":"p","generation_id":"g","run_id":"r"},
+            "spec": {"start":{"kind":"canonical_id","canonical_id":"A"},"steps":[],"prohibit_traversal_through":[],"exclude_from_projection":[]},
+            "clauses": [],
+            "disposition": {"kind":"unknown","contract_digest":"b".repeat(64),"gaps":[],"connected_receipts":[]},
+            "steps": [],
+            "receipts": []
+        });
+        let budget = json!({
+            "kind": "budget_exceeded",
+            "schema_version": 1,
+            "domain": "indexed_source_call_path_v1",
+            "contract_interpretation": "host_supplied",
+            "guard_version": "clause_guard_v1",
+            "source_text_sha256": "a".repeat(64),
+            "contract_digest": "b".repeat(64),
+            "core_publication": {"project_id":"p","generation_id":"g","run_id":"r"},
+            "disposition": {"kind":"unknown","contract_digest":"b".repeat(64),"gaps":[{"kind":"output_budget_exceeded"}]},
+            "cap_bytes": 65536,
+            "required_complete_size": 65537
+        });
+        let schema = proof_output_schema_v3();
+        assert!(crate::stdio_arguments::validate_structured_content(&schema, &complete).is_ok());
+        assert!(crate::stdio_arguments::validate_structured_content(&schema, &budget).is_ok());
+        let mut invalid = complete;
+        invalid["kind"] = json!("supported");
+        assert!(crate::stdio_arguments::validate_structured_content(&schema, &invalid).is_err());
+    }
+}

--- a/crates/codestory-cli/src/stdio_v3/diagnostics.rs
+++ b/crates/codestory-cli/src/stdio_v3/diagnostics.rs
@@ -1,0 +1,435 @@
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+pub(crate) const DIAGNOSTIC_ENTRY_MAX_BYTES_V3: usize = 1024 * 1024;
+pub(crate) const DIAGNOSTIC_REGISTRY_MAX_BYTES_V3: usize = 8 * 1024 * 1024;
+pub(crate) const DIAGNOSTIC_REGISTRY_MAX_ENTRIES_V3: usize = 8;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DiagnosticsBindingV3 {
+    pub(crate) packet_id: String,
+    pub(crate) project_id: String,
+    pub(crate) publication_id: String,
+    pub(crate) request_digest: String,
+    pub(crate) wall_expiry_epoch_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DiagnosticsGrantV3 {
+    pub(crate) uri: String,
+    pub(crate) byte_length: usize,
+    pub(crate) sha256: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DiagnosticsReadErrorV3 {
+    MalformedUri,
+    CapabilityUnavailable,
+    Internal,
+}
+
+impl DiagnosticsReadErrorV3 {
+    pub(crate) const fn jsonrpc_code(self) -> i64 {
+        match self {
+            Self::MalformedUri => -32602,
+            Self::CapabilityUnavailable => -32002,
+            Self::Internal => -32603,
+        }
+    }
+}
+
+struct DiagnosticsEntryV3 {
+    packet_id: String,
+    token: [u8; 32],
+    bytes: Arc<[u8]>,
+    expires_at: Instant,
+}
+
+pub(crate) struct DiagnosticsRegistryV3 {
+    secret: [u8; 32],
+    entries: VecDeque<DiagnosticsEntryV3>,
+    retained_bytes: usize,
+}
+
+impl DiagnosticsRegistryV3 {
+    #[allow(dead_code)]
+    pub(crate) fn new() -> Self {
+        let first = Uuid::new_v4().into_bytes();
+        let second = Uuid::new_v4().into_bytes();
+        let mut seed = [0_u8; 32];
+        seed[..16].copy_from_slice(&first);
+        seed[16..].copy_from_slice(&second);
+        let secret = Sha256::digest(seed).into();
+        Self::new_with_secret(secret)
+    }
+
+    pub(crate) fn new_with_secret(secret: [u8; 32]) -> Self {
+        Self {
+            secret,
+            entries: VecDeque::new(),
+            retained_bytes: 0,
+        }
+    }
+
+    pub(crate) fn register_at(
+        &mut self,
+        binding: DiagnosticsBindingV3,
+        bytes: Vec<u8>,
+        now: Instant,
+    ) -> Result<DiagnosticsGrantV3, DiagnosticsReadErrorV3> {
+        if bytes.len() > DIAGNOSTIC_ENTRY_MAX_BYTES_V3
+            || !is_random_packet_id_v3(&binding.packet_id)
+        {
+            return Err(DiagnosticsReadErrorV3::Internal);
+        }
+        let token = capability_token_v3(&self.secret, &binding);
+        let sha256 = sha256_hex_v3(&bytes);
+        let byte_length = bytes.len();
+        let uri = format!(
+            "codestory://packet-diagnostics/{}/{}",
+            binding.packet_id,
+            hex_v3(&token)
+        );
+        let bytes: Arc<[u8]> = bytes.into();
+        self.prune_expired_at(now);
+        while self.entries.len() >= DIAGNOSTIC_REGISTRY_MAX_ENTRIES_V3
+            || self.retained_bytes + bytes.len() > DIAGNOSTIC_REGISTRY_MAX_BYTES_V3
+        {
+            self.evict_oldest();
+        }
+        self.retained_bytes += bytes.len();
+        self.entries.push_back(DiagnosticsEntryV3 {
+            packet_id: binding.packet_id,
+            token,
+            bytes,
+            expires_at: now + Duration::from_secs(10 * 60),
+        });
+        Ok(DiagnosticsGrantV3 {
+            uri,
+            byte_length,
+            sha256,
+        })
+    }
+
+    pub(crate) fn read_at(
+        &mut self,
+        uri: &str,
+        now: Instant,
+    ) -> Result<Arc<[u8]>, DiagnosticsReadErrorV3> {
+        let (packet_id, supplied_token) = parse_capability_uri_v3(uri)?;
+        let Some(index) = self
+            .entries
+            .iter()
+            .position(|entry| entry.packet_id == packet_id)
+        else {
+            return Err(DiagnosticsReadErrorV3::CapabilityUnavailable);
+        };
+        if now >= self.entries[index].expires_at {
+            let expired = self
+                .entries
+                .remove(index)
+                .expect("entry index remains valid");
+            self.retained_bytes -= expired.bytes.len();
+            return Err(DiagnosticsReadErrorV3::CapabilityUnavailable);
+        }
+        let entry = &self.entries[index];
+        if !constant_time_eq_v3(&entry.token, &supplied_token) {
+            return Err(DiagnosticsReadErrorV3::CapabilityUnavailable);
+        }
+        Ok(Arc::clone(&entry.bytes))
+    }
+
+    #[cfg(test)]
+    fn entry_count(&self) -> usize {
+        self.entries.len()
+    }
+
+    #[cfg(test)]
+    fn retained_bytes(&self) -> usize {
+        self.retained_bytes
+    }
+
+    fn prune_expired_at(&mut self, now: Instant) {
+        let mut index = 0;
+        while index < self.entries.len() {
+            if now >= self.entries[index].expires_at {
+                let expired = self
+                    .entries
+                    .remove(index)
+                    .expect("entry index remains valid");
+                self.retained_bytes -= expired.bytes.len();
+            } else {
+                index += 1;
+            }
+        }
+    }
+
+    fn evict_oldest(&mut self) {
+        if let Some(evicted) = self.entries.pop_front() {
+            self.retained_bytes -= evicted.bytes.len();
+        }
+    }
+}
+
+pub(crate) fn attach_capability_uri_v3(
+    projection: &mut Value,
+    grant: &DiagnosticsGrantV3,
+) -> Result<(), DiagnosticsReadErrorV3> {
+    let reference = projection
+        .pointer_mut("/diagnostics/reference")
+        .and_then(Value::as_object_mut)
+        .ok_or(DiagnosticsReadErrorV3::Internal)?;
+    if reference.get("sha256").and_then(Value::as_str) != Some(grant.sha256.as_str())
+        || reference.get("byte_length").and_then(Value::as_u64)
+            != u64::try_from(grant.byte_length).ok()
+    {
+        return Err(DiagnosticsReadErrorV3::Internal);
+    }
+    reference.insert("uri".to_string(), Value::String(grant.uri.clone()));
+    Ok(())
+}
+
+fn capability_token_v3(secret: &[u8; 32], binding: &DiagnosticsBindingV3) -> [u8; 32] {
+    let mut message = Vec::new();
+    message.extend_from_slice(b"codestory.packet-diagnostics.v3\0");
+    for field in [
+        binding.packet_id.as_bytes(),
+        binding.project_id.as_bytes(),
+        binding.publication_id.as_bytes(),
+        binding.request_digest.as_bytes(),
+    ] {
+        message.extend_from_slice(&(field.len() as u64).to_be_bytes());
+        message.extend_from_slice(field);
+    }
+    message.extend_from_slice(&binding.wall_expiry_epoch_ms.to_be_bytes());
+    hmac_sha256_v3(secret, &message)
+}
+
+fn hmac_sha256_v3(key: &[u8], message: &[u8]) -> [u8; 32] {
+    const BLOCK_BYTES: usize = 64;
+    let mut padded = [0_u8; BLOCK_BYTES];
+    if key.len() > BLOCK_BYTES {
+        padded[..32].copy_from_slice(&Sha256::digest(key));
+    } else {
+        padded[..key.len()].copy_from_slice(key);
+    }
+    let mut inner_key = [0x36_u8; BLOCK_BYTES];
+    let mut outer_key = [0x5c_u8; BLOCK_BYTES];
+    for index in 0..BLOCK_BYTES {
+        inner_key[index] ^= padded[index];
+        outer_key[index] ^= padded[index];
+    }
+    let mut inner = Sha256::new();
+    inner.update(inner_key);
+    inner.update(message);
+    let inner = inner.finalize();
+    let mut outer = Sha256::new();
+    outer.update(outer_key);
+    outer.update(inner);
+    outer.finalize().into()
+}
+
+fn parse_capability_uri_v3(uri: &str) -> Result<(String, [u8; 32]), DiagnosticsReadErrorV3> {
+    let Some(path) = uri.strip_prefix("codestory://packet-diagnostics/") else {
+        return Err(DiagnosticsReadErrorV3::MalformedUri);
+    };
+    let mut segments = path.split('/');
+    let (Some(packet_id), Some(token), None) = (segments.next(), segments.next(), segments.next())
+    else {
+        return Err(DiagnosticsReadErrorV3::MalformedUri);
+    };
+    if !is_random_packet_id_v3(packet_id) {
+        return Err(DiagnosticsReadErrorV3::MalformedUri);
+    }
+    let token = decode_hex_32_v3(token).ok_or(DiagnosticsReadErrorV3::MalformedUri)?;
+    Ok((packet_id.to_string(), token))
+}
+
+fn is_random_packet_id_v3(value: &str) -> bool {
+    Uuid::parse_str(value)
+        .ok()
+        .is_some_and(|uuid| uuid.get_version() == Some(uuid::Version::Random))
+}
+
+fn decode_hex_32_v3(value: &str) -> Option<[u8; 32]> {
+    if value.len() != 64 {
+        return None;
+    }
+    let mut decoded = [0_u8; 32];
+    for (index, pair) in value.as_bytes().chunks_exact(2).enumerate() {
+        let high = hex_nibble_v3(pair[0])?;
+        let low = hex_nibble_v3(pair[1])?;
+        decoded[index] = (high << 4) | low;
+    }
+    Some(decoded)
+}
+
+fn hex_nibble_v3(value: u8) -> Option<u8> {
+    match value {
+        b'0'..=b'9' => Some(value - b'0'),
+        b'a'..=b'f' => Some(value - b'a' + 10),
+        _ => None,
+    }
+}
+
+fn constant_time_eq_v3(left: &[u8; 32], right: &[u8; 32]) -> bool {
+    left.iter()
+        .zip(right)
+        .fold(0_u8, |difference, (left, right)| {
+            difference | (left ^ right)
+        })
+        == 0
+}
+
+fn sha256_hex_v3(bytes: &[u8]) -> String {
+    hex_v3(&Sha256::digest(bytes))
+}
+
+fn hex_v3(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        encoded.push(HEX[(byte >> 4) as usize] as char);
+        encoded.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    encoded
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use uuid::Uuid;
+
+    use super::*;
+
+    fn binding(packet_id: String, wall_expiry_epoch_ms: u64) -> DiagnosticsBindingV3 {
+        DiagnosticsBindingV3 {
+            packet_id,
+            project_id: "project-1".into(),
+            publication_id: "core-1/retrieval-1".into(),
+            request_digest: "a".repeat(64),
+            wall_expiry_epoch_ms,
+        }
+    }
+
+    #[test]
+    fn capability_registry_serves_exact_immutable_bytes_with_same_session_hmac() {
+        assert_eq!(
+            hex_v3(&hmac_sha256_v3(&[0x0b; 20], b"Hi There")),
+            "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7"
+        );
+        let now = Instant::now();
+        let mut registry = DiagnosticsRegistryV3::new_with_secret([7; 32]);
+        let bytes = br#"{"kind":"complete","rows":[1,2,3]}"#.to_vec();
+        let grant = registry
+            .register_at(
+                binding(Uuid::new_v4().to_string(), 99_000),
+                bytes.clone(),
+                now,
+            )
+            .expect("registered capability");
+        assert_eq!(grant.byte_length, bytes.len());
+        assert_eq!(grant.sha256.len(), 64);
+        assert!(grant.uri.starts_with("codestory://packet-diagnostics/"));
+        let first = registry
+            .read_at(&grant.uri, now)
+            .expect("same-session read");
+        let second = registry
+            .read_at(&grant.uri, now + Duration::from_secs(599))
+            .expect("read before monotonic expiry");
+        assert_eq!(&*first, bytes);
+        assert!(Arc::ptr_eq(&first, &second));
+    }
+
+    #[test]
+    fn capability_tamper_expiry_eviction_and_cross_session_are_uniformly_unavailable() {
+        let now = Instant::now();
+        let mut registry = DiagnosticsRegistryV3::new_with_secret([3; 32]);
+        let first = registry
+            .register_at(binding(Uuid::new_v4().to_string(), 1), vec![1], now)
+            .unwrap();
+
+        let mut tampered = first.uri.clone();
+        let final_byte = tampered.pop().unwrap();
+        tampered.push(if final_byte == '0' { '1' } else { '0' });
+        assert_eq!(
+            registry.read_at(&tampered, now),
+            Err(DiagnosticsReadErrorV3::CapabilityUnavailable)
+        );
+        assert_eq!(
+            registry.read_at(&first.uri, now + Duration::from_secs(600)),
+            Err(DiagnosticsReadErrorV3::CapabilityUnavailable)
+        );
+
+        let mut newest = None;
+        for index in 0..=DIAGNOSTIC_REGISTRY_MAX_ENTRIES_V3 {
+            newest = Some(
+                registry
+                    .register_at(
+                        binding(Uuid::new_v4().to_string(), index as u64),
+                        vec![index as u8],
+                        now,
+                    )
+                    .unwrap(),
+            );
+        }
+        assert_eq!(registry.entry_count(), DIAGNOSTIC_REGISTRY_MAX_ENTRIES_V3);
+        assert_eq!(
+            registry.read_at(&first.uri, now),
+            Err(DiagnosticsReadErrorV3::CapabilityUnavailable)
+        );
+
+        let mut other_session = DiagnosticsRegistryV3::new_with_secret([4; 32]);
+        assert_eq!(
+            other_session.read_at(&newest.unwrap().uri, now),
+            Err(DiagnosticsReadErrorV3::CapabilityUnavailable)
+        );
+    }
+
+    #[test]
+    fn capability_registry_enforces_uri_and_storage_limits_without_live_reads() {
+        let now = Instant::now();
+        let mut registry = DiagnosticsRegistryV3::new_with_secret([9; 32]);
+        assert_eq!(
+            registry.read_at("codestory://packet-diagnostics/not-a-uuid/nope", now),
+            Err(DiagnosticsReadErrorV3::MalformedUri)
+        );
+        assert_eq!(DiagnosticsReadErrorV3::MalformedUri.jsonrpc_code(), -32602);
+        assert_eq!(
+            DiagnosticsReadErrorV3::CapabilityUnavailable.jsonrpc_code(),
+            -32002
+        );
+        assert_eq!(DiagnosticsReadErrorV3::Internal.jsonrpc_code(), -32603);
+
+        let oversized = vec![0; DIAGNOSTIC_ENTRY_MAX_BYTES_V3 + 1];
+        assert_eq!(
+            registry.register_at(binding(Uuid::new_v4().to_string(), 1), oversized, now),
+            Err(DiagnosticsReadErrorV3::Internal)
+        );
+        for _ in 0..DIAGNOSTIC_REGISTRY_MAX_ENTRIES_V3 {
+            registry
+                .register_at(
+                    binding(Uuid::new_v4().to_string(), 1),
+                    vec![0; DIAGNOSTIC_ENTRY_MAX_BYTES_V3],
+                    now,
+                )
+                .unwrap();
+        }
+        assert_eq!(registry.retained_bytes(), DIAGNOSTIC_REGISTRY_MAX_BYTES_V3);
+    }
+
+    #[test]
+    fn capability_registration_requires_random_uuid_v4_packet_identity() {
+        let mut registry = DiagnosticsRegistryV3::new_with_secret([5; 32]);
+        assert_eq!(
+            registry.register_at(binding(Uuid::nil().to_string(), 1), vec![1], Instant::now(),),
+            Err(DiagnosticsReadErrorV3::Internal)
+        );
+    }
+}

--- a/crates/codestory-cli/src/stdio_v3/discovery.rs
+++ b/crates/codestory-cli/src/stdio_v3/discovery.rs
@@ -1,0 +1,289 @@
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+
+use super::profile::McpRevisionV3;
+
+pub(crate) const PUBLICATION_SCHEMA_VERSION_V3: u16 = 3;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DiscoveryContractIdentityV3 {
+    pub(crate) revision: McpRevisionV3,
+    pub(crate) sha256: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RuntimeDiscoveryIdentityV3 {
+    pub(crate) revision: String,
+    pub(crate) discovery_sha256: String,
+    pub(crate) publication_schema_version: u16,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NativeSessionV3 {
+    requested_revision: Option<String>,
+    negotiated_revision: McpRevisionV3,
+    discovery_identity: DiscoveryContractIdentityV3,
+}
+
+impl NativeSessionV3 {
+    pub(crate) fn negotiate(requested: Option<&str>) -> Self {
+        let requested_revision = requested.map(str::to_string);
+        let negotiated_revision = requested
+            .and_then(McpRevisionV3::parse)
+            .unwrap_or_else(McpRevisionV3::preferred);
+        let discovery_identity = discovery_contract_v3(negotiated_revision);
+        Self {
+            requested_revision,
+            negotiated_revision,
+            discovery_identity,
+        }
+    }
+
+    pub(crate) const fn negotiated_revision(&self) -> McpRevisionV3 {
+        self.negotiated_revision
+    }
+
+    pub(crate) const fn discovery_identity(&self) -> &DiscoveryContractIdentityV3 {
+        &self.discovery_identity
+    }
+
+    pub(crate) fn initialize_result(&self) -> Value {
+        json!({
+            "protocolVersion": self.negotiated_revision.as_str(),
+            "serverInfo": {"name":"codestory","version":env!("CARGO_PKG_VERSION")},
+            "capabilities": initialize_capabilities_v3(),
+            "_meta": {
+                "codestory_protocol": {
+                    "requested": self.requested_revision,
+                    "negotiated": self.negotiated_revision.as_str(),
+                    "supported": McpRevisionV3::all()
+                        .iter()
+                        .map(|revision| revision.as_str())
+                        .collect::<Vec<_>>(),
+                    "preferred": McpRevisionV3::preferred().as_str(),
+                    "discovery_contract_sha256": self.discovery_identity.sha256
+                },
+                "codestory_publication": {
+                    "schema_version": PUBLICATION_SCHEMA_VERSION_V3,
+                    "minimum_compatible_schema_version": PUBLICATION_SCHEMA_VERSION_V3
+                }
+            }
+        })
+    }
+
+    pub(crate) fn validate_runtime(
+        &self,
+        runtime: &RuntimeDiscoveryIdentityV3,
+    ) -> Result<(), HandoffSkewV3> {
+        validate_runtime_handoff_v3(&self.discovery_identity, runtime)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum HandoffSkewV3 {
+    NegotiatedRevision,
+    DiscoveryContract,
+    PublicationSchema,
+}
+
+pub(crate) fn discovery_contract_v3(revision: McpRevisionV3) -> DiscoveryContractIdentityV3 {
+    let document = discovery_document_v3(revision);
+    let canonical = canonical_json_bytes_v3(&document);
+    DiscoveryContractIdentityV3 {
+        revision,
+        sha256: hex_v3(&Sha256::digest(canonical)),
+    }
+}
+
+pub(crate) fn initialize_result_v3(requested: Option<&str>) -> Value {
+    NativeSessionV3::negotiate(requested).initialize_result()
+}
+
+pub(crate) fn validate_runtime_handoff_v3(
+    expected: &DiscoveryContractIdentityV3,
+    runtime: &RuntimeDiscoveryIdentityV3,
+) -> Result<(), HandoffSkewV3> {
+    if runtime.revision != expected.revision.as_str() {
+        return Err(HandoffSkewV3::NegotiatedRevision);
+    }
+    if runtime.discovery_sha256 != expected.sha256 {
+        return Err(HandoffSkewV3::DiscoveryContract);
+    }
+    if runtime.publication_schema_version != PUBLICATION_SCHEMA_VERSION_V3 {
+        return Err(HandoffSkewV3::PublicationSchema);
+    }
+    Ok(())
+}
+
+fn discovery_document_v3(revision: McpRevisionV3) -> Value {
+    json!({
+        "domain": "codestory.mcp.discovery-contract.v3",
+        "protocolRevision": revision.as_str(),
+        "publicationSchemaVersion": PUBLICATION_SCHEMA_VERSION_V3,
+        "initializeCapabilities": initialize_capabilities_v3(),
+        "tools": super::catalog::tools_for_revision_v3(revision),
+        "resources": crate::stdio_catalog::resources_list_json()["result"]["resources"].clone(),
+        "resourceTemplates": crate::stdio_catalog::resource_templates_list_json()["result"]["resourceTemplates"].clone(),
+        "prompts": crate::stdio_catalog::prompts_list_json()["result"]["prompts"].clone()
+    })
+}
+
+fn initialize_capabilities_v3() -> Value {
+    json!({
+        "tools": {"listChanged":false},
+        "resources": {"subscribe":false,"listChanged":false},
+        "prompts": {"listChanged":false}
+    })
+}
+
+fn canonical_json_bytes_v3(value: &Value) -> Vec<u8> {
+    let mut out = Vec::new();
+    write_canonical_json_v3(value, &mut out);
+    out
+}
+
+fn write_canonical_json_v3(value: &Value, out: &mut Vec<u8>) {
+    match value {
+        Value::Null => out.extend_from_slice(b"null"),
+        Value::Bool(value) => out.extend_from_slice(if *value { b"true" } else { b"false" }),
+        Value::Number(value) => out.extend_from_slice(value.to_string().as_bytes()),
+        Value::String(value) => out.extend_from_slice(
+            serde_json::to_string(value)
+                .expect("JSON string serialization cannot fail")
+                .as_bytes(),
+        ),
+        Value::Array(values) => {
+            out.push(b'[');
+            for (index, value) in values.iter().enumerate() {
+                if index != 0 {
+                    out.push(b',');
+                }
+                write_canonical_json_v3(value, out);
+            }
+            out.push(b']');
+        }
+        Value::Object(values) => {
+            out.push(b'{');
+            let mut entries = values.iter().collect::<Vec<_>>();
+            entries.sort_by_key(|(name, _)| *name);
+            for (index, (name, value)) in entries.into_iter().enumerate() {
+                if index != 0 {
+                    out.push(b',');
+                }
+                out.extend_from_slice(
+                    serde_json::to_string(name)
+                        .expect("JSON object-key serialization cannot fail")
+                        .as_bytes(),
+                );
+                out.push(b':');
+                write_canonical_json_v3(value, out);
+            }
+            out.push(b'}');
+        }
+    }
+}
+
+fn hex_v3(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        encoded.push(HEX[(byte >> 4) as usize] as char);
+        encoded.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    encoded
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use super::*;
+
+    #[test]
+    fn discovery_contracts_are_deterministic_distinct_and_initialize_bound() {
+        let identities = McpRevisionV3::all()
+            .iter()
+            .map(|revision| discovery_contract_v3(*revision))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            identities
+                .iter()
+                .map(|identity| identity.sha256.as_str())
+                .collect::<BTreeSet<_>>()
+                .len(),
+            4
+        );
+        for identity in &identities {
+            assert_eq!(identity.sha256.len(), 64);
+            assert!(identity.sha256.bytes().all(|byte| byte.is_ascii_hexdigit()));
+            assert_eq!(discovery_contract_v3(identity.revision), *identity);
+
+            let initialized = initialize_result_v3(Some(identity.revision.as_str()));
+            assert_eq!(initialized["protocolVersion"], identity.revision.as_str());
+            assert_eq!(
+                initialized.pointer("/_meta/codestory_protocol/discovery_contract_sha256"),
+                Some(&json!(identity.sha256))
+            );
+            assert_eq!(
+                initialized.pointer("/_meta/codestory_publication/schema_version"),
+                Some(&json!(PUBLICATION_SCHEMA_VERSION_V3))
+            );
+        }
+        assert_eq!(
+            initialize_result_v3(Some("2099-01-01"))["protocolVersion"],
+            McpRevisionV3::preferred().as_str()
+        );
+    }
+
+    #[test]
+    fn native_session_pins_one_negotiated_revision_and_discovery_identity() {
+        let session = NativeSessionV3::negotiate(Some("2025-03-26"));
+        assert_eq!(session.negotiated_revision(), McpRevisionV3::March2025);
+        let first = session.initialize_result();
+        let second = session.initialize_result();
+        assert_eq!(first, second);
+        assert_eq!(first["protocolVersion"], "2025-03-26");
+        assert_eq!(
+            first.pointer("/_meta/codestory_protocol/discovery_contract_sha256"),
+            Some(&json!(session.discovery_identity().sha256))
+        );
+        assert_eq!(
+            session.validate_runtime(&RuntimeDiscoveryIdentityV3 {
+                revision: McpRevisionV3::November2025.as_str().into(),
+                discovery_sha256: session.discovery_identity().sha256.clone(),
+                publication_schema_version: PUBLICATION_SCHEMA_VERSION_V3,
+            }),
+            Err(HandoffSkewV3::NegotiatedRevision)
+        );
+    }
+
+    #[test]
+    fn old_new_and_wrong_v3_handoffs_fail_closed_by_exact_identity() {
+        let expected = discovery_contract_v3(McpRevisionV3::June2025);
+        let exact = RuntimeDiscoveryIdentityV3 {
+            revision: expected.revision.as_str().into(),
+            discovery_sha256: expected.sha256.clone(),
+            publication_schema_version: PUBLICATION_SCHEMA_VERSION_V3,
+        };
+        assert_eq!(validate_runtime_handoff_v3(&expected, &exact), Ok(()));
+
+        let mut old = exact.clone();
+        old.revision = McpRevisionV3::November2024.as_str().into();
+        assert_eq!(
+            validate_runtime_handoff_v3(&expected, &old),
+            Err(HandoffSkewV3::NegotiatedRevision)
+        );
+        let mut wrong_v3 = exact.clone();
+        wrong_v3.discovery_sha256 = "f".repeat(64);
+        assert_eq!(
+            validate_runtime_handoff_v3(&expected, &wrong_v3),
+            Err(HandoffSkewV3::DiscoveryContract)
+        );
+        let mut new_publication = exact;
+        new_publication.publication_schema_version = 4;
+        assert_eq!(
+            validate_runtime_handoff_v3(&expected, &new_publication),
+            Err(HandoffSkewV3::PublicationSchema)
+        );
+    }
+}

--- a/crates/codestory-cli/src/stdio_v3/mod.rs
+++ b/crates/codestory-cli/src/stdio_v3/mod.rs
@@ -1,0 +1,45 @@
+mod catalog;
+mod diagnostics;
+mod discovery;
+mod profile;
+mod transport;
+
+pub(crate) use profile::McpRevisionV3;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RevisionNativeToolResultMeasurementV3 {
+    pub(crate) revision: McpRevisionV3,
+    pub(crate) call_tool_result_bytes: Vec<u8>,
+    pub(crate) byte_length: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum StdioV3InternalError {
+    Serialization(String),
+    InvalidProjection(String),
+    OutputSchemaViolation,
+    ResultExceedsBudget {
+        maximum_bytes: usize,
+        actual_bytes: usize,
+    },
+}
+
+pub(crate) fn measure_revision_native_proof_result_v3(
+    root: &serde_json::Value,
+) -> Result<Vec<RevisionNativeToolResultMeasurementV3>, StdioV3InternalError> {
+    McpRevisionV3::all()
+        .iter()
+        .map(|revision| {
+            let result = transport::build_proof_tool_result_v3(*revision, root)?;
+            let call_tool_result_bytes =
+                crate::stdio_transport::v3_serialize_call_tool_result(&result)
+                    .map_err(|error| StdioV3InternalError::Serialization(error.to_string()))?;
+            let byte_length = call_tool_result_bytes.len();
+            Ok(RevisionNativeToolResultMeasurementV3 {
+                revision: *revision,
+                call_tool_result_bytes,
+                byte_length,
+            })
+        })
+        .collect()
+}

--- a/crates/codestory-cli/src/stdio_v3/profile.rs
+++ b/crates/codestory-cli/src/stdio_v3/profile.rs
@@ -1,0 +1,157 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum McpRevisionV3 {
+    November2024,
+    March2025,
+    June2025,
+    November2025,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BatchPolicyV3 {
+    AcceptIndependentOrdered,
+    Reject,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RevisionProfileV3 {
+    pub(crate) revision: McpRevisionV3,
+    pub(crate) tool_fields: &'static [&'static str],
+    pub(crate) structured_content: bool,
+    pub(crate) batch_policy: BatchPolicyV3,
+}
+
+impl McpRevisionV3 {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::November2024 => "2024-11-05",
+            Self::March2025 => "2025-03-26",
+            Self::June2025 => "2025-06-18",
+            Self::November2025 => "2025-11-25",
+        }
+    }
+
+    pub(crate) const fn all() -> &'static [Self] {
+        &[
+            Self::November2024,
+            Self::March2025,
+            Self::June2025,
+            Self::November2025,
+        ]
+    }
+
+    pub(crate) const fn preferred() -> Self {
+        Self::November2025
+    }
+
+    pub(crate) fn parse(value: &str) -> Option<Self> {
+        match value {
+            "2024-11-05" => Some(Self::November2024),
+            "2025-03-26" => Some(Self::March2025),
+            "2025-06-18" => Some(Self::June2025),
+            "2025-11-25" => Some(Self::November2025),
+            _ => None,
+        }
+    }
+
+    pub(crate) const fn profile(self) -> RevisionProfileV3 {
+        match self {
+            Self::November2024 => RevisionProfileV3 {
+                revision: self,
+                tool_fields: &["name", "description", "inputSchema"],
+                structured_content: false,
+                batch_policy: BatchPolicyV3::AcceptIndependentOrdered,
+            },
+            Self::March2025 => RevisionProfileV3 {
+                revision: self,
+                tool_fields: &["name", "description", "inputSchema", "annotations"],
+                structured_content: false,
+                batch_policy: BatchPolicyV3::AcceptIndependentOrdered,
+            },
+            Self::June2025 | Self::November2025 => RevisionProfileV3 {
+                revision: self,
+                tool_fields: &[
+                    "name",
+                    "title",
+                    "description",
+                    "inputSchema",
+                    "outputSchema",
+                    "_meta",
+                ],
+                structured_content: true,
+                batch_policy: BatchPolicyV3::Reject,
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn revision_profiles_are_session_scoped_native_and_prefer_newest() {
+        assert_eq!(
+            McpRevisionV3::all()
+                .iter()
+                .map(|revision| revision.as_str())
+                .collect::<Vec<_>>(),
+            ["2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25"]
+        );
+        assert_eq!(McpRevisionV3::preferred(), McpRevisionV3::November2025);
+        for revision in McpRevisionV3::all() {
+            assert_eq!(McpRevisionV3::parse(revision.as_str()), Some(*revision));
+            assert_eq!(revision.profile().revision, *revision);
+        }
+        assert_eq!(McpRevisionV3::parse("2026-01-01"), None);
+    }
+
+    #[test]
+    fn revision_profiles_pin_native_tool_result_and_batch_shapes() {
+        let cases = [
+            (
+                McpRevisionV3::November2024,
+                vec!["name", "description", "inputSchema"],
+                false,
+                BatchPolicyV3::AcceptIndependentOrdered,
+            ),
+            (
+                McpRevisionV3::March2025,
+                vec!["name", "description", "inputSchema", "annotations"],
+                false,
+                BatchPolicyV3::AcceptIndependentOrdered,
+            ),
+            (
+                McpRevisionV3::June2025,
+                vec![
+                    "name",
+                    "title",
+                    "description",
+                    "inputSchema",
+                    "outputSchema",
+                    "_meta",
+                ],
+                true,
+                BatchPolicyV3::Reject,
+            ),
+            (
+                McpRevisionV3::November2025,
+                vec![
+                    "name",
+                    "title",
+                    "description",
+                    "inputSchema",
+                    "outputSchema",
+                    "_meta",
+                ],
+                true,
+                BatchPolicyV3::Reject,
+            ),
+        ];
+        for (revision, fields, structured, batch) in cases {
+            let profile = revision.profile();
+            assert_eq!(profile.tool_fields, fields);
+            assert_eq!(profile.structured_content, structured);
+            assert_eq!(profile.batch_policy, batch);
+        }
+    }
+}

--- a/crates/codestory-cli/src/stdio_v3/transport.rs
+++ b/crates/codestory-cli/src/stdio_v3/transport.rs
@@ -1,0 +1,455 @@
+use serde_json::{Value, json};
+
+use super::{
+    StdioV3InternalError,
+    profile::{BatchPolicyV3, McpRevisionV3},
+};
+
+pub(crate) const PROOF_TOOL_RESULT_MAX_BYTES_V3: usize = 64 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum FrameResponseV3 {
+    None,
+    Single(Value),
+    Batch(Vec<Value>),
+}
+
+pub(crate) fn process_jsonrpc_frame_v3<F>(
+    revision: McpRevisionV3,
+    frame: &Value,
+    mut handler: F,
+) -> FrameResponseV3
+where
+    F: FnMut(&Value) -> Value,
+{
+    let Some(batch) = frame.as_array() else {
+        return dispatch_one_v3(frame, &mut handler)
+            .map_or(FrameResponseV3::None, FrameResponseV3::Single);
+    };
+    if batch.is_empty() || revision.profile().batch_policy == BatchPolicyV3::Reject {
+        return FrameResponseV3::Single(jsonrpc_error_v3(
+            Value::Null,
+            -32600,
+            "Invalid request: batches are not supported by the negotiated revision",
+        ));
+    }
+
+    let responses = batch
+        .iter()
+        .filter_map(|request| dispatch_one_v3(request, &mut handler))
+        .collect::<Vec<_>>();
+    if responses.is_empty() {
+        FrameResponseV3::None
+    } else {
+        FrameResponseV3::Batch(responses)
+    }
+}
+
+fn dispatch_one_v3<F>(request: &Value, handler: &mut F) -> Option<Value>
+where
+    F: FnMut(&Value) -> Value,
+{
+    let valid = request.as_object().is_some_and(|request| {
+        request.get("jsonrpc") == Some(&json!("2.0"))
+            && request.get("method").and_then(Value::as_str).is_some()
+    });
+    if !valid {
+        return Some(jsonrpc_error_v3(
+            Value::Null,
+            -32600,
+            "Invalid request: expected a JSON-RPC 2.0 request object",
+        ));
+    }
+    let response = handler(request);
+    request.get("id").map(|_| response)
+}
+
+fn jsonrpc_error_v3(id: Value, code: i64, message: &str) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": {"code": code, "message": message}
+    })
+}
+
+pub(crate) fn build_proof_tool_result_v3(
+    revision: McpRevisionV3,
+    root: &Value,
+) -> Result<Value, StdioV3InternalError> {
+    let result = build_tool_result_v3(revision, "prove_call_path", root)?;
+    let bytes = crate::stdio_transport::v3_serialize_call_tool_result(&result)
+        .map_err(|error| StdioV3InternalError::Serialization(error.to_string()))?;
+    if bytes.len() <= PROOF_TOOL_RESULT_MAX_BYTES_V3 {
+        return Ok(result);
+    }
+
+    let fallback = proof_budget_fallback_v3(root, bytes.len())?;
+    let fallback_result = build_tool_result_v3(revision, "prove_call_path", &fallback)?;
+    let fallback_bytes = crate::stdio_transport::v3_serialize_call_tool_result(&fallback_result)
+        .map_err(|error| StdioV3InternalError::Serialization(error.to_string()))?;
+    if fallback_bytes.len() > PROOF_TOOL_RESULT_MAX_BYTES_V3 {
+        return Err(StdioV3InternalError::ResultExceedsBudget {
+            maximum_bytes: PROOF_TOOL_RESULT_MAX_BYTES_V3,
+            actual_bytes: fallback_bytes.len(),
+        });
+    }
+    Ok(fallback_result)
+}
+
+pub(crate) fn build_tool_result_v3(
+    revision: McpRevisionV3,
+    tool_name: &str,
+    root: &Value,
+) -> Result<Value, StdioV3InternalError> {
+    let modern_tools = super::catalog::tools_for_revision_v3(McpRevisionV3::June2025);
+    let schema = modern_tools
+        .iter()
+        .find(|tool| tool.get("name").and_then(Value::as_str) == Some(tool_name))
+        .and_then(|tool| tool.get("outputSchema"))
+        .ok_or_else(|| StdioV3InternalError::InvalidProjection(tool_name.to_string()))?;
+    revision_native_tool_result_with_schema_v3(revision, root, schema)
+}
+
+fn revision_native_tool_result_with_schema_v3(
+    revision: McpRevisionV3,
+    root: &Value,
+    schema: &Value,
+) -> Result<Value, StdioV3InternalError> {
+    if revision.profile().structured_content
+        && crate::stdio_arguments::validate_structured_content(schema, root).is_err()
+    {
+        return Err(StdioV3InternalError::OutputSchemaViolation);
+    }
+    let text = serde_json::to_string(root)
+        .map_err(|error| StdioV3InternalError::Serialization(error.to_string()))?;
+    if revision.profile().structured_content {
+        Ok(json!({
+            "content": [{"type":"text","text":text}],
+            "structuredContent": root,
+            "isError": false,
+            "_meta": {
+                "com.thegreencedar.codestory/protocolRevision": revision.as_str()
+            }
+        }))
+    } else {
+        Ok(json!({
+            "content": [{"type":"text","text":text}],
+            "isError": false
+        }))
+    }
+}
+
+fn proof_budget_fallback_v3(
+    complete: &Value,
+    required_complete_size: usize,
+) -> Result<Value, StdioV3InternalError> {
+    if complete.get("kind") != Some(&json!("complete")) {
+        return Err(StdioV3InternalError::ResultExceedsBudget {
+            maximum_bytes: PROOF_TOOL_RESULT_MAX_BYTES_V3,
+            actual_bytes: required_complete_size,
+        });
+    }
+    let required = |name: &str| {
+        complete
+            .get(name)
+            .cloned()
+            .ok_or_else(|| StdioV3InternalError::InvalidProjection(name.to_string()))
+    };
+    let contract_digest = required("contract_digest")?;
+    Ok(json!({
+        "kind": "budget_exceeded",
+        "schema_version": required("schema_version")?,
+        "domain": required("domain")?,
+        "contract_interpretation": required("contract_interpretation")?,
+        "guard_version": required("guard_version")?,
+        "source_text_sha256": required("source_text_sha256")?,
+        "contract_digest": contract_digest,
+        "core_publication": required("core_publication")?,
+        "disposition": {
+            "kind": "unknown",
+            "contract_digest": contract_digest,
+            "gaps": [{"kind":"output_budget_exceeded"}]
+        },
+        "cap_bytes": PROOF_TOOL_RESULT_MAX_BYTES_V3,
+        "required_complete_size": required_complete_size
+    }))
+}
+
+pub(crate) fn semantic_tool_error_v3(message: &str) -> Value {
+    json!({
+        "content": [{"type":"text","text":message}],
+        "isError": true
+    })
+}
+
+pub(crate) fn jsonrpc_invalid_params_v3(id: Value, message: &str) -> Value {
+    jsonrpc_error_v3(id, -32602, message)
+}
+
+pub(crate) fn jsonrpc_internal_error_v3(id: Value, _error: &StdioV3InternalError) -> Value {
+    jsonrpc_error_v3(id, -32603, "Internal error")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn proof_root(disposition_kind: &str) -> Value {
+        let disposition = match disposition_kind {
+            "unavailable" => json!({
+                "kind": "unavailable",
+                "contract_digest": "b".repeat(64),
+                "reasons": ["publication_unavailable"]
+            }),
+            _ => json!({
+                "kind": "unknown",
+                "contract_digest": "b".repeat(64),
+                "gaps": [{"kind":"direct_call_missing"}],
+                "connected_receipts": []
+            }),
+        };
+        json!({
+            "kind": "complete",
+            "schema_version": 1,
+            "domain": "indexed_source_call_path_v1",
+            "contract_interpretation": "host_supplied",
+            "guard_version": "clause_guard_v1",
+            "source_text_sha256": "a".repeat(64),
+            "contract_digest": "b".repeat(64),
+            "core_publication": {"project_id":"p","generation_id":"g","run_id":"r"},
+            "spec": {"start":{"kind":"canonical_id","canonical_id":"A"},"steps":[],"prohibit_traversal_through":[],"exclude_from_projection":[]},
+            "clauses": [],
+            "disposition": disposition,
+            "steps": [],
+            "receipts": []
+        })
+    }
+
+    #[test]
+    fn legacy_batches_preserve_order_and_omit_notifications_while_modern_rejects() {
+        let frame = json!([
+            {"jsonrpc":"2.0","id":1,"method":"first"},
+            {"jsonrpc":"2.0","method":"notify"},
+            {"jsonrpc":"2.0","id":2,"method":"second"}
+        ]);
+        for revision in [McpRevisionV3::November2024, McpRevisionV3::March2025] {
+            let mut called = Vec::new();
+            let response = process_jsonrpc_frame_v3(revision, &frame, |request| {
+                called.push(request["method"].as_str().unwrap().to_string());
+                json!({"jsonrpc":"2.0","id":request.get("id").cloned().unwrap_or(Value::Null),"result":{"method":request["method"]}})
+            });
+            assert_eq!(called, ["first", "notify", "second"]);
+            let FrameResponseV3::Batch(responses) = response else {
+                panic!("legacy profile must return an ordered response batch")
+            };
+            assert_eq!(responses.len(), 2);
+            assert_eq!(responses[0]["id"], 1);
+            assert_eq!(responses[1]["id"], 2);
+        }
+
+        for revision in [McpRevisionV3::June2025, McpRevisionV3::November2025] {
+            let response = process_jsonrpc_frame_v3(revision, &frame, |_| {
+                panic!("modern batch rejection must happen before dispatch")
+            });
+            let FrameResponseV3::Single(response) = response else {
+                panic!("modern batch should be one invalid-request response")
+            };
+            assert_eq!(response.pointer("/error/code"), Some(&json!(-32600)));
+            assert_eq!(response["id"], Value::Null);
+        }
+    }
+
+    #[test]
+    fn result_profiles_are_revision_native_and_keep_typed_uncertainty_successful() {
+        for disposition in ["unknown", "unavailable"] {
+            let root = proof_root(disposition);
+            for revision in McpRevisionV3::all() {
+                let result = build_proof_tool_result_v3(*revision, &root).expect("tool result");
+                assert_eq!(result["isError"], false);
+                let text = result
+                    .pointer("/content/0/text")
+                    .and_then(Value::as_str)
+                    .unwrap();
+                assert_eq!(serde_json::from_str::<Value>(text).unwrap(), root);
+                if revision.profile().structured_content {
+                    assert_eq!(result["structuredContent"], root);
+                    assert_eq!(
+                        result.pointer("/_meta/com.thegreencedar.codestory~1protocolRevision"),
+                        Some(&json!(revision.as_str()))
+                    );
+                } else {
+                    assert!(result.get("structuredContent").is_none());
+                    assert!(result.get("_meta").is_none());
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn post_budget_validation_suppresses_invalid_payload_and_whole_result_falls_back() {
+        let mut invalid = proof_root("unknown");
+        invalid["undeclared"] = json!(true);
+        let error = build_proof_tool_result_v3(McpRevisionV3::June2025, &invalid)
+            .expect_err("undeclared output must fail closed");
+        assert_eq!(error, StdioV3InternalError::OutputSchemaViolation);
+        let response = jsonrpc_internal_error_v3(json!(7), &error);
+        assert_eq!(response.pointer("/error/code"), Some(&json!(-32603)));
+        assert!(response.pointer("/error/data/structuredContent").is_none());
+
+        let mut oversized = proof_root("unknown");
+        oversized["receipts"] = json!([{"line_window":{"text":"\\\"é".repeat(24_000)}}]);
+        let result = build_proof_tool_result_v3(McpRevisionV3::June2025, &oversized)
+            .expect("fallback result");
+        assert_eq!(
+            result.pointer("/structuredContent/kind"),
+            Some(&json!("budget_exceeded"))
+        );
+        assert!(result.pointer("/structuredContent/receipts").is_none());
+        assert!(
+            result
+                .pointer("/structuredContent/required_complete_size")
+                .and_then(Value::as_u64)
+                .is_some_and(|size| size > PROOF_TOOL_RESULT_MAX_BYTES_V3 as u64)
+        );
+        assert!(
+            crate::stdio_transport::v3_serialize_call_tool_result(&result)
+                .unwrap()
+                .len()
+                <= PROOF_TOOL_RESULT_MAX_BYTES_V3
+        );
+    }
+
+    #[test]
+    fn request_shape_semantic_and_internal_errors_keep_distinct_wire_classes() {
+        let invalid = jsonrpc_invalid_params_v3(json!(1), "bad arguments");
+        assert_eq!(invalid.pointer("/error/code"), Some(&json!(-32602)));
+
+        let semantic = semantic_tool_error_v3("invalid proof interpretation");
+        assert_eq!(semantic["isError"], true);
+        assert_eq!(
+            semantic.as_object().unwrap().keys().collect::<Vec<_>>(),
+            ["content", "isError"]
+        );
+        assert_eq!(semantic.pointer("/content/0/type"), Some(&json!("text")));
+
+        let internal = jsonrpc_internal_error_v3(
+            json!(2),
+            &StdioV3InternalError::Serialization("secret detail".into()),
+        );
+        assert_eq!(internal.pointer("/error/code"), Some(&json!(-32603)));
+        assert!(!internal.to_string().contains("secret detail"));
+    }
+
+    #[test]
+    fn preparing_is_a_successful_revision_native_tagged_variant() {
+        let preparing = json!({
+            "kind": "preparing",
+            "state": "preparing",
+            "retry_after_ms": 250,
+            "operation": {"stage":"publication"}
+        });
+        let schema = json!({
+            "type":"object",
+            "properties": {
+                "kind":{"type":"string","enum":["preparing"]},
+                "state":{"type":"string","enum":["preparing"]},
+                "retry_after_ms":{"type":"integer","minimum":1},
+                "operation":{"type":"object"}
+            },
+            "required":["kind","state","retry_after_ms","operation"],
+            "additionalProperties":false
+        });
+        for revision in McpRevisionV3::all() {
+            let result = revision_native_tool_result_with_schema_v3(*revision, &preparing, &schema)
+                .expect("preparing is successful");
+            assert_eq!(result["isError"], false);
+            assert_eq!(
+                serde_json::from_str::<Value>(result["content"][0]["text"].as_str().unwrap())
+                    .unwrap(),
+                preparing
+            );
+            if revision.profile().structured_content {
+                assert_eq!(result["structuredContent"], preparing);
+            }
+        }
+    }
+
+    #[test]
+    fn diagnostics_token_is_only_mirrored_inside_the_result_uri() {
+        let now = std::time::Instant::now();
+        let mut registry =
+            super::super::diagnostics::DiagnosticsRegistryV3::new_with_secret([8; 32]);
+        let artifact = br#"{"kind":"complete","rows":[]}"#.to_vec();
+        let grant = registry
+            .register_at(
+                super::super::diagnostics::DiagnosticsBindingV3 {
+                    packet_id: uuid::Uuid::new_v4().to_string(),
+                    project_id: "project-1".into(),
+                    publication_id: "core-1/retrieval-1".into(),
+                    request_digest: "a".repeat(64),
+                    wall_expiry_epoch_ms: 99_000,
+                },
+                artifact,
+                now,
+            )
+            .expect("registered diagnostic artifact");
+        let mut projection = json!({
+            "kind": "complete",
+            "schema_version": 3,
+            "diagnostics": {
+                "availability": "available",
+                "reference": {
+                    "artifact_id": "diagnostic-1",
+                    "sha256": grant.sha256,
+                    "byte_length": grant.byte_length
+                }
+            }
+        });
+        super::super::diagnostics::attach_capability_uri_v3(&mut projection, &grant)
+            .expect("bind capability URI to finalized projection");
+        let token = grant.uri.rsplit('/').next().unwrap();
+
+        for revision in McpRevisionV3::all() {
+            let result = build_tool_result_v3(*revision, "packet", &projection)
+                .expect("revision-native packet result");
+            let mirrored = result
+                .pointer("/content/0/text")
+                .and_then(Value::as_str)
+                .unwrap();
+            assert_eq!(serde_json::from_str::<Value>(mirrored).unwrap(), projection);
+            assert!(
+                !result
+                    .get("_meta")
+                    .is_some_and(|meta| meta.to_string().contains(token))
+            );
+            assert_eq!(
+                result.to_string().matches(token).count(),
+                if revision.profile().structured_content {
+                    2
+                } else {
+                    1
+                }
+            );
+            assert!(
+                !super::super::catalog::tools_for_revision_v3(*revision)
+                    .iter()
+                    .any(|tool| tool.to_string().contains(token))
+            );
+        }
+    }
+
+    #[test]
+    fn measurement_seam_owns_exact_builder_bytes_for_every_revision() {
+        let root = proof_root("unknown");
+        let measured = super::super::measure_revision_native_proof_result_v3(&root)
+            .expect("revision-native measurements");
+        assert_eq!(measured.len(), 4);
+        for measurement in measured {
+            let direct = build_proof_tool_result_v3(measurement.revision, &root).unwrap();
+            let direct_bytes = crate::stdio_transport::v3_serialize_call_tool_result(&direct)
+                .expect("exact tool result bytes");
+            assert_eq!(measurement.call_tool_result_bytes, direct_bytes);
+            assert_eq!(measurement.byte_length, direct_bytes.len());
+        }
+    }
+}

--- a/crates/codestory-cli/src/stdio_v3/transport.rs
+++ b/crates/codestory-cli/src/stdio_v3/transport.rs
@@ -27,11 +27,7 @@ where
             .map_or(FrameResponseV3::None, FrameResponseV3::Single);
     };
     if batch.is_empty() || revision.profile().batch_policy == BatchPolicyV3::Reject {
-        return FrameResponseV3::Single(jsonrpc_error_v3(
-            Value::Null,
-            -32600,
-            "Invalid request: batches are not supported by the negotiated revision",
-        ));
+        return FrameResponseV3::Single(jsonrpc_error_v3(Value::Null, -32600, "Invalid Request"));
     }
 
     let responses = batch
@@ -49,19 +45,34 @@ fn dispatch_one_v3<F>(request: &Value, handler: &mut F) -> Option<Value>
 where
     F: FnMut(&Value) -> Value,
 {
-    let valid = request.as_object().is_some_and(|request| {
-        request.get("jsonrpc") == Some(&json!("2.0"))
-            && request.get("method").and_then(Value::as_str).is_some()
+    let valid = request.as_object().is_some_and(|members| {
+        members
+            .keys()
+            .all(|field| matches!(field.as_str(), "jsonrpc" | "id" | "method" | "params"))
+            && members.get("jsonrpc") == Some(&json!("2.0"))
+            && members.get("method").and_then(Value::as_str).is_some()
+            && members.get("id").is_none_or(is_valid_jsonrpc_id_v3)
+            && members
+                .get("params")
+                .is_none_or(|params| params.is_object() || params.is_array())
     });
     if !valid {
         return Some(jsonrpc_error_v3(
-            Value::Null,
+            request
+                .get("id")
+                .filter(|id| is_valid_jsonrpc_id_v3(id))
+                .cloned()
+                .unwrap_or(Value::Null),
             -32600,
-            "Invalid request: expected a JSON-RPC 2.0 request object",
+            "Invalid Request",
         ));
     }
     let response = handler(request);
     request.get("id").map(|_| response)
+}
+
+fn is_valid_jsonrpc_id_v3(value: &Value) -> bool {
+    value.is_null() || value.is_string() || value.is_number()
 }
 
 fn jsonrpc_error_v3(id: Value, code: i64, message: &str) -> Value {
@@ -260,6 +271,63 @@ mod tests {
     }
 
     #[test]
+    fn legacy_batch_rejects_hostile_envelopes_and_preserves_valid_error_ids() {
+        let frame = json!([
+            {"jsonrpc":"2.0","id":"unknown-field","method":"tools/list","extra":true},
+            {"jsonrpc":"2.0","id":17,"method":"tools/call","params":null},
+            {"jsonrpc":"1.0","id":0,"method":"tools/list"},
+            {"jsonrpc":"2.0","id":"missing-method"},
+            {"jsonrpc":"2.0","id":false,"method":"tools/list"},
+            ["nested-batch"],
+            {"jsonrpc":"2.0","id":"array-params","method":"tools/call","params":[]},
+            {"jsonrpc":"2.0","method":"notifications/initialized","params":{}},
+            {"jsonrpc":"2.0","id":"object-params","method":"tools/call","params":{}}
+        ]);
+        for revision in [McpRevisionV3::November2024, McpRevisionV3::March2025] {
+            let mut called = Vec::new();
+            let response = process_jsonrpc_frame_v3(revision, &frame, |request| {
+                called.push(request["method"].as_str().unwrap().to_string());
+                json!({"jsonrpc":"2.0","id":request.get("id").cloned().unwrap_or(Value::Null),"result":{}})
+            });
+            assert_eq!(
+                called,
+                ["tools/call", "notifications/initialized", "tools/call"],
+                "only closed, valid JSON-RPC envelopes may reach dispatch"
+            );
+            let FrameResponseV3::Batch(responses) = response else {
+                panic!("legacy hostile batch must return every non-notification response")
+            };
+            assert_eq!(responses.len(), 8);
+            let expected_ids = json!([
+                "unknown-field",
+                17,
+                0,
+                "missing-method",
+                null,
+                null,
+                "array-params",
+                "object-params"
+            ]);
+            assert_eq!(
+                responses
+                    .iter()
+                    .map(|response| response["id"].clone())
+                    .collect::<Vec<_>>(),
+                expected_ids.as_array().unwrap().clone()
+            );
+            for response in &responses[..6] {
+                assert_eq!(response.pointer("/error/code"), Some(&json!(-32600)));
+                assert_eq!(
+                    response.pointer("/error/message"),
+                    Some(&json!("Invalid Request"))
+                );
+            }
+            assert!(responses[6].get("result").is_some());
+            assert!(responses[7].get("result").is_some());
+        }
+    }
+
+    #[test]
     fn result_profiles_are_revision_native_and_keep_typed_uncertainty_successful() {
         for disposition in ["unknown", "unavailable"] {
             let root = proof_root(disposition);
@@ -375,6 +443,41 @@ mod tests {
     }
 
     #[test]
+    fn every_activation_capable_tool_accepts_preparing_through_the_native_builder() {
+        let preparing = json!({
+            "kind": "preparing",
+            "state": "preparing",
+            "retry_after_ms": 250,
+            "operation": {"stage":"publication"}
+        });
+        let activation_tools = crate::stdio_catalog::v3_tool_source_json()
+            .into_iter()
+            .filter(|tool| tool.pointer("/safety/activatesProject") == Some(&json!(true)))
+            .map(|tool| tool["name"].as_str().unwrap().to_string())
+            .collect::<Vec<_>>();
+        assert!(activation_tools.iter().any(|name| name == "ground"));
+
+        for revision in [McpRevisionV3::June2025, McpRevisionV3::November2025] {
+            for tool_name in &activation_tools {
+                let result = build_tool_result_v3(revision, tool_name, &preparing)
+                    .unwrap_or_else(|error| panic!("{revision:?} {tool_name}: {error:?}"));
+                assert_eq!(result["isError"], false);
+                assert_eq!(result["structuredContent"], preparing);
+                assert_eq!(
+                    serde_json::from_str::<Value>(result["content"][0]["text"].as_str().unwrap())
+                        .unwrap(),
+                    preparing
+                );
+            }
+            assert_eq!(
+                build_tool_result_v3(revision, "status", &preparing),
+                Err(StdioV3InternalError::OutputSchemaViolation),
+                "observational tools must not gain a preparing branch"
+            );
+        }
+    }
+
+    #[test]
     fn diagnostics_token_is_only_mirrored_inside_the_result_uri() {
         let now = std::time::Instant::now();
         let mut registry =
@@ -396,6 +499,20 @@ mod tests {
         let mut projection = json!({
             "kind": "complete",
             "schema_version": 3,
+            "identity": {
+                "packet_id":"b96ac0cc-e552-4c35-a0ba-c83b9ead67de",
+                "request_id":"request-1",
+                "question_sha256":"a".repeat(64)
+            },
+            "publication": {
+                "core":{"project_id":"project-1","generation_id":"core-1","run_id":"run-1"},
+                "retrieval":null
+            },
+            "status":"available",
+            "retrieval":{"state":"full","generation_id":null},
+            "evidence":[],
+            "gaps":[],
+            "continuation":null,
             "diagnostics": {
                 "availability": "available",
                 "reference": {

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -849,6 +849,98 @@ fn dark_packet_v3_preparation_stays_inert_and_unshipped() {
 }
 
 #[test]
+fn proof_qualification_transport_measurement_is_bench_only_and_unregistered() {
+    let cli_lib = read("crates/codestory-cli/src/lib.rs");
+    assert!(
+        cli_lib.contains("#[cfg(test)]\nmod stdio_v3;"),
+        "the revision-native transport facade must stay test-only until the sealed benchmark feature lands"
+    );
+
+    let facade = read_source_tree("crates/codestory-cli/src/stdio_v3");
+    for required in [
+        "measure_revision_native_proof_result_v3",
+        "RevisionNativeToolResultMeasurementV3",
+        "StdioV3InternalError",
+    ] {
+        assert!(
+            facade.contains(required),
+            "the dark stdio v3 facade lost its qualification seam via {required}"
+        );
+    }
+
+    let production_cli = read_source_tree_excluding_many(
+        "crates/codestory-cli/src",
+        &[
+            "stdio_v3/catalog.rs",
+            "stdio_v3/mod.rs",
+            "stdio_v3/profile.rs",
+            "stdio_v3/transport.rs",
+            "stdio_v3/diagnostics.rs",
+            "stdio_v3/discovery.rs",
+        ],
+    );
+    for forbidden in [
+        "measure_revision_native_proof_result_v3",
+        "RevisionNativeToolResultMeasurementV3",
+        "stdio_v3::",
+    ] {
+        assert!(
+            !production_cli.contains(forbidden),
+            "a production CLI module references the dark qualification seam via {forbidden}"
+        );
+    }
+
+    for surface in [
+        "crates/codestory-cli/Cargo.toml",
+        "crates/codestory-bench/Cargo.toml",
+        "crates/codestory-cli/src/args.rs",
+        "crates/codestory-cli/src/http_transport.rs",
+        "plugins/codestory/generated-mcp-catalog.json",
+        "plugins/codestory/skills/codestory-grounding/references/generated-mcp-syntax.md",
+    ] {
+        let source = read(surface);
+        for forbidden in [
+            "measure_revision_native_proof_result_v3",
+            "RevisionNativeToolResultMeasurementV3",
+            "proof-qualification-support",
+            "prove_call_path",
+        ] {
+            assert!(
+                !source.contains(forbidden),
+                "{surface} registers or exposes the dark transport seam via {forbidden}"
+            );
+        }
+    }
+
+    let launcher = read("plugins/codestory/scripts/codestory-mcp.cjs");
+    let live_launcher = source_between(
+        &launcher,
+        "async function main()",
+        "function runLauncherError",
+    );
+    assert!(
+        !live_launcher.contains("darkV3"),
+        "the live launcher route must not select the dark v3 handoff machinery"
+    );
+
+    let diagnostics = production_source(&read("crates/codestory-cli/src/stdio_v3/diagnostics.rs"));
+    for forbidden in [
+        "std::fs::",
+        "codestory_runtime::",
+        "ActivationService",
+        "active_publication(",
+        "status(",
+        "source_text",
+        "render(",
+    ] {
+        assert!(
+            !diagnostics.contains(forbidden),
+            "diagnostic capability reads must serve immutable registry bytes without live work via {forbidden}"
+        );
+    }
+}
+
+#[test]
 fn dark_call_path_kernel_stays_on_the_test_support_side_of_the_crate_root() {
     let lib = read("crates/codestory-agent/src/lib.rs");
     assert!(
@@ -924,7 +1016,17 @@ fn dark_call_path_release_surface_violations() -> Vec<String> {
     let mut surfaces = vec![
         (
             "cli command/dispatcher/ToolSpec/HTTP/serializer source",
-            read_source_tree("crates/codestory-cli/src"),
+            read_source_tree_excluding_many(
+                "crates/codestory-cli/src",
+                &[
+                    "stdio_v3/catalog.rs",
+                    "stdio_v3/diagnostics.rs",
+                    "stdio_v3/discovery.rs",
+                    "stdio_v3/mod.rs",
+                    "stdio_v3/profile.rs",
+                    "stdio_v3/transport.rs",
+                ],
+            ),
         ),
         (
             "public API DTO source",

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -82,6 +82,12 @@ const managedCliProbeForceKillGraceMs = 1000;
 // catalog must not also lose the skew detector.
 const managedCliMcpProtocolVersion = '2024-11-05';
 const supportedMcpProtocolVersions = Object.freeze(['2024-11-05']);
+const darkV3SupportedMcpProtocolVersions = Object.freeze([
+  '2024-11-05',
+  '2025-03-26',
+  '2025-06-18',
+  '2025-11-25',
+]);
 const publicationStampSchemaVersion = 2;
 const minimumCompatiblePublicationStampSchemaVersion = 2;
 const runtimeStderrObservedBytesCap = 16 * 1024 * 1024;
@@ -2325,6 +2331,40 @@ function runtimeWireContractSkew(response, negotiatedProtocolVersion) {
   if (!isPlainObject(result)) return 'initialize_result_invalid';
   if (result.protocolVersion !== negotiatedProtocolVersion) return 'protocol_version_skew';
   return publicationStampSkew(result._meta?.codestory_publication);
+}
+
+function darkV3LauncherSession(requested, discoveryContracts) {
+  const asked = typeof requested === 'string' ? requested.trim() : '';
+  const negotiated = darkV3SupportedMcpProtocolVersions.includes(asked)
+    ? asked
+    : darkV3SupportedMcpProtocolVersions.at(-1);
+  const discoveryContractSha256 = discoveryContracts?.[negotiated];
+  if (!/^[0-9a-f]{64}$/u.test(String(discoveryContractSha256 || ''))) {
+    throw new Error('dark_v3_discovery_contract_missing');
+  }
+  return Object.freeze({
+    requested: asked || null,
+    negotiated,
+    discoveryContractSha256,
+    publicationSchemaVersion: 3,
+  });
+}
+
+function darkV3RuntimeWireContractSkew(response, session) {
+  if (!isPlainObject(response)) return 'initialize_response_invalid';
+  if (response.error !== undefined) return 'initialize_rejected';
+  const result = response.result;
+  if (!isPlainObject(result)) return 'initialize_result_invalid';
+  if (result.protocolVersion !== session?.negotiated) return 'protocol_version_skew';
+  if (result._meta?.codestory_protocol?.discovery_contract_sha256
+      !== session.discoveryContractSha256) {
+    return 'discovery_contract_skew';
+  }
+  if (result._meta?.codestory_publication?.schema_version
+      !== session.publicationSchemaVersion) {
+    return 'publication_schema_skew';
+  }
+  return null;
 }
 
 function probeManagedCliStdio(cliPath, timeoutMs = 5000, options = {}) {
@@ -4775,6 +4815,8 @@ if (require.main === module) {
       failOpenPublicationStamp,
       publicationStampSkew,
       runtimeWireContractSkew,
+      darkV3LauncherSession,
+      darkV3RuntimeWireContractSkew,
       supportedMcpProtocolVersions,
       managedCliMcpProtocolVersion,
       publicationStampSchemaVersion,

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -260,6 +260,62 @@ test("launcher classifies the runtime initialize contract fail-closed", () => {
   );
 });
 
+test("dark v3 launcher state rejects old new and wrong-v3 runtime identities without selecting it", () => {
+  const contracts = Object.fromEntries(
+    ["2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25"].map((revision, index) => [
+      revision,
+      String(index + 1).repeat(64),
+    ]),
+  );
+  const session = launcherTest.darkV3LauncherSession("2025-06-18", contracts);
+  assert.deepEqual(session, {
+    requested: "2025-06-18",
+    negotiated: "2025-06-18",
+    discoveryContractSha256: contracts["2025-06-18"],
+    publicationSchemaVersion: 3,
+  });
+  const response = (revision, digest, schemaVersion = 3) => ({
+    jsonrpc: "2.0",
+    id: "initialize",
+    result: {
+      protocolVersion: revision,
+      _meta: {
+        codestory_protocol: { discovery_contract_sha256: digest },
+        codestory_publication: { schema_version: schemaVersion },
+      },
+    },
+  });
+  assert.equal(
+    launcherTest.darkV3RuntimeWireContractSkew(
+      response(session.negotiated, session.discoveryContractSha256),
+      session,
+    ),
+    null,
+  );
+  assert.equal(
+    launcherTest.darkV3RuntimeWireContractSkew(
+      response("2024-11-05", contracts["2024-11-05"]),
+      session,
+    ),
+    "protocol_version_skew",
+  );
+  assert.equal(
+    launcherTest.darkV3RuntimeWireContractSkew(
+      response(session.negotiated, "f".repeat(64)),
+      session,
+    ),
+    "discovery_contract_skew",
+  );
+  assert.equal(
+    launcherTest.darkV3RuntimeWireContractSkew(
+      response(session.negotiated, session.discoveryContractSha256, 4),
+      session,
+    ),
+    "publication_schema_skew",
+  );
+  assert.deepEqual(launcherTest.supportedMcpProtocolVersions, ["2024-11-05"]);
+});
+
 test("fail-open relay bounds hostile frames and survives null input and a missing catalog", async () => {
   const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
   const status = {


### PR DESCRIPTION
Closes #1978
Refs #1973
Refs #1984

## What changed

Adds the production-unreachable MCP v3 transport facade for the four supported protocol revisions. The dark path owns revision-native tool views and result shapes, legacy batch behavior, modern final-output validation and budgeting, error mapping, successful preparation, diagnostics capabilities, revision-specific discovery identities, launcher skew comparison, and the exact proof-result measurement seam required by Q1.

The implementation remains test-only and unregistered. Public v2 initialize, discovery, results, constants, launcher dispatch, and generated catalog bytes are unchanged.

## Review notes

Independent review found three protocol defects and all were fixed in `b1608a2a`:

- legacy invalid batch elements now match the frozen envelope oracle and preserve valid IDs;
- every activation-capable tool admits the successful tagged `preparing` result;
- packet, context, and search use closed schemas that reject missing, unknown, and mistyped fields.

Scoped re-review found no remaining Critical or Important defect. Launcher/Rust discovery-digest provenance is deliberately not claimed here; the sealed Task-5 boundary owns that binding.

## Verification

- dark `stdio_v3` suite: 21 passed
- stdio protocol contracts: 61 passed
- architecture contracts: 50 passed
- plugin static suite: 135 passed, 1 Windows-only skip
- frozen future-protocol oracle: passed
- CLI clippy with `-D warnings`: passed
- generated skill syntax, package-scoped rustfmt, and `git diff --check`: passed
- independent review: 3 Important defects found, fixed, and re-reviewed clean

Public-v2 hashes remain byte-identical to base `d7a1da54`:

- generated catalog: `e96a7049922552198cc65270aeb7d4ee1c8d3d8b6974224f3c8305398bb6b7b6`
- output audit: `f767f83e186f244db8441a62a6690b5f4a3195c5f0ea07c46725e757912f13b1`
- protocol profiles: `dfe07707b35def9c268e2bd7e6ea053414c899e3fec6a17f307fd1eaa1d6622d`
- v2 transcripts: `7a164d1dad21fa67ceb36c5b7d7acba8acb1f309ff8f166861753138fe351c3c`

The linked-worktree `cargo fmt --all` command still encounters the repository's existing vendored-workspace resolution error; package-scoped formatting passes.

## Non-claim

This PR does not activate v3, qualify proof availability, bind the launcher digest map to Rust-generated discovery contracts, change release versions, or touch the 0.17 release line.
