### PR TITLE
[v3 qualification] Preserve invalid proof cases and close the gap domain

### DIFF
--- a/benchmarks/proof-availability/schemas/report.schema.json
+++ b/benchmarks/proof-availability/schemas/report.schema.json
@@ -149,7 +149,7 @@
               "items": {
                 "$ref": "#/$defs/ActualProofGapV1"
               },
-              "maxItems": 6,
+              "maxItems": 76,
               "minItems": 1,
               "type": "array"
             },

--- a/crates/codestory-bench/src/bin/codestory_proof_availability/contracts.rs
+++ b/crates/codestory-bench/src/bin/codestory_proof_availability/contracts.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
 
 pub const CORPUS_SCHEMA: &str = "codestory.proof-availability-corpus/v1";
 pub const PATH_FILE_SCHEMA: &str = "codestory.proof-availability-path-file/v1";
@@ -2446,6 +2447,29 @@ pub struct CaseReportV1 {
     pub negative_mutations: Vec<NegativeMutationResultV1>,
     pub proof_trace: ProofQualificationTraceV1,
 }
+
+/// Internal-only payload retained long enough to produce the owner-private
+/// invalid-case diagnostic. Its formatters deliberately expose no case data:
+/// this error is propagated to the CLI stderr path.
+pub(crate) struct CaseValidationFailure {
+    pub(crate) case_ordinal: usize,
+    pub(crate) case: Box<CaseReportV1>,
+    pub(crate) project: Option<ProjectMaterializationEvidenceV1>,
+}
+
+impl fmt::Display for CaseValidationFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("proof_availability_case_invalid")
+    }
+}
+
+impl fmt::Debug for CaseValidationFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("proof_availability_case_invalid")
+    }
+}
+
+impl std::error::Error for CaseValidationFailure {}
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub struct CaseReceiptMetricsV1 {
     pub observed_receipt_count: u64,
@@ -2970,7 +2994,7 @@ impl QualificationSummaryV1 {
         let mut expected_unclassified = 0u16;
         let mut expected_classified = 0u16;
         let mut mutation_ids = BTreeSet::new();
-        for c in &self.cases {
+        for (case_ordinal, c) in self.cases.iter().enumerate() {
             c.receipt_metrics()?;
             if empty(&c.case_id)
                 || empty(&c.repository_id)
@@ -3022,7 +3046,17 @@ impl QualificationSummaryV1 {
                 )
                 || !valid_disposition_structure(c)
             {
-                bail!("proof_availability_case_invalid")
+                return Err(CaseValidationFailure {
+                    case_ordinal,
+                    case: Box::new(c.clone()),
+                    project: self
+                        .environment
+                        .projects
+                        .iter()
+                        .find(|project| project.repository_id == c.repository_id)
+                        .cloned(),
+                }
+                .into());
             }
             *cases_per_project
                 .entry(c.repository_id.as_str())

--- a/crates/codestory-bench/src/bin/codestory_proof_availability/contracts.rs
+++ b/crates/codestory-bench/src/bin/codestory_proof_availability/contracts.rs
@@ -27,6 +27,15 @@ pub const MAX_CANDIDATE_EDGES_PER_STEP: usize =
         as usize;
 pub const MAX_OBSERVED_RECEIPTS_PER_CASE: usize =
     codestory_runtime::proof_qualification_support::MAX_QUALIFICATION_OBSERVED_RECEIPTS_PER_CASE;
+const ACTUAL_SELECTOR_GAP_VARIANTS: usize = 3;
+const ACTUAL_SELECTOR_GAP_INDEX_COUNT: usize = 7;
+const ACTUAL_STEP_GAP_VARIANTS: usize = 9;
+const ACTUAL_STEP_GAP_INDEX_COUNT: usize = 6;
+const ACTUAL_UNINDEXED_GAP_VARIANTS: usize = 1;
+pub const MAX_ACTUAL_PROOF_GAPS: usize = ACTUAL_SELECTOR_GAP_VARIANTS
+    * ACTUAL_SELECTOR_GAP_INDEX_COUNT
+    + ACTUAL_STEP_GAP_VARIANTS * ACTUAL_STEP_GAP_INDEX_COUNT
+    + ACTUAL_UNINDEXED_GAP_VARIANTS;
 const SHA256: &str = "^[0-9a-f]{64}$";
 const COMMIT: &str = "^[0-9a-f]{40}$";
 const QUALIFICATION_ID_PATTERN: &str = "^[0-9]{8}T[0-9]{6}Z-[0-9a-f]{12}$";
@@ -4326,7 +4335,7 @@ fn valid_actual_product_result(actual: &ActualProductResultV1) -> bool {
             connected_receipts,
         } => {
             hash(contract_digest)
-                && (1..=6).contains(&gaps.len())
+                && (1..=MAX_ACTUAL_PROOF_GAPS).contains(&gaps.len())
                 && gaps.iter().copied().collect::<BTreeSet<_>>().len() == gaps.len()
                 && gaps.iter().all(valid_actual_gap)
                 && valid_projected_receipts(connected_receipts)
@@ -5024,7 +5033,13 @@ fn semantic_contract_bounds(schema: &mut Value, document: SchemaDocument) {
                 Some(0),
                 Some(6),
             );
-            set_recursive_field_bounds(schema, "ActualProductResultV1", "gaps", Some(1), Some(6));
+            set_recursive_field_bounds(
+                schema,
+                "ActualProductResultV1",
+                "gaps",
+                Some(1),
+                Some(MAX_ACTUAL_PROOF_GAPS as u64),
+            );
             set_recursive_field_bounds(
                 schema,
                 "ActualProductResultV1",
@@ -5692,6 +5707,32 @@ fn ratio_milli(numerator: u64, denominator: u64) -> Result<u16> {
 mod contract_digest_binding_tests {
     use super::*;
 
+    fn every_actual_gap() -> Vec<ActualProofGapV1> {
+        let mut gaps = Vec::new();
+        for selector_index in 0..=6 {
+            gaps.extend([
+                ActualProofGapV1::SelectorMissing { selector_index },
+                ActualProofGapV1::SelectorAmbiguous { selector_index },
+                ActualProofGapV1::NonCallableSelector { selector_index },
+            ]);
+        }
+        for step_index in 0..=5 {
+            gaps.extend([
+                ActualProofGapV1::DirectCallMissing { step_index },
+                ActualProofGapV1::RecursiveCallNotRepresentable { step_index },
+                ActualProofGapV1::SourceWindowTooLarge { step_index },
+                ActualProofGapV1::InvalidUtf8 { step_index },
+                ActualProofGapV1::SourceLineOutOfRange { step_index },
+                ActualProofGapV1::EdgeContainmentUnproven { step_index },
+                ActualProofGapV1::MissingDirectCallReceipt { step_index },
+                ActualProofGapV1::ReceiptOrEdgeAlreadyUsed { step_index },
+                ActualProofGapV1::ProjectionExclusionConflictsWithRequiredReceipt { step_index },
+            ]);
+        }
+        gaps.push(ActualProofGapV1::OutputBudgetExceeded);
+        gaps
+    }
+
     #[test]
     fn wrong_well_formed_product_digest_is_rejected_against_frozen_oracle() {
         let path_file: CohortPathFileV1 = serde_json::from_str(include_str!(
@@ -5718,5 +5759,37 @@ mod contract_digest_binding_tests {
                 .to_string()
                 .contains("proof_availability_product_contract_digest_mismatch")
         );
+    }
+
+    #[test]
+    fn actual_unknown_accepts_the_closed_gap_domain_and_rejects_a_seventy_seventh_gap() {
+        let gaps = every_actual_gap();
+        assert_eq!(gaps.len(), MAX_ACTUAL_PROOF_GAPS);
+        let actual = ActualProductResultV1::Unknown {
+            contract_digest: "a".repeat(64),
+            gaps: gaps.clone(),
+            connected_receipts: Vec::new(),
+        };
+        assert!(valid_actual_product_result(&actual));
+
+        let mut duplicate = gaps.clone();
+        duplicate.push(gaps[0]);
+        assert!(!valid_actual_product_result(
+            &ActualProductResultV1::Unknown {
+                contract_digest: "a".repeat(64),
+                gaps: duplicate,
+                connected_receipts: Vec::new(),
+            }
+        ));
+
+        let mut invalid = gaps;
+        invalid.push(ActualProofGapV1::SelectorMissing { selector_index: 7 });
+        assert!(!valid_actual_product_result(
+            &ActualProductResultV1::Unknown {
+                contract_digest: "a".repeat(64),
+                gaps: invalid,
+                connected_receipts: Vec::new(),
+            }
+        ));
     }
 }

--- a/crates/codestory-bench/src/bin/codestory_proof_availability/mod.rs
+++ b/crates/codestory-bench/src/bin/codestory_proof_availability/mod.rs
@@ -44,8 +44,55 @@ pub fn execute(cli: cli::Cli) -> Result<()> {
                 &arguments.out,
                 &operational.environment.qualification_id,
             )?;
-            let input = runner::run_qualification(&loaded, &thresholds, &operational)?;
-            let summary = report::build_summary(input, &loaded.corpus, &thresholds)?;
+            let output_parent = arguments.out.parent().ok_or_else(|| {
+                anyhow::anyhow!("proof_availability_case_diagnostic_parent_invalid")
+            })?;
+            let reservation = report::reserve_case_diagnostic(
+                output_parent,
+                &operational.environment.qualification_id,
+            )?;
+            let input = match runner::run_qualification(&loaded, &thresholds, &operational) {
+                Ok(input) => input,
+                Err(error) => {
+                    let _ = reservation.remove_empty();
+                    return Err(error);
+                }
+            };
+            let summary = match report::build_summary(input, &loaded.corpus, &thresholds) {
+                Ok(summary) => {
+                    let _ = reservation.remove_empty();
+                    summary
+                }
+                Err(error) => {
+                    if let Some(failure) = error.downcast_ref::<contracts::CaseValidationFailure>()
+                    {
+                        let forbidden_values =
+                            std::iter::once(operational.workspace_root.display().to_string())
+                                .chain(std::iter::once(
+                                    operational.cache_root.display().to_string(),
+                                ))
+                                .chain(operational.repositories.iter().flat_map(|repository| {
+                                    [
+                                        repository.checkout_root.display().to_string(),
+                                        repository.project_root.display().to_string(),
+                                        repository.database_path.display().to_string(),
+                                    ]
+                                }))
+                                .collect::<Vec<_>>();
+                        report::write_invalid_case_diagnostic(
+                            &reservation,
+                            &operational.environment.qualification_id,
+                            &operational.environment.qualification_source_commit,
+                            &operational.environment.qualification_source_tree,
+                            failure,
+                            &forbidden_values,
+                        )?;
+                    } else {
+                        let _ = reservation.remove_empty();
+                    }
+                    return Err(error);
+                }
+            };
             let leak_policy = report::PublicLeakPolicy::new(
                 std::iter::once(operational.workspace_root.display().to_string())
                     .chain(std::iter::once(

--- a/crates/codestory-bench/src/bin/codestory_proof_availability/mod.rs
+++ b/crates/codestory-bench/src/bin/codestory_proof_availability/mod.rs
@@ -51,18 +51,9 @@ pub fn execute(cli: cli::Cli) -> Result<()> {
                 output_parent,
                 &operational.environment.qualification_id,
             )?;
-            let input = match runner::run_qualification(&loaded, &thresholds, &operational) {
-                Ok(input) => input,
-                Err(error) => {
-                    let _ = reservation.remove_empty();
-                    return Err(error);
-                }
-            };
+            let input = runner::run_qualification(&loaded, &thresholds, &operational)?;
             let summary = match report::build_summary(input, &loaded.corpus, &thresholds) {
-                Ok(summary) => {
-                    let _ = reservation.remove_empty();
-                    summary
-                }
+                Ok(summary) => summary,
                 Err(error) => {
                     if let Some(failure) = error.downcast_ref::<contracts::CaseValidationFailure>()
                     {
@@ -87,8 +78,6 @@ pub fn execute(cli: cli::Cli) -> Result<()> {
                             failure,
                             &forbidden_values,
                         )?;
-                    } else {
-                        let _ = reservation.remove_empty();
                     }
                     return Err(error);
                 }

--- a/crates/codestory-bench/src/bin/codestory_proof_availability/report.rs
+++ b/crates/codestory-bench/src/bin/codestory_proof_availability/report.rs
@@ -17,6 +17,16 @@ use std::fmt;
 use std::fs::{self, File, OpenOptions};
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
+#[cfg(all(
+    unix,
+    any(
+        target_os = "android",
+        target_os = "ios",
+        target_os = "linux",
+        target_os = "macos"
+    )
+))]
+use std::sync::atomic::{AtomicU64, Ordering};
 
 pub(crate) const PUBLIC_ARTIFACT_NAMES: [&str; 8] = [
     "cases.json",
@@ -37,12 +47,41 @@ const MAX_CASE_DIAGNOSTIC_BYTES: usize = 1024 * 1024;
 /// A process-owned, initially empty directory that makes a qualification ID
 /// single-use for the private invalid-case recovery artifact. It is never a
 /// public result artifact and it is intentionally left behind after a crash.
+/// A process-owned single-use directory. The held directory handle, rather
+/// than the discoverable pathname, is the only authority permitted to create
+/// or publish the private diagnostic file.
 #[derive(Debug)]
 pub(crate) struct CaseDiagnosticReservation {
     path: PathBuf,
-    #[cfg(unix)]
+    #[cfg(all(
+        unix,
+        any(
+            target_os = "android",
+            target_os = "ios",
+            target_os = "linux",
+            target_os = "macos"
+        )
+    ))]
+    directory: File,
+    #[cfg(all(
+        unix,
+        any(
+            target_os = "android",
+            target_os = "ios",
+            target_os = "linux",
+            target_os = "macos"
+        )
+    ))]
     device: u64,
-    #[cfg(unix)]
+    #[cfg(all(
+        unix,
+        any(
+            target_os = "android",
+            target_os = "ios",
+            target_os = "linux",
+            target_os = "macos"
+        )
+    ))]
     inode: u64,
 }
 
@@ -51,18 +90,17 @@ impl CaseDiagnosticReservation {
     pub(crate) fn path(&self) -> &Path {
         &self.path
     }
-
-    /// Remove only the same still-empty directory we created. `remove_dir`
-    /// provides the non-recursive empty-directory guarantee.
-    pub(crate) fn remove_empty(self) -> Result<()> {
-        if !same_reserved_directory(&self)? {
-            bail!("proof_availability_case_diagnostic_cleanup_failed")
-        }
-        fs::remove_dir(&self.path)
-            .map_err(|_| anyhow::anyhow!("proof_availability_case_diagnostic_cleanup_failed"))
-    }
 }
 
+#[cfg(all(
+    unix,
+    any(
+        target_os = "android",
+        target_os = "ios",
+        target_os = "linux",
+        target_os = "macos"
+    )
+))]
 pub(crate) fn reserve_case_diagnostic(
     output_parent: &Path,
     qualification_id: &str,
@@ -75,25 +113,28 @@ pub(crate) fn reserve_case_diagnostic(
     let path = output_parent.join(format!(
         ".codestory-proof-availability-case-diagnostic-{qualification_id}"
     ));
-    fs::create_dir(&path)
+    use std::os::unix::fs::DirBuilderExt as _;
+
+    let mut builder = fs::DirBuilder::new();
+    builder.mode(0o700);
+    builder
+        .create(&path)
         .map_err(|_| anyhow::anyhow!("proof_availability_case_diagnostic_exists"))?;
-    if set_private_directory(&path).is_err() {
-        let _ = fs::remove_dir(&path);
-        bail!("proof_availability_case_diagnostic_create_failed")
-    }
-    let metadata = fs::symlink_metadata(&path)
+    let directory = File::open(&path)
+        .map_err(|_| anyhow::anyhow!("proof_availability_case_diagnostic_create_failed"))?;
+    let metadata = directory
+        .metadata()
         .map_err(|_| anyhow::anyhow!("proof_availability_case_diagnostic_create_failed"))?;
     if !metadata.is_dir() || metadata.file_type().is_symlink() {
         bail!("proof_availability_case_diagnostic_create_failed")
     }
     Ok(CaseDiagnosticReservation {
         path,
-        #[cfg(unix)]
+        directory,
         device: {
             use std::os::unix::fs::MetadataExt as _;
             metadata.dev()
         },
-        #[cfg(unix)]
         inode: {
             use std::os::unix::fs::MetadataExt as _;
             metadata.ino()
@@ -101,6 +142,28 @@ pub(crate) fn reserve_case_diagnostic(
     })
 }
 
+#[cfg(not(all(
+    unix,
+    any(
+        target_os = "android",
+        target_os = "ios",
+        target_os = "linux",
+        target_os = "macos"
+    )
+)))]
+pub(crate) fn reserve_case_diagnostic(_: &Path, _: &str) -> Result<CaseDiagnosticReservation> {
+    bail!("proof_availability_case_diagnostic_unsupported")
+}
+
+#[cfg(all(
+    unix,
+    any(
+        target_os = "android",
+        target_os = "ios",
+        target_os = "linux",
+        target_os = "macos"
+    )
+))]
 pub(crate) fn write_invalid_case_diagnostic(
     reservation: &CaseDiagnosticReservation,
     qualification_id: &str,
@@ -109,11 +172,73 @@ pub(crate) fn write_invalid_case_diagnostic(
     failure: &CaseValidationFailure,
     forbidden_values: &[String],
 ) -> Result<()> {
-    if !same_reserved_directory(reservation)? {
+    // This compares only the recovery path with the held identity. It must
+    // never determine the write target: a pathname replacement cannot divert
+    // the private artifact away from the directory we opened at reservation.
+    let _path_still_names_reservation = path_matches_held_directory(reservation);
+    if !reservation_handle_is_directory(reservation)? {
         bail!("proof_availability_case_diagnostic_write_failed")
     }
     let unredacted_case = serde_json::to_value(&failure.case)
         .map_err(|_| anyhow::anyhow!("proof_availability_case_diagnostic_write_failed"))?;
+    let project_materialization = serde_json::to_value(&failure.project)
+        .map_err(|_| anyhow::anyhow!("proof_availability_case_diagnostic_write_failed"))?;
+    let artifact = build_invalid_case_diagnostic_artifact(
+        qualification_id,
+        source_commit,
+        source_tree,
+        failure.case_ordinal,
+        &failure.case.case_id,
+        &failure.case.repository_id,
+        unredacted_case,
+        project_materialization,
+        forbidden_values,
+    )?;
+    let bytes = canonical_json_file(&artifact)
+        .map_err(|_| anyhow::anyhow!("proof_availability_case_diagnostic_write_failed"))?;
+    if bytes.len() > MAX_CASE_DIAGNOSTIC_BYTES {
+        bail!("proof_availability_case_diagnostic_write_failed")
+    }
+    write_private_diagnostic_file(reservation, &bytes)
+        .map_err(|_| anyhow::anyhow!("proof_availability_case_diagnostic_write_failed"))?;
+    reservation
+        .directory
+        .sync_all()
+        .map_err(|_| anyhow::anyhow!("proof_availability_case_diagnostic_write_failed"))
+}
+
+#[cfg(not(all(
+    unix,
+    any(
+        target_os = "android",
+        target_os = "ios",
+        target_os = "linux",
+        target_os = "macos"
+    )
+)))]
+pub(crate) fn write_invalid_case_diagnostic(
+    _: &CaseDiagnosticReservation,
+    _: &str,
+    _: &str,
+    _: &str,
+    _: &CaseValidationFailure,
+    _: &[String],
+) -> Result<()> {
+    bail!("proof_availability_case_diagnostic_unsupported")
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_invalid_case_diagnostic_artifact(
+    qualification_id: &str,
+    source_commit: &str,
+    source_tree: &str,
+    case_ordinal: usize,
+    case_id: &str,
+    repository_id: &str,
+    unredacted_case: Value,
+    project_materialization: Value,
+    forbidden_values: &[String],
+) -> Result<Value> {
     let case_sha256 = domain_sha256(
         b"codestory.proof-availability.invalid-case-unredacted.v1\\0",
         &canonical_json_bytes(&unredacted_case)?,
@@ -127,41 +252,53 @@ pub(crate) fn write_invalid_case_diagnostic(
         "qualification_id": qualification_id,
         "validator_source_commit": source_commit,
         "validator_source_tree": source_tree,
-        "case_ordinal": failure.case_ordinal,
-        "case_id": failure.case.case_id,
-        "repository_id": failure.case.repository_id,
+        "case_ordinal": case_ordinal,
+        "case_id": case_id,
+        "repository_id": repository_id,
         "failure_code": "proof_availability_case_invalid",
         "unredacted_case_sha256": case_sha256,
-        "project_materialization": failure.project,
+        "project_materialization": project_materialization,
         "case": redacted_case,
         "removed_text_commitments": text_commitments,
     });
     validate_private_diagnostic_value(&artifact, forbidden_values)?;
-    let bytes = canonical_json_file(&artifact)
-        .map_err(|_| anyhow::anyhow!("proof_availability_case_diagnostic_write_failed"))?;
-    if bytes.len() > MAX_CASE_DIAGNOSTIC_BYTES {
-        bail!("proof_availability_case_diagnostic_write_failed")
-    }
-    write_private_diagnostic_file(&reservation.path.join(CASE_DIAGNOSTIC_FILE), &bytes)
-        .map_err(|_| anyhow::anyhow!("proof_availability_case_diagnostic_write_failed"))?;
-    sync_directory(&reservation.path)
-        .map_err(|_| anyhow::anyhow!("proof_availability_case_diagnostic_write_failed"))
+    Ok(artifact)
 }
 
-fn same_reserved_directory(reservation: &CaseDiagnosticReservation) -> Result<bool> {
+#[cfg(all(
+    unix,
+    any(
+        target_os = "android",
+        target_os = "ios",
+        target_os = "linux",
+        target_os = "macos"
+    )
+))]
+fn reservation_handle_is_directory(reservation: &CaseDiagnosticReservation) -> Result<bool> {
+    let metadata = reservation.directory.metadata()?;
+    if !metadata.is_dir() {
+        return Ok(false);
+    }
+    use std::os::unix::fs::MetadataExt as _;
+    Ok(metadata.dev() == reservation.device && metadata.ino() == reservation.inode)
+}
+
+#[cfg(all(
+    unix,
+    any(
+        target_os = "android",
+        target_os = "ios",
+        target_os = "linux",
+        target_os = "macos"
+    )
+))]
+fn path_matches_held_directory(reservation: &CaseDiagnosticReservation) -> Result<bool> {
     let metadata = fs::symlink_metadata(&reservation.path)?;
     if !metadata.is_dir() || metadata.file_type().is_symlink() {
         return Ok(false);
     }
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::MetadataExt as _;
-        Ok(metadata.dev() == reservation.device && metadata.ino() == reservation.inode)
-    }
-    #[cfg(not(unix))]
-    {
-        Ok(true)
-    }
+    use std::os::unix::fs::MetadataExt as _;
+    Ok(metadata.dev() == reservation.device && metadata.ino() == reservation.inode)
 }
 
 fn canonical_json_bytes(value: &Value) -> Result<Vec<u8>> {
@@ -216,6 +353,14 @@ fn json_pointer_escape(segment: &str) -> String {
 }
 
 fn validate_private_diagnostic_value(value: &Value, forbidden_values: &[String]) -> Result<()> {
+    validate_private_diagnostic_value_at(value, forbidden_values, "")
+}
+
+fn validate_private_diagnostic_value_at(
+    value: &Value,
+    forbidden_values: &[String],
+    pointer: &str,
+) -> Result<()> {
     match value {
         Value::Object(object) => {
             for (key, nested) in object {
@@ -235,25 +380,58 @@ fn validate_private_diagnostic_value(value: &Value, forbidden_values: &[String])
                 {
                     bail!("proof_availability_case_diagnostic_unsafe_value")
                 }
-                validate_private_diagnostic_value(nested, forbidden_values)?;
+                validate_private_diagnostic_value_at(
+                    nested,
+                    forbidden_values,
+                    &format!("{pointer}/{}", json_pointer_escape(key)),
+                )?;
             }
         }
         Value::Array(array) => {
-            for nested in array {
-                validate_private_diagnostic_value(nested, forbidden_values)?;
+            for (index, nested) in array.iter().enumerate() {
+                validate_private_diagnostic_value_at(
+                    nested,
+                    forbidden_values,
+                    &format!("{pointer}/{index}"),
+                )?;
             }
         }
-        Value::String(string)
-            if is_absolute_path(string)
-                || forbidden_values
-                    .iter()
-                    .any(|needle| !needle.is_empty() && string.contains(needle)) =>
-        {
-            bail!("proof_availability_case_diagnostic_unsafe_value")
+        Value::String(string) => {
+            let forbidden = forbidden_values
+                .iter()
+                .any(|needle| !needle.is_empty() && string.contains(needle));
+            if is_removed_text_commitment_pointer_field(pointer) {
+                if !valid_json_pointer(string) || forbidden {
+                    bail!("proof_availability_case_diagnostic_unsafe_value")
+                }
+            } else if is_absolute_path(string) || forbidden {
+                bail!("proof_availability_case_diagnostic_unsafe_value")
+            }
         }
         _ => {}
     }
     Ok(())
+}
+
+fn is_removed_text_commitment_pointer_field(pointer: &str) -> bool {
+    pointer.starts_with("/removed_text_commitments/") && pointer.ends_with("/json_pointer")
+}
+
+fn valid_json_pointer(value: &str) -> bool {
+    value.is_empty()
+        || (value.starts_with('/')
+            && value.split('/').skip(1).all(|segment| {
+                let mut bytes = segment.bytes();
+                while let Some(byte) = bytes.next() {
+                    if byte == b'~' && !matches!(bytes.next(), Some(b'0' | b'1')) {
+                        return false;
+                    }
+                    if byte.is_ascii_control() {
+                        return false;
+                    }
+                }
+                true
+            }))
 }
 
 fn is_absolute_path(value: &str) -> bool {
@@ -262,26 +440,113 @@ fn is_absolute_path(value: &str) -> bool {
         || value.as_bytes().get(1).is_some_and(|byte| *byte == b':')
 }
 
-fn write_private_diagnostic_file(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
-    let mut temporary = tempfile::Builder::new()
-        .prefix(".invalid-case-v1-")
-        .tempfile_in(
-            path.parent()
-                .ok_or_else(|| std::io::Error::other("missing parent"))?,
-        )?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt as _;
-        temporary
-            .as_file()
-            .set_permissions(fs::Permissions::from_mode(0o600))?;
+#[cfg(all(
+    unix,
+    any(
+        target_os = "android",
+        target_os = "ios",
+        target_os = "linux",
+        target_os = "macos"
+    )
+))]
+static CASE_DIAGNOSTIC_TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+#[cfg(all(
+    unix,
+    any(
+        target_os = "android",
+        target_os = "ios",
+        target_os = "linux",
+        target_os = "macos"
+    )
+))]
+fn write_private_diagnostic_file(
+    reservation: &CaseDiagnosticReservation,
+    bytes: &[u8],
+) -> std::io::Result<()> {
+    use std::ffi::CString;
+    use std::os::fd::{AsRawFd as _, FromRawFd as _};
+
+    let sequence = CASE_DIAGNOSTIC_TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    let temporary_name = format!(".invalid-case-v1-{}-{sequence}", std::process::id());
+    let temporary_c = CString::new(temporary_name.as_bytes())
+        .map_err(|_| std::io::Error::other("invalid temporary name"))?;
+    let final_c = CString::new(CASE_DIAGNOSTIC_FILE)
+        .map_err(|_| std::io::Error::other("invalid final name"))?;
+    let directory_fd = reservation.directory.as_raw_fd();
+    let descriptor = unsafe {
+        libc::openat(
+            directory_fd,
+            temporary_c.as_ptr(),
+            libc::O_WRONLY | libc::O_CREAT | libc::O_EXCL | libc::O_CLOEXEC,
+            0o600,
+        )
+    };
+    if descriptor < 0 {
+        return Err(std::io::Error::last_os_error());
     }
-    temporary.write_all(bytes)?;
-    temporary.as_file_mut().sync_all()?;
-    temporary
-        .persist_noclobber(path)
-        .map_err(|error| error.error)?;
+    let mut temporary = unsafe { File::from_raw_fd(descriptor) };
+    if let Err(error) = temporary
+        .write_all(bytes)
+        .and_then(|_| temporary.sync_all())
+    {
+        drop(temporary);
+        let _ = unsafe { libc::unlinkat(directory_fd, temporary_c.as_ptr(), 0) };
+        return Err(error);
+    }
+    drop(temporary);
+    let rename_result = rename_noreplace_at(directory_fd, &temporary_c, directory_fd, &final_c);
+    if let Err(error) = rename_result {
+        let _ = unsafe { libc::unlinkat(directory_fd, temporary_c.as_ptr(), 0) };
+        return Err(error);
+    }
     Ok(())
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn rename_noreplace_at(
+    from_fd: std::os::fd::RawFd,
+    from: &std::ffi::CString,
+    to_fd: std::os::fd::RawFd,
+    to: &std::ffi::CString,
+) -> std::io::Result<()> {
+    let result = unsafe {
+        libc::renameat2(
+            from_fd,
+            from.as_ptr(),
+            to_fd,
+            to.as_ptr(),
+            libc::RENAME_NOREPLACE,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+fn rename_noreplace_at(
+    from_fd: std::os::fd::RawFd,
+    from: &std::ffi::CString,
+    to_fd: std::os::fd::RawFd,
+    to: &std::ffi::CString,
+) -> std::io::Result<()> {
+    let result = unsafe {
+        libc::renameatx_np(
+            from_fd,
+            from.as_ptr(),
+            to_fd,
+            to.as_ptr(),
+            libc::RENAME_EXCL,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
 }
 
 #[derive(Debug)]
@@ -1525,8 +1790,11 @@ mod tests {
                 .to_string(),
             "proof_availability_case_diagnostic_exists"
         );
-        reservation.remove_empty().unwrap();
-        assert!(!reservation_path.exists());
+        drop(reservation);
+        assert!(
+            reservation_path.is_dir(),
+            "an empty reservation is single-use"
+        );
     }
 
     #[cfg(unix)]
@@ -1545,7 +1813,7 @@ mod tests {
                 & 0o777,
             0o700
         );
-        reservation.remove_empty().unwrap();
+        drop(reservation);
     }
 
     #[test]
@@ -1579,16 +1847,87 @@ mod tests {
         ] {
             assert!(validate_private_diagnostic_value(&unsafe_value, &[]).is_err());
         }
+        let pointer_artifact = json!({
+            "removed_text_commitments": [{
+                "json_pointer": "/receipt/source_line/text",
+                "utf8_byte_length": 1,
+                "sha256": "a"
+            }]
+        });
+        validate_private_diagnostic_value(&pointer_artifact, &[])
+            .expect("the typed RFC6901 field may begin with a slash");
+        let invalid_pointer = json!({
+            "removed_text_commitments": [{"json_pointer": "/bad~2pointer"}]
+        });
+        assert!(validate_private_diagnostic_value(&invalid_pointer, &[]).is_err());
     }
 
     #[test]
     fn case_diagnostic_file_is_newline_terminated_and_no_clobber() {
         let root = tempfile::tempdir().unwrap();
-        let target = root.path().join(CASE_DIAGNOSTIC_FILE);
-        write_private_diagnostic_file(&target, b"{}\\n").unwrap();
-        assert_eq!(fs::read(&target).unwrap(), b"{}\\n");
-        assert!(write_private_diagnostic_file(&target, b"changed\\n").is_err());
-        assert_eq!(fs::read(&target).unwrap(), b"{}\\n");
+        let reservation =
+            reserve_case_diagnostic(root.path(), "20260821T120000Z-222222222222").unwrap();
+        let target = reservation.path().join(CASE_DIAGNOSTIC_FILE);
+        write_private_diagnostic_file(&reservation, b"{}\n").unwrap();
+        assert_eq!(fs::read(&target).unwrap(), b"{}\n");
+        assert!(write_private_diagnostic_file(&reservation, b"changed\n").is_err());
+        assert_eq!(fs::read(&target).unwrap(), b"{}\n");
+    }
+
+    #[test]
+    fn complete_private_artifact_redacts_real_receipt_text_before_handle_relative_write() {
+        let root = tempfile::tempdir().unwrap();
+        let reservation =
+            reserve_case_diagnostic(root.path(), "20260821T120000Z-222222222222").unwrap();
+        let artifact = build_invalid_case_diagnostic_artifact(
+            "20260821T120000Z-222222222222",
+            &"a".repeat(40),
+            &"b".repeat(40),
+            0,
+            "case-1",
+            "repository-1",
+            json!({
+                "receipt_evidence": {"observed_receipts": [{
+                    "source_line": {"text": "call(target);\n"}
+                }]}
+            }),
+            Value::Null,
+            &[],
+        )
+        .unwrap();
+        let bytes = canonical_json_file(&artifact).unwrap();
+        write_private_diagnostic_file(&reservation, &bytes).unwrap();
+        let written: Value = serde_json::from_slice(
+            &fs::read(reservation.path().join(CASE_DIAGNOSTIC_FILE)).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(written["schema"], CASE_DIAGNOSTIC_SCHEMA);
+        assert_eq!(written["classification"], "non_evidence");
+        assert!(
+            written
+                .pointer("/case/receipt_evidence/observed_receipts/0/source_line/text")
+                .is_none()
+        );
+        assert_eq!(
+            written["removed_text_commitments"][0]["json_pointer"],
+            "/receipt_evidence/observed_receipts/0/source_line/text"
+        );
+        assert!(written["unredacted_case_sha256"].as_str().is_some());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reservation_handle_cannot_be_redirected_by_a_path_swap() {
+        let root = tempfile::tempdir().unwrap();
+        let reservation =
+            reserve_case_diagnostic(root.path(), "20260821T120000Z-222222222222").unwrap();
+        let original = root.path().join("held-directory");
+        fs::rename(reservation.path(), &original).unwrap();
+        fs::create_dir(reservation.path()).unwrap();
+        assert!(!path_matches_held_directory(&reservation).unwrap());
+        write_private_diagnostic_file(&reservation, b"{}\n").unwrap();
+        assert!(original.join(CASE_DIAGNOSTIC_FILE).is_file());
+        assert!(!reservation.path().join(CASE_DIAGNOSTIC_FILE).exists());
     }
 
     #[test]

--- a/crates/codestory-bench/src/bin/codestory_proof_availability/report.rs
+++ b/crates/codestory-bench/src/bin/codestory_proof_availability/report.rs
@@ -1,7 +1,7 @@
 use super::contracts::{
-    ActivationDecisionReportV1, ActualProductResultV1, CaseReportV1, CohortPathFileV1, CorpusV1,
-    DECISION_REPORT_SCHEMA, EnvironmentReportV1, FailureFunnelReportV1, FunnelOutcomeV1,
-    InventoryReportV1, ProductDispositionKindV1, ProductRefutationBasisV1,
+    ActivationDecisionReportV1, ActualProductResultV1, CaseReportV1, CaseValidationFailure,
+    CohortPathFileV1, CorpusV1, DECISION_REPORT_SCHEMA, EnvironmentReportV1, FailureFunnelReportV1,
+    FunnelOutcomeV1, InventoryReportV1, ProductDispositionKindV1, ProductRefutationBasisV1,
     ProjectedReceiptReferenceV1, ProvenanceV1, QualificationSummaryV1, REPORT_SCHEMA,
     ReceiptOracleComparisonV1, RoleThresholdsV1, StepQualificationOutcomeV1, ThresholdsV1,
     TrailReportV1, TransportErrorV1, TransportEvidenceV1, canonical_corpus_sha256,
@@ -10,7 +10,8 @@ use super::contracts::{
 use super::thresholds::{derive_observations, evaluate_activation_decision};
 use anyhow::{Context, Result, bail};
 use serde::Serialize;
-use serde_json::Value;
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::fmt;
 use std::fs::{self, File, OpenOptions};
@@ -29,6 +30,259 @@ pub(crate) const PUBLIC_ARTIFACT_NAMES: [&str; 8] = [
 ];
 const OWNER_MARKER: &str = ".codestory-proof-availability-report-staging";
 const MAX_PUBLIC_ARTIFACT_BYTES: u64 = 64 * 1024 * 1024;
+const CASE_DIAGNOSTIC_SCHEMA: &str = "codestory.proof-availability.invalid-case-diagnostic.v1";
+const CASE_DIAGNOSTIC_FILE: &str = "invalid-case-v1.json";
+const MAX_CASE_DIAGNOSTIC_BYTES: usize = 1024 * 1024;
+
+/// A process-owned, initially empty directory that makes a qualification ID
+/// single-use for the private invalid-case recovery artifact. It is never a
+/// public result artifact and it is intentionally left behind after a crash.
+#[derive(Debug)]
+pub(crate) struct CaseDiagnosticReservation {
+    path: PathBuf,
+    #[cfg(unix)]
+    device: u64,
+    #[cfg(unix)]
+    inode: u64,
+}
+
+impl CaseDiagnosticReservation {
+    #[cfg(test)]
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Remove only the same still-empty directory we created. `remove_dir`
+    /// provides the non-recursive empty-directory guarantee.
+    pub(crate) fn remove_empty(self) -> Result<()> {
+        if !same_reserved_directory(&self)? {
+            bail!("proof_availability_case_diagnostic_cleanup_failed")
+        }
+        fs::remove_dir(&self.path)
+            .map_err(|_| anyhow::anyhow!("proof_availability_case_diagnostic_cleanup_failed"))
+    }
+}
+
+pub(crate) fn reserve_case_diagnostic(
+    output_parent: &Path,
+    qualification_id: &str,
+) -> Result<CaseDiagnosticReservation> {
+    let metadata = fs::symlink_metadata(output_parent)
+        .map_err(|_| anyhow::anyhow!("proof_availability_case_diagnostic_parent_invalid"))?;
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        bail!("proof_availability_case_diagnostic_parent_invalid")
+    }
+    let path = output_parent.join(format!(
+        ".codestory-proof-availability-case-diagnostic-{qualification_id}"
+    ));
+    fs::create_dir(&path)
+        .map_err(|_| anyhow::anyhow!("proof_availability_case_diagnostic_exists"))?;
+    if set_private_directory(&path).is_err() {
+        let _ = fs::remove_dir(&path);
+        bail!("proof_availability_case_diagnostic_create_failed")
+    }
+    let metadata = fs::symlink_metadata(&path)
+        .map_err(|_| anyhow::anyhow!("proof_availability_case_diagnostic_create_failed"))?;
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        bail!("proof_availability_case_diagnostic_create_failed")
+    }
+    Ok(CaseDiagnosticReservation {
+        path,
+        #[cfg(unix)]
+        device: {
+            use std::os::unix::fs::MetadataExt as _;
+            metadata.dev()
+        },
+        #[cfg(unix)]
+        inode: {
+            use std::os::unix::fs::MetadataExt as _;
+            metadata.ino()
+        },
+    })
+}
+
+pub(crate) fn write_invalid_case_diagnostic(
+    reservation: &CaseDiagnosticReservation,
+    qualification_id: &str,
+    source_commit: &str,
+    source_tree: &str,
+    failure: &CaseValidationFailure,
+    forbidden_values: &[String],
+) -> Result<()> {
+    if !same_reserved_directory(reservation)? {
+        bail!("proof_availability_case_diagnostic_write_failed")
+    }
+    let unredacted_case = serde_json::to_value(&failure.case)
+        .map_err(|_| anyhow::anyhow!("proof_availability_case_diagnostic_write_failed"))?;
+    let case_sha256 = domain_sha256(
+        b"codestory.proof-availability.invalid-case-unredacted.v1\\0",
+        &canonical_json_bytes(&unredacted_case)?,
+    );
+    let mut redacted_case = unredacted_case;
+    let mut text_commitments = Vec::new();
+    redact_text_values(&mut redacted_case, "", &mut text_commitments)?;
+    let artifact = json!({
+        "schema": CASE_DIAGNOSTIC_SCHEMA,
+        "classification": "non_evidence",
+        "qualification_id": qualification_id,
+        "validator_source_commit": source_commit,
+        "validator_source_tree": source_tree,
+        "case_ordinal": failure.case_ordinal,
+        "case_id": failure.case.case_id,
+        "repository_id": failure.case.repository_id,
+        "failure_code": "proof_availability_case_invalid",
+        "unredacted_case_sha256": case_sha256,
+        "project_materialization": failure.project,
+        "case": redacted_case,
+        "removed_text_commitments": text_commitments,
+    });
+    validate_private_diagnostic_value(&artifact, forbidden_values)?;
+    let bytes = canonical_json_file(&artifact)
+        .map_err(|_| anyhow::anyhow!("proof_availability_case_diagnostic_write_failed"))?;
+    if bytes.len() > MAX_CASE_DIAGNOSTIC_BYTES {
+        bail!("proof_availability_case_diagnostic_write_failed")
+    }
+    write_private_diagnostic_file(&reservation.path.join(CASE_DIAGNOSTIC_FILE), &bytes)
+        .map_err(|_| anyhow::anyhow!("proof_availability_case_diagnostic_write_failed"))?;
+    sync_directory(&reservation.path)
+        .map_err(|_| anyhow::anyhow!("proof_availability_case_diagnostic_write_failed"))
+}
+
+fn same_reserved_directory(reservation: &CaseDiagnosticReservation) -> Result<bool> {
+    let metadata = fs::symlink_metadata(&reservation.path)?;
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return Ok(false);
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt as _;
+        Ok(metadata.dev() == reservation.device && metadata.ino() == reservation.inode)
+    }
+    #[cfg(not(unix))]
+    {
+        Ok(true)
+    }
+}
+
+fn canonical_json_bytes(value: &Value) -> Result<Vec<u8>> {
+    codestory_agent::proof_qualification_support::canonical_json_bytes(value)
+        .map_err(|_| anyhow::anyhow!("proof_availability_case_diagnostic_write_failed"))
+}
+
+fn domain_sha256(domain: &[u8], bytes: &[u8]) -> String {
+    let mut digest = Sha256::new();
+    digest.update(domain);
+    digest.update(bytes);
+    format!("{:x}", digest.finalize())
+}
+
+fn redact_text_values(
+    value: &mut Value,
+    pointer: &str,
+    commitments: &mut Vec<Value>,
+) -> Result<()> {
+    match value {
+        Value::Object(object) => {
+            if let Some(text) = object.remove("text") {
+                let text = text.as_str().ok_or_else(|| {
+                    anyhow::anyhow!("proof_availability_case_diagnostic_write_failed")
+                })?;
+                commitments.push(json!({
+                    "json_pointer": format!("{pointer}/text"),
+                    "utf8_byte_length": text.len(),
+                    "sha256": domain_sha256(b"codestory.proof-availability.removed-text.v1\\0", text.as_bytes()),
+                }));
+            }
+            for (key, nested) in object.iter_mut() {
+                redact_text_values(
+                    nested,
+                    &format!("{pointer}/{}", json_pointer_escape(key)),
+                    commitments,
+                )?;
+            }
+        }
+        Value::Array(array) => {
+            for (index, nested) in array.iter_mut().enumerate() {
+                redact_text_values(nested, &format!("{pointer}/{index}"), commitments)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn json_pointer_escape(segment: &str) -> String {
+    segment.replace('~', "~0").replace('/', "~1")
+}
+
+fn validate_private_diagnostic_value(value: &Value, forbidden_values: &[String]) -> Result<()> {
+    match value {
+        Value::Object(object) => {
+            for (key, nested) in object {
+                let lower = key.to_ascii_lowercase();
+                if matches!(lower.as_str(), "text" | "source_text")
+                    || [
+                        "secret",
+                        "token",
+                        "password",
+                        "private-key",
+                        "private_key",
+                        "api-key",
+                        "api_key",
+                    ]
+                    .iter()
+                    .any(|needle| lower.contains(needle))
+                {
+                    bail!("proof_availability_case_diagnostic_unsafe_value")
+                }
+                validate_private_diagnostic_value(nested, forbidden_values)?;
+            }
+        }
+        Value::Array(array) => {
+            for nested in array {
+                validate_private_diagnostic_value(nested, forbidden_values)?;
+            }
+        }
+        Value::String(string)
+            if is_absolute_path(string)
+                || forbidden_values
+                    .iter()
+                    .any(|needle| !needle.is_empty() && string.contains(needle)) =>
+        {
+            bail!("proof_availability_case_diagnostic_unsafe_value")
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn is_absolute_path(value: &str) -> bool {
+    Path::new(value).is_absolute()
+        || value.starts_with("\\\\")
+        || value.as_bytes().get(1).is_some_and(|byte| *byte == b':')
+}
+
+fn write_private_diagnostic_file(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let mut temporary = tempfile::Builder::new()
+        .prefix(".invalid-case-v1-")
+        .tempfile_in(
+            path.parent()
+                .ok_or_else(|| std::io::Error::other("missing parent"))?,
+        )?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        temporary
+            .as_file()
+            .set_permissions(fs::Permissions::from_mode(0o600))?;
+    }
+    temporary.write_all(bytes)?;
+    temporary.as_file_mut().sync_all()?;
+    temporary
+        .persist_noclobber(path)
+        .map_err(|error| error.error)?;
+    Ok(())
+}
 
 #[derive(Debug)]
 pub(crate) struct QualificationReportInputV1 {
@@ -1256,6 +1510,85 @@ mod tests {
             canonical_json_file(&json!({"z":2,"a":1})).unwrap(),
             b"{\"a\":1,\"z\":2}\n"
         );
+    }
+
+    #[test]
+    fn case_diagnostic_reservation_is_private_and_no_replace() {
+        let root = tempfile::tempdir().unwrap();
+        let qualification_id = "20260821T120000Z-222222222222";
+        let reservation = reserve_case_diagnostic(root.path(), qualification_id).unwrap();
+        assert!(reservation.path().is_dir());
+        let reservation_path = reservation.path().to_path_buf();
+        assert_eq!(
+            reserve_case_diagnostic(root.path(), qualification_id)
+                .unwrap_err()
+                .to_string(),
+            "proof_availability_case_diagnostic_exists"
+        );
+        reservation.remove_empty().unwrap();
+        assert!(!reservation_path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn case_diagnostic_reservation_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let root = tempfile::tempdir().unwrap();
+        let reservation =
+            reserve_case_diagnostic(root.path(), "20260821T120000Z-222222222222").unwrap();
+        assert_eq!(
+            fs::metadata(reservation.path())
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o700
+        );
+        reservation.remove_empty().unwrap();
+    }
+
+    #[test]
+    fn case_diagnostic_redacts_text_and_rejects_unsafe_values() {
+        let mut value = json!({
+            "receipt": {"text": "a\nλ", "other": [ {"text": "b"} ]}
+        });
+        let mut commitments = Vec::new();
+        redact_text_values(&mut value, "", &mut commitments).unwrap();
+        assert_eq!(value, json!({"receipt": {"other": [{}]}}));
+        assert_eq!(
+            commitments,
+            vec![
+                json!({
+                    "json_pointer": "/receipt/text",
+                    "utf8_byte_length": 4,
+                    "sha256": domain_sha256(b"codestory.proof-availability.removed-text.v1\\0", "a\nλ".as_bytes()),
+                }),
+                json!({
+                    "json_pointer": "/receipt/other/0/text",
+                    "utf8_byte_length": 1,
+                    "sha256": domain_sha256(b"codestory.proof-availability.removed-text.v1\\0", b"b"),
+                }),
+            ]
+        );
+        for unsafe_value in [
+            json!({"source_text": "private"}),
+            json!({"api_token": "private"}),
+            json!({"location": "/Users/albert/private"}),
+            json!({"location": "C:\\\\private"}),
+        ] {
+            assert!(validate_private_diagnostic_value(&unsafe_value, &[]).is_err());
+        }
+    }
+
+    #[test]
+    fn case_diagnostic_file_is_newline_terminated_and_no_clobber() {
+        let root = tempfile::tempdir().unwrap();
+        let target = root.path().join(CASE_DIAGNOSTIC_FILE);
+        write_private_diagnostic_file(&target, b"{}\\n").unwrap();
+        assert_eq!(fs::read(&target).unwrap(), b"{}\\n");
+        assert!(write_private_diagnostic_file(&target, b"changed\\n").is_err());
+        assert_eq!(fs::read(&target).unwrap(), b"{}\\n");
     }
 
     #[test]

--- a/crates/codestory-bench/src/bin/codestory_proof_availability/report.rs
+++ b/crates/codestory-bench/src/bin/codestory_proof_availability/report.rs
@@ -105,22 +105,26 @@ pub(crate) fn reserve_case_diagnostic(
     output_parent: &Path,
     qualification_id: &str,
 ) -> Result<CaseDiagnosticReservation> {
-    let metadata = fs::symlink_metadata(output_parent)
+    use std::ffi::CString;
+    use std::os::fd::AsRawFd as _;
+
+    let parent = open_directory_nofollow(output_parent)
         .map_err(|_| anyhow::anyhow!("proof_availability_case_diagnostic_parent_invalid"))?;
-    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+    if !parent
+        .metadata()
+        .map(|metadata| metadata.is_dir())
+        .unwrap_or(false)
+    {
         bail!("proof_availability_case_diagnostic_parent_invalid")
     }
-    let path = output_parent.join(format!(
-        ".codestory-proof-availability-case-diagnostic-{qualification_id}"
-    ));
-    use std::os::unix::fs::DirBuilderExt as _;
-
-    let mut builder = fs::DirBuilder::new();
-    builder.mode(0o700);
-    builder
-        .create(&path)
-        .map_err(|_| anyhow::anyhow!("proof_availability_case_diagnostic_exists"))?;
-    let directory = File::open(&path)
+    let name = format!(".codestory-proof-availability-case-diagnostic-{qualification_id}");
+    let path = output_parent.join(&name);
+    let component = CString::new(name.as_bytes())
+        .map_err(|_| anyhow::anyhow!("proof_availability_case_diagnostic_create_failed"))?;
+    if unsafe { libc::mkdirat(parent.as_raw_fd(), component.as_ptr(), 0o700) } != 0 {
+        return Err(anyhow::anyhow!("proof_availability_case_diagnostic_exists"));
+    }
+    let directory = open_directory_at_nofollow(&parent, &component)
         .map_err(|_| anyhow::anyhow!("proof_availability_case_diagnostic_create_failed"))?;
     let metadata = directory
         .metadata()
@@ -140,6 +144,64 @@ pub(crate) fn reserve_case_diagnostic(
             metadata.ino()
         },
     })
+}
+
+#[cfg(all(
+    unix,
+    any(
+        target_os = "android",
+        target_os = "ios",
+        target_os = "linux",
+        target_os = "macos"
+    )
+))]
+fn open_directory_nofollow(path: &Path) -> std::io::Result<File> {
+    use std::ffi::CString;
+    use std::os::fd::FromRawFd as _;
+    use std::os::unix::ffi::OsStrExt as _;
+
+    let path = CString::new(path.as_os_str().as_bytes())
+        .map_err(|_| std::io::Error::other("path contains NUL"))?;
+    let descriptor = unsafe {
+        libc::open(
+            path.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if descriptor < 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(unsafe { File::from_raw_fd(descriptor) })
+    }
+}
+
+#[cfg(all(
+    unix,
+    any(
+        target_os = "android",
+        target_os = "ios",
+        target_os = "linux",
+        target_os = "macos"
+    )
+))]
+fn open_directory_at_nofollow(
+    parent: &File,
+    component: &std::ffi::CString,
+) -> std::io::Result<File> {
+    use std::os::fd::{AsRawFd as _, FromRawFd as _};
+
+    let descriptor = unsafe {
+        libc::openat(
+            parent.as_raw_fd(),
+            component.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if descriptor < 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(unsafe { File::from_raw_fd(descriptor) })
+    }
 }
 
 #[cfg(not(all(
@@ -1777,6 +1839,15 @@ mod tests {
         );
     }
 
+    #[cfg(all(
+        unix,
+        any(
+            target_os = "android",
+            target_os = "ios",
+            target_os = "linux",
+            target_os = "macos"
+        )
+    ))]
     #[test]
     fn case_diagnostic_reservation_is_private_and_no_replace() {
         let root = tempfile::tempdir().unwrap();
@@ -1797,7 +1868,15 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
+    #[cfg(all(
+        unix,
+        any(
+            target_os = "android",
+            target_os = "ios",
+            target_os = "linux",
+            target_os = "macos"
+        )
+    ))]
     #[test]
     fn case_diagnostic_reservation_is_owner_only() {
         use std::os::unix::fs::PermissionsExt as _;
@@ -1862,6 +1941,15 @@ mod tests {
         assert!(validate_private_diagnostic_value(&invalid_pointer, &[]).is_err());
     }
 
+    #[cfg(all(
+        unix,
+        any(
+            target_os = "android",
+            target_os = "ios",
+            target_os = "linux",
+            target_os = "macos"
+        )
+    ))]
     #[test]
     fn case_diagnostic_file_is_newline_terminated_and_no_clobber() {
         let root = tempfile::tempdir().unwrap();
@@ -1874,6 +1962,15 @@ mod tests {
         assert_eq!(fs::read(&target).unwrap(), b"{}\n");
     }
 
+    #[cfg(all(
+        unix,
+        any(
+            target_os = "android",
+            target_os = "ios",
+            target_os = "linux",
+            target_os = "macos"
+        )
+    ))]
     #[test]
     fn complete_private_artifact_redacts_real_receipt_text_before_handle_relative_write() {
         let root = tempfile::tempdir().unwrap();
@@ -1915,7 +2012,15 @@ mod tests {
         assert!(written["unredacted_case_sha256"].as_str().is_some());
     }
 
-    #[cfg(unix)]
+    #[cfg(all(
+        unix,
+        any(
+            target_os = "android",
+            target_os = "ios",
+            target_os = "linux",
+            target_os = "macos"
+        )
+    ))]
     #[test]
     fn reservation_handle_cannot_be_redirected_by_a_path_swap() {
         let root = tempfile::tempdir().unwrap();
@@ -1928,6 +2033,62 @@ mod tests {
         write_private_diagnostic_file(&reservation, b"{}\n").unwrap();
         assert!(original.join(CASE_DIAGNOSTIC_FILE).is_file());
         assert!(!reservation.path().join(CASE_DIAGNOSTIC_FILE).exists());
+    }
+
+    #[cfg(all(
+        unix,
+        any(
+            target_os = "android",
+            target_os = "ios",
+            target_os = "linux",
+            target_os = "macos"
+        )
+    ))]
+    #[test]
+    fn nofollow_parent_and_replaced_reservation_paths_cannot_redirect_creation_or_writes() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        let actual_parent = root.path().join("actual-parent");
+        fs::create_dir(&actual_parent).unwrap();
+        let swapped_parent = root.path().join("swapped-parent");
+        symlink(&actual_parent, &swapped_parent).unwrap();
+        assert_eq!(
+            reserve_case_diagnostic(&swapped_parent, "20260821T120000Z-222222222222")
+                .unwrap_err()
+                .to_string(),
+            "proof_availability_case_diagnostic_parent_invalid"
+        );
+        assert!(fs::read_dir(&actual_parent).unwrap().next().is_none());
+
+        let reservation =
+            reserve_case_diagnostic(&actual_parent, "20260821T120000Z-222222222222").unwrap();
+        let held = root.path().join("held-reservation");
+        fs::rename(reservation.path(), &held).unwrap();
+        symlink(&actual_parent, reservation.path()).unwrap();
+        write_private_diagnostic_file(&reservation, b"{}\n").unwrap();
+        assert!(held.join(CASE_DIAGNOSTIC_FILE).is_file());
+        assert!(!actual_parent.join(CASE_DIAGNOSTIC_FILE).exists());
+    }
+
+    #[cfg(not(all(
+        unix,
+        any(
+            target_os = "android",
+            target_os = "ios",
+            target_os = "linux",
+            target_os = "macos"
+        )
+    )))]
+    #[test]
+    fn unsupported_target_rejects_before_runner_or_artifact_creation() {
+        let root = tempfile::tempdir().unwrap();
+        assert_eq!(
+            reserve_case_diagnostic(root.path(), "20260821T120000Z-222222222222")
+                .unwrap_err()
+                .to_string(),
+            "proof_availability_case_diagnostic_unsupported"
+        );
     }
 
     #[test]

--- a/crates/codestory-bench/src/bin/codestory_proof_availability/report.rs
+++ b/crates/codestory-bench/src/bin/codestory_proof_availability/report.rs
@@ -117,14 +117,20 @@ pub(crate) fn reserve_case_diagnostic(
     {
         bail!("proof_availability_case_diagnostic_parent_invalid")
     }
-    let name = format!(".codestory-proof-availability-case-diagnostic-{qualification_id}");
-    let path = output_parent.join(&name);
-    let component = CString::new(name.as_bytes())
+    let fixed_name = format!(".codestory-proof-availability-case-diagnostic-{qualification_id}");
+    let path = output_parent.join(&fixed_name);
+    let fixed_component = CString::new(fixed_name.as_bytes())
         .map_err(|_| anyhow::anyhow!("proof_availability_case_diagnostic_create_failed"))?;
-    if unsafe { libc::mkdirat(parent.as_raw_fd(), component.as_ptr(), 0o700) } != 0 {
-        return Err(anyhow::anyhow!("proof_availability_case_diagnostic_exists"));
+    let staging_name = random_staging_component()
+        .map_err(|_| anyhow::anyhow!("proof_availability_case_diagnostic_create_failed"))?;
+    let staging_component = CString::new(staging_name.as_bytes())
+        .map_err(|_| anyhow::anyhow!("proof_availability_case_diagnostic_create_failed"))?;
+    if unsafe { libc::mkdirat(parent.as_raw_fd(), staging_component.as_ptr(), 0o700) } != 0 {
+        return Err(anyhow::anyhow!(
+            "proof_availability_case_diagnostic_create_failed"
+        ));
     }
-    let directory = open_directory_at_nofollow(&parent, &component)
+    let directory = open_directory_at_nofollow(&parent, &staging_component)
         .map_err(|_| anyhow::anyhow!("proof_availability_case_diagnostic_create_failed"))?;
     let metadata = directory
         .metadata()
@@ -132,7 +138,7 @@ pub(crate) fn reserve_case_diagnostic(
     if !metadata.is_dir() || metadata.file_type().is_symlink() {
         bail!("proof_availability_case_diagnostic_create_failed")
     }
-    Ok(CaseDiagnosticReservation {
+    let reservation = CaseDiagnosticReservation {
         path,
         directory,
         device: {
@@ -143,7 +149,45 @@ pub(crate) fn reserve_case_diagnostic(
             use std::os::unix::fs::MetadataExt as _;
             metadata.ino()
         },
-    })
+    };
+    if rename_noreplace_at(
+        parent.as_raw_fd(),
+        &staging_component,
+        parent.as_raw_fd(),
+        &fixed_component,
+    )
+    .is_err()
+    {
+        return Err(anyhow::anyhow!("proof_availability_case_diagnostic_exists"));
+    }
+    if !path_matches_held_directory(&reservation).unwrap_or(false) {
+        bail!("proof_availability_case_diagnostic_create_failed")
+    }
+    Ok(reservation)
+}
+
+#[cfg(all(
+    unix,
+    any(
+        target_os = "android",
+        target_os = "ios",
+        target_os = "linux",
+        target_os = "macos"
+    )
+))]
+fn random_staging_component() -> std::io::Result<String> {
+    use std::io::Read as _;
+
+    let mut bytes = [0u8; 32];
+    File::open("/dev/urandom")?.read_exact(&mut bytes)?;
+    let mut encoded = String::with_capacity(64);
+    for byte in bytes {
+        use std::fmt::Write as _;
+        write!(&mut encoded, "{byte:02x}").expect("writing into String cannot fail");
+    }
+    Ok(format!(
+        ".codestory-proof-availability-case-staging-{encoded}"
+    ))
 }
 
 #[cfg(all(
@@ -237,10 +281,7 @@ pub(crate) fn write_invalid_case_diagnostic(
     // This compares only the recovery path with the held identity. It must
     // never determine the write target: a pathname replacement cannot divert
     // the private artifact away from the directory we opened at reservation.
-    let _path_still_names_reservation = path_matches_held_directory(reservation);
-    if !reservation_handle_is_directory(reservation)? {
-        bail!("proof_availability_case_diagnostic_write_failed")
-    }
+    ensure_discoverable_reservation(reservation)?;
     let unredacted_case = serde_json::to_value(&failure.case)
         .map_err(|_| anyhow::anyhow!("proof_availability_case_diagnostic_write_failed"))?;
     let project_materialization = serde_json::to_value(&failure.project)
@@ -267,6 +308,24 @@ pub(crate) fn write_invalid_case_diagnostic(
         .directory
         .sync_all()
         .map_err(|_| anyhow::anyhow!("proof_availability_case_diagnostic_write_failed"))
+}
+
+#[cfg(all(
+    unix,
+    any(
+        target_os = "android",
+        target_os = "ios",
+        target_os = "linux",
+        target_os = "macos"
+    )
+))]
+fn ensure_discoverable_reservation(reservation: &CaseDiagnosticReservation) -> Result<()> {
+    if !matches!(path_matches_held_directory(reservation), Ok(true))
+        || !reservation_handle_is_directory(reservation)?
+    {
+        bail!("proof_availability_case_diagnostic_write_failed")
+    }
+    Ok(())
 }
 
 #[cfg(not(all(
@@ -2030,8 +2089,13 @@ mod tests {
         fs::rename(reservation.path(), &original).unwrap();
         fs::create_dir(reservation.path()).unwrap();
         assert!(!path_matches_held_directory(&reservation).unwrap());
-        write_private_diagnostic_file(&reservation, b"{}\n").unwrap();
-        assert!(original.join(CASE_DIAGNOSTIC_FILE).is_file());
+        assert_eq!(
+            ensure_discoverable_reservation(&reservation)
+                .unwrap_err()
+                .to_string(),
+            "proof_availability_case_diagnostic_write_failed"
+        );
+        assert!(!original.join(CASE_DIAGNOSTIC_FILE).exists());
         assert!(!reservation.path().join(CASE_DIAGNOSTIC_FILE).exists());
     }
 
@@ -2066,8 +2130,8 @@ mod tests {
         let held = root.path().join("held-reservation");
         fs::rename(reservation.path(), &held).unwrap();
         symlink(&actual_parent, reservation.path()).unwrap();
-        write_private_diagnostic_file(&reservation, b"{}\n").unwrap();
-        assert!(held.join(CASE_DIAGNOSTIC_FILE).is_file());
+        assert!(ensure_discoverable_reservation(&reservation).is_err());
+        assert!(!held.join(CASE_DIAGNOSTIC_FILE).exists());
         assert!(!actual_parent.join(CASE_DIAGNOSTIC_FILE).exists());
     }
 

--- a/crates/codestory-bench/tests/proof_availability_contracts.rs
+++ b/crates/codestory-bench/tests/proof_availability_contracts.rs
@@ -2539,6 +2539,157 @@ fn make_non_proven_case(value: &mut Value, disposition: &str, gap: Option<&str>)
     rebuild_funnel(value);
 }
 
+fn six_step_case(value: &mut Value) -> &mut Value {
+    value["cases"]
+        .as_array_mut()
+        .expect("cases")
+        .iter_mut()
+        .find(|case| case["attempted_step_count"] == 6)
+        .expect("six-step fixture case")
+}
+
+fn selector_missing_gaps() -> Vec<Value> {
+    (0..=6)
+        .map(|selector_index| json!({"kind":"selector_missing","selector_index":selector_index}))
+        .collect()
+}
+
+fn set_six_step_selector_unknown_case(value: &mut Value, matching_trace: bool) {
+    let case = six_step_case(value);
+    let missing = case["receipt_evidence"]["observed_receipts"]
+        .as_array()
+        .expect("observed receipts")
+        .iter()
+        .map(|receipt| {
+            json!({
+                "step_index":receipt["step_index"],
+                "oracle_step":receipt["oracle_comparison"]["oracle_step"]
+            })
+        })
+        .collect::<Vec<_>>();
+    case["product_disposition"] = json!({
+        "kind":"unknown",
+        "gaps":["selector_missing"],
+        "authoritative_receipts":[],
+        "actual":{
+            "kind":"unknown",
+            "contract_digest":SHA,
+            "gaps":selector_missing_gaps(),
+            "connected_receipts":[]
+        }
+    });
+    case["receipt_evidence"]["missing_oracle_steps"] = Value::Array(missing);
+    if matching_trace {
+        for selector in case["proof_trace"]["selectors"]
+            .as_array_mut()
+            .expect("selector traces")
+        {
+            selector["outcome"] = json!({"kind":"failed","reason":"missing"});
+        }
+        case["proof_trace"]["selector_early_return"] = json!(true);
+        case["proof_trace"]["steps"] = json!([]);
+        case["unclassified_step_indices"] = json!([0, 1, 2, 3, 4, 5]);
+        case["receipt_evidence"]["observed_receipts"] = json!([]);
+        case["actionable_exact_gap"] = json!({
+            "gap":{"kind":"selector_missing","selector_index":0},
+            "boundary":{"kind":"selector","selector_index":0}
+        });
+    } else {
+        case["actionable_exact_gap"] = Value::Null;
+    }
+    rebuild_funnel(value);
+}
+
+#[test]
+fn actual_unknown_accepts_all_seven_selector_gaps_when_the_trace_matches() {
+    let mut value = report();
+    set_six_step_selector_unknown_case(&mut value, true);
+    rebind_results_digest(&mut value);
+
+    let parsed = QualificationSummaryV1::from_json(value)
+        .expect("seven legal selector gaps must remain structurally reportable");
+    let actual = &parsed
+        .cases
+        .iter()
+        .find(|case| case.attempted_step_count == 6)
+        .expect("six-step parsed case")
+        .product_disposition
+        .actual;
+    assert!(matches!(
+        actual,
+        ActualProductResultV1::Unknown { gaps, .. } if gaps.len() == 7
+    ));
+    assert!(
+        parsed
+            .cases
+            .iter()
+            .find(|case| case.attempted_step_count == 6)
+            .expect("six-step parsed case")
+            .evaluable_facts()
+            .expect("evaluable facts")
+            .product_disposition_matches_evidence
+    );
+}
+
+#[test]
+fn actual_unknown_trace_mismatch_remains_structurally_reportable_but_fails_evidence_gate() {
+    let mut value = report();
+    set_six_step_selector_unknown_case(&mut value, false);
+    rebind_results_digest(&mut value);
+
+    let parsed = QualificationSummaryV1::from_json(value)
+        .expect("trace disagreements must remain measurable evidence");
+    assert!(
+        !parsed
+            .cases
+            .iter()
+            .find(|case| case.attempted_step_count == 6)
+            .expect("six-step parsed case")
+            .evaluable_facts()
+            .expect("evaluable facts")
+            .product_disposition_matches_evidence
+    );
+}
+
+#[test]
+fn actual_unknown_rejects_empty_duplicate_invalid_index_and_digest_gaps() {
+    let mut empty = report();
+    set_six_step_selector_unknown_case(&mut empty, true);
+    six_step_case(&mut empty)["product_disposition"]["actual"]["gaps"] = json!([]);
+    assert_rebound_report_rejected(empty, "Unknown requires at least one actual gap");
+
+    let mut duplicate = report();
+    set_six_step_selector_unknown_case(&mut duplicate, true);
+    let duplicate_gap =
+        six_step_case(&mut duplicate)["product_disposition"]["actual"]["gaps"][0].clone();
+    six_step_case(&mut duplicate)["product_disposition"]["actual"]["gaps"]
+        .as_array_mut()
+        .expect("actual gaps")
+        .push(duplicate_gap);
+    assert_rebound_report_rejected(duplicate, "actual gaps must be unique");
+
+    let mut invalid_selector = report();
+    set_six_step_selector_unknown_case(&mut invalid_selector, true);
+    six_step_case(&mut invalid_selector)["product_disposition"]["actual"]["gaps"][6] =
+        json!({"kind":"selector_missing","selector_index":7});
+    assert_rebound_report_rejected(
+        invalid_selector,
+        "selector index seven is outside the domain",
+    );
+
+    let mut invalid_step = report();
+    set_six_step_selector_unknown_case(&mut invalid_step, true);
+    six_step_case(&mut invalid_step)["product_disposition"]["actual"]["gaps"][6] =
+        json!({"kind":"direct_call_missing","step_index":6});
+    assert_rebound_report_rejected(invalid_step, "step index six is outside the domain");
+
+    let mut invalid_digest = report();
+    set_six_step_selector_unknown_case(&mut invalid_digest, true);
+    six_step_case(&mut invalid_digest)["product_disposition"]["actual"]["contract_digest"] =
+        json!("not-a-sha256");
+    assert_rebound_report_rejected(invalid_digest, "actual results retain their digest binding");
+}
+
 #[test]
 fn invariant_table_exercises_remaining_closed_decision_and_funnel_variants() {
     for disposition in ["unknown", "certified_absence", "unavailable"] {
@@ -2759,6 +2910,14 @@ fn schemas_have_semantic_constants_patterns_and_bounds() {
     assert_eq!(
         report_schema["$defs"]["ActualProductResultV1"]["oneOf"][2]["properties"]["gaps"]["minItems"],
         1
+    );
+    assert_eq!(
+        report_schema["$defs"]["ActualProductResultV1"]["oneOf"][2]["properties"]["gaps"]["maxItems"],
+        76
+    );
+    assert_eq!(
+        report_schema["$defs"]["ProductDispositionV1"]["properties"]["gaps"]["maxItems"],
+        6
     );
     assert_eq!(
         report_schema["$defs"]["ActualProductResultV1"]["oneOf"][3]["properties"]["reasons"]["maxItems"],

--- a/crates/codestory-bench/tests/proof_availability_contracts.rs
+++ b/crates/codestory-bench/tests/proof_availability_contracts.rs
@@ -7,12 +7,13 @@ mod contracts;
 use clap::Parser;
 use contracts::{
     ActivationDecisionV1, ActualProductResultV1, CandidateFailureV1, CandidateGateV1,
-    ClauseClassificationV1, CohortPathFileV1, CorpusV1, ExactScopeSelectorV1,
-    ExactSymbolSelectorV1, FinalizationTraceV1, FunnelOutcomeV1, MAX_CANDIDATE_EDGES_PER_STEP,
-    MAX_OBSERVED_RECEIPTS_PER_CASE, ObservedReceiptV1, ProofContractFieldV1,
-    ProofQualificationTraceV1, QualificationSummaryV1, ReceiptOracleComparisonV1, SchemaDocument,
-    SelectorGateOutcomeV1, ThresholdsV1, TransportEvidenceV1, canonical_cohort_path_file_sha256,
-    canonical_corpus_sha256, canonical_thresholds_sha256,
+    CaseValidationFailure, ClauseClassificationV1, CohortPathFileV1, CorpusV1,
+    ExactScopeSelectorV1, ExactSymbolSelectorV1, FinalizationTraceV1, FunnelOutcomeV1,
+    MAX_CANDIDATE_EDGES_PER_STEP, MAX_OBSERVED_RECEIPTS_PER_CASE, ObservedReceiptV1,
+    ProofContractFieldV1, ProofQualificationTraceV1, QualificationSummaryV1,
+    ReceiptOracleComparisonV1, SchemaDocument, SelectorGateOutcomeV1, ThresholdsV1,
+    TransportEvidenceV1, canonical_cohort_path_file_sha256, canonical_corpus_sha256,
+    canonical_thresholds_sha256,
 };
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
@@ -1292,6 +1293,28 @@ fn threshold_corpus_summary_digest_dag_rejects_stale_or_mismatched_inputs() {
         .expect("summary")
         .validate_against_inputs(&altered_corpus, &threshold)
         .expect_err("summary corpus hash must bind exact corpus semantics");
+}
+
+#[test]
+fn invalid_case_retains_private_payload_but_renders_only_the_safe_umbrella() {
+    let threshold = ThresholdsV1::from_json(thresholds()).expect("thresholds");
+    let frozen_corpus = CorpusV1::from_json(corpus()).expect("corpus");
+    let mut invalid = report();
+    invalid["cases"][0]["negative_mutations"] = json!([]);
+    rebind_results_digest(&mut invalid);
+    let summary: QualificationSummaryV1 = serde_json::from_value(invalid).expect("shape");
+    let error = summary
+        .validate_against_inputs(&frozen_corpus, &threshold)
+        .expect_err("negative-mutation cardinality must remain invalid");
+    let failure = error
+        .downcast_ref::<CaseValidationFailure>()
+        .expect("private invalid-case payload");
+    assert_eq!(failure.case_ordinal, 0);
+    assert_eq!(failure.case.case_id, "codestory-rust-l1-0");
+    assert_eq!(failure.case.repository_id, "codestory-rust");
+    assert_eq!(failure.to_string(), "proof_availability_case_invalid");
+    assert_eq!(format!("{failure:?}"), "proof_availability_case_invalid");
+    assert_eq!(error.to_string(), "proof_availability_case_invalid");
 }
 
 #[test]


### PR DESCRIPTION
## Context

Q2 Candidate 3 completed fresh materialization and all 120 proof cases, then the benchmark report validator returned only `proof_availability_case_invalid` and discarded the runtime-complete first failing case. A single reviewed diagnostic-only run showed the owning defect: `flask-python-l6-01` correctly produced seven selector gaps (start plus six targets), while the qualification contract and generated report schema hard-capped every Unknown result at six.

## What changed

- Preserve the original case-validator predicate and public error behavior.
- On that existing boundary only, retain one owner-private, redacted, explicitly non-evidence case diagnostic outside the exactly-eight public result directory.
- Bind reservation creation and diagnostic publication to held directory handles with private permissions, no-replace publication, single-use identities, and fail-closed unsupported/platform/path behavior.
- Remove source-line text from diagnostics and retain only typed pointer/length/hash commitments plus the exact unredacted-case digest.
- Admit the complete finite structural `ActualProofGapV1` domain: 3 selector variants × 7 indices + 9 step variants × 6 indices + 1 output-budget variant = 76.
- Keep trace consistency in `evaluable_facts`; inconsistent product gaps remain measurable rows that fail the frozen product-disposition hard gate instead of aborting qualification.
- Align only the generated `ActualProductResultV1.gaps` schema maximum. The six closed coarse disposition variants remain capped at six.

## How to review

The semantic fix is the final commit `c853d6bbb3715855547277353b9d9bc828818bed`. Confirm that Unknown validation remains nonempty, unique, digest-bound, index-bound, and receipt-bound; that seven selector gaps are accepted; and that trace mismatch still returns `product_disposition_matches_evidence=false`.

For the diagnostic boundary, focus on manual safe error formatting, redaction, fixed 1 MiB cap, handle-relative reservation and atomic publication, and the fact that verify/public artifact enumeration remains exactly eight files.

## Verification

Exact reviewed head/tree:

- head: `c853d6bbb3715855547277353b9d9bc828818bed`
- tree: `14fa224ffe2ed33084eb273267b096cc7f29a2b9`

Passed serially:

- `cargo test --locked -p codestory-bench --test proof_availability_contracts` — 56 passed, 1 ignored
- `cargo test --locked -p codestory-bench proof_availability` — 115 passed, 2 ignored
- `cargo check --locked -p codestory-bench`
- `cargo clippy --locked -p codestory-bench --all-targets -- -D warnings`
- `cargo fmt -p codestory-bench -- --check`
- `git diff --check`

Independent reviews approved both the diagnostic boundary and the closed-gap fix with no Critical or Important findings.

The one diagnostic run was not Q2 evidence. It used a fresh release binary, ID, materialization, stores, cache, and root; emitted no public result; was not verified or retried; and only identified the benchmark-contract defect.

## Risk and follow-up

This changes qualification-report admission and private failure recovery only. It does not change the product kernel, runtime, index/store, oracle, corpus, thresholds, public MCP/CLI routes, catalogs, versions, release surfaces, `dev/codestory-next`, or 0.17. Candidate 4 must be a wholly new immutable Q2 run from the eventual merge head.

Closes #2008
Refs #1985
Refs #1984
