### PR TITLE
Keep admitted callsite identity opaque

### DIFF
--- a/crates/codestory-bench/src/bin/codestory_proof_availability/contracts.rs
+++ b/crates/codestory-bench/src/bin/codestory_proof_availability/contracts.rs
@@ -4478,22 +4478,15 @@ fn valid_observed_receipt_shape(receipt: &ObservedReceiptV1) -> bool {
     let Some(source_node_id) = valid_resolved_node_identity(&receipt.source) else {
         return false;
     };
-    let Some(target_node_id) = valid_resolved_node_identity(&receipt.target) else {
+    if valid_resolved_node_identity(&receipt.target).is_none() {
         return false;
-    };
-    let Some((file_node_id, callsite_line, _, callsite_target_node_id)) =
-        parse_callsite_identity(&receipt.callsite_identity)
-    else {
-        return false;
-    };
+    }
     valid_receipt_id(&receipt.receipt_id)
         && receipt.certainty == ReceiptCertaintyV1::Certain
         && receipt.source.pinned.project_id == receipt.target.pinned.project_id
         && receipt.source.pinned.core_generation_id == receipt.target.pinned.core_generation_id
         && receipt.source.pinned.core_run_id == receipt.target.pinned.core_run_id
-        && callsite_line == receipt.callsite_line
-        && file_node_id == receipt.containment.file_node_id
-        && callsite_target_node_id == target_node_id
+        && !empty(&receipt.callsite_identity)
         && receipt.containment.owner_node_id == source_node_id
         && receipt.containment.start_line > 0
         && receipt.containment.start_line <= receipt.callsite_line
@@ -4507,29 +4500,6 @@ fn valid_receipt_id(receipt_id: &str) -> bool {
     receipt_id
         .strip_prefix("indexed-call-edge:")
         .is_some_and(|suffix| !empty(suffix))
-}
-
-fn parse_callsite_identity(identity: &str) -> Option<(i64, u32, u32, i64)> {
-    if empty(identity) {
-        return None;
-    }
-    let pre_marker = identity
-        .split_once('|')
-        .map_or(identity, |(identity, _)| identity);
-    let mut fields = pre_marker.split(':');
-    let parsed = (
-        fields.next().and_then(|value| value.parse::<i64>().ok()),
-        fields.next().and_then(|value| value.parse::<u32>().ok()),
-        fields.next().and_then(|value| value.parse::<u32>().ok()),
-        fields.next().and_then(|value| value.parse::<i64>().ok()),
-    );
-    let (Some(file), Some(parsed_line), Some(column_or_ordinal), Some(target)) = parsed else {
-        return None;
-    };
-    (fields.next().is_none()
-        && parsed_line > 0
-        && format!("{file}:{parsed_line}:{column_or_ordinal}:{target}") == pre_marker)
-        .then_some((file, parsed_line, column_or_ordinal, target))
 }
 
 fn valid_resolved_node_identity(identity: &ResolvedNodeIdentityV1) -> Option<i64> {

--- a/crates/codestory-bench/tests/proof_availability_contracts.rs
+++ b/crates/codestory-bench/tests/proof_availability_contracts.rs
@@ -2251,6 +2251,97 @@ fn producer_facade_conversions_preserve_task4_and_task6_semantics() {
         .expect_err("Task 6 receipts must retain and require Certain certainty");
 }
 
+#[test]
+fn admitted_callsite_identity_is_opaque_after_task6() {
+    use codestory_agent::proof_qualification_support::{
+        CallableContainmentEvidence, IndexedCallEdgeReceipt, IndexedLineWindow, PinnedNodeIdentity,
+        ReceiptRef, ResolvedNodeIdentity,
+    };
+    use codestory_contracts::graph::{NodeId, ResolutionCertainty};
+
+    const RAW_TARGET: i64 = -8_657_445_931_347_514_024;
+    const RESOLVED_TARGET: i64 = -8_657_442_632_812_629_391;
+
+    let path_file =
+        CohortPathFileV1::from_json(cohort_path_file("codestory-rust")).expect("oracle path file");
+    let oracle = &path_file.paths[0].oracle_steps[0];
+    let project_file_components = oracle
+        .receipt_line_window
+        .path
+        .split('/')
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+    let identity =
+        |node_id: i64, declaration: &contracts::OracleDeclarationV1| ResolvedNodeIdentity {
+            pinned: PinnedNodeIdentity {
+                project_id: "project".into(),
+                core_generation_id: "generation".into(),
+                core_run_id: "run".into(),
+                node_id: node_id.to_string(),
+            },
+            canonical_id: format!("canonical-{node_id}"),
+            qualified_name: declaration.symbol.clone(),
+            project_file_components: project_file_components.clone(),
+        };
+    let callsite_identity = format!("-3:{}:0:{RAW_TARGET}|fixture", oracle.callsite_line);
+    let receipt = IndexedCallEdgeReceipt {
+        receipt: ReceiptRef {
+            receipt_id: "indexed-call-edge:raw-resolved-split".into(),
+            edge_id: "-42".into(),
+        },
+        source: identity(-1, &oracle.caller),
+        target: identity(RESOLVED_TARGET, &oracle.target),
+        certainty: ResolutionCertainty::Certain,
+        callsite_identity: callsite_identity.clone(),
+        containment: CallableContainmentEvidence {
+            file_node_id: NodeId(-3),
+            owner_node_id: NodeId(-1),
+            start_line: oracle.callsite_line,
+            end_line: oracle.callsite_line,
+        },
+        line_window: IndexedLineWindow {
+            kind: "indexed_line_v1",
+            project_file_components,
+            indexed_sha256: oracle.receipt_file_sha256.clone(),
+            observed_sha256: oracle.receipt_file_sha256.clone(),
+            anchor_line: oracle.callsite_line,
+            byte_start: usize::try_from(oracle.receipt_line_window.start_byte).unwrap(),
+            byte_end: usize::try_from(oracle.receipt_line_window.end_byte).unwrap(),
+            text: "call();\n".into(),
+        },
+    };
+
+    let observed = contracts::observed_receipt_from_task6(0, &receipt, oracle)
+        .expect("Task 6 already admitted the raw call occurrence");
+    assert_eq!(observed.callsite_identity, callsite_identity);
+    assert_eq!(observed.target.pinned.node_id, RESOLVED_TARGET.to_string());
+
+    let mut closed = report();
+    closed["cases"][0]["receipt_evidence"]["observed_receipts"][0]["callsite_identity"] =
+        json!(format!("-10000:1:0:{RAW_TARGET}|fixture"));
+    closed["cases"][0]["receipt_evidence"]["observed_receipts"][0]["target"]["pinned"]["node_id"] =
+        json!(RESOLVED_TARGET.to_string());
+    closed["cases"][0]["proof_trace"]["selectors"][1]["outcome"]["node_id"] =
+        json!(RESOLVED_TARGET);
+    rebind_results_digest(&mut closed);
+
+    let mut empty_identity = closed.clone();
+    empty_identity["cases"][0]["receipt_evidence"]["observed_receipts"][0]["callsite_identity"] =
+        json!("");
+    rebind_results_digest(&mut empty_identity);
+    QualificationSummaryV1::from_json(empty_identity)
+        .expect_err("the opaque diagnostic identity remains non-empty");
+
+    let parsed = QualificationSummaryV1::from_json(closed)
+        .expect("closed report validation keeps the admitted identity opaque");
+    parsed
+        .validate_against_oracle(
+            &CorpusV1::from_json(corpus()).expect("corpus"),
+            &parsed_path_files(),
+        )
+        .expect("the raw and resolved targets retain the same frozen oracle relation");
+}
+
 fn assert_valid_first_zero(gate: &str, kind: &str, reason: &str) {
     let mut value = report();
     let case = &mut value["cases"][0];


### PR DESCRIPTION
Closes #2006
Refs #1985
Refs #1984

## Context

The second immutable Q2 qualification run stopped before publishing results. The first admitted CodeStory call edge carried a raw call-occurrence target in its canonical callsite identity and a distinct resolved callable target in the receipt. Task 6 had already authenticated that raw identity against the stored edge, but the benchmark report validator parsed it again and compared the raw target with the resolved receipt target.

That made lawful resolved calls fail with `proof_availability_receipt_oracle_comparison_invalid`.

## What changed

- Treat the Task-6-admitted `callsite_identity` as an opaque, non-empty diagnostic value after admission.
- Add the observed raw-occurrence/resolved-callable regression through Task-6 conversion, closed report validation, and frozen-oracle validation.
- Preserve all independent resolved selector, publication, edge, authoritative receipt, containment, line-window, full-file hash, and oracle checks.

The product admission kernel and its raw-target hostile mutation coverage are unchanged.

## Verification

- `cargo test --locked -p codestory-bench --test proof_availability_contracts` — 51 passed, 0 failed, 1 ignored
- `cargo test --locked -p codestory-bench proof_availability` — 102 passed, 0 failed, 2 ignored
- `cargo test --locked -p codestory-agent indexed_source_call_path_v1` — 44 passed
- `cargo check --locked -p codestory-bench`
- `cargo clippy --locked -p codestory-bench --all-targets -- -D warnings`
- `cargo fmt -p codestory-bench -- --check`
- `node .github/scripts/check-doc-links.mjs` — 84 files, 316 links
- `git diff --check`

Independent exact-range review of `dfe43bc1d50dab1395555c210263df36765a69fb..335d4cbf879806101ca753d16004d61a41191d85` found no Critical or Important defect.

## Scope and nonclaims

This changes two benchmark/report files only. It does not change product admission, schemas, the frozen corpus or thresholds, public routes, versions, release surfaces, or the 0.17 lane. The invalidated Q2 candidate is not reused; a third candidate will be built from the eventual reviewed 0.18 merge head.
