### PR TITLE
[v3 qualification preflight] Bind qualification run and build identity

### DIFF
--- a/benchmarks/proof-availability/schemas/report.schema.json
+++ b/benchmarks/proof-availability/schemas/report.schema.json
@@ -1770,9 +1770,24 @@
           "maxLength": 8192,
           "minLength": 1,
           "type": "string"
+        },
+        "source_commit": {
+          "pattern": "^[0-9a-f]{40}$",
+          "type": "string"
+        },
+        "source_dirty": {
+          "const": false,
+          "type": "boolean"
+        },
+        "source_tree": {
+          "pattern": "^[0-9a-f]{40}$",
+          "type": "string"
         }
       },
       "required": [
+        "source_commit",
+        "source_tree",
+        "source_dirty",
         "rustc_vv",
         "cargo_profile",
         "prescribed_argv"

--- a/benchmarks/proof-availability/schemas/report.schema.json
+++ b/benchmarks/proof-availability/schemas/report.schema.json
@@ -757,6 +757,9 @@
           "pattern": "^[0-9a-f]{64}$",
           "type": "string"
         },
+        "build": {
+          "$ref": "#/$defs/QualificationBuildProvenanceV1"
+        },
         "environment_id": {
           "type": "string"
         },
@@ -773,6 +776,10 @@
           "maxItems": 4,
           "minItems": 4,
           "type": "array"
+        },
+        "qualification_id": {
+          "pattern": "^[0-9]{8}T[0-9]{6}Z-[0-9a-f]{12}$",
+          "type": "string"
         },
         "qualification_source_commit": {
           "pattern": "^[0-9a-f]{40}$",
@@ -791,6 +798,7 @@
         }
       },
       "required": [
+        "qualification_id",
         "environment_id",
         "os",
         "architecture",
@@ -799,6 +807,7 @@
         "qualification_source_commit",
         "qualification_source_tree",
         "recorded_at",
+        "build",
         "invocation",
         "projects"
       ],
@@ -1734,6 +1743,42 @@
       ],
       "type": "object"
     },
+    "QualificationBuildProvenanceV1": {
+      "additionalProperties": false,
+      "properties": {
+        "cargo_profile": {
+          "const": "release",
+          "type": "string"
+        },
+        "prescribed_argv": {
+          "const": [
+            "cargo",
+            "build",
+            "--release",
+            "--locked",
+            "-p",
+            "codestory-bench",
+            "--bin",
+            "codestory-proof-availability"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "rustc_vv": {
+          "maxLength": 8192,
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "rustc_vv",
+        "cargo_profile",
+        "prescribed_argv"
+      ],
+      "type": "object"
+    },
     "QualificationInvocationIdentityV1": {
       "additionalProperties": false,
       "properties": {
@@ -2459,6 +2504,7 @@
       "$ref": "#/$defs/ProvenanceV1"
     },
     "qualification_id": {
+      "pattern": "^[0-9]{8}T[0-9]{6}Z-[0-9a-f]{12}$",
       "type": "string"
     },
     "schema": {

--- a/crates/codestory-bench/build.rs
+++ b/crates/codestory-bench/build.rs
@@ -1,0 +1,25 @@
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn main() {
+    let rustc = env::var_os("RUSTC").expect("Cargo-selected RUSTC");
+    let output = Command::new(&rustc)
+        .arg("-vV")
+        .output()
+        .expect("run Cargo-selected rustc -vV");
+    assert!(
+        output.status.success(),
+        "Cargo-selected rustc -vV failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let rustc_vv = String::from_utf8(output.stdout).expect("rustc -vV is UTF-8");
+    assert!(!rustc_vv.trim().is_empty(), "rustc -vV is empty");
+    let profile = env::var("PROFILE").expect("Cargo PROFILE");
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("Cargo OUT_DIR"));
+    fs::write(out_dir.join("codestory-proof-rustc-vv.txt"), rustc_vv)
+        .expect("write embedded rustc identity");
+    fs::write(out_dir.join("codestory-proof-build-profile.txt"), profile)
+        .expect("write embedded build profile");
+}

--- a/crates/codestory-bench/build.rs
+++ b/crates/codestory-bench/build.rs
@@ -1,9 +1,41 @@
+use std::collections::BTreeSet;
 use std::env;
 use std::fs;
+use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 
 fn main() {
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("Cargo OUT_DIR"));
+    let hooks = out_dir.join("proof-build-empty-hooks");
+    fs::create_dir_all(&hooks).expect("create empty proof build hooks directory");
+    let global_config = out_dir.join("proof-build-empty-global.gitconfig");
+    fs::write(&global_config, []).expect("write empty proof build Git config");
+    let repository = Path::new(&env::var("CARGO_MANIFEST_DIR").expect("Cargo manifest directory"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("CodeStory repository root")
+        .to_path_buf();
+    emit_rerun_inputs(&repository, &hooks, &global_config);
+    let source_commit = git(
+        &repository,
+        &hooks,
+        &global_config,
+        &["rev-parse", "HEAD^{commit}"],
+    );
+    let source_tree = git(
+        &repository,
+        &hooks,
+        &global_config,
+        &["rev-parse", "HEAD^{tree}"],
+    );
+    let source_dirty = !git_bytes(
+        &repository,
+        &hooks,
+        &global_config,
+        &["status", "--porcelain=v1", "-z", "--untracked-files=all"],
+    )
+    .is_empty();
     let rustc = env::var_os("RUSTC").expect("Cargo-selected RUSTC");
     let output = Command::new(&rustc)
         .arg("-vV")
@@ -17,9 +49,115 @@ fn main() {
     let rustc_vv = String::from_utf8(output.stdout).expect("rustc -vV is UTF-8");
     assert!(!rustc_vv.trim().is_empty(), "rustc -vV is empty");
     let profile = env::var("PROFILE").expect("Cargo PROFILE");
-    let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("Cargo OUT_DIR"));
     fs::write(out_dir.join("codestory-proof-rustc-vv.txt"), rustc_vv)
         .expect("write embedded rustc identity");
     fs::write(out_dir.join("codestory-proof-build-profile.txt"), profile)
         .expect("write embedded build profile");
+    fs::write(
+        out_dir.join("codestory-proof-source-commit.txt"),
+        source_commit,
+    )
+    .expect("write embedded source commit");
+    fs::write(out_dir.join("codestory-proof-source-tree.txt"), source_tree)
+        .expect("write embedded source tree");
+    fs::write(
+        out_dir.join("codestory-proof-source-dirty.txt"),
+        if source_dirty { "true" } else { "false" },
+    )
+    .expect("write embedded source dirtiness");
+}
+
+fn git(repository: &Path, hooks: &Path, global_config: &Path, arguments: &[&str]) -> String {
+    String::from_utf8(git_bytes(repository, hooks, global_config, arguments))
+        .expect("Git identity is UTF-8")
+        .trim()
+        .to_owned()
+}
+
+fn git_bytes(repository: &Path, hooks: &Path, global_config: &Path, arguments: &[&str]) -> Vec<u8> {
+    let output = git_command(repository, hooks, global_config)
+        .args(arguments)
+        .output()
+        .expect("run Git for proof build provenance");
+    assert!(
+        output.status.success(),
+        "Git build provenance command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output.stdout
+}
+
+fn emit_rerun_inputs(repository: &Path, hooks: &Path, global_config: &Path) {
+    let git_dir = PathBuf::from(git(
+        repository,
+        hooks,
+        global_config,
+        &["rev-parse", "--absolute-git-dir"],
+    ));
+    let common = PathBuf::from(git(
+        repository,
+        hooks,
+        global_config,
+        &["rev-parse", "--git-common-dir"],
+    ));
+    let common_dir = if common.is_absolute() {
+        common
+    } else {
+        repository.join(common)
+    };
+    let mut paths = BTreeSet::from([
+        git_dir.join("HEAD"),
+        git_dir.join("index"),
+        common_dir.join("packed-refs"),
+    ]);
+    let worktree_git_link = repository.join(".git");
+    if fs::symlink_metadata(&worktree_git_link).is_ok_and(|metadata| metadata.is_file()) {
+        paths.insert(worktree_git_link);
+    }
+    let symbolic = git_command(repository, hooks, global_config)
+        .args(["symbolic-ref", "-q", "HEAD"])
+        .output()
+        .expect("resolve Git symbolic HEAD");
+    if symbolic.status.success() {
+        let reference = String::from_utf8(symbolic.stdout)
+            .expect("Git reference is UTF-8")
+            .trim()
+            .to_owned();
+        paths.insert(common_dir.join(reference));
+    }
+    for tracked in git_bytes(repository, hooks, global_config, &["ls-files", "-z"])
+        .split(|byte| *byte == 0)
+        .filter(|path| !path.is_empty())
+    {
+        let tracked = String::from_utf8(tracked.to_vec()).expect("tracked path is UTF-8");
+        let top_level = tracked.split('/').next().expect("tracked path component");
+        paths.insert(repository.join(top_level));
+    }
+    for path in paths {
+        println!("cargo:rerun-if-changed={}", path.display());
+    }
+}
+
+fn git_command(repository: &Path, hooks: &Path, global_config: &Path) -> Command {
+    let mut command = Command::new("git");
+    for (name, _) in env::vars_os() {
+        if name
+            .to_string_lossy()
+            .get(..4)
+            .is_some_and(|prefix| prefix.eq_ignore_ascii_case("GIT_"))
+        {
+            command.env_remove(name);
+        }
+    }
+    command
+        .current_dir(repository)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", global_config)
+        .env("GIT_OPTIONAL_LOCKS", "0")
+        .arg("-c")
+        .arg("core.fsmonitor=false")
+        .arg("-c")
+        .arg(format!("core.hooksPath={}", hooks.display()));
+    command
 }

--- a/crates/codestory-bench/src/bin/codestory_proof_availability/build_provenance.rs
+++ b/crates/codestory-bench/src/bin/codestory_proof_availability/build_provenance.rs
@@ -4,3 +4,13 @@ pub(crate) const BUILD_PROFILE: &str = include_str!(concat!(
     env!("OUT_DIR"),
     "/codestory-proof-build-profile.txt"
 ));
+pub(crate) const SOURCE_COMMIT: &str = include_str!(concat!(
+    env!("OUT_DIR"),
+    "/codestory-proof-source-commit.txt"
+));
+pub(crate) const SOURCE_TREE: &str =
+    include_str!(concat!(env!("OUT_DIR"), "/codestory-proof-source-tree.txt"));
+pub(crate) const SOURCE_DIRTY: &str = include_str!(concat!(
+    env!("OUT_DIR"),
+    "/codestory-proof-source-dirty.txt"
+));

--- a/crates/codestory-bench/src/bin/codestory_proof_availability/build_provenance.rs
+++ b/crates/codestory-bench/src/bin/codestory_proof_availability/build_provenance.rs
@@ -1,0 +1,6 @@
+pub(crate) const RUSTC_VV: &str =
+    include_str!(concat!(env!("OUT_DIR"), "/codestory-proof-rustc-vv.txt"));
+pub(crate) const BUILD_PROFILE: &str = include_str!(concat!(
+    env!("OUT_DIR"),
+    "/codestory-proof-build-profile.txt"
+));

--- a/crates/codestory-bench/src/bin/codestory_proof_availability/cli.rs
+++ b/crates/codestory-bench/src/bin/codestory_proof_availability/cli.rs
@@ -29,9 +29,33 @@ pub struct MaterializeArgs {
     pub cache_root: PathBuf,
     #[arg(long, value_name = "ENVIRONMENT_JSON")]
     pub out: PathBuf,
+    /// Immutable indexed-qualification identity bound to the source commit.
+    #[arg(
+        long,
+        value_name = "YYYYMMDDTHHMMSSZ-COMMIT12",
+        value_parser = parse_qualification_id,
+        required_unless_present = "verify_only",
+        conflicts_with = "verify_only"
+    )]
+    pub qualification_id: Option<String>,
     /// Validate corpus identities and oracle ranges without indexing or execution.
     #[arg(long)]
     pub verify_only: bool,
+}
+
+fn parse_qualification_id(value: &str) -> Result<String, String> {
+    if valid_qualification_id(value) {
+        Ok(value.to_owned())
+    } else {
+        Err(
+            "expected YYYYMMDDTHHMMSSZ followed by '-' and 12 lowercase hexadecimal characters"
+                .to_owned(),
+        )
+    }
+}
+
+pub(crate) fn valid_qualification_id(value: &str) -> bool {
+    super::contracts::valid_qualification_id(value)
 }
 
 #[derive(Debug, Args)]

--- a/crates/codestory-bench/src/bin/codestory_proof_availability/contracts.rs
+++ b/crates/codestory-bench/src/bin/codestory_proof_availability/contracts.rs
@@ -11,6 +11,16 @@ pub const PATH_FILE_SCHEMA: &str = "codestory.proof-availability-path-file/v1";
 pub const REPORT_SCHEMA: &str = "codestory.proof-availability-report/v1";
 pub const THRESHOLDS_SCHEMA: &str = "codestory.proof-availability-thresholds/v1";
 pub const DECISION_REPORT_SCHEMA: &str = "codestory.proof-availability-decision/v1";
+pub const PRESCRIBED_BUILD_ARGV: [&str; 8] = [
+    "cargo",
+    "build",
+    "--release",
+    "--locked",
+    "-p",
+    "codestory-bench",
+    "--bin",
+    "codestory-proof-availability",
+];
 pub const MAX_CANDIDATE_EDGES_PER_STEP: usize =
     codestory_runtime::proof_qualification_support::MAX_QUALIFICATION_CANDIDATE_EDGES_PER_STEP
         as usize;
@@ -18,6 +28,7 @@ pub const MAX_OBSERVED_RECEIPTS_PER_CASE: usize =
     codestory_runtime::proof_qualification_support::MAX_QUALIFICATION_OBSERVED_RECEIPTS_PER_CASE;
 const SHA256: &str = "^[0-9a-f]{64}$";
 const COMMIT: &str = "^[0-9a-f]{40}$";
+const QUALIFICATION_ID_PATTERN: &str = "^[0-9]{8}T[0-9]{6}Z-[0-9a-f]{12}$";
 
 mod u128_decimal {
     use serde::{Deserialize, Deserializer, Serializer};
@@ -1491,6 +1502,7 @@ pub struct ProvenanceV1 {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct EnvironmentReportV1 {
+    pub qualification_id: String,
     pub environment_id: String,
     pub os: String,
     pub architecture: String,
@@ -1499,8 +1511,16 @@ pub struct EnvironmentReportV1 {
     pub qualification_source_commit: String,
     pub qualification_source_tree: String,
     pub recorded_at: String,
+    pub build: QualificationBuildProvenanceV1,
     pub invocation: QualificationInvocationIdentityV1,
     pub projects: Vec<ProjectMaterializationEvidenceV1>,
+}
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct QualificationBuildProvenanceV1 {
+    pub rustc_vv: String,
+    pub cargo_profile: String,
+    pub prescribed_argv: Vec<String>,
 }
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
@@ -2787,7 +2807,8 @@ impl QualificationSummaryV1 {
                 total.checked_add(bucket.count)
             });
         if self.schema != REPORT_SCHEMA
-            || empty(&self.qualification_id)
+            || !valid_qualification_id(&self.qualification_id)
+            || self.qualification_id != self.environment.qualification_id
             || !commit(&self.provenance.source_commit)
             || !commit(&self.provenance.source_tree)
             || ![
@@ -2802,7 +2823,12 @@ impl QualificationSummaryV1 {
             || self.environment.binary_sha256 != self.provenance.binary_sha256
             || self.environment.qualification_source_commit != self.provenance.source_commit
             || self.environment.qualification_source_tree != self.provenance.source_tree
+            || !qualification_id_matches_commit(
+                &self.qualification_id,
+                &self.provenance.source_commit,
+            )
             || !rfc3339_utc(&self.environment.recorded_at)
+            || !valid_build_provenance(&self.environment)
             || self.environment.invocation.binary_name != "codestory-proof-availability"
             || self.environment.invocation.operation != QualificationOperationV1::Run
             || self.environment.invocation.profile != QualificationProfileV1::LocalCoreOnly
@@ -3410,7 +3436,8 @@ fn leap_year(year: u32) -> bool {
 }
 
 fn sanitized_environment(environment: &EnvironmentReportV1) -> bool {
-    sanitized_atom(&environment.environment_id)
+    valid_qualification_id(&environment.qualification_id)
+        && sanitized_atom(&environment.environment_id)
         && sanitized_atom(&environment.os)
         && sanitized_atom(&environment.architecture)
         && sanitized_atom(&environment.rust_host)
@@ -3421,6 +3448,72 @@ fn sanitized_environment(environment: &EnvironmentReportV1) -> bool {
                 && sanitized_atom(&project.identity.core_generation_id)
                 && sanitized_atom(&project.identity.core_run_id)
         })
+}
+
+fn valid_build_provenance(environment: &EnvironmentReportV1) -> bool {
+    let build = &environment.build;
+    let hosts = build
+        .rustc_vv
+        .lines()
+        .filter_map(|line| line.strip_prefix("host: "))
+        .collect::<Vec<_>>();
+    !build.rustc_vv.is_empty()
+        && build.rustc_vv.len() <= 8192
+        && !build.rustc_vv.contains('\0')
+        && build.cargo_profile == "release"
+        && hosts.as_slice() == [environment.rust_host.as_str()]
+        && build.prescribed_argv
+            == PRESCRIBED_BUILD_ARGV
+                .iter()
+                .map(|argument| (*argument).to_owned())
+                .collect::<Vec<_>>()
+}
+
+pub fn valid_qualification_id(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    if bytes.len() != 29
+        || bytes.get(8) != Some(&b'T')
+        || bytes.get(15) != Some(&b'Z')
+        || bytes.get(16) != Some(&b'-')
+        || !bytes[..8].iter().all(u8::is_ascii_digit)
+        || !bytes[9..15].iter().all(u8::is_ascii_digit)
+        || !bytes[17..]
+            .iter()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(byte))
+    {
+        return false;
+    }
+    let parse = |range: std::ops::Range<usize>| {
+        std::str::from_utf8(&bytes[range])
+            .ok()
+            .and_then(|component| component.parse::<u32>().ok())
+    };
+    let (Some(year), Some(month), Some(day), Some(hour), Some(minute), Some(second)) = (
+        parse(0..4),
+        parse(4..6),
+        parse(6..8),
+        parse(9..11),
+        parse(11..13),
+        parse(13..15),
+    ) else {
+        return false;
+    };
+    let maximum_day = match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if year.is_multiple_of(4) && (!year.is_multiple_of(100) || year.is_multiple_of(400)) => {
+            29
+        }
+        2 => 28,
+        _ => return false,
+    };
+    year > 0 && (1..=maximum_day).contains(&day) && hour <= 23 && minute <= 59 && second <= 59
+}
+
+pub fn qualification_id_matches_commit(qualification_id: &str, source_commit: &str) -> bool {
+    valid_qualification_id(qualification_id)
+        && commit(source_commit)
+        && qualification_id.get(17..) == source_commit.get(..12)
 }
 
 fn sanitized_atom(value: &str) -> bool {
@@ -4647,6 +4740,12 @@ fn semantic(schema: &mut Value, document: SchemaDocument) {
             ) {
                 property.insert("pattern".into(), Value::String(COMMIT.into()));
             }
+            if name == "qualification_id" {
+                property.insert(
+                    "pattern".into(),
+                    Value::String(QUALIFICATION_ID_PATTERN.into()),
+                );
+            }
         }
     }
     if let Some(definitions) = root.get_mut("$defs").and_then(Value::as_object_mut) {
@@ -4692,6 +4791,12 @@ fn semantic(schema: &mut Value, document: SchemaDocument) {
                         | "qualification_source_tree"
                 ) {
                     property.insert("pattern".into(), Value::String(COMMIT.into()));
+                }
+                if name == "qualification_id" {
+                    property.insert(
+                        "pattern".into(),
+                        Value::String(QUALIFICATION_ID_PATTERN.into()),
+                    );
                 }
                 if matches!(
                     name.as_str(),
@@ -4871,6 +4976,20 @@ fn semantic_contract_bounds(schema: &mut Value, document: SchemaDocument) {
                 "EnvironmentReportV1",
                 "recorded_at",
                 "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?Z$",
+            );
+            set_min_length(schema, "QualificationBuildProvenanceV1", "rustc_vv", 1);
+            set_max_length(schema, "QualificationBuildProvenanceV1", "rustc_vv", 8192);
+            set_const(
+                schema,
+                Some("QualificationBuildProvenanceV1"),
+                "cargo_profile",
+                Value::String("release".into()),
+            );
+            set_const(
+                schema,
+                Some("QualificationBuildProvenanceV1"),
+                "prescribed_argv",
+                serde_json::to_value(PRESCRIBED_BUILD_ARGV).expect("closed build argv"),
             );
             set_recursive_field_pattern(schema, "ActualProductResultV1", "contract_digest", SHA256);
             set_recursive_field_bounds(

--- a/crates/codestory-bench/src/bin/codestory_proof_availability/contracts.rs
+++ b/crates/codestory-bench/src/bin/codestory_proof_availability/contracts.rs
@@ -1518,6 +1518,9 @@ pub struct EnvironmentReportV1 {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct QualificationBuildProvenanceV1 {
+    pub source_commit: String,
+    pub source_tree: String,
+    pub source_dirty: bool,
     pub rustc_vv: String,
     pub cargo_profile: String,
     pub prescribed_argv: Vec<String>,
@@ -3457,7 +3460,12 @@ fn valid_build_provenance(environment: &EnvironmentReportV1) -> bool {
         .lines()
         .filter_map(|line| line.strip_prefix("host: "))
         .collect::<Vec<_>>();
-    !build.rustc_vv.is_empty()
+    commit(&build.source_commit)
+        && commit(&build.source_tree)
+        && build.source_commit == environment.qualification_source_commit
+        && build.source_tree == environment.qualification_source_tree
+        && !build.source_dirty
+        && !build.rustc_vv.is_empty()
         && build.rustc_vv.len() <= 8192
         && !build.rustc_vv.contains('\0')
         && build.cargo_profile == "release"
@@ -4984,6 +4992,12 @@ fn semantic_contract_bounds(schema: &mut Value, document: SchemaDocument) {
                 Some("QualificationBuildProvenanceV1"),
                 "cargo_profile",
                 Value::String("release".into()),
+            );
+            set_const(
+                schema,
+                Some("QualificationBuildProvenanceV1"),
+                "source_dirty",
+                Value::Bool(false),
             );
             set_const(
                 schema,

--- a/crates/codestory-bench/src/bin/codestory_proof_availability/materialize.rs
+++ b/crates/codestory-bench/src/bin/codestory_proof_availability/materialize.rs
@@ -1,10 +1,11 @@
+use super::build_provenance;
 use super::cli::MaterializeArgs;
 use super::contracts::{
     CohortPathFileV1, EnvironmentIdentityV1, EnvironmentReportV1, MaterializationFreshnessV1,
-    OraclePathV1, OracleSourceRangeV1, ProjectMaterializationEvidenceV1,
-    QUALIFICATION_REPOSITORIES, QualificationInvocationIdentityV1, QualificationOperationV1,
-    QualificationProfileV1, canonical_cohort_path_file_sha256, canonical_corpus_sha256,
-    validate_project_file,
+    OraclePathV1, OracleSourceRangeV1, PRESCRIBED_BUILD_ARGV, ProjectMaterializationEvidenceV1,
+    QUALIFICATION_REPOSITORIES, QualificationBuildProvenanceV1, QualificationInvocationIdentityV1,
+    QualificationOperationV1, QualificationProfileV1, canonical_cohort_path_file_sha256,
+    canonical_corpus_sha256, qualification_id_matches_commit, validate_project_file,
 };
 use super::corpus::LoadedCorpusV1;
 use anyhow::{Context, Result, bail};
@@ -158,6 +159,8 @@ struct QualificationBinaryIdentity {
     source_tree: String,
     recorded_at: String,
     rust_host: String,
+    rustc_vv: String,
+    build_profile: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -271,9 +274,7 @@ fn materialize_indexed_with_registry(
     allow_local_repositories: bool,
     qualification: QualificationBinaryIdentity,
 ) -> Result<()> {
-    if arguments.verify_only {
-        bail!("proof_availability_indexed_materialization_rejects_verify_only")
-    }
+    let qualification_id = require_indexed_qualification(arguments, &qualification)?;
     loaded
         .corpus
         .validate_with_path_files_and_registry(&loaded.path_files, registry)?;
@@ -453,6 +454,7 @@ fn materialize_indexed_with_registry(
             .as_bytes(),
         );
         let environment = EnvironmentReportV1 {
+            qualification_id,
             environment_id,
             os: std::env::consts::OS.to_owned(),
             architecture: std::env::consts::ARCH.to_owned(),
@@ -461,6 +463,14 @@ fn materialize_indexed_with_registry(
             qualification_source_commit: qualification.source_commit,
             qualification_source_tree: qualification.source_tree,
             recorded_at: qualification.recorded_at,
+            build: QualificationBuildProvenanceV1 {
+                rustc_vv: qualification.rustc_vv,
+                cargo_profile: qualification.build_profile,
+                prescribed_argv: PRESCRIBED_BUILD_ARGV
+                    .iter()
+                    .map(|argument| (*argument).to_owned())
+                    .collect(),
+            },
             invocation: QualificationInvocationIdentityV1 {
                 binary_name: "codestory-proof-availability".to_owned(),
                 operation: QualificationOperationV1::Run,
@@ -820,6 +830,23 @@ fn validate_operational_environment_with_identity(
     {
         bail!("proof_availability_qualification_binary_mismatch")
     }
+    if !qualification_id_matches_commit(
+        &descriptor.environment.qualification_id,
+        &qualification.source_commit,
+    ) {
+        bail!("proof_availability_qualification_identity_mismatch")
+    }
+    if descriptor.environment.rust_host != qualification.rust_host
+        || descriptor.environment.build.rustc_vv != qualification.rustc_vv
+        || descriptor.environment.build.cargo_profile != qualification.build_profile
+        || descriptor.environment.build.prescribed_argv
+            != PRESCRIBED_BUILD_ARGV
+                .iter()
+                .map(|argument| (*argument).to_owned())
+                .collect::<Vec<_>>()
+    {
+        bail!("proof_availability_qualification_build_mismatch")
+    }
     for path_file in &loaded.path_files {
         let repository = descriptor
             .repositories
@@ -969,13 +996,8 @@ fn qualification_binary_identity() -> Result<QualificationBinaryIdentity> {
     .trim()
     .to_owned();
     require_head_and_clean(repository, &source_commit, hooks.path())?;
-    let rustc = Command::new("rustc")
-        .args(["--version", "--verbose"])
-        .output()?;
-    if !rustc.status.success() {
-        bail!("proof_availability_rustc_identity_unavailable")
-    }
-    let rust_host = String::from_utf8(rustc.stdout)?
+    let rustc_vv = build_provenance::RUSTC_VV.to_owned();
+    let rust_host = rustc_vv
         .lines()
         .find_map(|line| line.strip_prefix("host: "))
         .ok_or_else(|| anyhow::anyhow!("proof_availability_rust_host_missing"))?
@@ -992,7 +1014,44 @@ fn qualification_binary_identity() -> Result<QualificationBinaryIdentity> {
         source_tree,
         recorded_at: String::from_utf8(date.stdout)?.trim().to_owned(),
         rust_host,
+        rustc_vv,
+        build_profile: build_provenance::BUILD_PROFILE.to_owned(),
     })
+}
+
+fn require_indexed_qualification(
+    arguments: &MaterializeArgs,
+    qualification: &QualificationBinaryIdentity,
+) -> Result<String> {
+    if arguments.verify_only {
+        bail!("proof_availability_indexed_materialization_rejects_verify_only")
+    }
+    let qualification_id = arguments
+        .qualification_id
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("proof_availability_qualification_id_missing"))?;
+    if !super::cli::valid_qualification_id(qualification_id) {
+        bail!("proof_availability_qualification_id_invalid")
+    }
+    let commit_prefix = qualification
+        .source_commit
+        .get(..12)
+        .ok_or_else(|| anyhow::anyhow!("proof_availability_source_commit_invalid"))?;
+    if qualification_id.get(17..) != Some(commit_prefix) {
+        bail!("proof_availability_qualification_id_source_commit_mismatch")
+    }
+    if qualification.build_profile != "release" {
+        bail!("proof_availability_qualification_build_profile_not_release")
+    }
+    let embedded_host = qualification
+        .rustc_vv
+        .lines()
+        .filter_map(|line| line.strip_prefix("host: "))
+        .collect::<Vec<_>>();
+    if embedded_host.as_slice() != [qualification.rust_host.as_str()] {
+        bail!("proof_availability_qualification_rust_host_mismatch")
+    }
+    Ok(qualification_id.to_owned())
 }
 
 fn create_private_directory(path: &Path) -> Result<()> {
@@ -2033,6 +2092,7 @@ mod tests {
             workspace: root.path().join("workspace"),
             cache_root: root.path().join("cache-must-not-exist"),
             out: root.path().join("source-environment.json"),
+            qualification_id: None,
             verify_only: true,
         };
 
@@ -2120,6 +2180,7 @@ mod tests {
             workspace: failure_root.path().join("workspace"),
             cache_root: failure_root.path().join("cache-must-not-exist"),
             out: failure_root.path().join("source-environment.json"),
+            qualification_id: None,
             verify_only: true,
         };
         let error = verify_only_with_registry(&failed, &invalid, &registry, true)
@@ -2246,6 +2307,7 @@ mod tests {
                 workspace: workspace.clone(),
                 cache_root,
                 out: out.clone(),
+                qualification_id: None,
                 verify_only: true,
             };
 
@@ -2277,6 +2339,7 @@ mod tests {
             workspace: workspace.clone(),
             cache_root: canonical_root,
             out: out.clone(),
+            qualification_id: None,
             verify_only: true,
         };
 
@@ -2490,6 +2553,59 @@ mod tests {
     }
 
     #[test]
+    fn indexed_qualification_preflight_binds_id_profile_and_compiler_host() {
+        let mut arguments = MaterializeArgs {
+            corpus: PathBuf::from("unused-corpus.json"),
+            workspace: PathBuf::from("unused-workspace"),
+            cache_root: PathBuf::from("unused-cache"),
+            out: PathBuf::from("unused-environment.json"),
+            qualification_id: Some("20260821T120000Z-222222222222".into()),
+            verify_only: false,
+        };
+        let qualification = QualificationBinaryIdentity {
+            binary_sha256: "1".repeat(64),
+            source_commit: "2".repeat(40),
+            source_tree: "3".repeat(40),
+            recorded_at: "2026-08-21T12:00:00Z".into(),
+            rust_host: "aarch64-apple-darwin".into(),
+            rustc_vv: "rustc 1.91.0\nbinary: rustc\nhost: aarch64-apple-darwin\n".into(),
+            build_profile: "release".into(),
+        };
+
+        assert_eq!(
+            require_indexed_qualification(&arguments, &qualification).unwrap(),
+            "20260821T120000Z-222222222222"
+        );
+
+        arguments.qualification_id = Some("20260821T120000Z-aaaaaaaaaaaa".into());
+        assert!(
+            require_indexed_qualification(&arguments, &qualification)
+                .unwrap_err()
+                .to_string()
+                .contains("qualification_id_source_commit_mismatch")
+        );
+        arguments.qualification_id = Some("20260821T120000Z-222222222222".into());
+
+        let mut debug = qualification.clone();
+        debug.build_profile = "debug".into();
+        assert!(
+            require_indexed_qualification(&arguments, &debug)
+                .unwrap_err()
+                .to_string()
+                .contains("qualification_build_profile_not_release")
+        );
+
+        let mut wrong_host = qualification.clone();
+        wrong_host.rust_host = "x86_64-unknown-linux-gnu".into();
+        assert!(
+            require_indexed_qualification(&arguments, &wrong_host)
+                .unwrap_err()
+                .to_string()
+                .contains("qualification_rust_host_mismatch")
+        );
+    }
+
+    #[test]
     fn non_verify_materialization_builds_a_fresh_core_only_index() {
         let (origin, commit, raw_tree) = cohort_repository();
         let tree_sha256 = sha256(&raw_tree);
@@ -2512,6 +2628,7 @@ mod tests {
             workspace: root.path().join("workspace"),
             cache_root: root.path().join("cache"),
             out: root.path().join("environment.json"),
+            qualification_id: Some("20260821T120000Z-222222222222".into()),
             verify_only: false,
         };
         let qualification = QualificationBinaryIdentity {
@@ -2520,6 +2637,8 @@ mod tests {
             source_tree: "3".repeat(40),
             recorded_at: "2026-08-21T12:00:00Z".into(),
             rust_host: "aarch64-apple-darwin".into(),
+            rustc_vv: "rustc 1.91.0\nbinary: rustc\nhost: aarch64-apple-darwin\n".into(),
+            build_profile: "release".into(),
         };
 
         materialize_indexed_with_registry(
@@ -2566,6 +2685,33 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("qualification_binary_mismatch")
+        );
+        let mut wrong_qualification_id = descriptor.clone();
+        wrong_qualification_id.environment.qualification_id =
+            "20260821T120000Z-aaaaaaaaaaaa".into();
+        assert!(
+            validate_operational_environment_with_identity(
+                &loaded,
+                &wrong_qualification_id,
+                &qualification,
+                &registry,
+            )
+            .unwrap_err()
+            .to_string()
+            .contains("qualification_identity_mismatch")
+        );
+        let mut wrong_build = descriptor.clone();
+        wrong_build.environment.build.cargo_profile = "debug".into();
+        assert!(
+            validate_operational_environment_with_identity(
+                &loaded,
+                &wrong_build,
+                &qualification,
+                &registry,
+            )
+            .unwrap_err()
+            .to_string()
+            .contains("qualification_build_mismatch")
         );
         let mut stale = descriptor.clone();
         stale.environment.projects[0].freshness = MaterializationFreshnessV1::Stale;

--- a/crates/codestory-bench/src/bin/codestory_proof_availability/materialize.rs
+++ b/crates/codestory-bench/src/bin/codestory_proof_availability/materialize.rs
@@ -161,6 +161,7 @@ struct QualificationBinaryIdentity {
     rust_host: String,
     rustc_vv: String,
     build_profile: String,
+    source_dirty: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -460,10 +461,13 @@ fn materialize_indexed_with_registry(
             architecture: std::env::consts::ARCH.to_owned(),
             rust_host: qualification.rust_host,
             binary_sha256: qualification.binary_sha256,
-            qualification_source_commit: qualification.source_commit,
-            qualification_source_tree: qualification.source_tree,
+            qualification_source_commit: qualification.source_commit.clone(),
+            qualification_source_tree: qualification.source_tree.clone(),
             recorded_at: qualification.recorded_at,
             build: QualificationBuildProvenanceV1 {
+                source_commit: qualification.source_commit.clone(),
+                source_tree: qualification.source_tree.clone(),
+                source_dirty: qualification.source_dirty,
                 rustc_vv: qualification.rustc_vv,
                 cargo_profile: qualification.build_profile,
                 prescribed_argv: PRESCRIBED_BUILD_ARGV
@@ -837,6 +841,9 @@ fn validate_operational_environment_with_identity(
         bail!("proof_availability_qualification_identity_mismatch")
     }
     if descriptor.environment.rust_host != qualification.rust_host
+        || descriptor.environment.build.source_commit != qualification.source_commit
+        || descriptor.environment.build.source_tree != qualification.source_tree
+        || descriptor.environment.build.source_dirty != qualification.source_dirty
         || descriptor.environment.build.rustc_vv != qualification.rustc_vv
         || descriptor.environment.build.cargo_profile != qualification.build_profile
         || descriptor.environment.build.prescribed_argv
@@ -980,7 +987,7 @@ fn qualification_binary_identity() -> Result<QualificationBinaryIdentity> {
         .and_then(Path::parent)
         .ok_or_else(|| anyhow::anyhow!("proof_availability_repository_root_missing"))?;
     let hooks = tempfile::tempdir()?;
-    let source_commit = String::from_utf8(
+    let live_commit = String::from_utf8(
         git(
             Some(repository),
             hooks.path(),
@@ -990,12 +997,25 @@ fn qualification_binary_identity() -> Result<QualificationBinaryIdentity> {
     )?
     .trim()
     .to_owned();
-    let source_tree = String::from_utf8(
+    let live_tree = String::from_utf8(
         git(Some(repository), hooks.path(), ["rev-parse", "HEAD^{tree}"])?.stdout,
     )?
     .trim()
     .to_owned();
-    require_head_and_clean(repository, &source_commit, hooks.path())?;
+    let live_clean = git(
+        Some(repository),
+        hooks.path(),
+        ["status", "--porcelain=v1", "-z", "--untracked-files=all"],
+    )?
+    .stdout
+    .is_empty();
+    let source_commit = build_provenance::SOURCE_COMMIT.trim().to_owned();
+    let source_tree = build_provenance::SOURCE_TREE.trim().to_owned();
+    let source_dirty = match build_provenance::SOURCE_DIRTY.trim() {
+        "true" => true,
+        "false" => false,
+        _ => bail!("proof_availability_qualification_build_dirty_state_invalid"),
+    };
     let rustc_vv = build_provenance::RUSTC_VV.to_owned();
     let rust_host = rustc_vv
         .lines()
@@ -1008,7 +1028,7 @@ fn qualification_binary_identity() -> Result<QualificationBinaryIdentity> {
     if !date.status.success() {
         bail!("proof_availability_recorded_at_unavailable")
     }
-    Ok(QualificationBinaryIdentity {
+    let qualification = QualificationBinaryIdentity {
         binary_sha256,
         source_commit,
         source_tree,
@@ -1016,7 +1036,28 @@ fn qualification_binary_identity() -> Result<QualificationBinaryIdentity> {
         rust_host,
         rustc_vv,
         build_profile: build_provenance::BUILD_PROFILE.to_owned(),
-    })
+        source_dirty,
+    };
+    require_live_source_matches_build(&qualification, &live_commit, &live_tree, live_clean)?;
+    Ok(qualification)
+}
+
+fn require_live_source_matches_build(
+    qualification: &QualificationBinaryIdentity,
+    live_commit: &str,
+    live_tree: &str,
+    live_clean: bool,
+) -> Result<()> {
+    if qualification.source_dirty {
+        bail!("proof_availability_qualification_binary_built_dirty")
+    }
+    if !live_clean {
+        bail!("proof_availability_qualification_live_source_dirty")
+    }
+    if qualification.source_commit != live_commit || qualification.source_tree != live_tree {
+        bail!("proof_availability_qualification_live_source_mismatch")
+    }
+    Ok(())
 }
 
 fn require_indexed_qualification(
@@ -2570,6 +2611,7 @@ mod tests {
             rust_host: "aarch64-apple-darwin".into(),
             rustc_vv: "rustc 1.91.0\nbinary: rustc\nhost: aarch64-apple-darwin\n".into(),
             build_profile: "release".into(),
+            source_dirty: false,
         };
 
         assert_eq!(
@@ -2577,7 +2619,7 @@ mod tests {
             "20260821T120000Z-222222222222"
         );
 
-        arguments.qualification_id = Some("20260821T120000Z-aaaaaaaaaaaa".into());
+        arguments.qualification_id = Some("20260821T120000Z-444444444444".into());
         assert!(
             require_indexed_qualification(&arguments, &qualification)
                 .unwrap_err()
@@ -2602,6 +2644,44 @@ mod tests {
                 .unwrap_err()
                 .to_string()
                 .contains("qualification_rust_host_mismatch")
+        );
+
+        require_live_source_matches_build(&qualification, &"2".repeat(40), &"3".repeat(40), true)
+            .unwrap();
+        assert!(
+            require_live_source_matches_build(
+                &qualification,
+                &"4".repeat(40),
+                &"5".repeat(40),
+                true,
+            )
+            .unwrap_err()
+            .to_string()
+            .contains("qualification_live_source_mismatch")
+        );
+        let mut dirty_build = qualification.clone();
+        dirty_build.source_dirty = true;
+        assert!(
+            require_live_source_matches_build(
+                &dirty_build,
+                &"2".repeat(40),
+                &"3".repeat(40),
+                true,
+            )
+            .unwrap_err()
+            .to_string()
+            .contains("qualification_binary_built_dirty")
+        );
+        assert!(
+            require_live_source_matches_build(
+                &qualification,
+                &"2".repeat(40),
+                &"3".repeat(40),
+                false,
+            )
+            .unwrap_err()
+            .to_string()
+            .contains("qualification_live_source_dirty")
         );
     }
 
@@ -2639,6 +2719,7 @@ mod tests {
             rust_host: "aarch64-apple-darwin".into(),
             rustc_vv: "rustc 1.91.0\nbinary: rustc\nhost: aarch64-apple-darwin\n".into(),
             build_profile: "release".into(),
+            source_dirty: false,
         };
 
         materialize_indexed_with_registry(

--- a/crates/codestory-bench/src/bin/codestory_proof_availability/mod.rs
+++ b/crates/codestory-bench/src/bin/codestory_proof_availability/mod.rs
@@ -5,6 +5,7 @@
 
 use anyhow::{Context, Result};
 
+mod build_provenance;
 pub mod cli;
 #[allow(dead_code)] // Later qualification tasks consume the full closed artifact surface.
 pub mod contracts;
@@ -39,6 +40,10 @@ pub fn execute(cli: cli::Cli) -> Result<()> {
                 .context("validate proof availability corpus against thresholds")?;
             util::refuse_existing_output(&arguments.out)?;
             let operational = materialize::load_operational_environment(&arguments.environment)?;
+            report::require_result_directory_identity(
+                &arguments.out,
+                &operational.environment.qualification_id,
+            )?;
             let input = runner::run_qualification(&loaded, &thresholds, &operational)?;
             let summary = report::build_summary(input, &loaded.corpus, &thresholds)?;
             let leak_policy = report::PublicLeakPolicy::new(

--- a/crates/codestory-bench/src/bin/codestory_proof_availability/report.rs
+++ b/crates/codestory-bench/src/bin/codestory_proof_availability/report.rs
@@ -227,6 +227,12 @@ pub(crate) fn build_and_publish(
     thresholds: &ThresholdsV1,
     leak_policy: &PublicLeakPolicy,
 ) -> std::result::Result<(), ReportPublishError> {
+    require_result_directory_identity(destination, &summary.qualification_id).map_err(|_| {
+        ReportPublishError::before_staging(
+            "proof_availability_result_directory_qualification_id_mismatch",
+            destination,
+        )
+    })?;
     let bundle = build_public_artifacts(summary, corpus, thresholds).map_err(|_| {
         ReportPublishError::before_staging(
             "proof_availability_public_artifact_build_failed",
@@ -263,6 +269,7 @@ pub(crate) fn verify_published(
     let findings_bytes = read_bounded(&destination.join("findings.md"))?;
 
     let summary: QualificationSummaryV1 = serde_json::from_value(summary_value)?;
+    require_result_directory_identity(destination, &summary.qualification_id)?;
     let reconstructed = QualificationSummaryV1 {
         schema: summary.schema.clone(),
         qualification_id: summary.qualification_id.clone(),
@@ -313,6 +320,16 @@ pub(crate) fn verify_published(
     }
     let decision: ActivationDecisionReportV1 = serde_json::from_value(decision_value)?;
     decision.validate()?;
+    Ok(())
+}
+
+pub(crate) fn require_result_directory_identity(
+    destination: &Path,
+    qualification_id: &str,
+) -> Result<()> {
+    if destination.file_name().and_then(|name| name.to_str()) != Some(qualification_id) {
+        bail!("proof_availability_result_directory_qualification_id_mismatch")
+    }
     Ok(())
 }
 
@@ -1217,6 +1234,20 @@ mod tests {
             decision: json!({}),
             findings: "# Findings\n\nNone.\n".to_owned(),
         }
+    }
+
+    #[test]
+    fn result_directory_basename_is_the_qualification_identity() {
+        let root = tempfile::tempdir().unwrap();
+        let qualification_id = "20260821T120000Z-222222222222";
+        require_result_directory_identity(&root.path().join(qualification_id), qualification_id)
+            .unwrap();
+        assert!(
+            require_result_directory_identity(&root.path().join("results"), qualification_id)
+                .unwrap_err()
+                .to_string()
+                .contains("result_directory_qualification_id_mismatch")
+        );
     }
 
     #[test]

--- a/crates/codestory-bench/src/bin/codestory_proof_availability/runner.rs
+++ b/crates/codestory-bench/src/bin/codestory_proof_availability/runner.rs
@@ -89,7 +89,7 @@ pub(crate) fn run_qualification(
     cases.sort_by(|left, right| left.case_id.cmp(&right.case_id));
     let failure_funnel = build_failure_funnel(&cases)?;
     Ok(QualificationReportInputV1 {
-        qualification_id: operational.environment.environment_id.clone(),
+        qualification_id: operational.environment.qualification_id.clone(),
         source_commit: operational.environment.qualification_source_commit.clone(),
         source_tree: operational.environment.qualification_source_tree.clone(),
         environment: operational.environment.clone(),

--- a/crates/codestory-bench/tests/proof_availability_contracts.rs
+++ b/crates/codestory-bench/tests/proof_availability_contracts.rs
@@ -129,6 +129,7 @@ fn task11a_environment_identity_is_closed_sanitized_and_bound_to_provenance() {
         } else {
             drift["environment"]["build"][mutation.0] = mutation.1;
         }
+        rebind_results_digest(&mut drift);
         assert!(
             QualificationSummaryV1::from_json(drift).is_err(),
             "environment must reject {} drift",
@@ -142,11 +143,24 @@ fn task11a_environment_identity_is_closed_sanitized_and_bound_to_provenance() {
 
     let mut host_drift = value.clone();
     host_drift["environment"]["rust_host"] = json!("x86_64-unknown-linux-gnu");
+    rebind_results_digest(&mut host_drift);
     assert!(QualificationSummaryV1::from_json(host_drift).is_err());
 
     let mut argv_drift = value.clone();
     argv_drift["environment"]["build"]["prescribed_argv"][2] = json!("--debug");
+    rebind_results_digest(&mut argv_drift);
     assert!(QualificationSummaryV1::from_json(argv_drift).is_err());
+
+    let mut dirty_build = value.clone();
+    dirty_build["environment"]["build"]["source_dirty"] = json!(true);
+    rebind_results_digest(&mut dirty_build);
+    assert!(QualificationSummaryV1::from_json(dirty_build).is_err());
+
+    let mut build_source_drift = value.clone();
+    build_source_drift["environment"]["build"]["source_commit"] =
+        json!("cccccccccccccccccccccccccccccccccccccccc");
+    rebind_results_digest(&mut build_source_drift);
+    assert!(QualificationSummaryV1::from_json(build_source_drift).is_err());
 
     for (field, bad) in [
         (
@@ -890,7 +904,7 @@ pub(crate) fn report() -> Value {
     let mut report = json!({
       "schema":"codestory.proof-availability-report/v1","qualification_id":"20260821T000000Z-bbbbbbbbbbbb",
       "provenance":{"source_commit":COMMIT,"source_tree":COMMIT,"binary_sha256":SHA,"corpus_sha256":corpus_hash,"thresholds_sha256":threshold_hash,"results_sha256":SHA},
-      "environment":{"qualification_id":"20260821T000000Z-bbbbbbbbbbbb","environment_id":"macos-arm64","os":"macos","architecture":"aarch64","rust_host":"aarch64-apple-darwin","binary_sha256":SHA,"qualification_source_commit":COMMIT,"qualification_source_tree":COMMIT,"recorded_at":"2026-08-21T12:34:56Z","build":{"rustc_vv":"rustc 1.91.0\nbinary: rustc\nhost: aarch64-apple-darwin\n","cargo_profile":"release","prescribed_argv":["cargo","build","--release","--locked","-p","codestory-bench","--bin","codestory-proof-availability"]},"invocation":{"binary_name":"codestory-proof-availability","operation":"run","profile":"local_core_only","corpus_sha256":corpus_hash,"thresholds_sha256":threshold_hash},"projects":frozen["cohorts"].as_array().unwrap().iter().map(|cohort|{let id=cohort["repository_id"].as_str().unwrap();json!({"repository_id":id,"source_head":cohort["commit"],"source_tree":SHA,"store_schema":"codestory-store/v1","file_count":10,"node_count":20,"edge_count":30,"freshness":"fresh","database_sha256":SHA,"core_generation":1,"identity":{"project_id":format!("project-{id}"),"core_generation_id":format!("generation-{id}"),"core_run_id":format!("run-{id}")}})}).collect::<Vec<_>>()},
+      "environment":{"qualification_id":"20260821T000000Z-bbbbbbbbbbbb","environment_id":"macos-arm64","os":"macos","architecture":"aarch64","rust_host":"aarch64-apple-darwin","binary_sha256":SHA,"qualification_source_commit":COMMIT,"qualification_source_tree":COMMIT,"recorded_at":"2026-08-21T12:34:56Z","build":{"source_commit":COMMIT,"source_tree":COMMIT,"source_dirty":false,"rustc_vv":"rustc 1.91.0\nbinary: rustc\nhost: aarch64-apple-darwin\n","cargo_profile":"release","prescribed_argv":["cargo","build","--release","--locked","-p","codestory-bench","--bin","codestory-proof-availability"]},"invocation":{"binary_name":"codestory-proof-availability","operation":"run","profile":"local_core_only","corpus_sha256":corpus_hash,"thresholds_sha256":threshold_hash},"projects":frozen["cohorts"].as_array().unwrap().iter().map(|cohort|{let id=cohort["repository_id"].as_str().unwrap();json!({"repository_id":id,"source_head":cohort["commit"],"source_tree":SHA,"store_schema":"codestory-store/v1","file_count":10,"node_count":20,"edge_count":30,"freshness":"fresh","database_sha256":SHA,"core_generation":1,"identity":{"project_id":format!("project-{id}"),"core_generation_id":format!("generation-{id}"),"core_run_id":format!("run-{id}")}})}).collect::<Vec<_>>()},
       "inventory":cohort_ids.iter().map(|id|json!({"repository_id":id,"stored_call_rows":"10","effective_endpoint_rows":"10","exact_resolved_rows":"8","admitted_rows":"7","unresolved_placeholder_rows":"2"})).collect::<Vec<_>>(),
       "trails":cohort_ids.iter().map(|id|json!({"repository_id":id,"lengths":[{"length":1,"effective_endpoint":"10","exact_resolved":"8","strictly_admitted":"7"},{"length":2,"effective_endpoint":"9","exact_resolved":"7","strictly_admitted":"6"},{"length":3,"effective_endpoint":"8","exact_resolved":"6","strictly_admitted":"5"},{"length":4,"effective_endpoint":"7","exact_resolved":"5","strictly_admitted":"4"},{"length":5,"effective_endpoint":"6","exact_resolved":"4","strictly_admitted":"3"},{"length":6,"effective_endpoint":"5","exact_resolved":"3","strictly_admitted":"2"}]})).collect::<Vec<_>>(),
       "cases":cases,
@@ -2606,6 +2620,18 @@ fn schemas_have_semantic_constants_patterns_and_bounds() {
             "--bin",
             "codestory-proof-availability"
         ])
+    );
+    assert_eq!(
+        report_schema["$defs"]["QualificationBuildProvenanceV1"]["properties"]["source_commit"]["pattern"],
+        "^[0-9a-f]{40}$"
+    );
+    assert_eq!(
+        report_schema["$defs"]["QualificationBuildProvenanceV1"]["properties"]["source_tree"]["pattern"],
+        "^[0-9a-f]{40}$"
+    );
+    assert_eq!(
+        report_schema["$defs"]["QualificationBuildProvenanceV1"]["properties"]["source_dirty"]["const"],
+        false
     );
     assert_eq!(
         report_schema["$defs"]["ActualProductResultV1"]["oneOf"][0]["properties"]["contract_digest"]

--- a/crates/codestory-bench/tests/proof_availability_contracts.rs
+++ b/crates/codestory-bench/tests/proof_availability_contracts.rs
@@ -119,6 +119,35 @@ fn task11a_environment_identity_is_closed_sanitized_and_bound_to_provenance() {
         json!(contracts::results_evidence_sha256_from_json(&value).unwrap());
     QualificationSummaryV1::from_json(value.clone()).expect("bound environment identity");
 
+    for mutation in [
+        ("qualification_id", json!("20260821T123456Z-aaaaaaaaaaaa")),
+        ("cargo_profile", json!("debug")),
+    ] {
+        let mut drift = value.clone();
+        if mutation.0 == "qualification_id" {
+            drift["environment"][mutation.0] = mutation.1;
+        } else {
+            drift["environment"]["build"][mutation.0] = mutation.1;
+        }
+        assert!(
+            QualificationSummaryV1::from_json(drift).is_err(),
+            "environment must reject {} drift",
+            mutation.0
+        );
+    }
+
+    let mut summary_identity_drift = value.clone();
+    summary_identity_drift["qualification_id"] = json!("20260821T123456Z-bbbbbbbbbbbb");
+    assert!(QualificationSummaryV1::from_json(summary_identity_drift).is_err());
+
+    let mut host_drift = value.clone();
+    host_drift["environment"]["rust_host"] = json!("x86_64-unknown-linux-gnu");
+    assert!(QualificationSummaryV1::from_json(host_drift).is_err());
+
+    let mut argv_drift = value.clone();
+    argv_drift["environment"]["build"]["prescribed_argv"][2] = json!("--debug");
+    assert!(QualificationSummaryV1::from_json(argv_drift).is_err());
+
     for (field, bad) in [
         (
             "qualification_source_commit",
@@ -859,9 +888,9 @@ pub(crate) fn report() -> Value {
         })
         .collect::<Vec<_>>();
     let mut report = json!({
-      "schema":"codestory.proof-availability-report/v1","qualification_id":"20260821T000000Z-0123456789ab",
+      "schema":"codestory.proof-availability-report/v1","qualification_id":"20260821T000000Z-bbbbbbbbbbbb",
       "provenance":{"source_commit":COMMIT,"source_tree":COMMIT,"binary_sha256":SHA,"corpus_sha256":corpus_hash,"thresholds_sha256":threshold_hash,"results_sha256":SHA},
-      "environment":{"environment_id":"macos-arm64","os":"macos","architecture":"aarch64","rust_host":"aarch64-apple-darwin","binary_sha256":SHA,"qualification_source_commit":COMMIT,"qualification_source_tree":COMMIT,"recorded_at":"2026-08-21T12:34:56Z","invocation":{"binary_name":"codestory-proof-availability","operation":"run","profile":"local_core_only","corpus_sha256":corpus_hash,"thresholds_sha256":threshold_hash},"projects":frozen["cohorts"].as_array().unwrap().iter().map(|cohort|{let id=cohort["repository_id"].as_str().unwrap();json!({"repository_id":id,"source_head":cohort["commit"],"source_tree":SHA,"store_schema":"codestory-store/v1","file_count":10,"node_count":20,"edge_count":30,"freshness":"fresh","database_sha256":SHA,"core_generation":1,"identity":{"project_id":format!("project-{id}"),"core_generation_id":format!("generation-{id}"),"core_run_id":format!("run-{id}")}})}).collect::<Vec<_>>()},
+      "environment":{"qualification_id":"20260821T000000Z-bbbbbbbbbbbb","environment_id":"macos-arm64","os":"macos","architecture":"aarch64","rust_host":"aarch64-apple-darwin","binary_sha256":SHA,"qualification_source_commit":COMMIT,"qualification_source_tree":COMMIT,"recorded_at":"2026-08-21T12:34:56Z","build":{"rustc_vv":"rustc 1.91.0\nbinary: rustc\nhost: aarch64-apple-darwin\n","cargo_profile":"release","prescribed_argv":["cargo","build","--release","--locked","-p","codestory-bench","--bin","codestory-proof-availability"]},"invocation":{"binary_name":"codestory-proof-availability","operation":"run","profile":"local_core_only","corpus_sha256":corpus_hash,"thresholds_sha256":threshold_hash},"projects":frozen["cohorts"].as_array().unwrap().iter().map(|cohort|{let id=cohort["repository_id"].as_str().unwrap();json!({"repository_id":id,"source_head":cohort["commit"],"source_tree":SHA,"store_schema":"codestory-store/v1","file_count":10,"node_count":20,"edge_count":30,"freshness":"fresh","database_sha256":SHA,"core_generation":1,"identity":{"project_id":format!("project-{id}"),"core_generation_id":format!("generation-{id}"),"core_run_id":format!("run-{id}")}})}).collect::<Vec<_>>()},
       "inventory":cohort_ids.iter().map(|id|json!({"repository_id":id,"stored_call_rows":"10","effective_endpoint_rows":"10","exact_resolved_rows":"8","admitted_rows":"7","unresolved_placeholder_rows":"2"})).collect::<Vec<_>>(),
       "trails":cohort_ids.iter().map(|id|json!({"repository_id":id,"lengths":[{"length":1,"effective_endpoint":"10","exact_resolved":"8","strictly_admitted":"7"},{"length":2,"effective_endpoint":"9","exact_resolved":"7","strictly_admitted":"6"},{"length":3,"effective_endpoint":"8","exact_resolved":"6","strictly_admitted":"5"},{"length":4,"effective_endpoint":"7","exact_resolved":"5","strictly_admitted":"4"},{"length":5,"effective_endpoint":"6","exact_resolved":"4","strictly_admitted":"3"},{"length":6,"effective_endpoint":"5","exact_resolved":"3","strictly_admitted":"2"}]})).collect::<Vec<_>>(),
       "cases":cases,
@@ -2554,6 +2583,31 @@ fn schemas_have_semantic_constants_patterns_and_bounds() {
         "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?Z$"
     );
     assert_eq!(
+        report_schema["$defs"]["EnvironmentReportV1"]["properties"]["qualification_id"]["pattern"],
+        "^[0-9]{8}T[0-9]{6}Z-[0-9a-f]{12}$"
+    );
+    assert_eq!(
+        report_schema["$defs"]["QualificationBuildProvenanceV1"]["properties"]["rustc_vv"]["maxLength"],
+        8192
+    );
+    assert_eq!(
+        report_schema["$defs"]["QualificationBuildProvenanceV1"]["properties"]["cargo_profile"]["const"],
+        "release"
+    );
+    assert_eq!(
+        report_schema["$defs"]["QualificationBuildProvenanceV1"]["properties"]["prescribed_argv"]["const"],
+        json!([
+            "cargo",
+            "build",
+            "--release",
+            "--locked",
+            "-p",
+            "codestory-bench",
+            "--bin",
+            "codestory-proof-availability"
+        ])
+    );
+    assert_eq!(
         report_schema["$defs"]["ActualProductResultV1"]["oneOf"][0]["properties"]["contract_digest"]
             ["pattern"],
         "^[0-9a-f]{64}$"
@@ -2648,6 +2702,29 @@ fn schemas_have_semantic_constants_patterns_and_bounds() {
 
 #[test]
 fn cli_matches_frozen_materialize_run_and_verify_shapes() {
+    let indexed = cli::Cli::try_parse_from([
+        "bin",
+        "materialize",
+        "--corpus",
+        "/tmp/c",
+        "--workspace",
+        "/tmp/w",
+        "--cache-root",
+        "/tmp/cache",
+        "--out",
+        "/tmp/e",
+        "--qualification-id",
+        "20260821T123456Z-0123456789ab",
+    ])
+    .expect("indexed materialization with closed qualification identity");
+    let cli::Command::Materialize(indexed) = indexed.command else {
+        panic!("materialize command")
+    };
+    assert_eq!(
+        indexed.qualification_id.as_deref(),
+        Some("20260821T123456Z-0123456789ab")
+    );
+
     assert!(matches!(
         cli::Cli::try_parse_from([
             "bin",
@@ -2666,6 +2743,66 @@ fn cli_matches_frozen_materialize_run_and_verify_shapes() {
         .command,
         cli::Command::Materialize(_)
     ));
+    for invalid in [
+        "20260821T123456Z-0123456789a",
+        "20260821T123456Z-0123456789AB",
+        "2026-08-21T12:34:56Z-0123456789ab",
+        "20260230T123456Z-0123456789ab",
+    ] {
+        assert!(
+            cli::Cli::try_parse_from([
+                "bin",
+                "materialize",
+                "--corpus",
+                "/tmp/c",
+                "--workspace",
+                "/tmp/w",
+                "--cache-root",
+                "/tmp/cache",
+                "--out",
+                "/tmp/e",
+                "--qualification-id",
+                invalid,
+            ])
+            .is_err(),
+            "indexed materialization must reject {invalid}"
+        );
+    }
+    assert!(
+        cli::Cli::try_parse_from([
+            "bin",
+            "materialize",
+            "--corpus",
+            "/tmp/c",
+            "--workspace",
+            "/tmp/w",
+            "--cache-root",
+            "/tmp/cache",
+            "--out",
+            "/tmp/e",
+        ])
+        .is_err(),
+        "indexed materialization requires a qualification ID"
+    );
+    assert!(
+        cli::Cli::try_parse_from([
+            "bin",
+            "materialize",
+            "--corpus",
+            "/tmp/c",
+            "--workspace",
+            "/tmp/w",
+            "--cache-root",
+            "/tmp/cache",
+            "--out",
+            "/tmp/e",
+            "--verify-only",
+            "--qualification-id",
+            "20260821T123456Z-0123456789ab",
+        ])
+        .is_err(),
+        "source-only audit rejects indexed qualification identity"
+    );
     assert!(matches!(
         cli::Cli::try_parse_from([
             "bin",

--- a/docs/superpowers/plans/2026-08-21-codestory-v3-proof-availability-qualification.md
+++ b/docs/superpowers/plans/2026-08-21-codestory-v3-proof-availability-qualification.md
@@ -395,22 +395,28 @@ binary name: codestory-proof-availability
 Commands:
 
 ```sh
+qualification_id="$(date -u +%Y%m%dT%H%M%SZ)-$(git rev-parse --short=12 HEAD)"
+run_root="target/proof-availability/$qualification_id"
+results_root="$run_root/results"
+mkdir -p "$run_root" "$results_root"
+
 ./target/release/codestory-proof-availability materialize \
+  --qualification-id "$qualification_id" \
   --corpus benchmarks/proof-availability/corpus-v1.json \
-  --workspace target/proof-availability/workspaces \
-  --cache-root target/proof-availability/cache \
-  --out target/proof-availability/run/environment.json
+  --workspace "$run_root/workspaces" \
+  --cache-root "$run_root/cache" \
+  --out "$run_root/environment.json"
 
 ./target/release/codestory-proof-availability run \
   --corpus benchmarks/proof-availability/corpus-v1.json \
   --thresholds benchmarks/proof-availability/thresholds-v1.json \
-  --environment target/proof-availability/run/environment.json \
-  --out target/proof-availability/run
+  --environment "$run_root/environment.json" \
+  --out "$results_root/$qualification_id"
 
 ./target/release/codestory-proof-availability verify \
   --corpus benchmarks/proof-availability/corpus-v1.json \
   --thresholds benchmarks/proof-availability/thresholds-v1.json \
-  --results target/proof-availability/run
+  --results "$results_root/$qualification_id"
 ```
 
 `materialize` creates detached pinned checkouts, verifies oracle hashes, builds fresh full indexes through the source-linked runtime/indexer, and records core generation/run plus database SHA. `run` is local and does not fetch. `verify` recomputes every aggregate and decision from case rows.
@@ -1289,14 +1295,16 @@ Expected: clean tracked tree. Record the command, binary SHA, Rust host/toolchai
 ```sh
 qualification_id="$(date -u +%Y%m%dT%H%M%SZ)-$(git rev-parse --short=12 HEAD)"
 run_root="target/proof-availability/$qualification_id"
+results_root="$run_root/results"
 test ! -e "$run_root"
-mkdir -p "$run_root"
+mkdir -p "$run_root" "$results_root"
 ```
 
 - [ ] **Step 4: Materialize, run, and verify once**
 
 ```sh
 "$qualification_bin" materialize \
+  --qualification-id "$qualification_id" \
   --corpus benchmarks/proof-availability/corpus-v1.json \
   --workspace "$run_root/workspaces" \
   --cache-root "$run_root/cache" \
@@ -1306,12 +1314,12 @@ mkdir -p "$run_root"
   --corpus benchmarks/proof-availability/corpus-v1.json \
   --thresholds benchmarks/proof-availability/thresholds-v1.json \
   --environment "$run_root/environment.json" \
-  --out "$run_root/results"
+  --out "$results_root/$qualification_id"
 
 "$qualification_bin" verify \
   --corpus benchmarks/proof-availability/corpus-v1.json \
   --thresholds benchmarks/proof-availability/thresholds-v1.json \
-  --results "$run_root/results"
+  --results "$results_root/$qualification_id"
 ```
 
 These commands are the complete Q2 interface. The evaluator is closed to A, B,
@@ -1333,7 +1341,7 @@ Require:
 
 - [ ] **Step 6: Copy machine results and generate findings**
 
-Copy only `results` artifacts to `benchmarks/proof-availability/results/$qualification_id`. `findings.md` is generated from the same case rows and names reproduced measurements, inferences, and selected thresholds separately.
+Copy only the eight artifacts from `$results_root/$qualification_id` to `benchmarks/proof-availability/results/$qualification_id`. The source and destination basenames, `environment.json`, and `summary.json` all carry the same qualification ID. `findings.md` is generated from the same case rows and names reproduced measurements, inferences, and selected thresholds separately.
 
 - [ ] **Step 7: Independent exact-artifact review**
 

--- a/docs/superpowers/plans/2026-08-21-codestory-v3-proof-availability-qualification.md
+++ b/docs/superpowers/plans/2026-08-21-codestory-v3-proof-availability-qualification.md
@@ -1288,7 +1288,7 @@ git status --short
 git rev-parse HEAD^{commit} HEAD^{tree}
 ```
 
-Expected: clean tracked tree. Record the command, binary SHA, Rust host/toolchain, OS/architecture, and source commit/tree in `environment.json`.
+Expected: clean tracked tree. The build embeds its source commit, source tree, dirty state, Cargo-selected `rustc -vV`, and Cargo profile. Indexed materialization rejects a dirty build, a non-release profile, or a live checkout whose clean commit/tree no longer equals that embedded identity. Record the prescribed command, binary SHA, Rust host/toolchain, OS/architecture, and embedded source identity in `environment.json`.
 
 - [ ] **Step 3: Create one immutable qualification ID**
 

--- a/docs/testing/proof-availability-v1.md
+++ b/docs/testing/proof-availability-v1.md
@@ -7,11 +7,15 @@ public.
 
 ## Inputs and lifecycle
 
-Use one locked `codestory-proof-availability` binary for both materialization and
-the run. Materialization checks out the exact frozen commits, verifies every
-oracle range and each receipt step's independently frozen full-source-file
-SHA-256, builds one fresh core index per project, and writes a private local
-environment descriptor:
+Build one locked release `codestory-proof-availability` binary with the closed
+command below, then use that same binary for materialization, the run, and
+verification. It embeds Cargo's selected `rustc -vV` and build profile. Indexed
+materialization rejects a non-release build and records that compiler identity,
+the prescribed build command, and the explicit qualification ID in public
+environment evidence. Materialization checks out the exact frozen commits,
+verifies every oracle range and each receipt step's independently frozen
+full-source-file SHA-256, builds one fresh core index per project, and writes a
+private local environment descriptor:
 
 Before Q2, Q1 must prove that the evidence-only v3 surface is separable from
 proof activation. The sealed conformance probe builds and validates packet,
@@ -38,16 +42,28 @@ run Q2. A successful Q1 gate constrains Q2 to Outcomes A, B, or C. The
 qualification binary never accepts caller-supplied dependency evidence.
 
 ```sh
-cargo run --locked -p codestory-bench --bin codestory-proof-availability -- \
-  materialize \
+cargo build --release --locked -p codestory-bench --bin codestory-proof-availability
+qualification_bin=target/release/codestory-proof-availability
+qualification_id="$(date -u +%Y%m%dT%H%M%SZ)-$(git rev-parse --short=12 HEAD)"
+run_root="target/proof-availability/$qualification_id"
+results_root="$run_root/results"
+mkdir -p "$run_root" "$results_root"
+
+"$qualification_bin" materialize \
+  --qualification-id "$qualification_id" \
   --corpus benchmarks/proof-availability/corpus-v1.json \
-  --workspace target/proof-availability/workspace \
-  --cache-root target/proof-availability/cache \
-  --out target/proof-availability/environment.json
+  --workspace "$run_root/workspace" \
+  --cache-root "$run_root/cache" \
+  --out "$run_root/environment.json"
 ```
 
-The source-only audit form is separate. It neither creates the cache nor indexes
-or executes proof:
+The ID is exactly `YYYYMMDDTHHMMSSZ-<12 lowercase commit hex>`, and its suffix
+must match the qualification source commit. `environment_id` remains a separate
+identity derived from measured environment and binary evidence.
+
+The source-only audit form is separate. It accepts no qualification ID, does not
+require a release build, and neither creates the cache nor indexes or executes
+proof:
 
 ```sh
 cargo run --locked -p codestory-bench --bin codestory-proof-availability -- \
@@ -63,12 +79,11 @@ Run qualification only against the private descriptor produced by the same
 clean source head and binary:
 
 ```sh
-cargo run --locked -p codestory-bench --bin codestory-proof-availability -- \
-  run \
+"$qualification_bin" run \
   --corpus benchmarks/proof-availability/corpus-v1.json \
   --thresholds benchmarks/proof-availability/thresholds-v1.json \
-  --environment target/proof-availability/environment.json \
-  --out target/proof-availability/results
+  --environment "$run_root/environment.json" \
+  --out "$results_root/$qualification_id"
 ```
 
 The command is the complete Q2 contract for Outcomes A, B, and C.
@@ -140,15 +155,16 @@ threshold, results, aggregate, and decision bindings, including the same
 three-way oracle/indexed/observed file-hash comparison, and writes nothing:
 
 ```sh
-cargo run --locked -p codestory-bench --bin codestory-proof-availability -- \
-  verify \
+"$qualification_bin" verify \
   --corpus benchmarks/proof-availability/corpus-v1.json \
   --thresholds benchmarks/proof-availability/thresholds-v1.json \
-  --results target/proof-availability/results
+  --results "$results_root/$qualification_id"
 ```
 
 This is the complete A/B/C verification contract. There is no runtime input for
-Outcome D.
+Outcome D. The result directory basename, public environment, summary, and
+verification identity must all equal the same qualification ID. The directory
+still contains exactly the eight artifacts listed above.
 
 ## Interpretation
 

--- a/docs/testing/proof-availability-v1.md
+++ b/docs/testing/proof-availability-v1.md
@@ -10,9 +10,11 @@ public.
 Build one locked release `codestory-proof-availability` binary with the closed
 command below, then use that same binary for materialization, the run, and
 verification. It embeds Cargo's selected `rustc -vV` and build profile. Indexed
-materialization rejects a non-release build and records that compiler identity,
-the prescribed build command, and the explicit qualification ID in public
-environment evidence. Materialization checks out the exact frozen commits,
+materialization rejects a non-release or dirty-source build. The embedded source
+commit and tree are authoritative: the live checkout must remain clean and at
+that exact identity. Public environment evidence records the build source,
+compiler identity, prescribed build command, and explicit qualification ID.
+Materialization checks out the exact frozen commits,
 verifies every oracle range and each receipt step's independently frozen
 full-source-file SHA-256, builds one fresh core index per project, and writes a
 private local environment descriptor:


### PR DESCRIPTION
## Context

Q1 merged as #2001, but the pre-Q2 audit found two evidence-contract gaps: the public run ID could diverge from the result directory, and the binary did not carry enough build provenance to distinguish the source it was built from from the checkout it later ran beside.

## What changed

- adds one explicit `materialize --qualification-id` bound to the clean source commit prefix;
- keeps `environment_id` as a separate derived environment identity;
- requires environment, summary, verification, and result-directory IDs to agree;
- embeds Cargo-selected compiler, profile, source commit/tree, and dirty state in the qualification binary;
- rejects dirty builds, dirty live source, source drift, non-release builds, or compiler-host drift before indexed materialization writes;
- records the closed prescribed build argv without accepting caller-authored provenance;
- preserves source-only `--verify-only`, the exact eight artifacts, and the frozen corpus/threshold/methodology identities.

## Review

The first independent review found one Important defect: a binary built at A could read and claim a later clean checkout B. The follow-up commit embeds source identity at build time and uses the live checkout only as an equality/freshness fence. Exact-head re-review approved the correction with no remaining Critical or Important finding.

## Verification

- `cargo test --locked -p codestory-bench proof_availability` — 101 passed, 2 intentional ignores
- `cargo test --locked -p codestory-bench --test proof_availability_contracts` — 50 passed, 1 intentional ignore
- `cargo check --locked -p codestory-bench`
- `cargo clippy --locked -p codestory-bench --all-targets -- -D warnings`
- `cargo fmt -p codestory-bench -- --check`
- docs links — 84 files / 316 links
- `git diff --check`
- exact committed-head debug binary accepted the embedded source identity, then refused indexed materialization because its profile was not `release`; no destination artifact was created

`cargo fmt --all -- --check` remains blocked in this linked worktree by the existing `vendor/tree-sitter-graph` workspace-membership metadata error; package-scoped formatting passes.

## Risk and non-claims

This changes the qualification report schema and binary identity only. It does not change product routes, MCP catalogs, CodeStory versions, the frozen corpus, methodology, thresholds, or the eight-artifact result set. Q2 has not run.

Closes #2002
Refs #1984
Refs #1985
