### PR TITLE
[v3 qualification] Preserve public artifact failure identity

### DIFF
--- a/crates/codestory-bench/src/bin/codestory_proof_availability/mod.rs
+++ b/crates/codestory-bench/src/bin/codestory_proof_availability/mod.rs
@@ -101,6 +101,12 @@ pub fn execute(cli: cli::Cli) -> Result<()> {
                 &loaded.corpus,
                 &thresholds,
                 &leak_policy,
+                report::PublicArtifactDiagnosticContext::new(
+                    &reservation,
+                    &operational.environment.qualification_id,
+                    &operational.environment.qualification_source_commit,
+                    &operational.environment.qualification_source_tree,
+                ),
             )?;
             Ok(())
         }

--- a/crates/codestory-bench/src/bin/codestory_proof_availability/report.rs
+++ b/crates/codestory-bench/src/bin/codestory_proof_availability/report.rs
@@ -180,21 +180,30 @@ impl PublicArtifactBuildFailure {
             rejected_string: Some((
                 rejected.len(),
                 domain_sha256(
-                    b"codestory.proof-availability.public-artifact-build-rejected-string.v1\\0",
+                    b"codestory.proof-availability.public-artifact-build-rejected-string.v1\0",
                     rejected.as_bytes(),
                 ),
             )),
         }
     }
 
-    fn artifact_closed(
+    fn rejected_without_pointer(
         stage: PublicArtifactBuildStage,
         reason: PublicArtifactBuildReason,
         artifact: PublicArtifactName,
+        case_ordinal: Option<usize>,
+        rejected: &str,
     ) -> Self {
         Self {
-            artifact: Some(artifact),
-            ..Self::closed(stage, reason)
+            json_pointer: None,
+            ..Self::rejected_string(
+                stage,
+                reason,
+                artifact,
+                case_ordinal,
+                String::new(),
+                rejected,
+            )
         }
     }
 
@@ -1933,10 +1942,13 @@ fn validate_public_bundle_for_build(
         validate_public_json_for_build(name, value, "", None)?;
     }
     if bundle.findings.contains('\0') || bundle.findings.contains('\r') {
-        return Err(PublicArtifactBuildFailure::artifact_closed(
+        return Err(PublicArtifactBuildFailure::rejected_string(
             PublicArtifactBuildStage::BundleValidation,
             PublicArtifactBuildReason::ExistingInvariant,
             PublicArtifactName::Findings,
+            None,
+            "/text".to_owned(),
+            &bundle.findings,
         ));
     }
     Ok(())
@@ -1951,23 +1963,22 @@ fn validate_public_json_for_build(
     match value {
         Value::Object(object) => {
             for (field, child) in object {
+                if secret_field(field) {
+                    let rejected = child.as_str().unwrap_or(field);
+                    return Err(PublicArtifactBuildFailure::rejected_without_pointer(
+                        PublicArtifactBuildStage::BundleValidation,
+                        PublicArtifactBuildReason::SecretField,
+                        artifact,
+                        case_ordinal,
+                        rejected,
+                    ));
+                }
                 let child_pointer = append_fixed_json_pointer(pointer, field).ok_or_else(|| {
                     PublicArtifactBuildFailure::closed(
                         PublicArtifactBuildStage::BundleValidation,
                         PublicArtifactBuildReason::ExistingInvariant,
                     )
                 })?;
-                if secret_field(field) {
-                    let rejected = child.as_str().unwrap_or(field);
-                    return Err(PublicArtifactBuildFailure::rejected_string(
-                        PublicArtifactBuildStage::BundleValidation,
-                        PublicArtifactBuildReason::SecretField,
-                        artifact,
-                        case_ordinal,
-                        child_pointer,
-                        rejected,
-                    ));
-                }
                 validate_public_json_for_build(artifact, child, &child_pointer, case_ordinal)?;
             }
         }
@@ -2011,9 +2022,43 @@ fn validate_public_json_for_build(
 
 fn append_fixed_json_pointer(pointer: &str, segment: &str) -> Option<String> {
     const MAX_DIAGNOSTIC_POINTER_BYTES: usize = 4096;
-    let escaped = json_pointer_escape(segment);
+    let escaped = if !segment.is_empty() && segment.bytes().all(|byte| byte.is_ascii_digit()) {
+        segment
+    } else {
+        fixed_json_pointer_segment(segment)?
+    };
     let length = pointer.len().checked_add(1)?.checked_add(escaped.len())?;
     (length <= MAX_DIAGNOSTIC_POINTER_BYTES).then(|| format!("{pointer}/{escaped}"))
+}
+
+fn fixed_json_pointer_segment(segment: &str) -> Option<&'static str> {
+    Some(match segment {
+        "schema" => "schema",
+        "canonical_id" => "canonical_id",
+        "case_id" => "case_id",
+        "repository_id" => "repository_id",
+        "qualification_id" => "qualification_id",
+        "workspace" => "workspace",
+        "environment" => "environment",
+        "inventory" => "inventory",
+        "trails" => "trails",
+        "cases" => "cases",
+        "failure_funnel" => "failure_funnel",
+        "summary" => "summary",
+        "decision" => "decision",
+        "findings" => "findings",
+        "provenance" => "provenance",
+        "observations" => "observations",
+        "results_sha256" => "results_sha256",
+        "thresholds_sha256" => "thresholds_sha256",
+        "observations_sha256" => "observations_sha256",
+        "outcome" => "outcome",
+        "failed_gates" => "failed_gates",
+        "text" => "text",
+        "path" => "path",
+        "value" => "value",
+        _ => return None,
+    })
 }
 
 fn validate_public_bundle(bundle: &PublicArtifactBundle, policy: &PublicLeakPolicy) -> Result<()> {
@@ -2127,6 +2172,7 @@ where
             }
             _ => "proof_availability_public_artifact_invalid",
         };
+        write_legacy_public_artifact_diagnostic(destination, code);
         ReportPublishError::before_staging(code, destination)
     })?;
     let parent = destination.parent().ok_or_else(|| {
@@ -2206,6 +2252,32 @@ where
         )
     })?;
     Ok(())
+}
+
+fn write_legacy_public_artifact_diagnostic(destination: &Path, code: &str) {
+    let reason = match code {
+        "proof_availability_public_path_leak" => PublicArtifactBuildReason::PathLeak,
+        "proof_availability_public_secret_leak" => PublicArtifactBuildReason::SecretField,
+        _ => PublicArtifactBuildReason::ExistingInvariant,
+    };
+    let Some(parent) = destination.parent() else {
+        return;
+    };
+    let Some(qualification_id) = destination.file_name().and_then(|name| name.to_str()) else {
+        return;
+    };
+    let Ok(reservation) = reserve_case_diagnostic(parent, qualification_id) else {
+        return;
+    };
+    let failure =
+        PublicArtifactBuildFailure::closed(PublicArtifactBuildStage::BundleValidation, reason);
+    let _ = write_public_artifact_build_diagnostic(
+        &reservation,
+        qualification_id,
+        "unavailable",
+        "unavailable",
+        &failure,
+    );
 }
 
 fn stage_bundle(staging: &Path, bundle: &PublicArtifactBundle) -> Result<()> {
@@ -2358,7 +2430,7 @@ mod tests {
 
     fn fixture_bundle() -> PublicArtifactBundle {
         PublicArtifactBundle {
-            environment: json!({"z": 2, "a": 1}),
+            environment: json!({"schema": "fixture"}),
             inventory: json!([]),
             trails: json!([]),
             cases: json!([]),
@@ -2431,7 +2503,7 @@ mod tests {
         assert_eq!(
             artifact["failure"]["rejected_string"]["sha256"],
             domain_sha256(
-                b"codestory.proof-availability.public-artifact-build-rejected-string.v1\\0",
+                b"codestory.proof-availability.public-artifact-build-rejected-string.v1\0",
                 b"/Users/albert/private/canonical-id",
             )
         );
@@ -2478,6 +2550,7 @@ mod tests {
 
         assert_eq!(artifact["failure"]["reason"], "secret_field");
         assert_eq!(artifact["failure"]["case_ordinal"], 0);
+        assert!(artifact["failure"]["json_pointer"].is_null());
         assert!(
             artifact["failure"]["rejected_string"]["sha256"]
                 .as_str()
@@ -2485,6 +2558,94 @@ mod tests {
         );
         let rendered = String::from_utf8(bytes).unwrap();
         assert!(!rendered.contains("TOKEN=do-not-publish"));
+    }
+
+    #[test]
+    fn public_artifact_validation_rejects_hostile_object_keys_without_retaining_them() {
+        for key in [
+            "private prose /Users/albert/secret",
+            "token-like-key=private",
+            "hostile\u{0}control",
+        ] {
+            let mut bundle = fixture_bundle();
+            bundle.cases = Value::Object(
+                [(
+                    key.to_owned(),
+                    Value::String("/Users/albert/secret".to_owned()),
+                )]
+                .into_iter()
+                .collect(),
+            );
+            let failure = validate_public_bundle_for_build(&bundle).unwrap_err();
+            let artifact = build_public_artifact_build_diagnostic_artifact(
+                "20260821T120000Z-222222222222",
+                &"a".repeat(40),
+                &"b".repeat(40),
+                &failure,
+            )
+            .unwrap();
+            let rendered = String::from_utf8(canonical_json_file(&artifact).unwrap()).unwrap();
+
+            assert_eq!(artifact["failure"]["reason"], "existing_invariant");
+            assert!(artifact["failure"]["json_pointer"].is_null());
+            assert!(!rendered.contains(key));
+            assert!(!rendered.contains("/Users/albert/secret"));
+        }
+    }
+
+    #[test]
+    fn public_artifact_findings_rejection_commits_nul_and_carriage_return_text() {
+        for findings in ["private\u{0}token", "private\rpath"] {
+            let mut bundle = fixture_bundle();
+            bundle.findings = findings.to_owned();
+            let failure = validate_public_bundle_for_build(&bundle).unwrap_err();
+            let artifact = build_public_artifact_build_diagnostic_artifact(
+                "20260821T120000Z-222222222222",
+                &"a".repeat(40),
+                &"b".repeat(40),
+                &failure,
+            )
+            .unwrap();
+            let rendered = String::from_utf8(canonical_json_file(&artifact).unwrap()).unwrap();
+
+            assert_eq!(artifact["failure"]["artifact"], "findings.md");
+            assert_eq!(artifact["failure"]["reason"], "existing_invariant");
+            assert_eq!(
+                artifact["failure"]["rejected_string"]["utf8_byte_length"],
+                findings.len()
+            );
+            assert_eq!(
+                artifact["failure"]["rejected_string"]["sha256"],
+                domain_sha256(
+                    b"codestory.proof-availability.public-artifact-build-rejected-string.v1\0",
+                    findings.as_bytes(),
+                )
+            );
+            assert!(!rendered.contains(findings));
+        }
+    }
+
+    #[test]
+    fn public_artifact_pointer_cap_accepts_the_exact_limit_and_rejects_the_next_byte() {
+        let exact = "x".repeat(4083);
+        let expected = format!("{exact}/canonical_id");
+        assert_eq!(
+            append_fixed_json_pointer(&exact, "canonical_id").as_deref(),
+            Some(expected.as_str())
+        );
+        assert!(append_fixed_json_pointer(&format!("{exact}/canonical_id"), "schema").is_none());
+    }
+
+    #[test]
+    fn public_artifact_path_classification_covers_each_supported_absolute_form() {
+        for path in [
+            "/Users/albert/private",
+            "C:\\\\private",
+            "\\\\server\\share\\private",
+            "\\\\?\\C:\\\\private",
+        ] {
+            assert!(absolute_path(path), "{path}");
+        }
     }
 
     #[cfg(all(
@@ -2942,6 +3103,34 @@ mod tests {
             .unwrap_err()
             .code,
             "proof_availability_public_secret_leak"
+        );
+    }
+
+    #[cfg(all(
+        unix,
+        any(
+            target_os = "android",
+            target_os = "ios",
+            target_os = "linux",
+            target_os = "macos"
+        )
+    ))]
+    #[test]
+    fn public_path_failure_writes_the_private_build_diagnostic() {
+        let root = tempfile::tempdir().unwrap();
+        let destination = root.path().join("behavior-red");
+        let mut bundle = fixture_bundle();
+        bundle.summary = json!({"workspace": "/Users/albert/private"});
+
+        let error = publish_bundle(&destination, &bundle, &PublicLeakPolicy::default())
+            .expect_err("synthetic path must fail");
+        assert_eq!(error.code, "proof_availability_public_path_leak");
+        assert!(
+            root.path()
+                .join(".codestory-proof-availability-case-diagnostic-behavior-red")
+                .join("public-artifact-build-v1.json")
+                .is_file(),
+            "the path failure must retain the fixed private diagnostic"
         );
     }
 

--- a/crates/codestory-bench/src/bin/codestory_proof_availability/report.rs
+++ b/crates/codestory-bench/src/bin/codestory_proof_availability/report.rs
@@ -1973,19 +1973,20 @@ fn validate_public_json_for_build(
                         rejected,
                     ));
                 }
-                let child_pointer = append_fixed_json_pointer(pointer, field).ok_or_else(|| {
-                    PublicArtifactBuildFailure::closed(
-                        PublicArtifactBuildStage::BundleValidation,
-                        PublicArtifactBuildReason::ExistingInvariant,
-                    )
-                })?;
+                let child_pointer =
+                    append_fixed_object_pointer(pointer, field).ok_or_else(|| {
+                        PublicArtifactBuildFailure::closed(
+                            PublicArtifactBuildStage::BundleValidation,
+                            PublicArtifactBuildReason::ExistingInvariant,
+                        )
+                    })?;
                 validate_public_json_for_build(artifact, child, &child_pointer, case_ordinal)?;
             }
         }
         Value::Array(values) => {
             for (index, child) in values.iter().enumerate() {
-                let child_pointer = append_fixed_json_pointer(pointer, &index.to_string())
-                    .ok_or_else(|| {
+                let child_pointer =
+                    append_array_index_pointer(pointer, index).ok_or_else(|| {
                         PublicArtifactBuildFailure::closed(
                             PublicArtifactBuildStage::BundleValidation,
                             PublicArtifactBuildReason::ExistingInvariant,
@@ -2020,15 +2021,18 @@ fn validate_public_json_for_build(
     Ok(())
 }
 
-fn append_fixed_json_pointer(pointer: &str, segment: &str) -> Option<String> {
+fn append_fixed_object_pointer(pointer: &str, segment: &str) -> Option<String> {
     const MAX_DIAGNOSTIC_POINTER_BYTES: usize = 4096;
-    let escaped = if !segment.is_empty() && segment.bytes().all(|byte| byte.is_ascii_digit()) {
-        segment
-    } else {
-        fixed_json_pointer_segment(segment)?
-    };
+    let escaped = fixed_json_pointer_segment(segment)?;
     let length = pointer.len().checked_add(1)?.checked_add(escaped.len())?;
     (length <= MAX_DIAGNOSTIC_POINTER_BYTES).then(|| format!("{pointer}/{escaped}"))
+}
+
+fn append_array_index_pointer(pointer: &str, index: usize) -> Option<String> {
+    const MAX_DIAGNOSTIC_POINTER_BYTES: usize = 4096;
+    let index = index.to_string();
+    let length = pointer.len().checked_add(1)?.checked_add(index.len())?;
+    (length <= MAX_DIAGNOSTIC_POINTER_BYTES).then(|| format!("{pointer}/{index}"))
 }
 
 fn fixed_json_pointer_segment(segment: &str) -> Option<&'static str> {
@@ -2172,7 +2176,6 @@ where
             }
             _ => "proof_availability_public_artifact_invalid",
         };
-        write_legacy_public_artifact_diagnostic(destination, code);
         ReportPublishError::before_staging(code, destination)
     })?;
     let parent = destination.parent().ok_or_else(|| {
@@ -2252,32 +2255,6 @@ where
         )
     })?;
     Ok(())
-}
-
-fn write_legacy_public_artifact_diagnostic(destination: &Path, code: &str) {
-    let reason = match code {
-        "proof_availability_public_path_leak" => PublicArtifactBuildReason::PathLeak,
-        "proof_availability_public_secret_leak" => PublicArtifactBuildReason::SecretField,
-        _ => PublicArtifactBuildReason::ExistingInvariant,
-    };
-    let Some(parent) = destination.parent() else {
-        return;
-    };
-    let Some(qualification_id) = destination.file_name().and_then(|name| name.to_str()) else {
-        return;
-    };
-    let Ok(reservation) = reserve_case_diagnostic(parent, qualification_id) else {
-        return;
-    };
-    let failure =
-        PublicArtifactBuildFailure::closed(PublicArtifactBuildStage::BundleValidation, reason);
-    let _ = write_public_artifact_build_diagnostic(
-        &reservation,
-        qualification_id,
-        "unavailable",
-        "unavailable",
-        &failure,
-    );
 }
 
 fn stage_bundle(staging: &Path, bundle: &PublicArtifactBundle) -> Result<()> {
@@ -2630,10 +2607,21 @@ mod tests {
         let exact = "x".repeat(4083);
         let expected = format!("{exact}/canonical_id");
         assert_eq!(
-            append_fixed_json_pointer(&exact, "canonical_id").as_deref(),
+            append_fixed_object_pointer(&exact, "canonical_id").as_deref(),
             Some(expected.as_str())
         );
-        assert!(append_fixed_json_pointer(&format!("{exact}/canonical_id"), "schema").is_none());
+        assert!(append_fixed_object_pointer(&format!("{exact}/canonical_id"), "schema").is_none());
+    }
+
+    #[test]
+    fn public_artifact_pointer_admits_numeric_segments_only_from_arrays() {
+        assert!(append_fixed_object_pointer("", "7").is_none());
+        assert_eq!(append_array_index_pointer("", 7).as_deref(), Some("/7"));
+        let mut bundle = fixture_bundle();
+        bundle.cases = json!({"7": "/Users/albert/private"});
+        let failure = validate_public_bundle_for_build(&bundle).unwrap_err();
+        assert_eq!(failure.reason, PublicArtifactBuildReason::ExistingInvariant);
+        assert!(failure.json_pointer.is_none());
     }
 
     #[test]
@@ -3103,34 +3091,6 @@ mod tests {
             .unwrap_err()
             .code,
             "proof_availability_public_secret_leak"
-        );
-    }
-
-    #[cfg(all(
-        unix,
-        any(
-            target_os = "android",
-            target_os = "ios",
-            target_os = "linux",
-            target_os = "macos"
-        )
-    ))]
-    #[test]
-    fn public_path_failure_writes_the_private_build_diagnostic() {
-        let root = tempfile::tempdir().unwrap();
-        let destination = root.path().join("behavior-red");
-        let mut bundle = fixture_bundle();
-        bundle.summary = json!({"workspace": "/Users/albert/private"});
-
-        let error = publish_bundle(&destination, &bundle, &PublicLeakPolicy::default())
-            .expect_err("synthetic path must fail");
-        assert_eq!(error.code, "proof_availability_public_path_leak");
-        assert!(
-            root.path()
-                .join(".codestory-proof-availability-case-diagnostic-behavior-red")
-                .join("public-artifact-build-v1.json")
-                .is_file(),
-            "the path failure must retain the fixed private diagnostic"
         );
     }
 

--- a/crates/codestory-bench/src/bin/codestory_proof_availability/report.rs
+++ b/crates/codestory-bench/src/bin/codestory_proof_availability/report.rs
@@ -41,8 +41,195 @@ pub(crate) const PUBLIC_ARTIFACT_NAMES: [&str; 8] = [
 const OWNER_MARKER: &str = ".codestory-proof-availability-report-staging";
 const MAX_PUBLIC_ARTIFACT_BYTES: u64 = 64 * 1024 * 1024;
 const CASE_DIAGNOSTIC_SCHEMA: &str = "codestory.proof-availability.invalid-case-diagnostic.v1";
-const CASE_DIAGNOSTIC_FILE: &str = "invalid-case-v1.json";
+const PUBLIC_ARTIFACT_BUILD_DIAGNOSTIC_SCHEMA: &str =
+    "codestory.proof-availability.public-artifact-build-diagnostic.v1";
 const MAX_CASE_DIAGNOSTIC_BYTES: usize = 1024 * 1024;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PrivateDiagnosticFileKind {
+    InvalidCaseV1,
+    PublicArtifactBuildV1,
+}
+
+impl PrivateDiagnosticFileKind {
+    const fn file_name(self) -> &'static str {
+        match self {
+            Self::InvalidCaseV1 => "invalid-case-v1.json",
+            Self::PublicArtifactBuildV1 => "public-artifact-build-v1.json",
+        }
+    }
+
+    const fn temporary_prefix(self) -> &'static str {
+        match self {
+            Self::InvalidCaseV1 => ".invalid-case-v1",
+            Self::PublicArtifactBuildV1 => ".public-artifact-build-v1",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum PublicArtifactName {
+    Environment,
+    Inventory,
+    Trails,
+    Cases,
+    FailureFunnel,
+    Summary,
+    Decision,
+    Findings,
+}
+
+impl PublicArtifactName {
+    const fn file_name(self) -> &'static str {
+        match self {
+            Self::Environment => "environment.json",
+            Self::Inventory => "inventory.json",
+            Self::Trails => "trails.json",
+            Self::Cases => "cases.json",
+            Self::FailureFunnel => "failure-funnel.json",
+            Self::Summary => "summary.json",
+            Self::Decision => "decision.json",
+            Self::Findings => "findings.md",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum PublicArtifactBuildStage {
+    SummaryValidation,
+    ObservationDerivation,
+    ObservationCanonicalization,
+    DecisionEvaluation,
+    DecisionValidation,
+    FindingsRendering,
+    Serialization,
+    BundleValidation,
+}
+
+impl PublicArtifactBuildStage {
+    const fn name(self) -> &'static str {
+        match self {
+            Self::SummaryValidation => "summary_validation",
+            Self::ObservationDerivation => "observation_derivation",
+            Self::ObservationCanonicalization => "observation_canonicalization",
+            Self::DecisionEvaluation => "decision_evaluation",
+            Self::DecisionValidation => "decision_validation",
+            Self::FindingsRendering => "findings_rendering",
+            Self::Serialization => "serialization",
+            Self::BundleValidation => "bundle_validation",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PublicArtifactBuildReason {
+    PathLeak,
+    SecretField,
+    ExistingInvariant,
+    Canonicalization,
+    Serialization,
+}
+
+impl PublicArtifactBuildReason {
+    const fn name(self) -> &'static str {
+        match self {
+            Self::PathLeak => "path_leak",
+            Self::SecretField => "secret_field",
+            Self::ExistingInvariant => "existing_invariant",
+            Self::Canonicalization => "canonicalization",
+            Self::Serialization => "serialization",
+        }
+    }
+}
+
+pub(crate) struct PublicArtifactBuildFailure {
+    stage: PublicArtifactBuildStage,
+    reason: PublicArtifactBuildReason,
+    artifact: Option<PublicArtifactName>,
+    case_ordinal: Option<usize>,
+    json_pointer: Option<String>,
+    rejected_string: Option<(usize, String)>,
+}
+
+impl PublicArtifactBuildFailure {
+    fn closed(stage: PublicArtifactBuildStage, reason: PublicArtifactBuildReason) -> Self {
+        Self {
+            stage,
+            reason,
+            artifact: None,
+            case_ordinal: None,
+            json_pointer: None,
+            rejected_string: None,
+        }
+    }
+
+    fn rejected_string(
+        stage: PublicArtifactBuildStage,
+        reason: PublicArtifactBuildReason,
+        artifact: PublicArtifactName,
+        case_ordinal: Option<usize>,
+        json_pointer: String,
+        rejected: &str,
+    ) -> Self {
+        Self {
+            stage,
+            reason,
+            artifact: Some(artifact),
+            case_ordinal,
+            json_pointer: Some(json_pointer),
+            rejected_string: Some((
+                rejected.len(),
+                domain_sha256(
+                    b"codestory.proof-availability.public-artifact-build-rejected-string.v1\\0",
+                    rejected.as_bytes(),
+                ),
+            )),
+        }
+    }
+
+    fn artifact_closed(
+        stage: PublicArtifactBuildStage,
+        reason: PublicArtifactBuildReason,
+        artifact: PublicArtifactName,
+    ) -> Self {
+        Self {
+            artifact: Some(artifact),
+            ..Self::closed(stage, reason)
+        }
+    }
+
+    #[cfg(test)]
+    fn path_leak(
+        stage: PublicArtifactBuildStage,
+        artifact: PublicArtifactName,
+        case_ordinal: Option<usize>,
+        json_pointer: &str,
+        rejected: &str,
+    ) -> Self {
+        Self::rejected_string(
+            stage,
+            PublicArtifactBuildReason::PathLeak,
+            artifact,
+            case_ordinal,
+            json_pointer.to_owned(),
+            rejected,
+        )
+    }
+}
+
+impl fmt::Display for PublicArtifactBuildFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("proof_availability_public_artifact_build_failed")
+    }
+}
+
+impl fmt::Debug for PublicArtifactBuildFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, formatter)
+    }
+}
+
+impl std::error::Error for PublicArtifactBuildFailure {}
 
 /// A process-owned, initially empty directory that makes a qualification ID
 /// single-use for the private invalid-case recovery artifact. It is never a
@@ -302,12 +489,106 @@ pub(crate) fn write_invalid_case_diagnostic(
     if bytes.len() > MAX_CASE_DIAGNOSTIC_BYTES {
         bail!("proof_availability_case_diagnostic_write_failed")
     }
-    write_private_diagnostic_file(reservation, &bytes)
-        .map_err(|_| anyhow::anyhow!("proof_availability_case_diagnostic_write_failed"))?;
+    write_private_diagnostic_file(
+        reservation,
+        PrivateDiagnosticFileKind::InvalidCaseV1,
+        &bytes,
+    )
+    .map_err(|_| anyhow::anyhow!("proof_availability_case_diagnostic_write_failed"))?;
     reservation
         .directory
         .sync_all()
         .map_err(|_| anyhow::anyhow!("proof_availability_case_diagnostic_write_failed"))
+}
+
+#[cfg(all(
+    unix,
+    any(
+        target_os = "android",
+        target_os = "ios",
+        target_os = "linux",
+        target_os = "macos"
+    )
+))]
+pub(crate) fn write_public_artifact_build_diagnostic(
+    reservation: &CaseDiagnosticReservation,
+    qualification_id: &str,
+    source_commit: &str,
+    source_tree: &str,
+    failure: &PublicArtifactBuildFailure,
+) -> Result<()> {
+    ensure_discoverable_reservation(reservation)?;
+    let artifact = build_public_artifact_build_diagnostic_artifact(
+        qualification_id,
+        source_commit,
+        source_tree,
+        failure,
+    )?;
+    let bytes = canonical_json_file(&artifact)
+        .map_err(|_| anyhow::anyhow!("proof_availability_case_diagnostic_write_failed"))?;
+    if bytes.len() > MAX_CASE_DIAGNOSTIC_BYTES {
+        bail!("proof_availability_case_diagnostic_write_failed")
+    }
+    write_private_diagnostic_file(
+        reservation,
+        PrivateDiagnosticFileKind::PublicArtifactBuildV1,
+        &bytes,
+    )
+    .map_err(|_| anyhow::anyhow!("proof_availability_case_diagnostic_write_failed"))?;
+    reservation
+        .directory
+        .sync_all()
+        .map_err(|_| anyhow::anyhow!("proof_availability_case_diagnostic_write_failed"))
+}
+
+#[cfg(not(all(
+    unix,
+    any(
+        target_os = "android",
+        target_os = "ios",
+        target_os = "linux",
+        target_os = "macos"
+    )
+)))]
+pub(crate) fn write_public_artifact_build_diagnostic(
+    _: &CaseDiagnosticReservation,
+    _: &str,
+    _: &str,
+    _: &str,
+    _: &PublicArtifactBuildFailure,
+) -> Result<()> {
+    bail!("proof_availability_case_diagnostic_unsupported")
+}
+
+fn build_public_artifact_build_diagnostic_artifact(
+    qualification_id: &str,
+    source_commit: &str,
+    source_tree: &str,
+    failure: &PublicArtifactBuildFailure,
+) -> Result<Value> {
+    let rejected_string = failure.rejected_string.as_ref().map(|(length, sha256)| {
+        json!({
+            "utf8_byte_length": length,
+            "sha256": sha256,
+        })
+    });
+    let artifact = json!({
+        "schema": PUBLIC_ARTIFACT_BUILD_DIAGNOSTIC_SCHEMA,
+        "classification": "non_evidence",
+        "qualification_id": qualification_id,
+        "validator_source_commit": source_commit,
+        "validator_source_tree": source_tree,
+        "failure": {
+            "stage": failure.stage.name(),
+            "reason": failure.reason.name(),
+            "artifact": failure.artifact.map(PublicArtifactName::file_name),
+            "case_ordinal": failure.case_ordinal,
+            "json_pointer": failure.json_pointer,
+            "rejected_string": rejected_string,
+        },
+    });
+    validate_private_diagnostic_value(&artifact, &[])?;
+    Ok(artifact)
 }
 
 #[cfg(all(
@@ -535,7 +816,8 @@ fn validate_private_diagnostic_value_at(
 }
 
 fn is_removed_text_commitment_pointer_field(pointer: &str) -> bool {
-    pointer.starts_with("/removed_text_commitments/") && pointer.ends_with("/json_pointer")
+    (pointer.starts_with("/removed_text_commitments/") && pointer.ends_with("/json_pointer"))
+        || pointer == "/failure/json_pointer"
 }
 
 fn valid_json_pointer(value: &str) -> bool {
@@ -583,17 +865,22 @@ static CASE_DIAGNOSTIC_TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 ))]
 fn write_private_diagnostic_file(
     reservation: &CaseDiagnosticReservation,
+    kind: PrivateDiagnosticFileKind,
     bytes: &[u8],
 ) -> std::io::Result<()> {
     use std::ffi::CString;
     use std::os::fd::{AsRawFd as _, FromRawFd as _};
 
     let sequence = CASE_DIAGNOSTIC_TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed);
-    let temporary_name = format!(".invalid-case-v1-{}-{sequence}", std::process::id());
+    let temporary_name = format!(
+        "{}-{}-{sequence}",
+        kind.temporary_prefix(),
+        std::process::id()
+    );
     let temporary_c = CString::new(temporary_name.as_bytes())
         .map_err(|_| std::io::Error::other("invalid temporary name"))?;
-    let final_c = CString::new(CASE_DIAGNOSTIC_FILE)
-        .map_err(|_| std::io::Error::other("invalid final name"))?;
+    let final_c =
+        CString::new(kind.file_name()).map_err(|_| std::io::Error::other("invalid final name"))?;
     let directory_fd = reservation.directory.as_raw_fd();
     let descriptor = unsafe {
         libc::openat(
@@ -827,15 +1114,38 @@ pub(crate) fn build_public_artifacts(
     summary: &QualificationSummaryV1,
     corpus: &CorpusV1,
     thresholds: &ThresholdsV1,
-) -> Result<PublicArtifactBundle> {
-    summary.validate_against_inputs(corpus, thresholds)?;
-    let observations = derive_observations(summary, thresholds)?;
+) -> std::result::Result<PublicArtifactBundle, PublicArtifactBuildFailure> {
+    summary
+        .validate_against_inputs(corpus, thresholds)
+        .map_err(|_| {
+            PublicArtifactBuildFailure::closed(
+                PublicArtifactBuildStage::SummaryValidation,
+                PublicArtifactBuildReason::ExistingInvariant,
+            )
+        })?;
+    let observations = derive_observations(summary, thresholds).map_err(|_| {
+        PublicArtifactBuildFailure::closed(
+            PublicArtifactBuildStage::ObservationDerivation,
+            PublicArtifactBuildReason::ExistingInvariant,
+        )
+    })?;
     let observations_sha256 = canonical_observations_sha256(
         &summary.provenance.results_sha256,
         &summary.provenance.thresholds_sha256,
         &observations,
-    )?;
-    let decision = evaluate_activation_decision(summary, corpus, thresholds)?;
+    )
+    .map_err(|_| {
+        PublicArtifactBuildFailure::closed(
+            PublicArtifactBuildStage::ObservationCanonicalization,
+            PublicArtifactBuildReason::Canonicalization,
+        )
+    })?;
+    let decision = evaluate_activation_decision(summary, corpus, thresholds).map_err(|_| {
+        PublicArtifactBuildFailure::closed(
+            PublicArtifactBuildStage::DecisionEvaluation,
+            PublicArtifactBuildReason::ExistingInvariant,
+        )
+    })?;
     let decision_report = ActivationDecisionReportV1 {
         schema: DECISION_REPORT_SCHEMA.to_owned(),
         results_sha256: summary.provenance.results_sha256.clone(),
@@ -844,19 +1154,64 @@ pub(crate) fn build_public_artifacts(
         observations_sha256,
         decision,
     };
-    decision_report.validate()?;
-    let findings = render_findings(summary, thresholds, &decision_report)?;
+    decision_report.validate().map_err(|_| {
+        PublicArtifactBuildFailure::closed(
+            PublicArtifactBuildStage::DecisionValidation,
+            PublicArtifactBuildReason::ExistingInvariant,
+        )
+    })?;
+    let findings = render_findings(summary, thresholds, &decision_report).map_err(|_| {
+        PublicArtifactBuildFailure::closed(
+            PublicArtifactBuildStage::FindingsRendering,
+            PublicArtifactBuildReason::ExistingInvariant,
+        )
+    })?;
     let bundle = PublicArtifactBundle {
-        environment: serde_json::to_value(&summary.environment)?,
-        inventory: serde_json::to_value(&summary.inventory)?,
-        trails: serde_json::to_value(&summary.trails)?,
-        cases: serde_json::to_value(&summary.cases)?,
-        failure_funnel: serde_json::to_value(&summary.failure_funnel)?,
-        summary: serde_json::to_value(summary)?,
-        decision: serde_json::to_value(decision_report)?,
+        environment: serde_json::to_value(&summary.environment).map_err(|_| {
+            PublicArtifactBuildFailure::closed(
+                PublicArtifactBuildStage::Serialization,
+                PublicArtifactBuildReason::Serialization,
+            )
+        })?,
+        inventory: serde_json::to_value(&summary.inventory).map_err(|_| {
+            PublicArtifactBuildFailure::closed(
+                PublicArtifactBuildStage::Serialization,
+                PublicArtifactBuildReason::Serialization,
+            )
+        })?,
+        trails: serde_json::to_value(&summary.trails).map_err(|_| {
+            PublicArtifactBuildFailure::closed(
+                PublicArtifactBuildStage::Serialization,
+                PublicArtifactBuildReason::Serialization,
+            )
+        })?,
+        cases: serde_json::to_value(&summary.cases).map_err(|_| {
+            PublicArtifactBuildFailure::closed(
+                PublicArtifactBuildStage::Serialization,
+                PublicArtifactBuildReason::Serialization,
+            )
+        })?,
+        failure_funnel: serde_json::to_value(&summary.failure_funnel).map_err(|_| {
+            PublicArtifactBuildFailure::closed(
+                PublicArtifactBuildStage::Serialization,
+                PublicArtifactBuildReason::Serialization,
+            )
+        })?,
+        summary: serde_json::to_value(summary).map_err(|_| {
+            PublicArtifactBuildFailure::closed(
+                PublicArtifactBuildStage::Serialization,
+                PublicArtifactBuildReason::Serialization,
+            )
+        })?,
+        decision: serde_json::to_value(decision_report).map_err(|_| {
+            PublicArtifactBuildFailure::closed(
+                PublicArtifactBuildStage::Serialization,
+                PublicArtifactBuildReason::Serialization,
+            )
+        })?,
         findings,
     };
-    validate_public_bundle(&bundle, &PublicLeakPolicy::default())?;
+    validate_public_bundle_for_build(&bundle)?;
     Ok(bundle)
 }
 
@@ -866,6 +1221,7 @@ pub(crate) fn build_and_publish(
     corpus: &CorpusV1,
     thresholds: &ThresholdsV1,
     leak_policy: &PublicLeakPolicy,
+    diagnostic: PublicArtifactDiagnosticContext<'_>,
 ) -> std::result::Result<(), ReportPublishError> {
     require_result_directory_identity(destination, &summary.qualification_id).map_err(|_| {
         ReportPublishError::before_staging(
@@ -873,13 +1229,52 @@ pub(crate) fn build_and_publish(
             destination,
         )
     })?;
-    let bundle = build_public_artifacts(summary, corpus, thresholds).map_err(|_| {
-        ReportPublishError::before_staging(
-            "proof_availability_public_artifact_build_failed",
-            destination,
-        )
-    })?;
+    let bundle = match build_public_artifacts(summary, corpus, thresholds) {
+        Ok(bundle) => bundle,
+        Err(failure) => {
+            write_public_artifact_build_diagnostic(
+                diagnostic.reservation,
+                diagnostic.qualification_id,
+                diagnostic.source_commit,
+                diagnostic.source_tree,
+                &failure,
+            )
+            .map_err(|_| {
+                ReportPublishError::before_staging(
+                    "proof_availability_public_artifact_build_failed",
+                    destination,
+                )
+            })?;
+            return Err(ReportPublishError::before_staging(
+                "proof_availability_public_artifact_build_failed",
+                destination,
+            ));
+        }
+    };
     publish_bundle(destination, &bundle, leak_policy)
+}
+
+pub(crate) struct PublicArtifactDiagnosticContext<'a> {
+    reservation: &'a CaseDiagnosticReservation,
+    qualification_id: &'a str,
+    source_commit: &'a str,
+    source_tree: &'a str,
+}
+
+impl<'a> PublicArtifactDiagnosticContext<'a> {
+    pub(crate) fn new(
+        reservation: &'a CaseDiagnosticReservation,
+        qualification_id: &'a str,
+        source_commit: &'a str,
+        source_tree: &'a str,
+    ) -> Self {
+        Self {
+            reservation,
+            qualification_id,
+            source_commit,
+            source_tree,
+        }
+    }
 }
 
 pub(crate) fn verify_published(
@@ -1523,6 +1918,104 @@ fn artifact_file_map(bundle: &PublicArtifactBundle) -> Result<Vec<(&'static str,
     Ok(files)
 }
 
+fn validate_public_bundle_for_build(
+    bundle: &PublicArtifactBundle,
+) -> std::result::Result<(), PublicArtifactBuildFailure> {
+    for (name, value) in [
+        (PublicArtifactName::Environment, &bundle.environment),
+        (PublicArtifactName::Inventory, &bundle.inventory),
+        (PublicArtifactName::Trails, &bundle.trails),
+        (PublicArtifactName::Cases, &bundle.cases),
+        (PublicArtifactName::FailureFunnel, &bundle.failure_funnel),
+        (PublicArtifactName::Summary, &bundle.summary),
+        (PublicArtifactName::Decision, &bundle.decision),
+    ] {
+        validate_public_json_for_build(name, value, "", None)?;
+    }
+    if bundle.findings.contains('\0') || bundle.findings.contains('\r') {
+        return Err(PublicArtifactBuildFailure::artifact_closed(
+            PublicArtifactBuildStage::BundleValidation,
+            PublicArtifactBuildReason::ExistingInvariant,
+            PublicArtifactName::Findings,
+        ));
+    }
+    Ok(())
+}
+
+fn validate_public_json_for_build(
+    artifact: PublicArtifactName,
+    value: &Value,
+    pointer: &str,
+    case_ordinal: Option<usize>,
+) -> std::result::Result<(), PublicArtifactBuildFailure> {
+    match value {
+        Value::Object(object) => {
+            for (field, child) in object {
+                let child_pointer = append_fixed_json_pointer(pointer, field).ok_or_else(|| {
+                    PublicArtifactBuildFailure::closed(
+                        PublicArtifactBuildStage::BundleValidation,
+                        PublicArtifactBuildReason::ExistingInvariant,
+                    )
+                })?;
+                if secret_field(field) {
+                    let rejected = child.as_str().unwrap_or(field);
+                    return Err(PublicArtifactBuildFailure::rejected_string(
+                        PublicArtifactBuildStage::BundleValidation,
+                        PublicArtifactBuildReason::SecretField,
+                        artifact,
+                        case_ordinal,
+                        child_pointer,
+                        rejected,
+                    ));
+                }
+                validate_public_json_for_build(artifact, child, &child_pointer, case_ordinal)?;
+            }
+        }
+        Value::Array(values) => {
+            for (index, child) in values.iter().enumerate() {
+                let child_pointer = append_fixed_json_pointer(pointer, &index.to_string())
+                    .ok_or_else(|| {
+                        PublicArtifactBuildFailure::closed(
+                            PublicArtifactBuildStage::BundleValidation,
+                            PublicArtifactBuildReason::ExistingInvariant,
+                        )
+                    })?;
+                let child_case_ordinal =
+                    if artifact == PublicArtifactName::Cases && pointer.is_empty() {
+                        Some(index)
+                    } else {
+                        case_ordinal
+                    };
+                validate_public_json_for_build(
+                    artifact,
+                    child,
+                    &child_pointer,
+                    child_case_ordinal,
+                )?;
+            }
+        }
+        Value::String(text) if !pointer.ends_with("/text") && absolute_path(text) => {
+            return Err(PublicArtifactBuildFailure::rejected_string(
+                PublicArtifactBuildStage::BundleValidation,
+                PublicArtifactBuildReason::PathLeak,
+                artifact,
+                case_ordinal,
+                pointer.to_owned(),
+                text,
+            ));
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn append_fixed_json_pointer(pointer: &str, segment: &str) -> Option<String> {
+    const MAX_DIAGNOSTIC_POINTER_BYTES: usize = 4096;
+    let escaped = json_pointer_escape(segment);
+    let length = pointer.len().checked_add(1)?.checked_add(escaped.len())?;
+    (length <= MAX_DIAGNOSTIC_POINTER_BYTES).then(|| format!("{pointer}/{escaped}"))
+}
+
 fn validate_public_bundle(bundle: &PublicArtifactBundle, policy: &PublicLeakPolicy) -> Result<()> {
     for value in [
         &bundle.environment,
@@ -1898,6 +2391,154 @@ mod tests {
         );
     }
 
+    #[test]
+    fn public_artifact_build_failure_keeps_only_a_path_commitment() {
+        let failure = PublicArtifactBuildFailure::path_leak(
+            PublicArtifactBuildStage::BundleValidation,
+            PublicArtifactName::Cases,
+            Some(0),
+            "/0/canonical_id",
+            "/Users/albert/private/canonical-id",
+        );
+
+        assert_eq!(
+            failure.to_string(),
+            "proof_availability_public_artifact_build_failed"
+        );
+        assert_eq!(
+            format!("{failure:?}"),
+            "proof_availability_public_artifact_build_failed"
+        );
+        let artifact = build_public_artifact_build_diagnostic_artifact(
+            "20260821T120000Z-222222222222",
+            &"a".repeat(40),
+            &"b".repeat(40),
+            &failure,
+        )
+        .unwrap();
+        let bytes = canonical_json_file(&artifact).unwrap();
+
+        assert_eq!(artifact["classification"], "non_evidence");
+        assert_eq!(artifact["failure"]["stage"], "bundle_validation");
+        assert_eq!(artifact["failure"]["reason"], "path_leak");
+        assert_eq!(artifact["failure"]["artifact"], "cases.json");
+        assert_eq!(artifact["failure"]["case_ordinal"], 0);
+        assert_eq!(artifact["failure"]["json_pointer"], "/0/canonical_id");
+        assert_eq!(
+            artifact["failure"]["rejected_string"]["utf8_byte_length"],
+            "/Users/albert/private/canonical-id".len()
+        );
+        assert_eq!(
+            artifact["failure"]["rejected_string"]["sha256"],
+            domain_sha256(
+                b"codestory.proof-availability.public-artifact-build-rejected-string.v1\\0",
+                b"/Users/albert/private/canonical-id",
+            )
+        );
+        assert!(
+            !String::from_utf8(bytes)
+                .unwrap()
+                .contains("/Users/albert/private")
+        );
+    }
+
+    #[test]
+    fn public_artifact_validation_keeps_first_artifact_and_case_in_depth_first_order() {
+        let mut bundle = fixture_bundle();
+        bundle.environment = json!({"workspace": "C:\\\\private"});
+        bundle.cases = json!([
+            {"canonical_id": "\\\\server\\share\\private"},
+            {"canonical_id": "\\\\?\\\\C:\\\\private"}
+        ]);
+        let failure = validate_public_bundle_for_build(&bundle).unwrap_err();
+        assert_eq!(failure.artifact, Some(PublicArtifactName::Environment));
+        assert_eq!(failure.case_ordinal, None);
+        assert_eq!(failure.json_pointer.as_deref(), Some("/workspace"));
+
+        bundle.environment = json!({"workspace": "relative"});
+        let failure = validate_public_bundle_for_build(&bundle).unwrap_err();
+        assert_eq!(failure.artifact, Some(PublicArtifactName::Cases));
+        assert_eq!(failure.case_ordinal, Some(0));
+        assert_eq!(failure.json_pointer.as_deref(), Some("/0/canonical_id"));
+    }
+
+    #[test]
+    fn public_artifact_validation_commits_secret_field_without_retaining_it() {
+        let mut bundle = fixture_bundle();
+        bundle.cases = json!([{"api_token": "private\\0TOKEN=do-not-publish"}]);
+        let failure = validate_public_bundle_for_build(&bundle).unwrap_err();
+        let artifact = build_public_artifact_build_diagnostic_artifact(
+            "20260821T120000Z-222222222222",
+            &"a".repeat(40),
+            &"b".repeat(40),
+            &failure,
+        )
+        .unwrap();
+        let bytes = canonical_json_file(&artifact).unwrap();
+
+        assert_eq!(artifact["failure"]["reason"], "secret_field");
+        assert_eq!(artifact["failure"]["case_ordinal"], 0);
+        assert!(
+            artifact["failure"]["rejected_string"]["sha256"]
+                .as_str()
+                .is_some()
+        );
+        let rendered = String::from_utf8(bytes).unwrap();
+        assert!(!rendered.contains("TOKEN=do-not-publish"));
+    }
+
+    #[cfg(all(
+        unix,
+        any(
+            target_os = "android",
+            target_os = "ios",
+            target_os = "linux",
+            target_os = "macos"
+        )
+    ))]
+    #[test]
+    fn public_artifact_diagnostic_uses_the_fixed_owner_private_file_kind() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let root = tempfile::tempdir().unwrap();
+        let reservation =
+            reserve_case_diagnostic(root.path(), "20260821T120000Z-222222222222").unwrap();
+        let failure = PublicArtifactBuildFailure::path_leak(
+            PublicArtifactBuildStage::BundleValidation,
+            PublicArtifactName::Cases,
+            Some(0),
+            "/0/canonical_id",
+            "/private",
+        );
+        write_public_artifact_build_diagnostic(
+            &reservation,
+            "20260821T120000Z-222222222222",
+            &"a".repeat(40),
+            &"b".repeat(40),
+            &failure,
+        )
+        .unwrap();
+        let target = reservation
+            .path()
+            .join(PrivateDiagnosticFileKind::PublicArtifactBuildV1.file_name());
+        let bytes = fs::read(&target).unwrap();
+        assert!(bytes.ends_with(b"\n"));
+        assert_eq!(
+            fs::metadata(&target).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+        assert!(
+            write_public_artifact_build_diagnostic(
+                &reservation,
+                "20260821T120000Z-222222222222",
+                &"a".repeat(40),
+                &"b".repeat(40),
+                &failure,
+            )
+            .is_err()
+        );
+    }
+
     #[cfg(all(
         unix,
         any(
@@ -2014,10 +2655,24 @@ mod tests {
         let root = tempfile::tempdir().unwrap();
         let reservation =
             reserve_case_diagnostic(root.path(), "20260821T120000Z-222222222222").unwrap();
-        let target = reservation.path().join(CASE_DIAGNOSTIC_FILE);
-        write_private_diagnostic_file(&reservation, b"{}\n").unwrap();
+        let target = reservation
+            .path()
+            .join(PrivateDiagnosticFileKind::InvalidCaseV1.file_name());
+        write_private_diagnostic_file(
+            &reservation,
+            PrivateDiagnosticFileKind::InvalidCaseV1,
+            b"{}\n",
+        )
+        .unwrap();
         assert_eq!(fs::read(&target).unwrap(), b"{}\n");
-        assert!(write_private_diagnostic_file(&reservation, b"changed\n").is_err());
+        assert!(
+            write_private_diagnostic_file(
+                &reservation,
+                PrivateDiagnosticFileKind::InvalidCaseV1,
+                b"changed\n",
+            )
+            .is_err()
+        );
         assert_eq!(fs::read(&target).unwrap(), b"{}\n");
     }
 
@@ -2052,9 +2707,19 @@ mod tests {
         )
         .unwrap();
         let bytes = canonical_json_file(&artifact).unwrap();
-        write_private_diagnostic_file(&reservation, &bytes).unwrap();
+        write_private_diagnostic_file(
+            &reservation,
+            PrivateDiagnosticFileKind::InvalidCaseV1,
+            &bytes,
+        )
+        .unwrap();
         let written: Value = serde_json::from_slice(
-            &fs::read(reservation.path().join(CASE_DIAGNOSTIC_FILE)).unwrap(),
+            &fs::read(
+                reservation
+                    .path()
+                    .join(PrivateDiagnosticFileKind::InvalidCaseV1.file_name()),
+            )
+            .unwrap(),
         )
         .unwrap();
         assert_eq!(written["schema"], CASE_DIAGNOSTIC_SCHEMA);
@@ -2095,8 +2760,17 @@ mod tests {
                 .to_string(),
             "proof_availability_case_diagnostic_write_failed"
         );
-        assert!(!original.join(CASE_DIAGNOSTIC_FILE).exists());
-        assert!(!reservation.path().join(CASE_DIAGNOSTIC_FILE).exists());
+        assert!(
+            !original
+                .join(PrivateDiagnosticFileKind::InvalidCaseV1.file_name())
+                .exists()
+        );
+        assert!(
+            !reservation
+                .path()
+                .join(PrivateDiagnosticFileKind::InvalidCaseV1.file_name())
+                .exists()
+        );
     }
 
     #[cfg(all(
@@ -2131,8 +2805,16 @@ mod tests {
         fs::rename(reservation.path(), &held).unwrap();
         symlink(&actual_parent, reservation.path()).unwrap();
         assert!(ensure_discoverable_reservation(&reservation).is_err());
-        assert!(!held.join(CASE_DIAGNOSTIC_FILE).exists());
-        assert!(!actual_parent.join(CASE_DIAGNOSTIC_FILE).exists());
+        assert!(
+            !held
+                .join(PrivateDiagnosticFileKind::InvalidCaseV1.file_name())
+                .exists()
+        );
+        assert!(
+            !actual_parent
+                .join(PrivateDiagnosticFileKind::InvalidCaseV1.file_name())
+                .exists()
+        );
     }
 
     #[cfg(not(all(

--- a/crates/codestory-bench/src/bin/codestory_proof_availability/report.rs
+++ b/crates/codestory-bench/src/bin/codestory_proof_availability/report.rs
@@ -2036,33 +2036,18 @@ fn append_array_index_pointer(pointer: &str, index: usize) -> Option<String> {
 }
 
 fn fixed_json_pointer_segment(segment: &str) -> Option<&'static str> {
-    Some(match segment {
-        "schema" => "schema",
-        "canonical_id" => "canonical_id",
-        "case_id" => "case_id",
-        "repository_id" => "repository_id",
-        "qualification_id" => "qualification_id",
-        "workspace" => "workspace",
-        "environment" => "environment",
-        "inventory" => "inventory",
-        "trails" => "trails",
-        "cases" => "cases",
-        "failure_funnel" => "failure_funnel",
-        "summary" => "summary",
-        "decision" => "decision",
-        "findings" => "findings",
-        "provenance" => "provenance",
-        "observations" => "observations",
-        "results_sha256" => "results_sha256",
-        "thresholds_sha256" => "thresholds_sha256",
-        "observations_sha256" => "observations_sha256",
-        "outcome" => "outcome",
-        "failed_gates" => "failed_gates",
-        "text" => "text",
-        "path" => "path",
-        "value" => "value",
-        _ => return None,
-    })
+    const ADDITIONAL_FIXED: &[&str] = &["oracle_step_index", "projection_bytes", "receipts"];
+    const FIXED: &str = "actionable_exact_gap actionable_incomplete_gap actual actual_bytes admitted_rows all_authoritative_receipts_exact architecture attempted_positive_steps attempted_step_count audit authoritative_exact_receipt_count authoritative_receipt_count authoritative_receipts automatic automatic_thresholds_met binary_name binary_sha256 boundary buckets build byte_end byte_start caller caller_body callsite_expression callsite_identity callsite_line candidate_edge_ids canonical_id cargo_profile case_id cases certainty certified_absence classification classified_positive_steps clause_id clauses code cohorts commit complete_projection_bytes complete_response_p95_bytes containment contract_digest contract_proven contract_proven_supported core_generation core_generation_id core_run_id corpus_id corpus_sha256 count curator database_sha256 decision denominator detail diagnostic_candidate_count edge_count edge_id edge_ids effective_endpoint effective_endpoint_rows elapsed_ns end_byte end_byte_exclusive end_line environment environment_id exact_oracle_step_count exact_resolved exact_resolved_rows exclude_from_projection expected_cohort_count expected_negative_requests expected_positive_requests expected_positive_steps experimental failed_gates failure_funnel false_contract_proven false_positive_receipt_count file_byte_length file_count file_node_id finalization finding freshness full_or_useful_partial full_proof_wilson full_proofs gap gaps gate_id hard_gates identity incomplete_provenance indexed_sha256 invalid_results inventory invocation kind language length lengths line_window lower lower_milli maximum_certified_absence maximum_complete_response_p95_bytes maximum_false_contract_proven maximum_invalid_results maximum_over_cap_results maximum_proof_bytes maximum_response_bytes maximum_transport_errors maximum_transport_p95_ms maximum_unknown_p95_ms maximum_unknown_response_p95_bytes measurements methodology_sha256 milli minimum_actionable_exact_gap_milli minimum_cohort_wilson_lower_milli minimum_full_or_useful_partial_milli minimum_full_proof_wilson_lower_milli minimum_full_proofs minimum_full_proofs_per_cohort minimum_positive_step_recall_milli missing_oracle_step_count missing_oracle_steps mutated_spec mutation_id negative_mutations negative_request_count node_count node_id non_exact_authoritative_receipts numerator observations observations_sha256 observed_receipt_count observed_receipts observed_sha256 operation oracle_comparison oracle_receipts_exact oracle_step oracle_steps os outcome over_cap_results owner_node_id path path_count path_file path_file_sha256 path_id path_length path_length_distribution paths pinned positive_request_count positive_step_count positive_step_precision_milli positive_step_recall positive_step_recall_milli prescribed_argv product_disposition product_disposition_matches_evidence product_disposition_mismatches profile project_file_components project_id projects proof_trace prohibit_traversal_through proven_prefix_length proven_prefix_step_count proven_step_precision_milli proven_step_recall_milli provenance qualification_id qualification_source_commit qualification_source_tree qualified_name quote range reason receipt_evidence receipt_file_sha256 receipt_id receipt_line_window recorded_at repository repository_id require_complete_failure_funnel require_complete_provenance require_each_cohort require_exact_receipt_matches require_product_disposition_match results_sha256 review_date reviewer revision rust_host rustc_vv schema selector selector_early_return selector_index selectors sha256 source source_area source_area_requirement source_audit source_commit source_dirty source_head source_text source_tree source_tree_sha256 spec stable_explicit stage stage_durations_ms start start_byte start_line step_index steps store_schema stored_call_rows strictly_admitted symbol target text thresholds_id thresholds_sha256 trails transport transport_errors transport_p95 unclassified_positive_steps unclassified_step_indices unknown_response_p95_bytes unknown_warm_p95_ms unresolved_placeholder_rows upper validation warm_end_to_end_ms wilson wilson_z workspace";
+    if let Some(candidate) = ADDITIONAL_FIXED
+        .iter()
+        .copied()
+        .find(|candidate| *candidate == segment)
+    {
+        return Some(candidate);
+    }
+    FIXED
+        .split_ascii_whitespace()
+        .find(|candidate| *candidate == segment)
 }
 
 fn validate_public_bundle(bundle: &PublicArtifactBundle, policy: &PublicLeakPolicy) -> Result<()> {
@@ -2634,6 +2619,114 @@ mod tests {
         ] {
             assert!(absolute_path(path), "{path}");
         }
+    }
+
+    #[test]
+    fn fixed_pointer_vocabulary_accepts_the_full_closed_summary() {
+        let (report, corpus, thresholds) =
+            super::super::thresholds::tests::accepted_fixture::values();
+        let summary = QualificationSummaryV1::from_json(report).unwrap();
+        let corpus = CorpusV1::from_json(corpus).unwrap();
+        let thresholds = ThresholdsV1::from_json(thresholds).unwrap();
+
+        summary
+            .validate_against_inputs(&corpus, &thresholds)
+            .unwrap();
+        for value in [
+            serde_json::to_value(&summary.environment).unwrap(),
+            serde_json::to_value(&summary.inventory).unwrap(),
+            serde_json::to_value(&summary.trails).unwrap(),
+            serde_json::to_value(&summary.cases).unwrap(),
+            serde_json::to_value(&summary.failure_funnel).unwrap(),
+            serde_json::to_value(&summary).unwrap(),
+        ] {
+            assert_fixed_object_keys(&value);
+        }
+        build_public_artifacts(&summary, &corpus, &thresholds)
+            .expect("every typed report field has a fixed pointer segment");
+    }
+
+    fn assert_fixed_object_keys(value: &Value) {
+        match value {
+            Value::Object(object) => {
+                for (field, child) in object {
+                    assert!(
+                        fixed_json_pointer_segment(field).is_some(),
+                        "unlisted fixture field: {field}"
+                    );
+                    assert_fixed_object_keys(child);
+                }
+            }
+            Value::Array(values) => {
+                for child in values {
+                    assert_fixed_object_keys(child);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    #[cfg(all(
+        unix,
+        any(
+            target_os = "android",
+            target_os = "ios",
+            target_os = "linux",
+            target_os = "macos"
+        )
+    ))]
+    #[test]
+    fn builder_path_writes_the_first_cases_path_failure_diagnostic() {
+        let (mut report, corpus, thresholds) =
+            super::super::thresholds::tests::accepted_fixture::values();
+        report["cases"][0]["receipt_evidence"]["observed_receipts"][0]["source"]["canonical_id"] =
+            json!("/private/canonical-id");
+        super::super::thresholds::tests::refresh_results_digest(&mut report);
+        let summary = QualificationSummaryV1::from_json(report).unwrap();
+        let corpus = CorpusV1::from_json(corpus).unwrap();
+        let thresholds = ThresholdsV1::from_json(thresholds).unwrap();
+        summary
+            .validate_against_inputs(&corpus, &thresholds)
+            .unwrap();
+
+        let root = tempfile::tempdir().unwrap();
+        let destination = root.path().join(&summary.qualification_id);
+        let reservation = reserve_case_diagnostic(root.path(), &summary.qualification_id).unwrap();
+        let error = build_and_publish(
+            &destination,
+            &summary,
+            &corpus,
+            &thresholds,
+            &PublicLeakPolicy::default(),
+            PublicArtifactDiagnosticContext::new(
+                &reservation,
+                &summary.qualification_id,
+                &summary.provenance.source_commit,
+                &summary.provenance.source_tree,
+            ),
+        )
+        .unwrap_err();
+        assert_eq!(
+            error.code,
+            "proof_availability_public_artifact_build_failed"
+        );
+        assert!(!destination.exists());
+        let diagnostic: Value = serde_json::from_slice(
+            &fs::read(
+                reservation
+                    .path()
+                    .join(PrivateDiagnosticFileKind::PublicArtifactBuildV1.file_name()),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(diagnostic["failure"]["reason"], "path_leak");
+        assert_eq!(diagnostic["failure"]["artifact"], "cases.json");
+        assert_eq!(diagnostic["failure"]["case_ordinal"], 0);
+        assert_eq!(
+            diagnostic["failure"]["json_pointer"],
+            "/0/receipt_evidence/observed_receipts/0/source/canonical_id"
+        );
     }
 
     #[cfg(all(

--- a/crates/codestory-bench/src/bin/codestory_proof_availability/thresholds.rs
+++ b/crates/codestory-bench/src/bin/codestory_proof_availability/thresholds.rs
@@ -693,16 +693,16 @@ fn maximum(
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::super::contracts::{canonical_thresholds_sha256, results_evidence_sha256_from_json};
     use super::*;
     use sha2::{Digest, Sha256};
 
     #[allow(clippy::duplicate_mod)] // Reuse the accepted closed 120-case fixture verbatim.
-    mod accepted_fixture {
+    pub(crate) mod accepted_fixture {
         include!("../../../tests/proof_availability_contracts.rs");
 
-        pub(super) fn values() -> (serde_json::Value, serde_json::Value, serde_json::Value) {
+        pub(crate) fn values() -> (serde_json::Value, serde_json::Value, serde_json::Value) {
             (report(), corpus(), thresholds())
         }
     }
@@ -745,7 +745,7 @@ mod tests {
         }
     }
 
-    fn refresh_results_digest(report: &mut serde_json::Value) {
+    pub(crate) fn refresh_results_digest(report: &mut serde_json::Value) {
         let digest = results_evidence_sha256_from_json(report).expect("recomputed results digest");
         report["provenance"]["results_sha256"] = serde_json::json!(digest);
     }


### PR DESCRIPTION
## Context

Q2 Candidate 4 completed fresh materialization and crossed the repaired case-validation boundary, then failed during public artifact construction. Read-only control-flow elimination proved the swallowed inner error was an absolute-path rejection in `cases.json`, but the exact case, pointer, and value commitment were discarded with the in-memory bundle.

## What changed

- Preserve the first public-artifact build failure as a closed private diagnostic containing only stage, artifact, bounded fixed-field/numeric-index pointer, closed reason, rejected-string length, and domain-separated SHA-256 commitment.
- Reuse the single caller-created owner-private reservation and its held handle, no-follow/openat, atomic no-replace, sync, and fixed-filename publication path.
- Keep arbitrary and numeric object keys out of pointers; numeric segments come only from array traversal.
- Preserve NUL/CR findings commitments without retaining text.
- Keep the public umbrella error, successful exactly-eight artifact set, public acceptance, and invalid-case precedence unchanged.
- Add a full accepted-fixture vocabulary ratchet and a real base/head behavioral proof through `build_and_publish → build_public_artifacts`.

## Verification

Exact reviewed head/tree:

- head: `5280428f658e1a8df55c6ce8c67867e9c2db0352`
- tree: `82983b2210e515911d3747260c2c3136112ed13d`

RED on base `a943d5aa`: real five-argument builder flow compiled and failed 0/1 because the fixed private diagnostic was absent.

GREEN on the reviewed head:

- identical fixture/mutation through the six-argument builder: 1/1, exact `path_leak` in `cases.json` at `/0/receipt_evidence/observed_receipts/0/source/canonical_id`
- report tests: 26/26
- `cargo test --locked -p codestory-bench --test proof_availability_contracts`: 56 passed, 1 ignored
- `cargo check --locked -p codestory-bench`
- `cargo clippy --locked -p codestory-bench --all-targets -- -D warnings`
- `cargo fmt -p codestory-bench -- --check`
- `git diff --check`

Independent task review required two fix rounds and approved the final exact delta with no Critical or Important findings.

## Risk and follow-up

This is diagnostic-only. It does not sanitize or admit the rejected public value and does not change product proof/runtime/index/store semantics, corpus, thresholds, schemas, public routes/catalogs, versions, releases, `dev/codestory-next`, or 0.17.

After merge, one fresh non-evidence execution will identify the actual Candidate 4 path-bearing field. No Q2 Candidate 5 or projection repair begins before that evidence and independent review.

Closes #2010
Refs #1985
Refs #1984
