### PR TITLE
[v3 qualification preflight] admit exact JSONC configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- TypeScript and JavaScript config files can now be indexed when they use JSONC comments or trailing commas. Ordinary JSON stays strict, and malformed config changes leave the previous complete index available.
+
 ## 0.17.4
 
 Cursor marketplace MCP tool results match the schemas Cursor validates. After the server started, Cursor rejected `status`, `packet`, and `files` because the advertised output schema forbade extra compact-status fields, typed packet `support` as an object, and omitted `files.coverage_gaps`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,6 +615,7 @@ dependencies = [
  "codestory-workspace",
  "crossbeam-channel",
  "ignore",
+ "jsonc-parser",
  "parking_lot",
  "rayon",
  "rusqlite",
@@ -2742,6 +2743,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "jsonc-parser"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0560e3f9a9a03ea6b6e90b41138c5db9e21526c99eb192c1a26c68176593285"
 
 [[package]]
 name = "kasuari"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ tantivy = "0.26"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_json_canonicalizer = "=0.3.2"
+jsonc-parser = "=0.33.1"
 schemars = { version = "1", features = ["derive"] }
 serde_with = "3.21.0"
 saphyr-parser = "0.0.11"

--- a/crates/codestory-contracts/src/language_support.rs
+++ b/crates/codestory-contracts/src/language_support.rs
@@ -279,7 +279,7 @@ pub const STRUCTURAL_SOURCE_PROOF_CONTRACTS: &[StructuralSourceProofContract] = 
     },
     StructuralSourceProofContract {
         collector_name: "json",
-        path_pattern: "generic **/*.json after dedicated OpenAPI routing",
+        path_pattern: "generic **/*.json after dedicated OpenAPI and TypeScript/JavaScript config JSONC routing",
         emitted_node_kinds: GENERIC_STRUCTURAL_NODE_KINDS,
         source_span: "1-based exact source span for an object-key anchor",
         evidence_tier: PacketEvidenceTierDto::StructuralText,
@@ -287,6 +287,18 @@ pub const STRUCTURAL_SOURCE_PROOF_CONTRACTS: &[StructuralSourceProofContract] = 
         confidence: 1.0,
         unsupported_shape_notes: GENERIC_STRUCTURAL_UNSUPPORTED_SHAPES,
         claim_boundary: "structural exact-source proof only; not OpenAPI semantics, typed target resolution, or packet semantic-proof admission",
+        semantic_proof_allowed: false,
+    },
+    StructuralSourceProofContract {
+        collector_name: "typescript_config_jsonc",
+        path_pattern: "basename-scoped tsconfig.json, tsconfig.<suffix>.json, jsconfig.json, or jsconfig.<suffix>.json",
+        emitted_node_kinds: GENERIC_STRUCTURAL_NODE_KINDS,
+        source_span: "1-based exact source span for a quoted JSONC object-key anchor",
+        evidence_tier: PacketEvidenceTierDto::StructuralText,
+        resolution: PacketEvidenceResolutionDto::SourceRangeOnly,
+        confidence: 1.0,
+        unsupported_shape_notes: GENERIC_STRUCTURAL_UNSUPPORTED_SHAPES,
+        claim_boundary: "structural exact-source proof only; not generic JSONC support, TypeScript compiler semantics, typed target resolution, or packet semantic-proof admission",
         semantic_proof_allowed: false,
     },
     StructuralSourceProofContract {
@@ -719,6 +731,32 @@ pub fn is_cargo_manifest_file_path_with_case(path: &str, path_case: NativePathCa
         .is_some_and(|file_name| match path_case {
             NativePathCase::Sensitive => file_name == "Cargo.toml",
             NativePathCase::Insensitive => file_name.eq_ignore_ascii_case("Cargo.toml"),
+        })
+}
+
+/// Whether a path names a TypeScript or JavaScript config that admits the
+/// JSONC dialect under explicit native basename-case rules.
+pub fn is_typescript_config_jsonc_file_path(path: &str) -> bool {
+    is_typescript_config_jsonc_file_path_with_case(path, NativePathCase::current())
+}
+
+/// Whether a path names a TypeScript or JavaScript config under `path_case`.
+pub fn is_typescript_config_jsonc_file_path_with_case(
+    path: &str,
+    path_case: NativePathCase,
+) -> bool {
+    let normalized = path.replace('\\', "/");
+    let file_name = normalized.rsplit('/').next().unwrap_or_default();
+    let file_name = match path_case {
+        NativePathCase::Sensitive => std::borrow::Cow::Borrowed(file_name),
+        NativePathCase::Insensitive => std::borrow::Cow::Owned(file_name.to_ascii_lowercase()),
+    };
+    matches!(file_name.as_ref(), "tsconfig.json" | "jsconfig.json")
+        || ["tsconfig.", "jsconfig."].into_iter().any(|prefix| {
+            file_name
+                .strip_prefix(prefix)
+                .and_then(|suffix| suffix.strip_suffix(".json"))
+                .is_some_and(|suffix| !suffix.is_empty())
         })
 }
 
@@ -1466,6 +1504,41 @@ mod tests {
             );
         }
         assert!(!is_structural_source_path("config.jsonc"));
+    }
+
+    #[test]
+    fn typescript_config_jsonc_routing_is_basename_scoped_under_native_case_rules() {
+        for path in [
+            "tsconfig.json",
+            "config/tsconfig.build.json",
+            r"config\\jsconfig.editor.json",
+            "jsconfig.json",
+        ] {
+            assert!(
+                is_typescript_config_jsonc_file_path_with_case(path, NativePathCase::Sensitive),
+                "{path}"
+            );
+        }
+        for path in [
+            "config.json",
+            "my-tsconfig.json",
+            "tsconfig.json.bak",
+            "tsconfig..json",
+            "tsconfig.jsonc",
+        ] {
+            assert!(
+                !is_typescript_config_jsonc_file_path_with_case(path, NativePathCase::Sensitive),
+                "{path}"
+            );
+        }
+        assert!(is_typescript_config_jsonc_file_path_with_case(
+            "TSCONFIG.JSON",
+            NativePathCase::Insensitive
+        ));
+        assert!(!is_typescript_config_jsonc_file_path_with_case(
+            "TSCONFIG.JSON",
+            NativePathCase::Sensitive
+        ));
     }
 
     #[test]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -14,6 +14,7 @@ codestory-store = { workspace = true }
 codestory-workspace = { workspace = true }
 crossbeam-channel = { workspace = true }
 ignore = { workspace = true }
+jsonc-parser = { workspace = true }
 parking_lot = { workspace = true }
 rayon = { workspace = true }
 rusqlite = { workspace = true }

--- a/crates/codestory-indexer/src/cache.rs
+++ b/crates/codestory-indexer/src/cache.rs
@@ -109,9 +109,9 @@ impl CachedStructuralArtifact {
     }
 }
 
-// Bumped to 3 alongside the index artifact cache: the SQL, HTML, and callable
-// projection changes in this wave all reach structural artifacts too.
-pub(crate) const STRUCTURAL_ARTIFACT_CACHE_VERSION: u32 = 3;
+// Bumped to 4 because workspace-relative role classification changes persisted
+// structural file metadata and zero-byte JSON admission.
+pub(crate) const STRUCTURAL_ARTIFACT_CACHE_VERSION: u32 = 4;
 
 pub(crate) fn build_structural_artifact_cache_key(
     cache_path: &Path,

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -996,6 +996,7 @@ struct PreparedIndexInput {
 #[derive(Debug)]
 struct PreparedStructuralInput {
     full_path: PathBuf,
+    role_classification_path: PathBuf,
     artifact_cache_path: Option<PathBuf>,
     artifact_cache_key: Option<String>,
     source: String,
@@ -3244,6 +3245,9 @@ impl WorkspaceIndexer {
         stats: &mut IncrementalIndexingStats,
     ) -> std::result::Result<PreparedIndexWork, IntermediateStorage> {
         let full_path = Self::normalize_index_path(root, path);
+        let role_classification_path =
+            codestory_workspace::workspace_relative_path(root, &full_path)
+                .unwrap_or_else(|| path.to_path_buf());
         let language = structural::structural_language_name(&full_path);
         let producer = structural::structural_producer(&full_path)
             .expect("admitted structural paths have one producer");
@@ -3324,6 +3328,7 @@ impl WorkspaceIndexer {
         stats.structural_artifact_cache.record_lookup();
         let prepared_input = || PreparedStructuralInput {
             full_path: full_path.clone(),
+            role_classification_path: role_classification_path.clone(),
             artifact_cache_path: artifact_cache_path.clone(),
             artifact_cache_key: artifact_cache_key.clone(),
             source: source.clone(),
@@ -3499,6 +3504,8 @@ impl WorkspaceIndexer {
         if codestory_contracts::language_support::is_github_actions_workflow_path(
             path_text.as_ref(),
         ) || codestory_contracts::language_support::is_docker_compose_file_path(
+            path_text.as_ref(),
+        ) || codestory_contracts::language_support::is_typescript_config_jsonc_file_path(
             path_text.as_ref(),
         ) {
             return Ok(None);
@@ -3714,8 +3721,9 @@ impl WorkspaceIndexer {
             .as_ref()
             .map(|policy| policy.structural_unit_cap)
             .unwrap_or(codestory_contracts::workspace::DEFAULT_STRUCTURAL_UNIT_CAP);
-        let collected = match structural::index_structural_source_with_unit_cap(
+        let collected = match structural::index_structural_source_with_role_and_unit_cap(
             &prepared_input.full_path,
+            &prepared_input.role_classification_path,
             &prepared_input.source,
             structural_unit_cap,
             self.structural_source_byte_cap,

--- a/crates/codestory-indexer/src/structural/jsonc.rs
+++ b/crates/codestory-indexer/src/structural/jsonc.rs
@@ -1,0 +1,88 @@
+use crate::intermediate_storage::IntermediateStorage;
+use codestory_contracts::graph::{NodeId, NodeKind};
+use jsonc_parser::ast::Value;
+use jsonc_parser::common::Ranged;
+use jsonc_parser::{CollectOptions, ParseOptions, parse_to_ast};
+use std::path::Path;
+
+use super::StructuralCollectionError;
+use super::blanking::byte_offset_line_col;
+use super::common::{StructuralSourceSpan, push_member_edge, push_structural_node};
+
+pub(crate) fn collect_typescript_config_jsonc_entities(
+    path: &Path,
+    source: &str,
+    file_id: NodeId,
+    storage: &mut IntermediateStorage,
+) -> Result<(), StructuralCollectionError> {
+    let options = ParseOptions {
+        allow_comments: true,
+        allow_loose_object_property_names: false,
+        allow_trailing_commas: true,
+        allow_missing_commas: false,
+        allow_single_quoted_strings: false,
+        allow_hexadecimal_numbers: false,
+        allow_unary_plus_numbers: false,
+    };
+    let parsed = parse_to_ast(source, &CollectOptions::default(), &options).map_err(|error| {
+        StructuralCollectionError::Malformed(format!(
+            "invalid TypeScript config JSONC syntax: {error}"
+        ))
+    })?;
+    let value = parsed.value.ok_or_else(|| {
+        StructuralCollectionError::Malformed(
+            "invalid TypeScript config JSONC syntax: expected one JSON value".to_string(),
+        )
+    })?;
+    let mut ordinal = 0usize;
+    collect_value_keys(path, source, file_id, storage, &value, &mut ordinal);
+    Ok(())
+}
+
+fn collect_value_keys(
+    path: &Path,
+    source: &str,
+    file_id: NodeId,
+    storage: &mut IntermediateStorage,
+    value: &Value<'_>,
+    ordinal: &mut usize,
+) {
+    match value {
+        Value::Object(object) => {
+            for property in &object.properties {
+                *ordinal += 1;
+                let range = property.name.range();
+                let (line, column) = byte_offset_line_col(source, range.start);
+                let node_id = push_structural_node(
+                    storage,
+                    file_id,
+                    NodeKind::ANNOTATION,
+                    property.name.as_str(),
+                    &format!(
+                        "structural-jsonc:{}:object-key:{}:{}:{}",
+                        path.to_string_lossy().replace('\\', "/"),
+                        *ordinal,
+                        line,
+                        column
+                    ),
+                    StructuralSourceSpan::token(
+                        line,
+                        column.saturating_sub(1) as usize,
+                        range.end.saturating_sub(range.start),
+                    ),
+                );
+                push_member_edge(storage, file_id, file_id, node_id, line);
+                collect_value_keys(path, source, file_id, storage, &property.value, ordinal);
+            }
+        }
+        Value::Array(array) => {
+            for element in &array.elements {
+                collect_value_keys(path, source, file_id, storage, element, ordinal);
+            }
+        }
+        Value::StringLit(_)
+        | Value::NumberLit(_)
+        | Value::BooleanLit(_)
+        | Value::NullKeyword(_) => {}
+    }
+}

--- a/crates/codestory-indexer/src/structural/mod.rs
+++ b/crates/codestory-indexer/src/structural/mod.rs
@@ -14,6 +14,7 @@ mod docker_compose;
 mod generic;
 mod github_actions;
 mod html;
+mod jsonc;
 mod sql;
 
 pub(crate) use blanking::byte_offset_line_col;
@@ -31,6 +32,7 @@ use anyhow::Result;
 use codestory_contracts::graph::NodeId;
 use codestory_contracts::language_support::{
     is_cargo_manifest_file_path, is_docker_compose_file_path, is_github_actions_workflow_path,
+    is_typescript_config_jsonc_file_path,
 };
 use sha2::{Digest, Sha256};
 use std::path::Path;
@@ -102,6 +104,9 @@ pub(crate) fn decode_structural_source(
 
 pub(crate) fn structural_producer(path: &Path) -> Option<&'static str> {
     let path_text = path.to_string_lossy();
+    if is_typescript_config_jsonc_file_path(path_text.as_ref()) {
+        return Some("structural_typescript_config_jsonc_collector");
+    }
     if is_github_actions_workflow_path(path_text.as_ref()) {
         return Some("structural_github_actions_workflow_collector");
     }
@@ -351,7 +356,17 @@ pub(crate) fn index_structural_source_with_unit_cap(
     storage.nodes.push(file_node);
 
     let path_key = path.to_string_lossy();
-    if is_github_actions_workflow_path(path_key.as_ref()) {
+    let exact_empty_test_or_benchmark_json = source.is_empty()
+        && matches!(structural_extension(path).as_deref(), Some("json"))
+        // The helper deliberately recognizes test/benchmark scope even when
+        // an absolute build-root ancestor has stronger diagnostic role precedence.
+        && codestory_store::FileRole::path_is_test_or_bench(path_key.as_ref());
+    if exact_empty_test_or_benchmark_json {
+        // A zero-byte test or benchmark artifact is a verified complete file,
+        // deliberately without structural evidence or semantic claims.
+    } else if is_typescript_config_jsonc_file_path(path_key.as_ref()) {
+        jsonc::collect_typescript_config_jsonc_entities(path, source, file_id, &mut storage)?;
+    } else if is_github_actions_workflow_path(path_key.as_ref()) {
         github_actions::collect_github_actions_workflow_entities(
             path,
             source,
@@ -859,6 +874,169 @@ mod tests {
                 "missing streamed JSON object-key anchor {expected}"
             );
         }
+    }
+
+    #[test]
+    fn typescript_config_jsonc_accepts_comments_and_trailing_commas_with_exact_key_anchors() {
+        let source = concat!(
+            "{\n",
+            "  // \"commentedOut\": false\n",
+            "  \"compilerOptions\": {\n",
+            "    /* URL: https://example.com/\\\"quoted\\\" */\n",
+            "    \"strict\": true,\n",
+            "  },\n",
+            "  \"endpoint\": \"https://example.com//keep/*literal*/\\\"quote\\\"\",\n",
+            "}\n",
+        );
+        let storage = index_structural_source(Path::new("tsconfig.build.json"), source)
+            .expect("recognized TypeScript configs should accept strict JSONC");
+
+        let mut anchors = storage
+            .nodes
+            .iter()
+            .filter(|node| node.kind != NodeKind::FILE)
+            .map(|node| {
+                std::str::from_utf8(
+                    exact_source_range_bytes(
+                        source,
+                        node.start_line.expect("anchor start line"),
+                        node.start_col.expect("anchor start column"),
+                        node.end_line.expect("anchor end line"),
+                        node.end_col.expect("anchor end column"),
+                    )
+                    .expect("exact key span"),
+                )
+                .expect("UTF-8 key span")
+                .to_string()
+            })
+            .collect::<Vec<_>>();
+        anchors.sort();
+        assert_eq!(
+            anchors,
+            ["\"compilerOptions\"", "\"endpoint\"", "\"strict\""]
+        );
+        assert_eq!(
+            structural_producer(Path::new("tsconfig.build.json")),
+            Some("structural_typescript_config_jsonc_collector")
+        );
+    }
+
+    #[test]
+    fn exact_zero_byte_test_json_emits_a_complete_zero_unit_projection() {
+        let path = Path::new("tests/fixtures/empty.json");
+        let collected = index_structural_source(path, "")
+            .expect("exact zero-byte test JSON should be a verified structural file");
+        assert_eq!(
+            collected.files[0].file_role,
+            codestory_store::FileRole::Test
+        );
+        assert!(collected.files[0].complete);
+        assert_eq!(collected.nodes.len(), 1);
+        assert!(collected.edges.is_empty());
+        assert!(collected.occurrences.is_empty());
+        assert!(collected.structural_unit_node_ids.is_empty());
+
+        let projected =
+            finalize_structural_storage(path, "", &format!("{:x}", Sha256::digest([])), collected)
+                .expect("zero-byte test JSON should finalize");
+        assert_eq!(projected.structural_text_projections[0].unit_count, 0);
+    }
+
+    #[test]
+    fn typescript_config_jsonc_rejects_every_unapproved_json_extension() {
+        for source in [
+            "{ loose: true }",
+            "{ \"first\": true \"second\": false }",
+            "{ 'single': true }",
+            "{ \"hex\": 0x10 }",
+            "{ \"plus\": +1 }",
+            "{ \"first\": true } { \"second\": false }",
+            "{ /* unterminated",
+            "{ \"valid\": true } trailing",
+        ] {
+            assert!(
+                matches!(
+                    index_structural_source(Path::new("tsconfig.json"), source),
+                    Err(StructuralCollectionError::Malformed(_))
+                ),
+                "{source:?} must remain outside the JSONC dialect"
+            );
+        }
+        assert!(matches!(
+            index_structural_source(
+                Path::new("config.json"),
+                "{ // comment\n \"strict\": true }"
+            ),
+            Err(StructuralCollectionError::Malformed(_))
+        ));
+    }
+
+    #[test]
+    fn jsonc_and_generic_json_use_distinct_cache_producers() {
+        let source = br#"{"strict":true}"#;
+        let generic = structural_producer(Path::new("config.json")).expect("generic producer");
+        let jsonc = structural_producer(Path::new("tsconfig.json")).expect("JSONC producer");
+        assert_eq!(generic, "structural_json_collector");
+        assert_eq!(jsonc, "structural_typescript_config_jsonc_collector");
+        assert_ne!(
+            crate::cache::build_structural_artifact_cache_key(
+                Path::new("config.json"),
+                source,
+                generic
+            ),
+            crate::cache::build_structural_artifact_cache_key(
+                Path::new("config.json"),
+                source,
+                jsonc
+            )
+        );
+    }
+
+    #[test]
+    fn only_exact_empty_test_or_benchmark_json_can_publish_without_units() {
+        for path in [
+            "tests/empty.json",
+            "__tests__/empty.json",
+            "fixtures/empty.json",
+            "benchmarks/empty.json",
+        ] {
+            let storage = index_structural_source(Path::new(path), "").expect(path);
+            assert!(storage.files[0].complete, "{path}");
+            assert_eq!(storage.nodes.len(), 1, "{path}");
+            assert!(storage.edges.is_empty(), "{path}");
+            assert!(storage.occurrences.is_empty(), "{path}");
+            assert!(storage.structural_unit_node_ids.is_empty(), "{path}");
+        }
+        for (path, source) in [
+            ("config.json", ""),
+            ("tests/blank.json", " \n"),
+            ("fixtures/bad.json", "{\"bad\":"),
+        ] {
+            assert!(
+                matches!(
+                    index_structural_source(Path::new(path), source),
+                    Err(StructuralCollectionError::Malformed(_))
+                ),
+                "{path}"
+            );
+        }
+        assert!(matches!(
+            decode_structural_source(vec![b'{', 0, b'}']),
+            Err(StructuralCollectionError::Binary)
+        ));
+        assert!(matches!(
+            index_structural_source_with_unit_cap(Path::new("tests/large.json"), "{}", 10, 1),
+            Err(StructuralCollectionError::SourceByteLimit { .. })
+        ));
+    }
+
+    #[test]
+    fn exact_empty_test_json_stays_admitted_when_an_absolute_parent_looks_generated() {
+        let path = Path::new("/tmp/proof/target/workspaces/vite/src/__tests__/fixtures/empty.json");
+        let storage = index_structural_source(path, "")
+            .expect("test scope must win for zero-byte structural JSON admission");
+        assert_eq!(storage.nodes.len(), 1);
+        assert!(storage.structural_unit_node_ids.is_empty());
     }
 
     #[test]

--- a/crates/codestory-indexer/src/structural/mod.rs
+++ b/crates/codestory-indexer/src/structural/mod.rs
@@ -332,6 +332,22 @@ pub(crate) fn index_structural_source_with_unit_cap(
     structural_unit_cap: u64,
     structural_byte_cap: u64,
 ) -> std::result::Result<IntermediateStorage, StructuralCollectionError> {
+    index_structural_source_with_role_and_unit_cap(
+        path,
+        path,
+        source,
+        structural_unit_cap,
+        structural_byte_cap,
+    )
+}
+
+pub(crate) fn index_structural_source_with_role_and_unit_cap(
+    path: &Path,
+    role_classification_path: &Path,
+    source: &str,
+    structural_unit_cap: u64,
+    structural_byte_cap: u64,
+) -> std::result::Result<IntermediateStorage, StructuralCollectionError> {
     if source.len() as u64 > structural_byte_cap {
         return Err(StructuralCollectionError::SourceByteLimit {
             observed_size: source.len() as u64,
@@ -343,6 +359,7 @@ pub(crate) fn index_structural_source_with_unit_cap(
     }
     let mut storage = IntermediateStorage::default();
     let (file_node, _file_name, file_id) = crate::file_node_from_source(path, source);
+    let file_role = codestory_store::FileRole::classify_path(role_classification_path);
     storage.files.push(codestory_store::FileInfo {
         id: file_id.0,
         path: path.to_path_buf(),
@@ -351,16 +368,17 @@ pub(crate) fn index_structural_source_with_unit_cap(
         indexed: true,
         complete: true,
         line_count: source.lines().count() as u32,
-        file_role: codestory_store::FileRole::classify_path(path),
+        file_role,
     });
     storage.nodes.push(file_node);
 
     let path_key = path.to_string_lossy();
     let exact_empty_test_or_benchmark_json = source.is_empty()
         && matches!(structural_extension(path).as_deref(), Some("json"))
-        // The helper deliberately recognizes test/benchmark scope even when
-        // an absolute build-root ancestor has stronger diagnostic role precedence.
-        && codestory_store::FileRole::path_is_test_or_bench(path_key.as_ref());
+        && matches!(
+            file_role,
+            codestory_store::FileRole::Test | codestory_store::FileRole::Benchmark
+        );
     if exact_empty_test_or_benchmark_json {
         // A zero-byte test or benchmark artifact is a verified complete file,
         // deliberately without structural evidence or semantic claims.
@@ -1031,12 +1049,28 @@ mod tests {
     }
 
     #[test]
-    fn exact_empty_test_json_stays_admitted_when_an_absolute_parent_looks_generated() {
-        let path = Path::new("/tmp/proof/target/workspaces/vite/src/__tests__/fixtures/empty.json");
-        let storage = index_structural_source(path, "")
-            .expect("test scope must win for zero-byte structural JSON admission");
-        assert_eq!(storage.nodes.len(), 1);
-        assert!(storage.structural_unit_node_ids.is_empty());
+    fn exact_empty_json_requires_the_existing_test_or_benchmark_file_role() {
+        for (path, expected_role) in [
+            (
+                "/tmp/proof/target/workspaces/vite/src/__tests__/fixtures/empty.json",
+                codestory_store::FileRole::Generated,
+            ),
+            (
+                "/tmp/proof/vendor/fixture/tests/empty.json",
+                codestory_store::FileRole::Vendor,
+            ),
+        ] {
+            let path = Path::new(path);
+            assert_eq!(
+                codestory_store::FileRole::classify_path(path),
+                expected_role,
+                "role precedence must remain intact for {path:?}"
+            );
+            assert!(matches!(
+                index_structural_source(path, ""),
+                Err(StructuralCollectionError::Malformed(_))
+            ));
+        }
     }
 
     #[test]

--- a/crates/codestory-indexer/src/tests/mod.rs
+++ b/crates/codestory-indexer/src/tests/mod.rs
@@ -1944,6 +1944,7 @@ fn structural_source_drift_discards_units_and_cache_write_even_with_restored_mti
     let content_hash = source_content_hash(original.as_bytes());
     let prepared = PreparedStructuralInput {
         full_path: path.clone(),
+        role_classification_path: PathBuf::from("schema.sql"),
         artifact_cache_path: Some(PathBuf::from("schema.sql")),
         artifact_cache_key: Some("v1:original".to_string()),
         source: original.to_string(),
@@ -2121,6 +2122,11 @@ fn prepare_path_preserves_specialized_structural_and_openapi_routing() -> Result
             "[package]\nname = \"app\"\n",
             "structural_cargo_manifest_collector",
         ),
+        (
+            "tsconfig.json",
+            "{\"openapi\":\"3.1.0\",\"paths\":{\"/health\":{\"get\":{}}},\"compilerOptions\":{\"strict\":true}}",
+            "structural_typescript_config_jsonc_collector",
+        ),
     ];
     for (relative, source, _expected_producer) in fixtures {
         let path = dir.path().join(relative);
@@ -2229,6 +2235,49 @@ fn prepare_path_preserves_specialized_structural_and_openapi_routing() -> Result
         Ok(_) => panic!("parser-backed .sh entered structural fallback"),
         Err(_) => panic!("parser-backed .sh preparation failed"),
     }
+    Ok(())
+}
+
+#[test]
+fn structural_zero_byte_role_uses_the_workspace_relative_path() -> Result<()> {
+    let dir = tempdir()?;
+    let root = dir.path().join("target/workspace");
+    let relative = PathBuf::from("src/__tests__/fixtures/empty.json");
+    let full_path = root.join(&relative);
+    std::fs::create_dir_all(full_path.parent().expect("fixture parent"))?;
+    std::fs::write(&full_path, [])?;
+
+    let indexer = WorkspaceIndexer::new(root.clone());
+    let mut storage = Storage::new_in_memory()?;
+    let symbol_table = Arc::new(SymbolTable::new());
+    let mut stats = IncrementalIndexingStats::default();
+    let prepared_result = {
+        let mut cache_access =
+            ArtifactCacheAccess::storage(&mut storage, ArtifactCachePolicies::default());
+        indexer.prepare_index_work(
+            &mut cache_access,
+            &relative,
+            &root,
+            None,
+            &symbol_table,
+            &mut stats,
+        )
+    };
+    let prepared = match prepared_result {
+        Ok(prepared) => prepared,
+        Err(_) => panic!("zero-byte test JSON preparation failed"),
+    };
+    let input = match prepared {
+        PreparedIndexWork::Structural(input) => input,
+        _ => panic!("zero-byte test JSON must enter structural collection"),
+    };
+    let projected = indexer.execute_prepared_structural_index(&input);
+    assert!(projected.local_storage.errors.is_empty());
+    assert_eq!(
+        projected.local_storage.files[0].file_role,
+        codestory_store::FileRole::Test
+    );
+    assert!(projected.local_storage.structural_text_units.is_empty());
     Ok(())
 }
 

--- a/crates/codestory-runtime/src/tests.rs
+++ b/crates/codestory-runtime/src/tests.rs
@@ -3184,6 +3184,62 @@ fn full_refresh_publishes_structural_unit_exclusion_without_graph_claims() {
 }
 
 #[test]
+fn full_refresh_publishes_typescript_jsonc_and_exact_empty_test_json_then_preserves_previous_core()
+{
+    let _env = hybrid_test_env();
+    let workspace = tempdir().expect("workspace");
+    let config_path = workspace.path().join("tsconfig.json");
+    let empty_test_path = workspace.path().join("tests/empty.json");
+    fs::create_dir_all(empty_test_path.parent().expect("test parent")).expect("create test parent");
+    fs::write(
+        &config_path,
+        "{\n  // strict JSONC config\n  \"compilerOptions\": { \"strict\": true, },\n}\n",
+    )
+    .expect("write JSONC config");
+    fs::write(&empty_test_path, []).expect("write exact empty test JSON");
+
+    let storage_path = workspace.path().join(".cache/codestory.db");
+    let controller = AppController::new_with_config(test_sidecar_runtime_from_env());
+    controller
+        .open_project_summary_with_storage_path(
+            workspace.path().to_path_buf(),
+            storage_path.clone(),
+        )
+        .expect("open project summary");
+    controller
+        .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+        .expect("recognized JSONC config and exact empty test artifact should publish");
+
+    let baseline = Storage::open(&storage_path)
+        .expect("open baseline storage")
+        .get_complete_index_publication()
+        .expect("read baseline publication")
+        .expect("complete baseline publication");
+    let storage = Storage::open(&storage_path).expect("open published storage");
+    assert_eq!(
+        storage
+            .get_file_by_path(&empty_test_path)
+            .expect("read empty test JSON")
+            .expect("empty test JSON file row")
+            .file_role,
+        codestory_store::FileRole::Test
+    );
+    drop(storage);
+
+    fs::write(&config_path, "{ \"compilerOptions\": , }").expect("write malformed JSONC");
+    controller
+        .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+        .expect_err("malformed JSONC must reject a later full refresh");
+    assert_eq!(
+        Storage::open(&storage_path)
+            .expect("open preserved storage")
+            .get_complete_index_publication()
+            .expect("read preserved publication"),
+        Some(baseline)
+    );
+}
+
+#[test]
 fn incremental_refresh_replaces_structural_projection_and_semantics_with_unit_exclusion() {
     let _env = hybrid_test_env();
     let workspace = tempdir().expect("workspace");

--- a/docs/architecture/language-support.md
+++ b/docs/architecture/language-support.md
@@ -36,7 +36,7 @@ inventory only and make no graph, semantic, typed-target, or sufficiency claim.
 | Runtime claim | Languages | Evidence floor | Safe claim |
 | --- | --- | --- | --- |
 | Parser-backed graph, fidelity-gated | Python, Java, Rust, JavaScript, TypeScript/TSX, C++, C, Go, Ruby, PHP, C#, Kotlin, Swift, Dart, Bash | fidelity lab, tictactoe coverage, raw graph contracts, targeted rule/resolution suites, opt-in OSS corpus | daily graph navigation on typical code, with caveats |
-| Structural source-proof | HTML, CSS, SQL, Markdown/MDX, generic YAML/TOML/JSON, non-parser shell, PowerShell, path-scoped GitHub Actions workflows, path-scoped Docker Compose manifests, basename-scoped Cargo manifests, dedicated OpenAPI/Swagger endpoint schema anchors | structural collector and OpenAPI schema-anchor tests | structural-text/schema anchors |
+| Structural source-proof | HTML, CSS, SQL, Markdown/MDX, generic YAML/TOML/JSON, basename-scoped TypeScript/JavaScript config JSONC, non-parser shell, PowerShell, path-scoped GitHub Actions workflows, path-scoped Docker Compose manifests, basename-scoped Cargo manifests, dedicated OpenAPI/Swagger endpoint schema anchors | structural collector and OpenAPI schema-anchor tests | structural-text/schema anchors |
 
 Agent-facing packet/search quality is separate. Run-specific A/B artifacts are
 not blanket promotion proof for every parser-backed language.
@@ -96,7 +96,12 @@ Generic Markdown/MDX emits heading, link/reference-definition, and fenced-block
 labels while suppressing heading/reference syntax inside fences. Generic YAML
 emits conservative block mapping keys without treating URL colons or block
 scalar bodies as mappings; generic TOML emits table and key labels outside
-multiline strings; generic JSON emits object keys in source order. The shell
+multiline strings; generic JSON emits object keys in source order. Only
+`tsconfig.json`, `tsconfig.<suffix>.json`, `jsconfig.json`, and
+`jsconfig.<suffix>.json` admit JSONC comments and trailing commas, under native
+basename case rules; that parser still rejects every other JSON extension and
+emits quoted property-key spans from its AST. Other `.json` files remain strict
+JSON. The shell
 fallback emits function and import anchors outside heredocs only for `.zsh`,
 `.ksh`, and `.command`; `.sh` and `.bash` remain parser-backed Bash. PowerShell
 `.ps1` and `.psm1` emit function and module/dot-source anchors outside block
@@ -104,8 +109,9 @@ comments. These collectors do not interpret references, substitutions,
 imports, execution behavior, or typed targets.
 
 Dedicated routing wins before generic collection: workflow and Compose paths
-keep their YAML producers, `Cargo.toml` keeps its manifest producer, and
-OpenAPI/Swagger JSON or YAML keeps its `exact_source` endpoint path. Structural
+keep their YAML producers, `Cargo.toml` keeps its manifest producer, recognized
+TypeScript/JavaScript config names keep their JSONC producer, and OpenAPI/Swagger
+JSON or YAML keeps its `exact_source` endpoint path. Structural
 admission evaluates only workspace-relative paths and rejects
 generated/vendor, secret-bearing, lockfile, minified, and declared high-noise
 descendants before inventory metadata or content reads. Repository ancestors
@@ -125,8 +131,9 @@ can complete measured suites, but publishable agent-facing packet quality is not
 promoted until one coherent run has all quality, sufficiency, and cold-SLA gates
 green. Run-specific scorecards belong in PRs, issues, release notes, or ignored
 `target/` artifacts; this page records the durable claim boundaries. HTML, CSS,
-SQL, Markdown/MDX, generic YAML/TOML/JSON, non-parser shell, PowerShell, GitHub
-Actions workflows, Docker Compose manifests, and Cargo manifests remain
+SQL, Markdown/MDX, generic YAML/TOML/JSON, basename-scoped TypeScript/JavaScript
+config JSONC, non-parser shell, PowerShell, GitHub Actions workflows, Docker
+Compose manifests, and Cargo manifests remain
 structural source-proof collectors; OpenAPI schemas remain a dedicated
 schema-anchor path.
 


### PR DESCRIPTION
## Context

The first immutable v3 proof-availability run stopped before producing any result artifact because a fresh full index classified Vite's `tsconfig` JSON-with-comments files and one exact empty test fixture as malformed. The publication fence behaved correctly; the structural source classifier did not model these two narrow cases.

## What changed

- recognizes exact `tsconfig.json`, `tsconfig.<suffix>.json`, `jsconfig.json`, and `jsconfig.<suffix>.json` basenames under native case rules;
- parses those files with a distinct structural JSONC producer that permits comments and trailing commas but no other permissive syntax;
- keeps ordinary non-empty JSON on the existing strict parser;
- treats an exact zero-byte JSON file as a complete zero-unit projection only when its stored workspace-relative role is `Test` or `Benchmark`;
- prevents OpenAPI probing from taking a recognized config file first;
- bumps the structural collector/cache identity and documents the language-tier boundary.

## Review

Independent review found two Important defects in the first commit: the empty-file path bypassed `FileRole` precedence, and OpenAPI routing could steal a recognized config. Both were fixed in `62fd5788`; exact-delta re-review approved the amended head with no remaining Critical or Important finding.

## Verification

- contracts language-support tests: 14 passed
- structural indexer tests: 32 passed, 1 ignored
- focused runtime full-refresh regression: passed
- fidelity regression: 8 passed
- language coverage: 12 passed
- focused locked check and all-target clippy with `-D warnings`: passed
- docs link check: 84 files, 316 links
- scoped Rust 2024 format and diff checks: passed
- source-built Vite full-index microprobe: 238 files, 15,983 nodes, 10,708 edges, zero errors, fresh generation 1

`cargo fmt --all -- --check` remains blocked before formatting by the linked-worktree `vendor/tree-sitter-graph` workspace metadata issue; the complete changed Rust file set passes direct `rustfmt --check`.

## Risk and nonclaims

The patch does not weaken the full-publication fence, exclude corpus paths, change proof thresholds, modify the qualification harness, register v3 surfaces, or touch the 0.17.4 release lane. The failed Q2 binary and qualification ID remain invalid and will not be reused.

Closes #2004
Refs #1985
Refs #1984
Refs #1355
