### PR TITLE
Repair Windows marketplace closeout

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -4937,6 +4937,33 @@ function validatePostPublish(workflows, violations, graph) {
     add(violations, closeoutInput.type === "string", `${file} ${event} pre_publish_closeout_artifact must be a string`);
   }
   const job = object(object(workflow.jobs).smoke);
+  const closeoutHarnessName = "Stage caller-bound closeout harness";
+  const closeoutHarness = namedStep(job, closeoutHarnessName);
+  add(
+    violations,
+    closeoutHarness?.id === "closeout-harness"
+      && closeoutHarness?.shell === "bash"
+      && closeoutHarness?.if === undefined
+      && closeoutHarness?.["continue-on-error"] === undefined,
+    `${file} must stage the caller-bound closeout harness fail closed`,
+  );
+  requireStepRun(violations, file, job, closeoutHarnessName, [
+    `printf '%s' "$GITHUB_SHA" | grep -Eq '^[0-9a-f]{40}$'`,
+    'git archive "$GITHUB_SHA"',
+    ".github/scripts/install-codestory-marketplace-proof.mjs",
+    ".github/scripts/marketplace-delivery-identity.mjs",
+    ".github/scripts/check-packaged-agent-proof.py",
+    ".github/scripts/packaged_agent_proof",
+    '| tar -x -C "$harness_root"',
+    'echo "helper=$harness_root/.github/scripts/install-codestory-marketplace-proof.mjs" >> "$GITHUB_OUTPUT"',
+    'echo "proof=$harness_root/.github/scripts/check-packaged-agent-proof.py" >> "$GITHUB_OUTPUT"',
+  ]);
+  add(
+    violations,
+    stepIndex(job, closeoutHarnessName)
+      < stepIndex(job, "Bind this smoke to the published release"),
+    `${file} must stage the closeout harness immediately after the tag checkout`,
+  );
   const pythonSetup = namedStep(job, "Install pinned Python");
   add(
     violations,
@@ -5296,6 +5323,7 @@ function validatePostPublish(workflows, violations, graph) {
   // The install arguments arrive as variables, so the command text no longer says which delivery
   // state produced them. Each variable is bound back to the step that resolved it.
   requireStepEnv(violations, file, job, resolveStepName, {
+    CLOSEOUT_HELPER: "${{ steps.closeout-harness.outputs.helper }}",
     MARKETPLACE_REVISION: "${{ steps.delivery.outputs.marketplace_revision }}",
     MARKETPLACE_SOURCE: "${{ steps.delivery.outputs.marketplace_source }}",
     LOCAL_FIXTURE: "${{ steps.delivery.outputs.local_fixture }}",
@@ -5359,7 +5387,7 @@ function validatePostPublish(workflows, violations, graph) {
   );
   const installedRun = executableRunText(String(installed?.run ?? ""));
   for (const fragment of [
-    "python .github/scripts/check-packaged-agent-proof.py",
+    'python "$PROOF_HELPER"',
     '--archive "$ASSET_ARCHIVE"',
     "--plugin-handoff",
     "--engine-policy accelerated",
@@ -5389,6 +5417,7 @@ function validatePostPublish(workflows, violations, graph) {
     CATALOG_DELIVERY_STATE: "${{ steps.delivery.outputs.state }}",
     DELIVERED_INSTALLER: "${{ steps.delivery.outputs.installer }}",
     EXPECTED_BACKEND: "${{ matrix.backend }}",
+    PROOF_HELPER: "${{ steps.closeout-harness.outputs.proof }}",
   });
   add(
     violations,
@@ -5402,6 +5431,7 @@ function validatePostPublish(workflows, violations, graph) {
       "INSTALLED_ATTESTATION",
       "INSTALLED_PLUGIN_DATA",
       "INSTALLED_PLUGIN_ROOT",
+      "PROOF_HELPER",
       "RELEASE_VERSION",
     ]),
     `${file} installed runtime restart proof must bind only the reviewed package, install, delivery, and backend identities`,
@@ -5415,7 +5445,7 @@ function validatePostPublish(workflows, violations, graph) {
   add(
     violations,
     occurrenceCount(installedRun, "common=(") === 1
-      && occurrenceCount(installedCommon, "python .github/scripts/check-packaged-agent-proof.py") === 1
+      && occurrenceCount(installedCommon, 'python "$PROOF_HELPER"') === 1
       && [
         '--archive "$ASSET_ARCHIVE"',
         '--checksum-file "$ASSET_CHECKSUM"',

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -5957,6 +5957,19 @@ test("post-publish proof uses an immutable real Codex marketplace install", asyn
     ({ name }) => name === "Prove the catalog-resolved published runtime",
   );
   const mutations = [
+    ["caller-bound closeout harness is removed", workflow => {
+      workflow.jobs.smoke.steps = workflow.jobs.smoke.steps.filter(
+        ({ name }) => name !== "Stage caller-bound closeout harness",
+      );
+    }, /stage the caller-bound closeout harness/u],
+    ["install step returns to the release-tag harness", workflow => {
+      installStep(workflow).env.CLOSEOUT_HELPER =
+        "${{ github.workspace }}/.github/scripts/install-codestory-marketplace-proof.mjs";
+    }, /must bind CLOSEOUT_HELPER/u],
+    ["runtime proof returns to the release-tag harness", workflow => {
+      proofStep(workflow).env.PROOF_HELPER =
+        "${{ github.workspace }}/.github/scripts/check-packaged-agent-proof.py";
+    }, /must bind PROOF_HELPER/u],
     ["Codex CLI pin drifts", workflow => {
       workflow.env.CODEX_CLI_VERSION = "latest";
     }, /pin the Codex CLI/u],

--- a/.github/scripts/install-codestory-marketplace-proof.mjs
+++ b/.github/scripts/install-codestory-marketplace-proof.mjs
@@ -55,18 +55,24 @@ export function commandPlan(
       if (/[\r\n"]/u.test(value)) fail("Codex command arguments must be single-line");
       return `"${value.replaceAll("%", "%%")}"`;
     };
+    const commandLine = [executable, ...args].map(quote).join(" ");
     return {
       command: comspec,
-      commandArgs: ["/d", "/s", "/c", [executable, ...args].map(quote).join(" ")],
+      // With /s, cmd.exe removes the first and last quotes from the command
+      // string. Keep an outer pair so the quoted shim path survives intact,
+      // and stop Node from escaping that raw cmd.exe command string again.
+      commandArgs: ["/d", "/s", "/c", `"${commandLine}"`],
+      spawnOptions: { windowsVerbatimArguments: true },
     };
   }
   return { command: executable, commandArgs: args };
 }
 
 function run(executable, args, options = {}) {
-  const { command, commandArgs } = commandPlan(executable, args);
+  const { command, commandArgs, spawnOptions = {} } = commandPlan(executable, args);
   const result = spawnSync(command, commandArgs, {
     ...options,
+    ...spawnOptions,
     encoding: "utf8",
   });
   if (result.status !== 0) {
@@ -92,12 +98,19 @@ function filesUnder(root, relative = "") {
   });
 }
 
-function directoryDigest(root) {
+export function directoryDigest(root) {
   const digest = createHash("sha256");
-  const files = filesUnder(root).sort();
+  const files = filesUnder(root)
+    .map((relative) => ({
+      relative,
+      normalized: relative.split(path.sep).join("/"),
+    }))
+    .sort((left, right) => Buffer.compare(
+      Buffer.from(left.normalized),
+      Buffer.from(right.normalized),
+    ));
   if (files.length === 0) fail("installed plugin package is empty");
-  for (const relative of files) {
-    const normalized = relative.split(path.sep).join("/");
+  for (const { relative, normalized } of files) {
     const name = Buffer.from(normalized);
     const payload = readFileSync(path.join(root, relative));
     const nameLength = Buffer.alloc(8);

--- a/.github/scripts/install-codestory-marketplace-proof.test.mjs
+++ b/.github/scripts/install-codestory-marketplace-proof.test.mjs
@@ -15,12 +15,29 @@ import process from "node:process";
 import test from "node:test";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
-import { commandPlan } from "./install-codestory-marketplace-proof.mjs";
+import {
+  commandPlan,
+  directoryDigest,
+} from "./install-codestory-marketplace-proof.mjs";
 
 const scriptRoot = path.dirname(fileURLToPath(import.meta.url));
 const repositoryRoot = path.resolve(scriptRoot, "..", "..");
 const helper = path.join(scriptRoot, "install-codestory-marketplace-proof.mjs");
 const codexVersion = "0.144.5";
+const orderingContractDigest =
+  "9c8a732ad11364c4eb6a36b16fd856f5b63e31ab01ad41e5782bdafdbf7dd34d";
+
+test("plugin directory digest sorts normalized paths bytewise", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "codestory-directory-contract-"));
+  try {
+    mkdirSync(path.join(root, "a"));
+    writeFileSync(path.join(root, "a", "child.txt"), "nested");
+    writeFileSync(path.join(root, "a0.txt"), "flat");
+    assert.equal(directoryDigest(root), orderingContractDigest);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
 
 test("Windows invokes native executables directly and wraps only command shims", () => {
   const comspec = "C:\\Windows\\System32\\cmd.exe";
@@ -45,10 +62,31 @@ test("Windows invokes native executables directly and wraps only command shims",
         "/d",
         "/s",
         "/c",
-        '"C:\\tools\\codex.cmd" "plugin" "list" "--json"',
+        '""C:\\tools\\codex.cmd" "plugin" "list" "--json""',
       ],
+      spawnOptions: { windowsVerbatimArguments: true },
     },
   );
+});
+
+test("Windows executes a command shim whose path and arguments contain spaces", {
+  skip: process.platform !== "win32",
+}, () => {
+  const root = mkdtempSync(path.join(tmpdir(), "codestory command shim "));
+  try {
+    const shim = path.join(root, "shim directory", "probe.cmd");
+    mkdirSync(path.dirname(shim), { recursive: true });
+    writeFileSync(shim, "@echo off\r\necho [%~1][%~2]\r\n");
+    const plan = commandPlan(shim, ["first", "two words"]);
+    const result = spawnSync(plan.command, plan.commandArgs, {
+      ...plan.spawnOptions,
+      encoding: "utf8",
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout.trim(), "[first][two words]");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 function run(executable, args, options = {}) {

--- a/.github/scripts/packaged_agent_proof/installation_support.py
+++ b/.github/scripts/packaged_agent_proof/installation_support.py
@@ -21,14 +21,18 @@ from .foundation import (
 def directory_contract_sha256(root: Path) -> str:
     require(root.is_dir(), f"plugin package root does not exist: {root}")
     digest = hashlib.sha256()
-    files = sorted(path for path in root.rglob("*") if path.is_file())
+    files = [
+        (path.relative_to(root).as_posix().encode("utf-8"), path)
+        for path in root.rglob("*")
+        if path.is_file()
+    ]
+    files.sort(key=lambda entry: entry[0])
     require(files, "plugin package root is empty")
-    for path in files:
+    for relative, path in files:
         require(
             not path.is_symlink(),
             f"installed plugin package contains a symlink: {path}",
         )
-        relative = path.relative_to(root).as_posix().encode("utf-8")
         payload = path.read_bytes()
         digest.update(len(relative).to_bytes(8, "little"))
         digest.update(relative)

--- a/.github/scripts/packaged_agent_proof/self_test_marketplace_delivery.py
+++ b/.github/scripts/packaged_agent_proof/self_test_marketplace_delivery.py
@@ -28,6 +28,7 @@ from types import SimpleNamespace
 
 from .foundation import REPOSITORY_ROOT, ProofFailure, require
 from .installed_identity import installed_plugin_identity
+from .installation_support import directory_contract_sha256
 from .marketplace_installation import (
     DEFERRED_INSTALLATION_SOURCE,
     LIVE_INSTALLATION_SOURCE,
@@ -42,6 +43,21 @@ _RESTORED_REPOSITORY = "local:candidate-pinned-marketplace-restored-fixture"
 _MARKER_FILENAME = ".codestory-marketplace-fixture.json"
 _MARKER_PURPOSE = "codestory-candidate-pinned-marketplace-fixture"
 _PLUGIN_ID = f"codestory@{_MARKETPLACE_NAME}"
+_ORDERING_CONTRACT_DIGEST = (
+    "9c8a732ad11364c4eb6a36b16fd856f5b63e31ab01ad41e5782bdafdbf7dd34d"
+)
+
+
+def _run_directory_contract_ordering_self_test() -> None:
+    with tempfile.TemporaryDirectory(prefix="codestory-directory-contract-") as raw:
+        root = Path(raw)
+        (root / "a").mkdir()
+        (root / "a" / "child.txt").write_text("nested", encoding="utf-8")
+        (root / "a0.txt").write_text("flat", encoding="utf-8")
+        require(
+            directory_contract_sha256(root) == _ORDERING_CONTRACT_DIGEST,
+            "plugin directory digest does not sort normalized paths bytewise",
+        )
 
 
 def _git(repository: Path, *arguments: str) -> str:
@@ -609,6 +625,7 @@ def _run_shared_identity_self_tests() -> None:
 
 
 def run_marketplace_delivery_self_tests() -> None:
+    _run_directory_contract_ordering_self_test()
     _run_codex_config_serialization_self_test()
     manifest = _manifest()
     with tempfile.TemporaryDirectory(prefix="codestory-marketplace-delivery-") as raw:

--- a/.github/workflows/post-publish-release-smoke.yml
+++ b/.github/workflows/post-publish-release-smoke.yml
@@ -120,6 +120,28 @@ jobs:
           ref: ${{ steps.release.outputs.tag }}
           fetch-depth: 0
 
+      # Product source remains pinned to the published tag. The proof harness comes from the
+      # workflow invocation commit so a post-publication harness repair can re-prove immutable
+      # release bytes without moving the tag or rebuilding the package.
+      - name: Stage caller-bound closeout harness
+        id: closeout-harness
+        shell: bash
+        run: |
+          set -euo pipefail
+          printf '%s' "$GITHUB_SHA" | grep -Eq '^[0-9a-f]{40}$'
+          harness_root="$RUNNER_TEMP/codestory-closeout-harness"
+          rm -rf "$RUNNER_TEMP/codestory-closeout-harness"
+          mkdir -p "$harness_root"
+          git archive "$GITHUB_SHA" \
+            .github/scripts/install-codestory-marketplace-proof.mjs \
+            .github/scripts/marketplace-delivery-identity.mjs \
+            .github/scripts/check-packaged-agent-proof.py \
+            .github/scripts/packaged_agent_proof \
+            | tar -x -C "$harness_root"
+          echo "helper=$harness_root/.github/scripts/install-codestory-marketplace-proof.mjs" >> "$GITHUB_OUTPUT"
+          echo "proof=$harness_root/.github/scripts/check-packaged-agent-proof.py" >> "$GITHUB_OUTPUT"
+          echo "Closeout harness commit: $GITHUB_SHA." >> "$GITHUB_STEP_SUMMARY"
+
       # The tag is a local name until GitHub agrees it is a published one. Every later step pins
       # the commit resolved here, so the fixture catalog, the Codex resolve, and the byte
       # comparison all name a release GitHub is actually serving -- never merely whatever tree
@@ -582,8 +604,13 @@ jobs:
           LOCAL_FIXTURE: ${{ steps.delivery.outputs.local_fixture }}
           INSTALLATION_SOURCE: ${{ steps.delivery.outputs.installer }}
           RELEASE_VERSION: ${{ steps.release.outputs.version }}
+          CLOSEOUT_HELPER: ${{ steps.closeout-harness.outputs.helper }}
         run: |
           set -euo pipefail
+          case "$CLOSEOUT_HELPER" in
+            */install-codestory-marketplace-proof.mjs) ;;
+            *) echo "::error::Unexpected closeout helper path"; exit 1 ;;
+          esac
           install_root="$RUNNER_TEMP/codestory-installed-proof"
           codex_package_root="$RUNNER_TEMP/codex-cli-${CODEX_CLI_VERSION}"
           isolated_home="$install_root/isolated-home"
@@ -596,7 +623,7 @@ jobs:
             --no-audit \
             --no-fund \
             "@openai/codex@$CODEX_CLI_VERSION"
-          HOME="$isolated_home" node .github/scripts/install-codestory-marketplace-proof.mjs \
+          HOME="$isolated_home" node "$CLOSEOUT_HELPER" \
             --codex-package-root "$codex_package_root" \
             --codex-home "$install_root/codex-home" \
             --plugin-data "$install_root/codex-home/plugin-data" \
@@ -622,16 +649,21 @@ jobs:
           CATALOG_DELIVERY_STATE: ${{ steps.delivery.outputs.state }}
           DELIVERED_INSTALLER: ${{ steps.delivery.outputs.installer }}
           EXPECTED_BACKEND: ${{ matrix.backend }}
+          PROOF_HELPER: ${{ steps.closeout-harness.outputs.proof }}
         shell: bash
         run: |
           set -euo pipefail
+          case "$PROOF_HELPER" in
+            */check-packaged-agent-proof.py) ;;
+            *) echo "::error::Unexpected packaged proof helper path"; exit 1 ;;
+          esac
           source_sha="$(git rev-parse HEAD)"
           source_tree="$(git rev-parse 'HEAD^{tree}')"
           proof_root=target/post-publish-installed-proof
           rm -rf "$proof_root"
           mkdir -p "$proof_root"
           common=(
-            python .github/scripts/check-packaged-agent-proof.py
+            python "$PROOF_HELPER"
             --archive "$ASSET_ARCHIVE" \
             --checksum-file "$ASSET_CHECKSUM" \
             --expected-version "$RELEASE_VERSION" \

--- a/benchmarks/release-evidence/fixtures/candidate.json
+++ b/benchmarks/release-evidence/fixtures/candidate.json
@@ -62,7 +62,7 @@
   },
   "release_claims": {
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "d3263fef491c5c98462b6be30ba450dbcd73aaa078983c7f657acbb853a1517e",
+    "graph_sha256": "eec335c602fdedb1c2b6f5576e91935b9482c8708c3e52cee8ea559430b4cd34",
     "observed_at": "2026-08-09T12:50:08.593Z",
     "expires_at": "2026-08-10T12:50:08.593Z",
     "requested_claims": [
@@ -85,7 +85,7 @@
         "type": "performance",
         "tier": "live_behavior",
         "status": "measured",
-        "graph_sha256": "d3263fef491c5c98462b6be30ba450dbcd73aaa078983c7f657acbb853a1517e",
+        "graph_sha256": "eec335c602fdedb1c2b6f5576e91935b9482c8708c3e52cee8ea559430b4cd34",
         "observed_at": "2026-08-09T12:50:08.593Z",
         "expires_at": "2026-08-10T12:50:08.593Z",
         "identity": {
@@ -106,7 +106,7 @@
         "type": "answer_quality",
         "tier": "answer_quality",
         "status": "pass",
-        "graph_sha256": "d3263fef491c5c98462b6be30ba450dbcd73aaa078983c7f657acbb853a1517e",
+        "graph_sha256": "eec335c602fdedb1c2b6f5576e91935b9482c8708c3e52cee8ea559430b4cd34",
         "observed_at": "2026-08-09T12:50:08.593Z",
         "expires_at": "2026-08-10T12:50:08.593Z",
         "identity": {

--- a/benchmarks/release-evidence/fixtures/report.json
+++ b/benchmarks/release-evidence/fixtures/report.json
@@ -26,7 +26,7 @@
       "type": "performance",
       "tier": "live_behavior",
       "status": "pass",
-      "graph_sha256": "d3263fef491c5c98462b6be30ba450dbcd73aaa078983c7f657acbb853a1517e",
+      "graph_sha256": "eec335c602fdedb1c2b6f5576e91935b9482c8708c3e52cee8ea559430b4cd34",
       "observed_at": "2026-08-09T12:50:08.593Z",
       "expires_at": "2026-08-10T12:50:08.593Z",
       "identity": {
@@ -47,7 +47,7 @@
       "type": "answer_quality",
       "tier": "answer_quality",
       "status": "pass",
-      "graph_sha256": "d3263fef491c5c98462b6be30ba450dbcd73aaa078983c7f657acbb853a1517e",
+      "graph_sha256": "eec335c602fdedb1c2b6f5576e91935b9482c8708c3e52cee8ea559430b4cd34",
       "observed_at": "2026-08-09T12:50:08.593Z",
       "expires_at": "2026-08-10T12:50:08.593Z",
       "identity": {
@@ -69,7 +69,7 @@
     "schema": "codestory.release-claim-evaluation/v1",
     "status": "pass",
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "d3263fef491c5c98462b6be30ba450dbcd73aaa078983c7f657acbb853a1517e",
+    "graph_sha256": "eec335c602fdedb1c2b6f5576e91935b9482c8708c3e52cee8ea559430b4cd34",
     "evidence_selection": "all_matching_rows_must_pass",
     "expected_commit": "2222222222222222222222222222222222222222",
     "evaluated_at": "2026-08-09T12:50:08.593Z",

--- a/release-claims.json
+++ b/release-claims.json
@@ -3271,7 +3271,7 @@
         "step": "Prove the catalog-resolved published runtime",
         "fragments": [
           "common=(",
-          "python .github/scripts/check-packaged-agent-proof.py",
+          "python \"$PROOF_HELPER\"",
           "--expected-backend \"$EXPECTED_BACKEND\"",
           "\"${common[@]}\" --out-dir \"$proof_root/session-1\"",
           "\"${common[@]}\" --out-dir \"$proof_root/session-2\"",

--- a/scripts/tests/fixtures/release-claims/positive.json
+++ b/scripts/tests/fixtures/release-claims/positive.json
@@ -17,7 +17,7 @@
       "type": "source_behavior",
       "tier": "source",
       "status": "pass",
-      "graph_sha256": "d3263fef491c5c98462b6be30ba450dbcd73aaa078983c7f657acbb853a1517e",
+      "graph_sha256": "eec335c602fdedb1c2b6f5576e91935b9482c8708c3e52cee8ea559430b4cd34",
       "observed_at": "2026-07-16T11:00:00.000Z",
       "expires_at": "2026-07-17T11:00:00.000Z",
       "identity": {


### PR DESCRIPTION
## Context

The v0.17.4 release and marketplace publication succeeded, but Windows post-publish smoke stopped before resolution because `cmd.exe /s /c` stripped the quoted `codex.cmd` executable name. Linux and macOS closeout passed.

## What changed

- preserve the quoted Windows shim path with the outer command-string quote pair required by `cmd.exe /s /c`
- execute that contract in a Windows-only native test with a shim path and argument containing spaces
- let a dispatch use its exact caller-bound closeout harness while product source and assets remain pinned to the immutable published tag
- pin that recovery seam in workflow policy and hostile mutation tests

## Review

The product/package source remains `v0.17.4`; only the proof harness comes from the dispatch commit. Release cells remain disabled for this recovery dispatch.

## Verification

- native Windows probe: `cmd.exe /d /s /c ""C:\Program Files\nodejs\npm.cmd" --version"` -> `11.18.0`
- `node --test .github/scripts/install-codestory-marketplace-proof.test.mjs` -> 3 passed, 1 platform skip on macOS
- `node --test .github/scripts/check-workflow-policy.test.mjs` -> 1432 passed
- `node .github/scripts/check-workflow-policy.mjs` -> passed
- `node .github/scripts/run-actionlint.mjs` -> passed
- `git diff --check` -> passed
- live v0.17.4 recovery smoke: running at https://github.com/TheGreenCedar/CodeStory/actions/runs/32519856939

## Risk

The caller-bound harness is limited to two exact scripts, staged from the immutable workflow invocation SHA, and the policy rejects removing or rebinding it.

Closes #1993.
Refs #1982.