### PR TITLE
[codex] accept Cursor-validated files, snippet, and preparing envelopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+Cursor still dropped `files`, `snippet`, and preparing `packet`/`search`/`context` results: empty `policy_exclusions` were omitted, batched snippets used a ranges document, and the shared `codestory_preparing` envelope was undeclared.
+
 ## 0.17.4
 
 Cursor marketplace MCP tool results match the schemas Cursor validates. After the server started, Cursor rejected `status`, `packet`, and `files` because the advertised output schema forbade extra compact-status fields, typed packet `support` as an object, and omitted `files.coverage_gaps`.

--- a/crates/codestory-cli/src/stdio_catalog.rs
+++ b/crates/codestory-cli/src/stdio_catalog.rs
@@ -119,7 +119,10 @@ impl ToolSpec {
             ("annotations".to_string(), self.safety.annotations_json()),
         ]);
         if let Some(output_schema) = self.output_schema {
-            tool.insert("outputSchema".to_string(), output_schema.to_json());
+            tool.insert(
+                "outputSchema".to_string(),
+                attach_stdio_retry_envelope(output_schema.to_json()),
+            );
         }
         Value::Object(tool)
     }
@@ -874,6 +877,44 @@ static STATUS_OUTPUT_SCHEMA: SchemaObject = SchemaObject::object(
     ],
 );
 
+static STDIO_RETRY_NEXT_CALL_SCHEMA: SchemaObject = SchemaObject::object(
+    "Host-executable retry of the same tool after a preparing delay.",
+    &[
+        SchemaProperty::string("method", "JSON-RPC method."),
+        SchemaProperty::string("tool", "Tool to retry."),
+        SchemaProperty::object("arguments", "Original tool arguments."),
+        SchemaProperty::integer("after_ms", "Delay before retry."),
+    ],
+    &["method", "tool"],
+);
+
+static STDIO_RETRY_ENVELOPE_SCHEMA: SchemaObject = SchemaObject::object(
+    "Shared stdio retry or unavailable envelope returned instead of a tool DTO while managed activation is still updating.",
+    &[
+        SchemaProperty::string("code", "Typed stdio retry or unavailable code."),
+        SchemaProperty::string("message", "Human-readable retry or unavailable message."),
+        SchemaProperty::object("details", "Structured API error repair guidance.").nullable(),
+        SchemaProperty::string("cause_code", "Underlying activation or cache cause code."),
+        SchemaProperty::string("tool", "Tool that produced this envelope."),
+        SchemaProperty::string("state", "preparing, unavailable, or cancelled."),
+        SchemaProperty::string(
+            "retry_tool",
+            "Tool to retry when the envelope is preparing.",
+        )
+        .nullable(),
+        SchemaProperty::integer("retry_after_ms", "Retry delay while preparing.").nullable(),
+        SchemaProperty::object("operation", "Current managed preparation operation.").nullable(),
+        SchemaProperty::string("next_action", "Direct next action for the caller."),
+        SchemaProperty::array(
+            "recommended_next_calls",
+            "Host-executable retries of the intended tool.",
+            &STDIO_RETRY_NEXT_CALL_SCHEMA,
+        ),
+        SchemaProperty::string("diagnostics_uri", "Optional full diagnostic resource URI."),
+    ],
+    &["code", "message"],
+);
+
 static RESOURCE_LINK_SCHEMA: SchemaObject = SchemaObject::object(
     "Continuation resource link.",
     &[
@@ -1525,8 +1566,26 @@ static GRAPH_TOOL_OUTPUT_SCHEMA: SchemaObject = SchemaObject::object(
     ],
 );
 
+static SNIPPET_RANGE_SCHEMA: SchemaObject = SchemaObject::object(
+    "One requested source range from a batched snippet.paths call.",
+    &[
+        SchemaProperty::string("path", "Project-relative file path."),
+        SchemaProperty::integer("start_line", "1-based first line."),
+        SchemaProperty::integer("end_line", "1-based last line."),
+        SchemaProperty::string("snippet", "Source snippet text."),
+        SchemaProperty::boolean("snippet_truncated", "Whether this range hit a byte cap."),
+    ],
+    &[
+        "path",
+        "start_line",
+        "end_line",
+        "snippet",
+        "snippet_truncated",
+    ],
+);
+
 static SNIPPET_CONTEXT_SCHEMA: SchemaObject = SchemaObject::object(
-    "CodeStory snippet context DTO.",
+    "CodeStory snippet context DTO, or a batched paths result.",
     &[
         SchemaProperty::object("node", "Node details DTO."),
         SchemaProperty::string("path", "Project-relative file path."),
@@ -1548,7 +1607,19 @@ static SNIPPET_CONTEXT_SCHEMA: SchemaObject = SchemaObject::object(
             "truncation_guidance",
             "Follow-up guidance when the snippet hit its byte cap.",
         ),
+        SchemaProperty::array(
+            "ranges",
+            "Requested source ranges from a batched paths call.",
+            &SNIPPET_RANGE_SCHEMA,
+        ),
+        SchemaProperty::integer(
+            "max_total_bytes",
+            "Total byte cap for a batched paths call.",
+        ),
     ],
+    &[],
+)
+.with_any_of_required(&[
     &[
         "node",
         "path",
@@ -1558,7 +1629,8 @@ static SNIPPET_CONTEXT_SCHEMA: SchemaObject = SchemaObject::object(
         "requested_context",
         "snippet_truncated",
     ],
-);
+    &["ranges", "max_total_bytes"],
+]);
 
 static DEFINITION_OUTPUT_SCHEMA: SchemaObject = SchemaObject::object(
     "CodeStory definition tool output.",
@@ -2515,6 +2587,56 @@ pub(crate) fn tool_input_schema(name: &str) -> Option<&'static Value> {
         .get(name)
 }
 
+fn attach_stdio_retry_envelope(mut schema: Value) -> Value {
+    let retry = STDIO_RETRY_ENVELOPE_SCHEMA.to_json();
+    let retry_properties = retry
+        .get("properties")
+        .and_then(Value::as_object)
+        .expect("retry envelope properties")
+        .clone();
+    let properties = schema
+        .get_mut("properties")
+        .and_then(Value::as_object_mut)
+        .expect("output schema properties");
+    for (name, property) in retry_properties {
+        properties.entry(name).or_insert(property);
+    }
+    let error_branch = json!({ "required": ["code", "message"] });
+    let has_error_branch = schema
+        .get("anyOf")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .any(|branch| {
+            let required = branch
+                .get("required")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .filter_map(Value::as_str)
+                .collect::<Vec<_>>();
+            required.contains(&"code") && required.contains(&"message")
+        });
+    if has_error_branch {
+        return schema;
+    }
+    match schema.get_mut("anyOf") {
+        Some(Value::Array(any_of)) => any_of.push(error_branch),
+        _ => {
+            let required = schema.get("required").cloned().unwrap_or_else(|| json!([]));
+            let mut branches = Vec::new();
+            if required.as_array().is_some_and(|items| !items.is_empty()) {
+                branches.push(json!({ "required": required }));
+            }
+            branches.push(error_branch);
+            let object = schema.as_object_mut().expect("output schema object");
+            object.insert("anyOf".to_string(), Value::Array(branches));
+            object.insert("required".to_string(), json!([]));
+        }
+    }
+    schema
+}
+
 /// Build the `tools/list` response.
 pub(crate) fn tools_list_json() -> Value {
     json!({
@@ -2740,6 +2862,203 @@ mod tests {
             undeclared.is_empty(),
             "the packet emits {undeclared:?}, which its published output schema \
              forbids: declared = {declared:?}"
+        );
+    }
+
+    const STDIO_RETRY_ENVELOPE_FIELDS: &[&str] = &[
+        "code",
+        "message",
+        "details",
+        "cause_code",
+        "tool",
+        "state",
+        "retry_tool",
+        "retry_after_ms",
+        "operation",
+        "next_action",
+        "recommended_next_calls",
+        "diagnostics_uri",
+    ];
+
+    fn tool_output_schema(name: &str) -> Value {
+        tools_list_json()["result"]["tools"]
+            .as_array()
+            .expect("tools")
+            .iter()
+            .find(|tool| tool["name"] == name)
+            .unwrap_or_else(|| panic!("{name} tool"))["outputSchema"]
+            .clone()
+    }
+
+    fn schema_required_fields(schema: &Value) -> Vec<&str> {
+        schema
+            .get("required")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(Value::as_str)
+            .collect()
+    }
+
+    fn undeclared_object_keys(schema: &Value, data: &Value) -> Vec<String> {
+        let Some(properties) = schema.get("properties").and_then(Value::as_object) else {
+            return Vec::new();
+        };
+        if schema.get("additionalProperties") != Some(&json!(false)) {
+            return Vec::new();
+        }
+        data.as_object()
+            .expect("object payload")
+            .keys()
+            .filter(|key| !properties.contains_key(*key))
+            .cloned()
+            .collect()
+    }
+
+    fn satisfies_required_any_of(schema: &Value, data: &Value) -> bool {
+        let Some(object) = data.as_object() else {
+            return false;
+        };
+        if let Some(any_of) = schema.get("anyOf").and_then(Value::as_array) {
+            return any_of.iter().any(|branch| {
+                schema_required_fields(branch)
+                    .iter()
+                    .all(|field| object.contains_key(*field))
+            });
+        }
+        schema_required_fields(schema)
+            .iter()
+            .all(|field| object.contains_key(*field))
+    }
+
+    fn preparing_envelope(tool: &str) -> Value {
+        json!({
+            "code": "codestory_preparing",
+            "message": "project activation is still Updating at Publication; retry after 250ms",
+            "cause_code": "activation_preparing",
+            "details": null,
+            "tool": tool,
+            "state": "preparing",
+            "retry_tool": tool,
+            "retry_after_ms": 250,
+            "operation": {
+                "state": "updating",
+                "stage": "publication",
+                "progress": 75
+            },
+            "next_action": "retry_intended_tool",
+            "recommended_next_calls": [{
+                "method": "tools/call",
+                "tool": tool,
+                "arguments": {"project": "/repo"},
+                "after_ms": 250
+            }],
+            "diagnostics_uri": "codestory://status?project=%2Frepo"
+        })
+    }
+
+    #[test]
+    fn every_tool_output_schema_declares_the_stdio_retry_envelope() {
+        let catalog = tools_list_json();
+        for tool in catalog["result"]["tools"].as_array().expect("tools") {
+            let name = tool["name"].as_str().expect("tool name");
+            let schema = &tool["outputSchema"];
+            let properties = schema["properties"]
+                .as_object()
+                .unwrap_or_else(|| panic!("{name} outputSchema properties"));
+            for field in STDIO_RETRY_ENVELOPE_FIELDS {
+                assert!(
+                    properties.contains_key(*field),
+                    "{name} outputSchema must declare retry envelope field {field}"
+                );
+            }
+            let has_error_branch = schema["anyOf"]
+                .as_array()
+                .into_iter()
+                .flatten()
+                .any(|branch| {
+                    let required = schema_required_fields(branch);
+                    required.contains(&"code") && required.contains(&"message")
+                });
+            assert!(
+                has_error_branch,
+                "{name} outputSchema must anyOf a code/message retry branch so Cursor can accept preparing envelopes"
+            );
+            let envelope = preparing_envelope(name);
+            let undeclared = undeclared_object_keys(schema, &envelope);
+            assert!(
+                undeclared.is_empty(),
+                "{name} preparing envelope emits undeclared {undeclared:?}"
+            );
+            assert!(
+                satisfies_required_any_of(schema, &envelope),
+                "{name} preparing envelope must satisfy an anyOf required branch: {schema}"
+            );
+        }
+    }
+
+    #[test]
+    fn snippet_output_schema_accepts_a_paths_ranges_payload() {
+        let schema = tool_output_schema("snippet");
+        let payload = json!({
+            "max_total_bytes": 65_536,
+            "ranges": [{
+                "path": "src/lib.rs",
+                "start_line": 10,
+                "end_line": 12,
+                "snippet": "fn run() {}",
+                "snippet_truncated": false
+            }]
+        });
+        let undeclared = undeclared_object_keys(&schema, &payload);
+        assert!(
+            undeclared.is_empty(),
+            "snippet ranges payload emits undeclared {undeclared:?}"
+        );
+        assert!(
+            satisfies_required_any_of(&schema, &payload),
+            "snippet ranges payload must satisfy an anyOf required branch: {schema}"
+        );
+    }
+
+    #[test]
+    fn indexed_files_dto_emits_empty_policy_exclusions() {
+        let files = codestory_contracts::api::IndexedFilesDto {
+            project_root: "/repo".to_string(),
+            usable: true,
+            summary: codestory_contracts::api::IndexedFilesSummaryDto {
+                file_count: 0,
+                indexed_file_count: 0,
+                filtered_file_count: 0,
+                visible_file_count: 0,
+                incomplete_file_count: 0,
+                error_file_count: 0,
+                policy_exclusion_count: 0,
+                incomplete_reason_counts: Vec::new(),
+                truncated: false,
+                language_counts: Vec::new(),
+                framework_route_coverage: Vec::new(),
+                coverage_notes: Vec::new(),
+            },
+            coverage_gaps: Vec::new(),
+            policy_exclusions: Vec::new(),
+            files: Vec::new(),
+        };
+        let payload = serde_json::to_value(&files).expect("serialize indexed files");
+        assert_eq!(
+            payload.get("policy_exclusions"),
+            Some(&json!([])),
+            "Cursor's files anyOf requires policy_exclusions even when empty: {payload}"
+        );
+        let schema = tool_output_schema("files");
+        let undeclared = undeclared_object_keys(&schema, &payload);
+        assert!(
+            undeclared.is_empty(),
+            "files success payload emits undeclared {undeclared:?}"
+        );
+        assert!(
+            satisfies_required_any_of(&schema, &payload),
+            "files success payload must satisfy an anyOf required branch: {schema}"
         );
     }
 }

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -722,6 +722,22 @@ fn tool_output_schema<'a>(tools: &'a Value, name: &str) -> &'a Value {
         .unwrap_or_else(|| panic!("tool {name} should include outputSchema: {tools}"))
 }
 
+fn required_on_any_branch(schema: &Value, field: &str) -> bool {
+    schema
+        .get("required")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .any(|value| value.as_str() == Some(field))
+        || schema["anyOf"].as_array().is_some_and(|any_of| {
+            any_of.iter().any(|branch| {
+                branch["required"].as_array().is_some_and(|required| {
+                    required.iter().any(|value| value.as_str() == Some(field))
+                })
+            })
+        })
+}
+
 fn required_fields(schema: &Value) -> BTreeSet<&str> {
     schema
         .get("required")
@@ -2566,7 +2582,7 @@ fn tool_catalog_exposes_output_schemas_for_stable_dto_backed_tools() {
                 "retrieval_trace_summary",
             ] {
                 assert!(
-                    required_fields(output_schema).contains(field),
+                    required_on_any_branch(output_schema, field),
                     "packet outputSchema should require {field}: {tool}"
                 );
             }
@@ -2584,7 +2600,7 @@ fn tool_catalog_exposes_output_schemas_for_stable_dto_backed_tools() {
             );
             for field in ["stats", "coverage", "orientation", "root_symbols", "files"] {
                 assert!(
-                    required_fields(output_schema).contains(field),
+                    required_on_any_branch(output_schema, field),
                     "ground outputSchema should require grounding DTO field {field}: {tool}"
                 );
             }
@@ -2897,7 +2913,7 @@ fn tool_catalog_exposes_output_schemas_for_stable_dto_backed_tools() {
     let snippet = tool_output_schema(&tools, "snippet");
     for field in ["scope", "requested_context", "snippet_truncated"] {
         assert!(
-            required_fields(snippet).contains(field),
+            required_on_any_branch(snippet, field),
             "snippet outputSchema should require emitted DTO field {field}: {snippet}"
         );
         let _ = schema_property(snippet, field);

--- a/crates/codestory-contracts/src/api/dto.rs
+++ b/crates/codestory-contracts/src/api/dto.rs
@@ -1319,7 +1319,7 @@ pub struct IndexedFilesDto {
     pub summary: IndexedFilesSummaryDto,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub coverage_gaps: Vec<FileCoverageDiagnosticDto>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     pub policy_exclusions: Vec<SourcePolicyExclusionDto>,
     pub files: Vec<IndexedFileDto>,
 }

--- a/plugins/codestory/generated-mcp-catalog.json
+++ b/plugins/codestory/generated-mcp-catalog.json
@@ -34,11 +34,36 @@
       "name": "status",
       "outputSchema": {
         "additionalProperties": false,
+        "anyOf": [
+          {
+            "required": [
+              "project",
+              "state",
+              "capabilities",
+              "next_action",
+              "diagnostics_uri"
+            ]
+          },
+          {
+            "required": [
+              "code",
+              "message"
+            ]
+          }
+        ],
         "description": "Compact capability state. Read codestory://status{?project} with the same absolute project root when full diagnostics are needed.",
         "properties": {
           "capabilities": {
             "description": "Local navigation and broad-search states.",
             "type": "object"
+          },
+          "cause_code": {
+            "description": "Underlying activation or cache cause code.",
+            "type": "string"
+          },
+          "code": {
+            "description": "Typed stdio retry or unavailable code.",
+            "type": "string"
           },
           "current_operation": {
             "description": "Current managed preparation operation.",
@@ -51,6 +76,13 @@
             "description": "Why a full publication is not live-ready, when that is known.",
             "type": [
               "string",
+              "null"
+            ]
+          },
+          "details": {
+            "description": "Structured API error repair guidance.",
+            "type": [
+              "object",
               "null"
             ]
           },
@@ -69,13 +101,55 @@
             "description": "Whether packet/search may use full retrieval without a degraded reason.",
             "type": "boolean"
           },
+          "message": {
+            "description": "Human-readable retry or unavailable message.",
+            "type": "string"
+          },
           "next_action": {
             "description": "Direct next action for the caller.",
             "type": "string"
           },
+          "operation": {
+            "description": "Current managed preparation operation.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
           "project": {
             "description": "Requested repository root.",
             "type": "string"
+          },
+          "recommended_next_calls": {
+            "description": "Host-executable retries of the intended tool.",
+            "items": {
+              "additionalProperties": false,
+              "description": "Host-executable retry of the same tool after a preparing delay.",
+              "properties": {
+                "after_ms": {
+                  "description": "Delay before retry.",
+                  "type": "integer"
+                },
+                "arguments": {
+                  "description": "Original tool arguments.",
+                  "type": "object"
+                },
+                "method": {
+                  "description": "JSON-RPC method.",
+                  "type": "string"
+                },
+                "tool": {
+                  "description": "Tool to retry.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "method",
+                "tool"
+              ],
+              "type": "object"
+            },
+            "type": "array"
           },
           "retrieval_mode": {
             "description": "Pinned retrieval publication class; full is eligibility, not live-ready.",
@@ -91,6 +165,13 @@
               "null"
             ]
           },
+          "retry_tool": {
+            "description": "Tool to retry when the envelope is preparing.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "state": {
             "description": "Overall capability state.",
             "enum": [
@@ -101,15 +182,13 @@
               "unavailable"
             ],
             "type": "string"
+          },
+          "tool": {
+            "description": "Tool that produced this envelope.",
+            "type": "string"
           }
         },
-        "required": [
-          "project",
-          "state",
-          "capabilities",
-          "next_action",
-          "diagnostics_uri"
-        ],
+        "required": [],
         "type": "object"
       },
       "safety": {
@@ -665,6 +744,26 @@
       "name": "packet",
       "outputSchema": {
         "additionalProperties": false,
+        "anyOf": [
+          {
+            "required": [
+              "packet_id",
+              "question",
+              "plan",
+              "answer",
+              "budget",
+              "support",
+              "disposition",
+              "retrieval_trace_summary"
+            ]
+          },
+          {
+            "required": [
+              "code",
+              "message"
+            ]
+          }
+        ],
         "description": "CodeStory broad task packet DTO with compiled support units and a machine stop or one-round drill disposition.",
         "properties": {
           "answer": {
@@ -675,9 +774,43 @@
             "description": "Budget limits, usage, and truncation metadata.",
             "type": "object"
           },
+          "cause_code": {
+            "description": "Underlying activation or cache cause code.",
+            "type": "string"
+          },
+          "code": {
+            "description": "Typed stdio retry or unavailable code.",
+            "type": "string"
+          },
+          "details": {
+            "description": "Structured API error repair guidance.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "diagnostics_uri": {
+            "description": "Optional full diagnostic resource URI.",
+            "type": "string"
+          },
           "disposition": {
             "description": "Machine stop or one-round drill decision: supported, drill_once, not_established, or unavailable.",
             "type": "object"
+          },
+          "message": {
+            "description": "Human-readable retry or unavailable message.",
+            "type": "string"
+          },
+          "next_action": {
+            "description": "Direct next action for the caller.",
+            "type": "string"
+          },
+          "operation": {
+            "description": "Current managed preparation operation.",
+            "type": [
+              "object",
+              "null"
+            ]
           },
           "packet_id": {
             "description": "Stable packet id.",
@@ -691,9 +824,58 @@
             "description": "Packet question.",
             "type": "string"
           },
+          "recommended_next_calls": {
+            "description": "Host-executable retries of the intended tool.",
+            "items": {
+              "additionalProperties": false,
+              "description": "Host-executable retry of the same tool after a preparing delay.",
+              "properties": {
+                "after_ms": {
+                  "description": "Delay before retry.",
+                  "type": "integer"
+                },
+                "arguments": {
+                  "description": "Original tool arguments.",
+                  "type": "object"
+                },
+                "method": {
+                  "description": "JSON-RPC method.",
+                  "type": "string"
+                },
+                "tool": {
+                  "description": "Tool to retry.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "method",
+                "tool"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
           "retrieval_trace_summary": {
             "description": "Compact retrieval trace telemetry summary.",
             "type": "object"
+          },
+          "retry_after_ms": {
+            "description": "Retry delay while preparing.",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "retry_tool": {
+            "description": "Tool to retry when the envelope is preparing.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "state": {
+            "description": "preparing, unavailable, or cancelled.",
+            "type": "string"
           },
           "support": {
             "description": "Compiled evidence atoms: symbol locations, source ranges, typed graph edges, and complete-query negatives.",
@@ -780,18 +962,13 @@
               "string",
               "null"
             ]
+          },
+          "tool": {
+            "description": "Tool that produced this envelope.",
+            "type": "string"
           }
         },
-        "required": [
-          "packet_id",
-          "question",
-          "plan",
-          "answer",
-          "budget",
-          "support",
-          "disposition",
-          "retrieval_trace_summary"
-        ],
+        "required": [],
         "type": "object"
       },
       "safety": {
@@ -876,6 +1053,10 @@
         ],
         "description": "CodeStory discovery results DTO. Treat broad structural questions as packet-first; search rows select candidates for proof-bearing graph/source follow-up.",
         "properties": {
+          "cause_code": {
+            "description": "Underlying activation or cache cause code.",
+            "type": "string"
+          },
           "code": {
             "description": "Typed API error code.",
             "type": "string"
@@ -890,6 +1071,10 @@
               "object",
               "null"
             ]
+          },
+          "diagnostics_uri": {
+            "description": "Optional full diagnostic resource URI.",
+            "type": "string"
           },
           "hits": {
             "description": "Merged hit list.",
@@ -1060,6 +1245,17 @@
             "description": "Human-readable API error message.",
             "type": "string"
           },
+          "next_action": {
+            "description": "Direct next action for the caller.",
+            "type": "string"
+          },
+          "operation": {
+            "description": "Current managed preparation operation.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
           "query": {
             "description": "Search query.",
             "type": "string"
@@ -1070,6 +1266,37 @@
               "object",
               "null"
             ]
+          },
+          "recommended_next_calls": {
+            "description": "Host-executable retries of the intended tool.",
+            "items": {
+              "additionalProperties": false,
+              "description": "Host-executable retry of the same tool after a preparing delay.",
+              "properties": {
+                "after_ms": {
+                  "description": "Delay before retry.",
+                  "type": "integer"
+                },
+                "arguments": {
+                  "description": "Original tool arguments.",
+                  "type": "object"
+                },
+                "method": {
+                  "description": "JSON-RPC method.",
+                  "type": "string"
+                },
+                "tool": {
+                  "description": "Tool to retry.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "method",
+                "tool"
+              ],
+              "type": "object"
+            },
+            "type": "array"
           },
           "repo_text_enabled": {
             "description": "Whether repo text search was enabled.",
@@ -1094,6 +1321,28 @@
           "retrieval": {
             "description": "Retrieval readiness.",
             "type": "object"
+          },
+          "retry_after_ms": {
+            "description": "Retry delay while preparing.",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "retry_tool": {
+            "description": "Tool to retry when the envelope is preparing.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "state": {
+            "description": "preparing, unavailable, or cancelled.",
+            "type": "string"
+          },
+          "tool": {
+            "description": "Tool that produced this envelope.",
+            "type": "string"
           }
         },
         "required": [],
@@ -1148,6 +1397,26 @@
       "name": "ground",
       "outputSchema": {
         "additionalProperties": false,
+        "anyOf": [
+          {
+            "required": [
+              "root",
+              "budget",
+              "generated_at_epoch_ms",
+              "stats",
+              "coverage",
+              "orientation",
+              "root_symbols",
+              "files"
+            ]
+          },
+          {
+            "required": [
+              "code",
+              "message"
+            ]
+          }
+        ],
         "description": "CodeStory grounding snapshot DTO for compact repository orientation.",
         "properties": {
           "budget": {
@@ -1157,6 +1426,14 @@
               "balanced",
               "max"
             ],
+            "type": "string"
+          },
+          "cause_code": {
+            "description": "Underlying activation or cache cause code.",
+            "type": "string"
+          },
+          "code": {
+            "description": "Typed stdio retry or unavailable code.",
             "type": "string"
           },
           "coverage": {
@@ -1174,6 +1451,17 @@
             },
             "type": "array"
           },
+          "details": {
+            "description": "Structured API error repair guidance.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "diagnostics_uri": {
+            "description": "Optional full diagnostic resource URI.",
+            "type": "string"
+          },
           "files": {
             "description": "File digests.",
             "items": {
@@ -1189,12 +1477,27 @@
             "description": "Snapshot generation time.",
             "type": "integer"
           },
+          "message": {
+            "description": "Human-readable retry or unavailable message.",
+            "type": "string"
+          },
+          "next_action": {
+            "description": "Direct next action for the caller.",
+            "type": "string"
+          },
           "notes": {
             "description": "Grounding notes.",
             "items": {
               "type": "string"
             },
             "type": "array"
+          },
+          "operation": {
+            "description": "Current managed preparation operation.",
+            "type": [
+              "object",
+              "null"
+            ]
           },
           "orientation": {
             "additionalProperties": false,
@@ -1262,12 +1565,57 @@
             ],
             "type": "object"
           },
+          "recommended_next_calls": {
+            "description": "Host-executable retries of the intended tool.",
+            "items": {
+              "additionalProperties": false,
+              "description": "Host-executable retry of the same tool after a preparing delay.",
+              "properties": {
+                "after_ms": {
+                  "description": "Delay before retry.",
+                  "type": "integer"
+                },
+                "arguments": {
+                  "description": "Original tool arguments.",
+                  "type": "object"
+                },
+                "method": {
+                  "description": "JSON-RPC method.",
+                  "type": "string"
+                },
+                "tool": {
+                  "description": "Tool to retry.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "method",
+                "tool"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
           "recommended_queries": {
             "description": "Suggested follow-up queries.",
             "items": {
               "type": "string"
             },
             "type": "array"
+          },
+          "retry_after_ms": {
+            "description": "Retry delay while preparing.",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "retry_tool": {
+            "description": "Tool to retry when the envelope is preparing.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "root": {
             "description": "Project root.",
@@ -1284,21 +1632,20 @@
             },
             "type": "array"
           },
+          "state": {
+            "description": "preparing, unavailable, or cancelled.",
+            "type": "string"
+          },
           "stats": {
             "description": "Indexed project stats.",
             "type": "object"
+          },
+          "tool": {
+            "description": "Tool that produced this envelope.",
+            "type": "string"
           }
         },
-        "required": [
-          "root",
-          "budget",
-          "generated_at_epoch_ms",
-          "stats",
-          "coverage",
-          "orientation",
-          "root_symbols",
-          "files"
-        ],
+        "required": [],
         "type": "object"
       },
       "safety": {
@@ -1385,6 +1732,10 @@
         ],
         "description": "Indexed file inventory and coverage summary.",
         "properties": {
+          "cause_code": {
+            "description": "Underlying activation or cache cause code.",
+            "type": "string"
+          },
           "code": {
             "description": "Typed API error code.",
             "type": "string"
@@ -1444,6 +1795,10 @@
               "null"
             ]
           },
+          "diagnostics_uri": {
+            "description": "Optional full diagnostic resource URI.",
+            "type": "string"
+          },
           "files": {
             "description": "Indexed file rows.",
             "items": {
@@ -1501,6 +1856,17 @@
           "message": {
             "description": "Human-readable API error message.",
             "type": "string"
+          },
+          "next_action": {
+            "description": "Direct next action for the caller.",
+            "type": "string"
+          },
+          "operation": {
+            "description": "Current managed preparation operation.",
+            "type": [
+              "object",
+              "null"
+            ]
           },
           "policy_exclusions": {
             "description": "Verified policy exclusions without graph or semantic coverage.",
@@ -1596,9 +1962,62 @@
             "description": "Project root.",
             "type": "string"
           },
+          "recommended_next_calls": {
+            "description": "Host-executable retries of the intended tool.",
+            "items": {
+              "additionalProperties": false,
+              "description": "Host-executable retry of the same tool after a preparing delay.",
+              "properties": {
+                "after_ms": {
+                  "description": "Delay before retry.",
+                  "type": "integer"
+                },
+                "arguments": {
+                  "description": "Original tool arguments.",
+                  "type": "object"
+                },
+                "method": {
+                  "description": "JSON-RPC method.",
+                  "type": "string"
+                },
+                "tool": {
+                  "description": "Tool to retry.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "method",
+                "tool"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "retry_after_ms": {
+            "description": "Retry delay while preparing.",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "retry_tool": {
+            "description": "Tool to retry when the envelope is preparing.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "state": {
+            "description": "preparing, unavailable, or cancelled.",
+            "type": "string"
+          },
           "summary": {
             "description": "Indexed file summary DTO.",
             "type": "object"
+          },
+          "tool": {
+            "description": "Tool that produced this envelope.",
+            "type": "string"
           },
           "usable": {
             "description": "Whether the index has usable files.",
@@ -1812,6 +2231,10 @@
             ],
             "type": "object"
           },
+          "cause_code": {
+            "description": "Underlying activation or cache cause code.",
+            "type": "string"
+          },
           "change_records": {
             "description": "Normalized changed file records.",
             "items": {
@@ -1938,6 +2361,10 @@
               "object",
               "null"
             ]
+          },
+          "diagnostics_uri": {
+            "description": "Optional full diagnostic resource URI.",
+            "type": "string"
           },
           "follow_ups": {
             "description": "Evidence-derived follow-up actions with optional structured invocations.",
@@ -2109,6 +2536,10 @@
             "description": "Human-readable API error message.",
             "type": "string"
           },
+          "next_action": {
+            "description": "Direct next action for the caller.",
+            "type": "string"
+          },
           "notes": {
             "description": "Additional analysis notes.",
             "items": {
@@ -2116,8 +2547,68 @@
             },
             "type": "array"
           },
+          "operation": {
+            "description": "Current managed preparation operation.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
           "project_root": {
             "description": "Project root.",
+            "type": "string"
+          },
+          "recommended_next_calls": {
+            "description": "Host-executable retries of the intended tool.",
+            "items": {
+              "additionalProperties": false,
+              "description": "Host-executable retry of the same tool after a preparing delay.",
+              "properties": {
+                "after_ms": {
+                  "description": "Delay before retry.",
+                  "type": "integer"
+                },
+                "arguments": {
+                  "description": "Original tool arguments.",
+                  "type": "object"
+                },
+                "method": {
+                  "description": "JSON-RPC method.",
+                  "type": "string"
+                },
+                "tool": {
+                  "description": "Tool to retry.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "method",
+                "tool"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "retry_after_ms": {
+            "description": "Retry delay while preparing.",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "retry_tool": {
+            "description": "Tool to retry when the envelope is preparing.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "state": {
+            "description": "preparing, unavailable, or cancelled.",
+            "type": "string"
+          },
+          "tool": {
+            "description": "Tool that produced this envelope.",
             "type": "string"
           },
           "truncated": {
@@ -2315,8 +2806,28 @@
       "name": "symbol",
       "outputSchema": {
         "additionalProperties": false,
+        "anyOf": [
+          {
+            "required": [
+              "node",
+              "children",
+              "related_hits",
+              "edge_digest"
+            ]
+          },
+          {
+            "required": [
+              "code",
+              "message"
+            ]
+          }
+        ],
         "description": "CodeStory symbol context DTO.",
         "properties": {
+          "cause_code": {
+            "description": "Underlying activation or cache cause code.",
+            "type": "string"
+          },
           "children": {
             "description": "Child symbol summaries.",
             "items": {
@@ -2358,6 +2869,21 @@
             },
             "type": "array"
           },
+          "code": {
+            "description": "Typed stdio retry or unavailable code.",
+            "type": "string"
+          },
+          "details": {
+            "description": "Structured API error repair guidance.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "diagnostics_uri": {
+            "description": "Optional full diagnostic resource URI.",
+            "type": "string"
+          },
           "edge_digest": {
             "description": "Readable edge digest entries.",
             "items": {
@@ -2365,9 +2891,55 @@
             },
             "type": "array"
           },
+          "message": {
+            "description": "Human-readable retry or unavailable message.",
+            "type": "string"
+          },
+          "next_action": {
+            "description": "Direct next action for the caller.",
+            "type": "string"
+          },
           "node": {
             "description": "Node details DTO.",
             "type": "object"
+          },
+          "operation": {
+            "description": "Current managed preparation operation.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "recommended_next_calls": {
+            "description": "Host-executable retries of the intended tool.",
+            "items": {
+              "additionalProperties": false,
+              "description": "Host-executable retry of the same tool after a preparing delay.",
+              "properties": {
+                "after_ms": {
+                  "description": "Delay before retry.",
+                  "type": "integer"
+                },
+                "arguments": {
+                  "description": "Original tool arguments.",
+                  "type": "object"
+                },
+                "method": {
+                  "description": "JSON-RPC method.",
+                  "type": "string"
+                },
+                "tool": {
+                  "description": "Tool to retry.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "method",
+                "tool"
+              ],
+              "type": "object"
+            },
+            "type": "array"
           },
           "related_hits": {
             "description": "Related search hits.",
@@ -2530,20 +3102,37 @@
             },
             "type": "array"
           },
+          "retry_after_ms": {
+            "description": "Retry delay while preparing.",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "retry_tool": {
+            "description": "Tool to retry when the envelope is preparing.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "state": {
+            "description": "preparing, unavailable, or cancelled.",
+            "type": "string"
+          },
           "summary": {
             "description": "Optional generated summary.",
             "type": [
               "string",
               "null"
             ]
+          },
+          "tool": {
+            "description": "Tool that produced this envelope.",
+            "type": "string"
           }
         },
-        "required": [
-          "node",
-          "children",
-          "related_hits",
-          "edge_digest"
-        ],
+        "required": [],
         "type": "object"
       },
       "safety": {
@@ -2642,11 +3231,108 @@
       "name": "trail",
       "outputSchema": {
         "additionalProperties": false,
+        "anyOf": [
+          {
+            "required": [
+              "focus",
+              "trail"
+            ]
+          },
+          {
+            "required": [
+              "code",
+              "message"
+            ]
+          }
+        ],
         "description": "CodeStory trail context DTO.",
         "properties": {
+          "cause_code": {
+            "description": "Underlying activation or cache cause code.",
+            "type": "string"
+          },
+          "code": {
+            "description": "Typed stdio retry or unavailable code.",
+            "type": "string"
+          },
+          "details": {
+            "description": "Structured API error repair guidance.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "diagnostics_uri": {
+            "description": "Optional full diagnostic resource URI.",
+            "type": "string"
+          },
           "focus": {
             "description": "Focused node details DTO.",
             "type": "object"
+          },
+          "message": {
+            "description": "Human-readable retry or unavailable message.",
+            "type": "string"
+          },
+          "next_action": {
+            "description": "Direct next action for the caller.",
+            "type": "string"
+          },
+          "operation": {
+            "description": "Current managed preparation operation.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "recommended_next_calls": {
+            "description": "Host-executable retries of the intended tool.",
+            "items": {
+              "additionalProperties": false,
+              "description": "Host-executable retry of the same tool after a preparing delay.",
+              "properties": {
+                "after_ms": {
+                  "description": "Delay before retry.",
+                  "type": "integer"
+                },
+                "arguments": {
+                  "description": "Original tool arguments.",
+                  "type": "object"
+                },
+                "method": {
+                  "description": "JSON-RPC method.",
+                  "type": "string"
+                },
+                "tool": {
+                  "description": "Tool to retry.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "method",
+                "tool"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "retry_after_ms": {
+            "description": "Retry delay while preparing.",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "retry_tool": {
+            "description": "Tool to retry when the envelope is preparing.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "state": {
+            "description": "preparing, unavailable, or cancelled.",
+            "type": "string"
           },
           "story": {
             "description": "Optional readable trail story DTO.",
@@ -2655,15 +3341,16 @@
               "null"
             ]
           },
+          "tool": {
+            "description": "Tool that produced this envelope.",
+            "type": "string"
+          },
           "trail": {
             "description": "Graph response DTO.",
             "type": "object"
           }
         },
-        "required": [
-          "focus",
-          "trail"
-        ],
+        "required": [],
         "type": "object"
       },
       "safety": {
@@ -2747,10 +3434,47 @@
       "name": "callers",
       "outputSchema": {
         "additionalProperties": false,
+        "anyOf": [
+          {
+            "required": [
+              "certainty",
+              "file_refs",
+              "limits",
+              "node_count",
+              "edge_count",
+              "truncated"
+            ]
+          },
+          {
+            "required": [
+              "code",
+              "message"
+            ]
+          }
+        ],
         "description": "Bounded CodeStory graph primitive output.",
         "properties": {
+          "cause_code": {
+            "description": "Underlying activation or cache cause code.",
+            "type": "string"
+          },
           "certainty": {
             "description": "Overall certainty note.",
+            "type": "string"
+          },
+          "code": {
+            "description": "Typed stdio retry or unavailable code.",
+            "type": "string"
+          },
+          "details": {
+            "description": "Structured API error repair guidance.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "diagnostics_uri": {
+            "description": "Optional full diagnostic resource URI.",
             "type": "string"
           },
           "edge_count": {
@@ -2779,6 +3503,14 @@
             "description": "Applied bounds for this graph primitive.",
             "type": "object"
           },
+          "message": {
+            "description": "Human-readable retry or unavailable message.",
+            "type": "string"
+          },
+          "next_action": {
+            "description": "Direct next action for the caller.",
+            "type": "string"
+          },
           "node": {
             "description": "Node details DTO.",
             "type": [
@@ -2790,6 +3522,44 @@
             "description": "Returned node count.",
             "type": "integer"
           },
+          "operation": {
+            "description": "Current managed preparation operation.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "recommended_next_calls": {
+            "description": "Host-executable retries of the intended tool.",
+            "items": {
+              "additionalProperties": false,
+              "description": "Host-executable retry of the same tool after a preparing delay.",
+              "properties": {
+                "after_ms": {
+                  "description": "Delay before retry.",
+                  "type": "integer"
+                },
+                "arguments": {
+                  "description": "Original tool arguments.",
+                  "type": "object"
+                },
+                "method": {
+                  "description": "JSON-RPC method.",
+                  "type": "string"
+                },
+                "tool": {
+                  "description": "Tool to retry.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "method",
+                "tool"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
           "resolution": {
             "description": "Optional query resolution metadata.",
             "type": [
@@ -2797,19 +3567,34 @@
               "null"
             ]
           },
+          "retry_after_ms": {
+            "description": "Retry delay while preparing.",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "retry_tool": {
+            "description": "Tool to retry when the envelope is preparing.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "state": {
+            "description": "preparing, unavailable, or cancelled.",
+            "type": "string"
+          },
+          "tool": {
+            "description": "Tool that produced this envelope.",
+            "type": "string"
+          },
           "truncated": {
             "description": "Whether the graph result was truncated.",
             "type": "boolean"
           }
         },
-        "required": [
-          "certainty",
-          "file_refs",
-          "limits",
-          "node_count",
-          "edge_count",
-          "truncated"
-        ],
+        "required": [],
         "type": "object"
       },
       "safety": {
@@ -2893,10 +3678,47 @@
       "name": "callees",
       "outputSchema": {
         "additionalProperties": false,
+        "anyOf": [
+          {
+            "required": [
+              "certainty",
+              "file_refs",
+              "limits",
+              "node_count",
+              "edge_count",
+              "truncated"
+            ]
+          },
+          {
+            "required": [
+              "code",
+              "message"
+            ]
+          }
+        ],
         "description": "Bounded CodeStory graph primitive output.",
         "properties": {
+          "cause_code": {
+            "description": "Underlying activation or cache cause code.",
+            "type": "string"
+          },
           "certainty": {
             "description": "Overall certainty note.",
+            "type": "string"
+          },
+          "code": {
+            "description": "Typed stdio retry or unavailable code.",
+            "type": "string"
+          },
+          "details": {
+            "description": "Structured API error repair guidance.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "diagnostics_uri": {
+            "description": "Optional full diagnostic resource URI.",
             "type": "string"
           },
           "edge_count": {
@@ -2925,6 +3747,14 @@
             "description": "Applied bounds for this graph primitive.",
             "type": "object"
           },
+          "message": {
+            "description": "Human-readable retry or unavailable message.",
+            "type": "string"
+          },
+          "next_action": {
+            "description": "Direct next action for the caller.",
+            "type": "string"
+          },
           "node": {
             "description": "Node details DTO.",
             "type": [
@@ -2936,6 +3766,44 @@
             "description": "Returned node count.",
             "type": "integer"
           },
+          "operation": {
+            "description": "Current managed preparation operation.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "recommended_next_calls": {
+            "description": "Host-executable retries of the intended tool.",
+            "items": {
+              "additionalProperties": false,
+              "description": "Host-executable retry of the same tool after a preparing delay.",
+              "properties": {
+                "after_ms": {
+                  "description": "Delay before retry.",
+                  "type": "integer"
+                },
+                "arguments": {
+                  "description": "Original tool arguments.",
+                  "type": "object"
+                },
+                "method": {
+                  "description": "JSON-RPC method.",
+                  "type": "string"
+                },
+                "tool": {
+                  "description": "Tool to retry.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "method",
+                "tool"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
           "resolution": {
             "description": "Optional query resolution metadata.",
             "type": [
@@ -2943,19 +3811,34 @@
               "null"
             ]
           },
+          "retry_after_ms": {
+            "description": "Retry delay while preparing.",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "retry_tool": {
+            "description": "Tool to retry when the envelope is preparing.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "state": {
+            "description": "preparing, unavailable, or cancelled.",
+            "type": "string"
+          },
+          "tool": {
+            "description": "Tool that produced this envelope.",
+            "type": "string"
+          },
           "truncated": {
             "description": "Whether the graph result was truncated.",
             "type": "boolean"
           }
         },
-        "required": [
-          "certainty",
-          "file_refs",
-          "limits",
-          "node_count",
-          "edge_count",
-          "truncated"
-        ],
+        "required": [],
         "type": "object"
       },
       "safety": {
@@ -3054,11 +3937,108 @@
       "name": "trace",
       "outputSchema": {
         "additionalProperties": false,
+        "anyOf": [
+          {
+            "required": [
+              "focus",
+              "trail"
+            ]
+          },
+          {
+            "required": [
+              "code",
+              "message"
+            ]
+          }
+        ],
         "description": "CodeStory trail context DTO.",
         "properties": {
+          "cause_code": {
+            "description": "Underlying activation or cache cause code.",
+            "type": "string"
+          },
+          "code": {
+            "description": "Typed stdio retry or unavailable code.",
+            "type": "string"
+          },
+          "details": {
+            "description": "Structured API error repair guidance.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "diagnostics_uri": {
+            "description": "Optional full diagnostic resource URI.",
+            "type": "string"
+          },
           "focus": {
             "description": "Focused node details DTO.",
             "type": "object"
+          },
+          "message": {
+            "description": "Human-readable retry or unavailable message.",
+            "type": "string"
+          },
+          "next_action": {
+            "description": "Direct next action for the caller.",
+            "type": "string"
+          },
+          "operation": {
+            "description": "Current managed preparation operation.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "recommended_next_calls": {
+            "description": "Host-executable retries of the intended tool.",
+            "items": {
+              "additionalProperties": false,
+              "description": "Host-executable retry of the same tool after a preparing delay.",
+              "properties": {
+                "after_ms": {
+                  "description": "Delay before retry.",
+                  "type": "integer"
+                },
+                "arguments": {
+                  "description": "Original tool arguments.",
+                  "type": "object"
+                },
+                "method": {
+                  "description": "JSON-RPC method.",
+                  "type": "string"
+                },
+                "tool": {
+                  "description": "Tool to retry.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "method",
+                "tool"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "retry_after_ms": {
+            "description": "Retry delay while preparing.",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "retry_tool": {
+            "description": "Tool to retry when the envelope is preparing.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "state": {
+            "description": "preparing, unavailable, or cancelled.",
+            "type": "string"
           },
           "story": {
             "description": "Optional readable trail story DTO.",
@@ -3067,15 +4047,16 @@
               "null"
             ]
           },
+          "tool": {
+            "description": "Tool that produced this envelope.",
+            "type": "string"
+          },
           "trail": {
             "description": "Graph response DTO.",
             "type": "object"
           }
         },
-        "required": [
-          "focus",
-          "trail"
-        ],
+        "required": [],
         "type": "object"
       },
       "safety": {
@@ -3145,10 +4126,47 @@
       "name": "get_node",
       "outputSchema": {
         "additionalProperties": false,
+        "anyOf": [
+          {
+            "required": [
+              "certainty",
+              "file_refs",
+              "limits",
+              "node_count",
+              "edge_count",
+              "truncated"
+            ]
+          },
+          {
+            "required": [
+              "code",
+              "message"
+            ]
+          }
+        ],
         "description": "Bounded CodeStory graph primitive output.",
         "properties": {
+          "cause_code": {
+            "description": "Underlying activation or cache cause code.",
+            "type": "string"
+          },
           "certainty": {
             "description": "Overall certainty note.",
+            "type": "string"
+          },
+          "code": {
+            "description": "Typed stdio retry or unavailable code.",
+            "type": "string"
+          },
+          "details": {
+            "description": "Structured API error repair guidance.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "diagnostics_uri": {
+            "description": "Optional full diagnostic resource URI.",
             "type": "string"
           },
           "edge_count": {
@@ -3177,6 +4195,14 @@
             "description": "Applied bounds for this graph primitive.",
             "type": "object"
           },
+          "message": {
+            "description": "Human-readable retry or unavailable message.",
+            "type": "string"
+          },
+          "next_action": {
+            "description": "Direct next action for the caller.",
+            "type": "string"
+          },
           "node": {
             "description": "Node details DTO.",
             "type": [
@@ -3188,6 +4214,44 @@
             "description": "Returned node count.",
             "type": "integer"
           },
+          "operation": {
+            "description": "Current managed preparation operation.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "recommended_next_calls": {
+            "description": "Host-executable retries of the intended tool.",
+            "items": {
+              "additionalProperties": false,
+              "description": "Host-executable retry of the same tool after a preparing delay.",
+              "properties": {
+                "after_ms": {
+                  "description": "Delay before retry.",
+                  "type": "integer"
+                },
+                "arguments": {
+                  "description": "Original tool arguments.",
+                  "type": "object"
+                },
+                "method": {
+                  "description": "JSON-RPC method.",
+                  "type": "string"
+                },
+                "tool": {
+                  "description": "Tool to retry.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "method",
+                "tool"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
           "resolution": {
             "description": "Optional query resolution metadata.",
             "type": [
@@ -3195,19 +4259,34 @@
               "null"
             ]
           },
+          "retry_after_ms": {
+            "description": "Retry delay while preparing.",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "retry_tool": {
+            "description": "Tool to retry when the envelope is preparing.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "state": {
+            "description": "preparing, unavailable, or cancelled.",
+            "type": "string"
+          },
+          "tool": {
+            "description": "Tool that produced this envelope.",
+            "type": "string"
+          },
           "truncated": {
             "description": "Whether the graph result was truncated.",
             "type": "boolean"
           }
         },
-        "required": [
-          "certainty",
-          "file_refs",
-          "limits",
-          "node_count",
-          "edge_count",
-          "truncated"
-        ],
+        "required": [],
         "type": "object"
       },
       "safety": {
@@ -3301,10 +4380,47 @@
       "name": "neighbors",
       "outputSchema": {
         "additionalProperties": false,
+        "anyOf": [
+          {
+            "required": [
+              "certainty",
+              "file_refs",
+              "limits",
+              "node_count",
+              "edge_count",
+              "truncated"
+            ]
+          },
+          {
+            "required": [
+              "code",
+              "message"
+            ]
+          }
+        ],
         "description": "Bounded CodeStory graph primitive output.",
         "properties": {
+          "cause_code": {
+            "description": "Underlying activation or cache cause code.",
+            "type": "string"
+          },
           "certainty": {
             "description": "Overall certainty note.",
+            "type": "string"
+          },
+          "code": {
+            "description": "Typed stdio retry or unavailable code.",
+            "type": "string"
+          },
+          "details": {
+            "description": "Structured API error repair guidance.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "diagnostics_uri": {
+            "description": "Optional full diagnostic resource URI.",
             "type": "string"
           },
           "edge_count": {
@@ -3333,6 +4449,14 @@
             "description": "Applied bounds for this graph primitive.",
             "type": "object"
           },
+          "message": {
+            "description": "Human-readable retry or unavailable message.",
+            "type": "string"
+          },
+          "next_action": {
+            "description": "Direct next action for the caller.",
+            "type": "string"
+          },
           "node": {
             "description": "Node details DTO.",
             "type": [
@@ -3344,6 +4468,44 @@
             "description": "Returned node count.",
             "type": "integer"
           },
+          "operation": {
+            "description": "Current managed preparation operation.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "recommended_next_calls": {
+            "description": "Host-executable retries of the intended tool.",
+            "items": {
+              "additionalProperties": false,
+              "description": "Host-executable retry of the same tool after a preparing delay.",
+              "properties": {
+                "after_ms": {
+                  "description": "Delay before retry.",
+                  "type": "integer"
+                },
+                "arguments": {
+                  "description": "Original tool arguments.",
+                  "type": "object"
+                },
+                "method": {
+                  "description": "JSON-RPC method.",
+                  "type": "string"
+                },
+                "tool": {
+                  "description": "Tool to retry.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "method",
+                "tool"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
           "resolution": {
             "description": "Optional query resolution metadata.",
             "type": [
@@ -3351,19 +4513,34 @@
               "null"
             ]
           },
+          "retry_after_ms": {
+            "description": "Retry delay while preparing.",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "retry_tool": {
+            "description": "Tool to retry when the envelope is preparing.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "state": {
+            "description": "preparing, unavailable, or cancelled.",
+            "type": "string"
+          },
+          "tool": {
+            "description": "Tool that produced this envelope.",
+            "type": "string"
+          },
           "truncated": {
             "description": "Whether the graph result was truncated.",
             "type": "boolean"
           }
         },
-        "required": [
-          "certainty",
-          "file_refs",
-          "limits",
-          "node_count",
-          "edge_count",
-          "truncated"
-        ],
+        "required": [],
         "type": "object"
       },
       "safety": {
@@ -3431,10 +4608,47 @@
       "name": "shortest_path",
       "outputSchema": {
         "additionalProperties": false,
+        "anyOf": [
+          {
+            "required": [
+              "certainty",
+              "file_refs",
+              "limits",
+              "node_count",
+              "edge_count",
+              "truncated"
+            ]
+          },
+          {
+            "required": [
+              "code",
+              "message"
+            ]
+          }
+        ],
         "description": "Bounded CodeStory graph primitive output.",
         "properties": {
+          "cause_code": {
+            "description": "Underlying activation or cache cause code.",
+            "type": "string"
+          },
           "certainty": {
             "description": "Overall certainty note.",
+            "type": "string"
+          },
+          "code": {
+            "description": "Typed stdio retry or unavailable code.",
+            "type": "string"
+          },
+          "details": {
+            "description": "Structured API error repair guidance.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "diagnostics_uri": {
+            "description": "Optional full diagnostic resource URI.",
             "type": "string"
           },
           "edge_count": {
@@ -3463,6 +4677,14 @@
             "description": "Applied bounds for this graph primitive.",
             "type": "object"
           },
+          "message": {
+            "description": "Human-readable retry or unavailable message.",
+            "type": "string"
+          },
+          "next_action": {
+            "description": "Direct next action for the caller.",
+            "type": "string"
+          },
           "node": {
             "description": "Node details DTO.",
             "type": [
@@ -3474,6 +4696,44 @@
             "description": "Returned node count.",
             "type": "integer"
           },
+          "operation": {
+            "description": "Current managed preparation operation.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "recommended_next_calls": {
+            "description": "Host-executable retries of the intended tool.",
+            "items": {
+              "additionalProperties": false,
+              "description": "Host-executable retry of the same tool after a preparing delay.",
+              "properties": {
+                "after_ms": {
+                  "description": "Delay before retry.",
+                  "type": "integer"
+                },
+                "arguments": {
+                  "description": "Original tool arguments.",
+                  "type": "object"
+                },
+                "method": {
+                  "description": "JSON-RPC method.",
+                  "type": "string"
+                },
+                "tool": {
+                  "description": "Tool to retry.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "method",
+                "tool"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
           "resolution": {
             "description": "Optional query resolution metadata.",
             "type": [
@@ -3481,19 +4741,34 @@
               "null"
             ]
           },
+          "retry_after_ms": {
+            "description": "Retry delay while preparing.",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "retry_tool": {
+            "description": "Tool to retry when the envelope is preparing.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "state": {
+            "description": "preparing, unavailable, or cancelled.",
+            "type": "string"
+          },
+          "tool": {
+            "description": "Tool that produced this envelope.",
+            "type": "string"
+          },
           "truncated": {
             "description": "Whether the graph result was truncated.",
             "type": "boolean"
           }
         },
-        "required": [
-          "certainty",
-          "file_refs",
-          "limits",
-          "node_count",
-          "edge_count",
-          "truncated"
-        ],
+        "required": [],
         "type": "object"
       },
       "safety": {
@@ -3587,10 +4862,47 @@
       "name": "query_subgraph",
       "outputSchema": {
         "additionalProperties": false,
+        "anyOf": [
+          {
+            "required": [
+              "certainty",
+              "file_refs",
+              "limits",
+              "node_count",
+              "edge_count",
+              "truncated"
+            ]
+          },
+          {
+            "required": [
+              "code",
+              "message"
+            ]
+          }
+        ],
         "description": "Bounded CodeStory graph primitive output.",
         "properties": {
+          "cause_code": {
+            "description": "Underlying activation or cache cause code.",
+            "type": "string"
+          },
           "certainty": {
             "description": "Overall certainty note.",
+            "type": "string"
+          },
+          "code": {
+            "description": "Typed stdio retry or unavailable code.",
+            "type": "string"
+          },
+          "details": {
+            "description": "Structured API error repair guidance.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "diagnostics_uri": {
+            "description": "Optional full diagnostic resource URI.",
             "type": "string"
           },
           "edge_count": {
@@ -3619,6 +4931,14 @@
             "description": "Applied bounds for this graph primitive.",
             "type": "object"
           },
+          "message": {
+            "description": "Human-readable retry or unavailable message.",
+            "type": "string"
+          },
+          "next_action": {
+            "description": "Direct next action for the caller.",
+            "type": "string"
+          },
           "node": {
             "description": "Node details DTO.",
             "type": [
@@ -3630,6 +4950,44 @@
             "description": "Returned node count.",
             "type": "integer"
           },
+          "operation": {
+            "description": "Current managed preparation operation.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "recommended_next_calls": {
+            "description": "Host-executable retries of the intended tool.",
+            "items": {
+              "additionalProperties": false,
+              "description": "Host-executable retry of the same tool after a preparing delay.",
+              "properties": {
+                "after_ms": {
+                  "description": "Delay before retry.",
+                  "type": "integer"
+                },
+                "arguments": {
+                  "description": "Original tool arguments.",
+                  "type": "object"
+                },
+                "method": {
+                  "description": "JSON-RPC method.",
+                  "type": "string"
+                },
+                "tool": {
+                  "description": "Tool to retry.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "method",
+                "tool"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
           "resolution": {
             "description": "Optional query resolution metadata.",
             "type": [
@@ -3637,19 +4995,34 @@
               "null"
             ]
           },
+          "retry_after_ms": {
+            "description": "Retry delay while preparing.",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "retry_tool": {
+            "description": "Tool to retry when the envelope is preparing.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "state": {
+            "description": "preparing, unavailable, or cancelled.",
+            "type": "string"
+          },
+          "tool": {
+            "description": "Tool that produced this envelope.",
+            "type": "string"
+          },
           "truncated": {
             "description": "Whether the graph result was truncated.",
             "type": "boolean"
           }
         },
-        "required": [
-          "certainty",
-          "file_refs",
-          "limits",
-          "node_count",
-          "edge_count",
-          "truncated"
-        ],
+        "required": [],
         "type": "object"
       },
       "safety": {
@@ -3719,11 +5092,45 @@
       "name": "definition",
       "outputSchema": {
         "additionalProperties": false,
+        "anyOf": [
+          {
+            "required": [
+              "resolution",
+              "definition",
+              "symbol"
+            ]
+          },
+          {
+            "required": [
+              "code",
+              "message"
+            ]
+          }
+        ],
         "description": "CodeStory definition tool output.",
         "properties": {
+          "cause_code": {
+            "description": "Underlying activation or cache cause code.",
+            "type": "string"
+          },
+          "code": {
+            "description": "Typed stdio retry or unavailable code.",
+            "type": "string"
+          },
           "definition": {
             "description": "Resolved definition search hit.",
             "type": "object"
+          },
+          "details": {
+            "description": "Structured API error repair guidance.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "diagnostics_uri": {
+            "description": "Optional full diagnostic resource URI.",
+            "type": "string"
           },
           "links": {
             "description": "Continuation resource links for the resolved definition.",
@@ -3752,20 +5159,84 @@
             },
             "type": "array"
           },
+          "message": {
+            "description": "Human-readable retry or unavailable message.",
+            "type": "string"
+          },
+          "next_action": {
+            "description": "Direct next action for the caller.",
+            "type": "string"
+          },
+          "operation": {
+            "description": "Current managed preparation operation.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "recommended_next_calls": {
+            "description": "Host-executable retries of the intended tool.",
+            "items": {
+              "additionalProperties": false,
+              "description": "Host-executable retry of the same tool after a preparing delay.",
+              "properties": {
+                "after_ms": {
+                  "description": "Delay before retry.",
+                  "type": "integer"
+                },
+                "arguments": {
+                  "description": "Original tool arguments.",
+                  "type": "object"
+                },
+                "method": {
+                  "description": "JSON-RPC method.",
+                  "type": "string"
+                },
+                "tool": {
+                  "description": "Tool to retry.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "method",
+                "tool"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
           "resolution": {
             "description": "Query resolution metadata.",
             "type": "object"
           },
+          "retry_after_ms": {
+            "description": "Retry delay while preparing.",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "retry_tool": {
+            "description": "Tool to retry when the envelope is preparing.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "state": {
+            "description": "preparing, unavailable, or cancelled.",
+            "type": "string"
+          },
           "symbol": {
             "description": "Symbol context DTO.",
             "type": "object"
+          },
+          "tool": {
+            "description": "Tool that produced this envelope.",
+            "type": "string"
           }
         },
-        "required": [
-          "resolution",
-          "definition",
-          "symbol"
-        ],
+        "required": [],
         "type": "object"
       },
       "safety": {
@@ -3835,11 +5306,108 @@
       "name": "references",
       "outputSchema": {
         "additionalProperties": false,
+        "anyOf": [
+          {
+            "required": [
+              "focus",
+              "trail"
+            ]
+          },
+          {
+            "required": [
+              "code",
+              "message"
+            ]
+          }
+        ],
         "description": "CodeStory trail context DTO.",
         "properties": {
+          "cause_code": {
+            "description": "Underlying activation or cache cause code.",
+            "type": "string"
+          },
+          "code": {
+            "description": "Typed stdio retry or unavailable code.",
+            "type": "string"
+          },
+          "details": {
+            "description": "Structured API error repair guidance.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "diagnostics_uri": {
+            "description": "Optional full diagnostic resource URI.",
+            "type": "string"
+          },
           "focus": {
             "description": "Focused node details DTO.",
             "type": "object"
+          },
+          "message": {
+            "description": "Human-readable retry or unavailable message.",
+            "type": "string"
+          },
+          "next_action": {
+            "description": "Direct next action for the caller.",
+            "type": "string"
+          },
+          "operation": {
+            "description": "Current managed preparation operation.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "recommended_next_calls": {
+            "description": "Host-executable retries of the intended tool.",
+            "items": {
+              "additionalProperties": false,
+              "description": "Host-executable retry of the same tool after a preparing delay.",
+              "properties": {
+                "after_ms": {
+                  "description": "Delay before retry.",
+                  "type": "integer"
+                },
+                "arguments": {
+                  "description": "Original tool arguments.",
+                  "type": "object"
+                },
+                "method": {
+                  "description": "JSON-RPC method.",
+                  "type": "string"
+                },
+                "tool": {
+                  "description": "Tool to retry.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "method",
+                "tool"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "retry_after_ms": {
+            "description": "Retry delay while preparing.",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "retry_tool": {
+            "description": "Tool to retry when the envelope is preparing.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "state": {
+            "description": "preparing, unavailable, or cancelled.",
+            "type": "string"
           },
           "story": {
             "description": "Optional readable trail story DTO.",
@@ -3848,15 +5416,16 @@
               "null"
             ]
           },
+          "tool": {
+            "description": "Tool that produced this envelope.",
+            "type": "string"
+          },
           "trail": {
             "description": "Graph response DTO.",
             "type": "object"
           }
         },
-        "required": [
-          "focus",
-          "trail"
-        ],
+        "required": [],
         "type": "object"
       },
       "safety": {
@@ -3910,15 +5479,114 @@
       "name": "symbols",
       "outputSchema": {
         "additionalProperties": false,
+        "anyOf": [
+          {
+            "required": [
+              "symbols",
+              "returned_count",
+              "limit",
+              "truncated"
+            ]
+          },
+          {
+            "required": [
+              "code",
+              "message"
+            ]
+          }
+        ],
         "description": "CodeStory symbol list output.",
         "properties": {
+          "cause_code": {
+            "description": "Underlying activation or cache cause code.",
+            "type": "string"
+          },
+          "code": {
+            "description": "Typed stdio retry or unavailable code.",
+            "type": "string"
+          },
+          "details": {
+            "description": "Structured API error repair guidance.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "diagnostics_uri": {
+            "description": "Optional full diagnostic resource URI.",
+            "type": "string"
+          },
           "limit": {
             "description": "Applied result limit.",
             "type": "integer"
           },
+          "message": {
+            "description": "Human-readable retry or unavailable message.",
+            "type": "string"
+          },
+          "next_action": {
+            "description": "Direct next action for the caller.",
+            "type": "string"
+          },
+          "operation": {
+            "description": "Current managed preparation operation.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "recommended_next_calls": {
+            "description": "Host-executable retries of the intended tool.",
+            "items": {
+              "additionalProperties": false,
+              "description": "Host-executable retry of the same tool after a preparing delay.",
+              "properties": {
+                "after_ms": {
+                  "description": "Delay before retry.",
+                  "type": "integer"
+                },
+                "arguments": {
+                  "description": "Original tool arguments.",
+                  "type": "object"
+                },
+                "method": {
+                  "description": "JSON-RPC method.",
+                  "type": "string"
+                },
+                "tool": {
+                  "description": "Tool to retry.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "method",
+                "tool"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "retry_after_ms": {
+            "description": "Retry delay while preparing.",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "retry_tool": {
+            "description": "Tool to retry when the envelope is preparing.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "returned_count": {
             "description": "Symbol rows included in this response.",
             "type": "integer"
+          },
+          "state": {
+            "description": "preparing, unavailable, or cancelled.",
+            "type": "string"
           },
           "symbols": {
             "description": "Root or child symbol summaries.",
@@ -3961,17 +5629,16 @@
             },
             "type": "array"
           },
+          "tool": {
+            "description": "Tool that produced this envelope.",
+            "type": "string"
+          },
           "truncated": {
             "description": "Whether matching symbols exceeded the limit.",
             "type": "boolean"
           }
         },
-        "required": [
-          "symbols",
-          "returned_count",
-          "limit",
-          "truncated"
-        ],
+        "required": [],
         "type": "object"
       },
       "safety": {
@@ -4172,8 +5839,52 @@
       "name": "snippet",
       "outputSchema": {
         "additionalProperties": false,
-        "description": "CodeStory snippet context DTO.",
+        "anyOf": [
+          {
+            "required": [
+              "node",
+              "path",
+              "line",
+              "snippet",
+              "scope",
+              "requested_context",
+              "snippet_truncated"
+            ]
+          },
+          {
+            "required": [
+              "ranges",
+              "max_total_bytes"
+            ]
+          },
+          {
+            "required": [
+              "code",
+              "message"
+            ]
+          }
+        ],
+        "description": "CodeStory snippet context DTO, or a batched paths result.",
         "properties": {
+          "cause_code": {
+            "description": "Underlying activation or cache cause code.",
+            "type": "string"
+          },
+          "code": {
+            "description": "Typed stdio retry or unavailable code.",
+            "type": "string"
+          },
+          "details": {
+            "description": "Structured API error repair guidance.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "diagnostics_uri": {
+            "description": "Optional full diagnostic resource URI.",
+            "type": "string"
+          },
           "fallback_reason": {
             "description": "Reason function-body selection fell back to line context, when applicable.",
             "type": "string"
@@ -4189,9 +5900,28 @@
               "null"
             ]
           },
+          "max_total_bytes": {
+            "description": "Total byte cap for a batched paths call.",
+            "type": "integer"
+          },
+          "message": {
+            "description": "Human-readable retry or unavailable message.",
+            "type": "string"
+          },
+          "next_action": {
+            "description": "Direct next action for the caller.",
+            "type": "string"
+          },
           "node": {
             "description": "Node details DTO.",
             "type": "object"
+          },
+          "operation": {
+            "description": "Current managed preparation operation.",
+            "type": [
+              "object",
+              "null"
+            ]
           },
           "path": {
             "description": "Project-relative file path.",
@@ -4201,9 +5931,92 @@
             "description": "Source of the selected function-body range, when available.",
             "type": "string"
           },
+          "ranges": {
+            "description": "Requested source ranges from a batched paths call.",
+            "items": {
+              "additionalProperties": false,
+              "description": "One requested source range from a batched snippet.paths call.",
+              "properties": {
+                "end_line": {
+                  "description": "1-based last line.",
+                  "type": "integer"
+                },
+                "path": {
+                  "description": "Project-relative file path.",
+                  "type": "string"
+                },
+                "snippet": {
+                  "description": "Source snippet text.",
+                  "type": "string"
+                },
+                "snippet_truncated": {
+                  "description": "Whether this range hit a byte cap.",
+                  "type": "boolean"
+                },
+                "start_line": {
+                  "description": "1-based first line.",
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "path",
+                "start_line",
+                "end_line",
+                "snippet",
+                "snippet_truncated"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "recommended_next_calls": {
+            "description": "Host-executable retries of the intended tool.",
+            "items": {
+              "additionalProperties": false,
+              "description": "Host-executable retry of the same tool after a preparing delay.",
+              "properties": {
+                "after_ms": {
+                  "description": "Delay before retry.",
+                  "type": "integer"
+                },
+                "arguments": {
+                  "description": "Original tool arguments.",
+                  "type": "object"
+                },
+                "method": {
+                  "description": "JSON-RPC method.",
+                  "type": "string"
+                },
+                "tool": {
+                  "description": "Tool to retry.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "method",
+                "tool"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
           "requested_context": {
             "description": "Requested context line count.",
             "type": "integer"
+          },
+          "retry_after_ms": {
+            "description": "Retry delay while preparing.",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "retry_tool": {
+            "description": "Tool to retry when the envelope is preparing.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "scope": {
             "description": "Snippet scope.",
@@ -4221,20 +6034,20 @@
             "description": "Whether the snippet hit a byte cap.",
             "type": "boolean"
           },
+          "state": {
+            "description": "preparing, unavailable, or cancelled.",
+            "type": "string"
+          },
+          "tool": {
+            "description": "Tool that produced this envelope.",
+            "type": "string"
+          },
           "truncation_guidance": {
             "description": "Follow-up guidance when the snippet hit its byte cap.",
             "type": "string"
           }
         },
-        "required": [
-          "node",
-          "path",
-          "line",
-          "snippet",
-          "scope",
-          "requested_context",
-          "snippet_truncated"
-        ],
+        "required": [],
         "type": "object"
       },
       "safety": {
@@ -4320,8 +6133,33 @@
       "name": "context",
       "outputSchema": {
         "additionalProperties": false,
+        "anyOf": [
+          {
+            "required": [
+              "packet_id",
+              "target",
+              "summary",
+              "sections",
+              "citations",
+              "subgraph_ids",
+              "retrieval_version",
+              "graphs",
+              "retrieval_trace"
+            ]
+          },
+          {
+            "required": [
+              "code",
+              "message"
+            ]
+          }
+        ],
         "description": "CodeStory context packet DTO.",
         "properties": {
+          "cause_code": {
+            "description": "Underlying activation or cache cause code.",
+            "type": "string"
+          },
           "citations": {
             "description": "Evidence citations.",
             "items": {
@@ -4469,6 +6307,21 @@
             },
             "type": "array"
           },
+          "code": {
+            "description": "Typed stdio retry or unavailable code.",
+            "type": "string"
+          },
+          "details": {
+            "description": "Structured API error repair guidance.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "diagnostics_uri": {
+            "description": "Optional full diagnostic resource URI.",
+            "type": "string"
+          },
           "freshness": {
             "description": "Index freshness observation, when one was made.",
             "type": "object"
@@ -4484,9 +6337,55 @@
             },
             "type": "array"
           },
+          "message": {
+            "description": "Human-readable retry or unavailable message.",
+            "type": "string"
+          },
+          "next_action": {
+            "description": "Direct next action for the caller.",
+            "type": "string"
+          },
+          "operation": {
+            "description": "Current managed preparation operation.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
           "packet_id": {
             "description": "Stable context packet id.",
             "type": "string"
+          },
+          "recommended_next_calls": {
+            "description": "Host-executable retries of the intended tool.",
+            "items": {
+              "additionalProperties": false,
+              "description": "Host-executable retry of the same tool after a preparing delay.",
+              "properties": {
+                "after_ms": {
+                  "description": "Delay before retry.",
+                  "type": "integer"
+                },
+                "arguments": {
+                  "description": "Original tool arguments.",
+                  "type": "object"
+                },
+                "method": {
+                  "description": "JSON-RPC method.",
+                  "type": "string"
+                },
+                "tool": {
+                  "description": "Tool to retry.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "method",
+                "tool"
+              ],
+              "type": "object"
+            },
+            "type": "array"
           },
           "retrieval_trace": {
             "description": "Retrieval trace and summary.",
@@ -4495,6 +6394,20 @@
           "retrieval_version": {
             "description": "Retrieval version.",
             "type": "string"
+          },
+          "retry_after_ms": {
+            "description": "Retry delay while preparing.",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "retry_tool": {
+            "description": "Tool to retry when the envelope is preparing.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "sections": {
             "description": "Context sections.",
@@ -4518,6 +6431,10 @@
             },
             "type": "array"
           },
+          "state": {
+            "description": "preparing, unavailable, or cancelled.",
+            "type": "string"
+          },
           "subgraph_ids": {
             "description": "Related graph ids.",
             "items": {
@@ -4532,19 +6449,13 @@
           "target": {
             "description": "Resolved retrieval target label.",
             "type": "string"
+          },
+          "tool": {
+            "description": "Tool that produced this envelope.",
+            "type": "string"
           }
         },
-        "required": [
-          "packet_id",
-          "target",
-          "summary",
-          "sections",
-          "citations",
-          "subgraph_ids",
-          "retrieval_version",
-          "graphs",
-          "retrieval_trace"
-        ],
+        "required": [],
         "type": "object"
       },
       "safety": {


### PR DESCRIPTION
## Summary

- Cursor 0.17.4 still rejected `files`, batched `snippet`, and preparing `packet`/`search`/`context` because `structuredContent` did not match `outputSchema`.
- Empty `policy_exclusions` are now serialized as `[]`. Snippet `paths`/`file_path` results declare `{max_total_bytes, ranges}`. Every tool output schema also declares the shared `codestory_preparing` retry envelope.
- Regenerated `plugins/codestory/generated-mcp-catalog.json` from the CLI. Native contract change, not plugin-only.

Closes #1995

## Test plan

- [x] `cargo test --locked -p codestory-cli --lib every_tool_output_schema_declares_the_stdio_retry_envelope`
- [x] `cargo test --locked -p codestory-cli --lib snippet_output_schema_accepts_a_paths_ranges_payload`
- [x] `cargo test --locked -p codestory-cli --lib indexed_files_dto_emits_empty_policy_exclusions`
- [x] `cargo test --locked -p codestory-cli --test stdio_protocol_contracts tool_catalog_exposes_output_schemas_for_stable_dto_backed_tools`
- [x] Cursor Ajv accepts files (empty exclusions), snippet ranges, preparing packet/search, and a success packet DTO
- [x] `node --test plugins/codestory/tests/plugin-static.test.mjs` (134 pass, 1 Windows skip)
- [x] `git diff --check`
- [x] `node .github/scripts/check-doc-links.mjs`
- [ ] After a CLI built from this head is installed, Cursor `files` / `snippet` / preparing `packet` should return instead of `-32602`

## How to review

Exact head `daddd0e3`. Read `attach_stdio_retry_envelope` and `SNIPPET_CONTEXT_SCHEMA` in `crates/codestory-cli/src/stdio_catalog.rs`, plus the `policy_exclusions` serde change on `IndexedFilesDto`.

## Risk

Hosts that ignore `outputSchema` see one extra empty array on files. Cursor keeps rejecting until it runs a CLI from this head. No version bump.


Made with [Cursor](https://cursor.com)