### PR TITLE
[codex] bump native version to 0.17.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.17.5
+
 Cursor still dropped `files`, `snippet`, and preparing `packet`/`search`/`context` results: empty `policy_exclusions` were omitted, batched snippets used a ranges document, and the shared `codestory_preparing` envelope was undeclared.
 
 Operators start, inspect, advance, and resume a release with `node scripts/codestory-release.mjs` instead of assembling a receipt by hand. Promotion still needs one recorded combined approval, and `--rehearse` walks the same machine without tagging or publishing.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-agent"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "codestory-contracts",
  "serde",
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-bench"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -588,7 +588,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -647,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-llama-sys"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "codestory-contracts",
  "crossbeam-channel",
@@ -662,7 +662,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "anyhow",
  "codestory-agent",
@@ -711,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-agent/Cargo.toml
+++ b/crates/codestory-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-agent"
-version = "0.17.4"
+version = "0.17.5"
 edition = "2024"
 
 [features]

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.17.4"
+version = "0.17.5"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.17.4"
+version = "0.17.5"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.17.4"
+version = "0.17.5"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.17.4"
+version = "0.17.5"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-llama-sys/Cargo.toml
+++ b/crates/codestory-llama-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-llama-sys"
-version = "0.17.4"
+version = "0.17.5"
 edition = "2024"
 build = "build.rs"
 

--- a/crates/codestory-llama-sys/model-contract.json
+++ b/crates/codestory-llama-sys/model-contract.json
@@ -37,7 +37,7 @@
   "producer": {
     "name": "codestory-llama-sys",
     "embedding_revision": "0.16.1",
-    "version": "0.17.4"
+    "version": "0.17.5"
   },
   "license": {
     "spdx_id": "MIT",

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.17.4"
+version = "0.17.5"
 edition = "2024"
 
 [features]

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.17.4"
+version = "0.17.5"
 edition = "2024"
 
 [features]

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.17.4"
+version = "0.17.5"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.17.4"
+version = "0.17.5"
 edition = "2024"
 
 [features]

--- a/plugins/codestory/.claude-plugin/plugin.json
+++ b/plugins/codestory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.17.4",
+  "version": "0.17.5",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.17.4",
+  "version": "0.17.5",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.cursor-plugin/plugin.json
+++ b/plugins/codestory/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.17.4",
+  "version": "0.17.5",
   "description": "CodeStory grounding for Cursor over the local codestory-cli runtime.",
   "author": {
     "name": "The Green Cedar"

--- a/plugins/codestory/.github/plugin/plugin.json
+++ b/plugins/codestory/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codestory",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
-  "version": "0.17.4",
+  "version": "0.17.5",
   "author": {
     "name": "The Green Cedar",
     "url": "https://github.com/TheGreenCedar"

--- a/plugins/codestory/cli-version.json
+++ b/plugins/codestory/cli-version.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
-  "cli_version": "0.17.4",
-  "release_tag": "v0.17.4"
+  "cli_version": "0.17.5",
+  "release_tag": "v0.17.5"
 }

--- a/plugins/codestory/plugin.json
+++ b/plugins/codestory/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "codestory",
-  "version": "0.17.4",
+  "version": "0.17.5",
   "description": "CodeStory grounding for coding agents over a local managed runtime.",
   "author": {
     "name": "The Green Cedar",

--- a/scripts/codestory-release.mjs
+++ b/scripts/codestory-release.mjs
@@ -1082,19 +1082,11 @@ export function createDefaultHost({ repository = "TheGreenCedar/CodeStory" } = {
     marketplace: { state: "unpublished" },
     assets: [...NATIVE_ASSETS],
     createIssue({ title, body }) {
-      const created = JSON.parse(gh([
-        "issue",
-        "create",
-        "--repo",
-        repository,
-        "--title",
-        title,
-        "--body",
-        body,
-        "--json",
-        "number,title",
-      ]));
-      return created;
+      const created = JSON.parse(gh(
+        ["api", "--method", "POST", `repos/${repository}/issues`, "--input", "-"],
+        { input: JSON.stringify({ title, body }) },
+      ));
+      return { number: created.number, title: created.title };
     },
     listOpenCoordinatorIssues() {
       const rows = JSON.parse(gh([
@@ -1119,13 +1111,13 @@ export function createDefaultHost({ repository = "TheGreenCedar/CodeStory" } = {
     },
     createIssueComment(number, body) {
       return JSON.parse(gh(
-        ["api", "--method", "POST", `repos/${repository}/issues/${number}/comments`],
+        ["api", "--method", "POST", `repos/${repository}/issues/${number}/comments`, "--input", "-"],
         { input: JSON.stringify({ body }) },
       ));
     },
     updateIssueComment(id, body) {
       return JSON.parse(gh(
-        ["api", "--method", "PATCH", `repos/${repository}/issues/comments/${id}`],
+        ["api", "--method", "PATCH", `repos/${repository}/issues/comments/${id}`, "--input", "-"],
         { input: JSON.stringify({ body }) },
       ));
     },


### PR DESCRIPTION
## Summary

- Native 0.17.5 bump from current `dev/codestory-next` after #1996 (Cursor catalog) and #1997 (release coordinator).
- Parent commit `a77a0255` fixes coordinator GitHub issue/comment writes so `start` works with this `gh`. The bump commit `c7cf5345` is calibration source **C** and contains only version surfaces plus the promoted changelog.
- Please **fast-forward** (do not squash). No freeze, calibration, or main promotion in this PR.

Closes #1999

## Test plan

- [x] `node scripts/bump-version.mjs --version 0.17.5`
- [x] `python .github/scripts/check-codestory-release.py --version 0.17.5`
- [x] `node .github/scripts/check-workflow-policy.mjs`
- [ ] Ubuntu draft source checks / plugin-static on this PR

## How to review

Exact C `c7cf5345`. Confirm `crates/codestory-cli/Cargo.toml` is 0.17.5 and CHANGELOG has `## 0.17.5` with the catalog and coordinator notes.

## Risk

This is the calibration source. Do not calibrate before this lands on next. Promotion to main still needs combined maintainer approval after freeze **F**.


Made with [Cursor](https://cursor.com)