### PR TITLE
[v3 qualification] Bind public receipt identities without host paths

### DIFF
--- a/benchmarks/proof-availability/schemas/report.schema.json
+++ b/benchmarks/proof-availability/schemas/report.schema.json
@@ -2010,8 +2010,9 @@
     "ResolvedNodeIdentityV1": {
       "additionalProperties": false,
       "properties": {
-        "canonical_id": {
+        "canonical_id_binding_sha256": {
           "minLength": 1,
+          "pattern": "^[0-9a-f]{64}$",
           "type": "string"
         },
         "pinned": {
@@ -2032,7 +2033,7 @@
       },
       "required": [
         "pinned",
-        "canonical_id",
+        "canonical_id_binding_sha256",
         "qualified_name",
         "project_file_components"
       ],
@@ -2489,7 +2490,7 @@
       "type": "string"
     }
   },
-  "$id": "codestory.proof-availability-report/v1",
+  "$id": "codestory.proof-availability-report/v2",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
   "properties": {
@@ -2523,7 +2524,7 @@
       "type": "string"
     },
     "schema": {
-      "const": "codestory.proof-availability-report/v1",
+      "const": "codestory.proof-availability-report/v2",
       "type": "string"
     },
     "trails": {

--- a/crates/codestory-bench/src/bin/codestory_proof_availability/contracts.rs
+++ b/crates/codestory-bench/src/bin/codestory_proof_availability/contracts.rs
@@ -9,7 +9,7 @@ use std::fmt;
 
 pub const CORPUS_SCHEMA: &str = "codestory.proof-availability-corpus/v1";
 pub const PATH_FILE_SCHEMA: &str = "codestory.proof-availability-path-file/v1";
-pub const REPORT_SCHEMA: &str = "codestory.proof-availability-report/v1";
+pub const REPORT_SCHEMA: &str = "codestory.proof-availability-report/v2";
 pub const THRESHOLDS_SCHEMA: &str = "codestory.proof-availability-thresholds/v1";
 pub const DECISION_REPORT_SCHEMA: &str = "codestory.proof-availability-decision/v1";
 pub const PRESCRIBED_BUILD_ARGV: [&str; 8] = [
@@ -2241,26 +2241,56 @@ pub struct PinnedNodeIdentityV1 {
 #[serde(deny_unknown_fields)]
 pub struct ResolvedNodeIdentityV1 {
     pub pinned: PinnedNodeIdentityV1,
-    pub canonical_id: String,
+    pub canonical_id_binding_sha256: String,
     pub qualified_name: String,
     pub project_file_components: Vec<String>,
 }
-impl From<&codestory_agent::proof_qualification_support::ResolvedNodeIdentity>
+impl TryFrom<&codestory_agent::proof_qualification_support::ResolvedNodeIdentity>
     for ResolvedNodeIdentityV1
 {
-    fn from(value: &codestory_agent::proof_qualification_support::ResolvedNodeIdentity) -> Self {
-        Self {
-            pinned: PinnedNodeIdentityV1 {
-                project_id: value.pinned.project_id.clone(),
-                core_generation_id: value.pinned.core_generation_id.clone(),
-                core_run_id: value.pinned.core_run_id.clone(),
-                node_id: value.pinned.node_id.clone(),
-            },
-            canonical_id: value.canonical_id.clone(),
+    type Error = anyhow::Error;
+
+    fn try_from(
+        value: &codestory_agent::proof_qualification_support::ResolvedNodeIdentity,
+    ) -> Result<Self> {
+        let pinned = PinnedNodeIdentityV1 {
+            project_id: value.pinned.project_id.clone(),
+            core_generation_id: value.pinned.core_generation_id.clone(),
+            core_run_id: value.pinned.core_run_id.clone(),
+            node_id: value.pinned.node_id.clone(),
+        };
+        Ok(Self {
+            canonical_id_binding_sha256: resolved_canonical_id_binding_sha256(
+                &pinned,
+                &value.canonical_id,
+            )?,
+            pinned,
             qualified_name: value.qualified_name.clone(),
             project_file_components: value.project_file_components.clone(),
-        }
+        })
     }
+}
+
+#[derive(Serialize)]
+struct ResolvedCanonicalIdBindingV1<'a> {
+    pinned: &'a PinnedNodeIdentityV1,
+    canonical_id: &'a str,
+}
+
+pub(crate) fn resolved_canonical_id_binding_sha256(
+    pinned: &PinnedNodeIdentityV1,
+    canonical_id: &str,
+) -> Result<String> {
+    if canonical_id.is_empty() {
+        bail!("proof_availability_resolved_canonical_id_empty")
+    }
+    canonical_artifact_sha256(
+        b"codestory.proof-availability-resolved-canonical-id/v1\0",
+        &ResolvedCanonicalIdBindingV1 {
+            pinned,
+            canonical_id,
+        },
+    )
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
@@ -2314,8 +2344,8 @@ impl ObservedReceiptV1 {
                 .edge_id
                 .parse()
                 .map_err(|_| anyhow::anyhow!("proof_availability_receipt_edge_id_invalid"))?,
-            source: (&receipt.source).into(),
-            target: (&receipt.target).into(),
+            source: (&receipt.source).try_into()?,
+            target: (&receipt.target).try_into()?,
             certainty: receipt.certainty.try_into()?,
             callsite_identity: receipt.callsite_identity.clone(),
             callsite_line: receipt.line_window.anchor_line,
@@ -2353,8 +2383,8 @@ pub(crate) fn compare_task6_receipt_to_oracle(
     oracle: &OracleStepV1,
 ) -> Result<ReceiptOracleComparisonV1> {
     let oracle_step = ReceiptOracleStepV1::from(oracle);
-    let observed_source = ResolvedNodeIdentityV1::from(&receipt.source);
-    let observed_target = ResolvedNodeIdentityV1::from(&receipt.target);
+    let observed_source = ResolvedNodeIdentityV1::try_from(&receipt.source)?;
+    let observed_target = ResolvedNodeIdentityV1::try_from(&receipt.target)?;
     let mut mismatches = Vec::new();
     if !resolved_identity_matches_declaration(&observed_source, &oracle_step.caller) {
         mismatches.push(ReceiptMismatchFieldV1::Caller);
@@ -3351,7 +3381,7 @@ pub(crate) fn results_evidence_sha256(
             )
     });
     canonical_artifact_sha256(
-        b"codestory.proof-availability-results-evidence/v1\0",
+        b"codestory.proof-availability-results-evidence/v2\0",
         &ResultsEvidenceV1 {
             environment: &environment,
             inventory: &inventory,
@@ -4549,7 +4579,7 @@ fn valid_resolved_node_identity(identity: &ResolvedNodeIdentityV1) -> Option<i64
     (!empty(&identity.pinned.project_id)
         && !empty(&identity.pinned.core_generation_id)
         && !empty(&identity.pinned.core_run_id)
-        && !empty(&identity.canonical_id)
+        && hash(&identity.canonical_id_binding_sha256)
         && !empty(&identity.qualified_name)
         && valid_project_file_components(&identity.project_file_components))
     .then(|| parse_node_id(&identity.pinned.node_id))
@@ -4673,7 +4703,8 @@ fn resolved_identity_matches_declaration(
                 && identity.pinned.node_id == *node_id
         }
         ExactSymbolSelectorV1::CanonicalId { canonical_id } => {
-            identity.canonical_id == *canonical_id
+            resolved_canonical_id_binding_sha256(&identity.pinned, canonical_id)
+                .is_ok_and(|binding| binding == identity.canonical_id_binding_sha256)
         }
         ExactSymbolSelectorV1::QualifiedName {
             qualified_name,
@@ -5248,7 +5279,7 @@ fn semantic_contract_bounds(schema: &mut Value, document: SchemaDocument) {
                 ("PinnedNodeIdentityV1", "core_generation_id"),
                 ("PinnedNodeIdentityV1", "core_run_id"),
                 ("PinnedNodeIdentityV1", "node_id"),
-                ("ResolvedNodeIdentityV1", "canonical_id"),
+                ("ResolvedNodeIdentityV1", "canonical_id_binding_sha256"),
                 ("ResolvedNodeIdentityV1", "qualified_name"),
                 ("ProjectedReceiptReferenceV1", "receipt_id"),
                 ("ProjectedReceiptReferenceV1", "edge_id"),
@@ -5280,6 +5311,12 @@ fn semantic_contract_bounds(schema: &mut Value, document: SchemaDocument) {
                 "PinnedNodeIdentityV1",
                 "node_id",
                 "^-?(0|[1-9][0-9]*)$",
+            );
+            set_pattern(
+                schema,
+                "ResolvedNodeIdentityV1",
+                "canonical_id_binding_sha256",
+                SHA256,
             );
             set_pattern(
                 schema,

--- a/crates/codestory-bench/src/bin/codestory_proof_availability/report.rs
+++ b/crates/codestory-bench/src/bin/codestory_proof_availability/report.rs
@@ -2037,7 +2037,7 @@ fn append_array_index_pointer(pointer: &str, index: usize) -> Option<String> {
 
 fn fixed_json_pointer_segment(segment: &str) -> Option<&'static str> {
     const ADDITIONAL_FIXED: &[&str] = &["oracle_step_index", "projection_bytes", "receipts"];
-    const FIXED: &str = "actionable_exact_gap actionable_incomplete_gap actual actual_bytes admitted_rows all_authoritative_receipts_exact architecture attempted_positive_steps attempted_step_count audit authoritative_exact_receipt_count authoritative_receipt_count authoritative_receipts automatic automatic_thresholds_met binary_name binary_sha256 boundary buckets build byte_end byte_start caller caller_body callsite_expression callsite_identity callsite_line candidate_edge_ids canonical_id cargo_profile case_id cases certainty certified_absence classification classified_positive_steps clause_id clauses code cohorts commit complete_projection_bytes complete_response_p95_bytes containment contract_digest contract_proven contract_proven_supported core_generation core_generation_id core_run_id corpus_id corpus_sha256 count curator database_sha256 decision denominator detail diagnostic_candidate_count edge_count edge_id edge_ids effective_endpoint effective_endpoint_rows elapsed_ns end_byte end_byte_exclusive end_line environment environment_id exact_oracle_step_count exact_resolved exact_resolved_rows exclude_from_projection expected_cohort_count expected_negative_requests expected_positive_requests expected_positive_steps experimental failed_gates failure_funnel false_contract_proven false_positive_receipt_count file_byte_length file_count file_node_id finalization finding freshness full_or_useful_partial full_proof_wilson full_proofs gap gaps gate_id hard_gates identity incomplete_provenance indexed_sha256 invalid_results inventory invocation kind language length lengths line_window lower lower_milli maximum_certified_absence maximum_complete_response_p95_bytes maximum_false_contract_proven maximum_invalid_results maximum_over_cap_results maximum_proof_bytes maximum_response_bytes maximum_transport_errors maximum_transport_p95_ms maximum_unknown_p95_ms maximum_unknown_response_p95_bytes measurements methodology_sha256 milli minimum_actionable_exact_gap_milli minimum_cohort_wilson_lower_milli minimum_full_or_useful_partial_milli minimum_full_proof_wilson_lower_milli minimum_full_proofs minimum_full_proofs_per_cohort minimum_positive_step_recall_milli missing_oracle_step_count missing_oracle_steps mutated_spec mutation_id negative_mutations negative_request_count node_count node_id non_exact_authoritative_receipts numerator observations observations_sha256 observed_receipt_count observed_receipts observed_sha256 operation oracle_comparison oracle_receipts_exact oracle_step oracle_steps os outcome over_cap_results owner_node_id path path_count path_file path_file_sha256 path_id path_length path_length_distribution paths pinned positive_request_count positive_step_count positive_step_precision_milli positive_step_recall positive_step_recall_milli prescribed_argv product_disposition product_disposition_matches_evidence product_disposition_mismatches profile project_file_components project_id projects proof_trace prohibit_traversal_through proven_prefix_length proven_prefix_step_count proven_step_precision_milli proven_step_recall_milli provenance qualification_id qualification_source_commit qualification_source_tree qualified_name quote range reason receipt_evidence receipt_file_sha256 receipt_id receipt_line_window recorded_at repository repository_id require_complete_failure_funnel require_complete_provenance require_each_cohort require_exact_receipt_matches require_product_disposition_match results_sha256 review_date reviewer revision rust_host rustc_vv schema selector selector_early_return selector_index selectors sha256 source source_area source_area_requirement source_audit source_commit source_dirty source_head source_text source_tree source_tree_sha256 spec stable_explicit stage stage_durations_ms start start_byte start_line step_index steps store_schema stored_call_rows strictly_admitted symbol target text thresholds_id thresholds_sha256 trails transport transport_errors transport_p95 unclassified_positive_steps unclassified_step_indices unknown_response_p95_bytes unknown_warm_p95_ms unresolved_placeholder_rows upper validation warm_end_to_end_ms wilson wilson_z workspace";
+    const FIXED: &str = "actionable_exact_gap actionable_incomplete_gap actual actual_bytes admitted_rows all_authoritative_receipts_exact architecture attempted_positive_steps attempted_step_count audit authoritative_exact_receipt_count authoritative_receipt_count authoritative_receipts automatic automatic_thresholds_met binary_name binary_sha256 boundary buckets build byte_end byte_start caller caller_body callsite_expression callsite_identity callsite_line candidate_edge_ids canonical_id canonical_id_binding_sha256 cargo_profile case_id cases certainty certified_absence classification classified_positive_steps clause_id clauses code cohorts commit complete_projection_bytes complete_response_p95_bytes containment contract_digest contract_proven contract_proven_supported core_generation core_generation_id core_run_id corpus_id corpus_sha256 count curator database_sha256 decision denominator detail diagnostic_candidate_count edge_count edge_id edge_ids effective_endpoint effective_endpoint_rows elapsed_ns end_byte end_byte_exclusive end_line environment environment_id exact_oracle_step_count exact_resolved exact_resolved_rows exclude_from_projection expected_cohort_count expected_negative_requests expected_positive_requests expected_positive_steps experimental failed_gates failure_funnel false_contract_proven false_positive_receipt_count file_byte_length file_count file_node_id finalization finding freshness full_or_useful_partial full_proof_wilson full_proofs gap gaps gate_id hard_gates identity incomplete_provenance indexed_sha256 invalid_results inventory invocation kind language length lengths line_window lower lower_milli maximum_certified_absence maximum_complete_response_p95_bytes maximum_false_contract_proven maximum_invalid_results maximum_over_cap_results maximum_proof_bytes maximum_response_bytes maximum_transport_errors maximum_transport_p95_ms maximum_unknown_p95_ms maximum_unknown_response_p95_bytes measurements methodology_sha256 milli minimum_actionable_exact_gap_milli minimum_cohort_wilson_lower_milli minimum_full_or_useful_partial_milli minimum_full_proof_wilson_lower_milli minimum_full_proofs minimum_full_proofs_per_cohort minimum_positive_step_recall_milli missing_oracle_step_count missing_oracle_steps mutated_spec mutation_id negative_mutations negative_request_count node_count node_id non_exact_authoritative_receipts numerator observations observations_sha256 observed_receipt_count observed_receipts observed_sha256 operation oracle_comparison oracle_receipts_exact oracle_step oracle_steps os outcome over_cap_results owner_node_id path path_count path_file path_file_sha256 path_id path_length path_length_distribution paths pinned positive_request_count positive_step_count positive_step_precision_milli positive_step_recall positive_step_recall_milli prescribed_argv product_disposition product_disposition_matches_evidence product_disposition_mismatches profile project_file_components project_id projects proof_trace prohibit_traversal_through proven_prefix_length proven_prefix_step_count proven_step_precision_milli proven_step_recall_milli provenance qualification_id qualification_source_commit qualification_source_tree qualified_name quote range reason receipt_evidence receipt_file_sha256 receipt_id receipt_line_window recorded_at repository repository_id require_complete_failure_funnel require_complete_provenance require_each_cohort require_exact_receipt_matches require_product_disposition_match results_sha256 review_date reviewer revision rust_host rustc_vv schema selector selector_early_return selector_index selectors sha256 source source_area source_area_requirement source_audit source_commit source_dirty source_head source_text source_tree source_tree_sha256 spec stable_explicit stage stage_durations_ms start start_byte start_line step_index steps store_schema stored_call_rows strictly_admitted symbol target text thresholds_id thresholds_sha256 trails transport transport_errors transport_p95 unclassified_positive_steps unclassified_step_indices unknown_response_p95_bytes unknown_warm_p95_ms unresolved_placeholder_rows upper validation warm_end_to_end_ms wilson wilson_z workspace";
     if let Some(candidate) = ADDITIONAL_FIXED
         .iter()
         .copied()
@@ -2676,11 +2676,150 @@ mod tests {
         )
     ))]
     #[test]
-    fn builder_path_writes_the_first_cases_path_failure_diagnostic() {
+    fn task6_receipt_paths_are_bound_before_public_artifact_publication() {
+        use codestory_agent::proof_qualification_support::{
+            CallableContainmentEvidence, IndexedCallEdgeReceipt, IndexedLineWindow,
+            PinnedNodeIdentity, ReceiptRef, ResolvedNodeIdentity,
+        };
+        use codestory_contracts::graph::{NodeId, ResolutionCertainty};
+
+        const SOURCE_CANONICAL_ID: &str = "/Users/private/worktree/src/caller.rs::caller";
+        const TARGET_CANONICAL_ID: &str = r"C:\private\worktree\src\target.rs::target";
+
         let (mut report, corpus, thresholds) =
             super::super::thresholds::tests::accepted_fixture::values();
-        report["cases"][0]["receipt_evidence"]["observed_receipts"][0]["source"]["canonical_id"] =
-            json!("/private/canonical-id");
+        let path_files =
+            super::super::thresholds::tests::accepted_fixture::oracle_path_file_values()
+                .into_iter()
+                .map(CohortPathFileV1::from_json)
+                .collect::<Result<Vec<_>>>()
+                .unwrap();
+        let oracle = &path_files[0].paths[0].oracle_steps[0];
+        let prior: super::super::contracts::ObservedReceiptV1 = serde_json::from_value(
+            report["cases"][0]["receipt_evidence"]["observed_receipts"][0].clone(),
+        )
+        .unwrap();
+        let resolved = |identity: &super::super::contracts::ResolvedNodeIdentityV1,
+                        canonical_id: &str| {
+            ResolvedNodeIdentity {
+                pinned: PinnedNodeIdentity {
+                    project_id: identity.pinned.project_id.clone(),
+                    core_generation_id: identity.pinned.core_generation_id.clone(),
+                    core_run_id: identity.pinned.core_run_id.clone(),
+                    node_id: identity.pinned.node_id.clone(),
+                },
+                canonical_id: canonical_id.to_owned(),
+                qualified_name: identity.qualified_name.clone(),
+                project_file_components: identity.project_file_components.clone(),
+            }
+        };
+        let task6_receipt = IndexedCallEdgeReceipt {
+            receipt: ReceiptRef {
+                receipt_id: prior.receipt_id.clone(),
+                edge_id: prior.edge_id.to_string(),
+            },
+            source: resolved(&prior.source, SOURCE_CANONICAL_ID),
+            target: resolved(&prior.target, TARGET_CANONICAL_ID),
+            certainty: ResolutionCertainty::Certain,
+            callsite_identity: prior.callsite_identity.clone(),
+            containment: CallableContainmentEvidence {
+                file_node_id: NodeId(prior.containment.file_node_id),
+                owner_node_id: NodeId(prior.containment.owner_node_id),
+                start_line: prior.containment.start_line,
+                end_line: prior.containment.end_line,
+            },
+            line_window: IndexedLineWindow {
+                kind: "indexed_line_v1",
+                project_file_components: prior.line_window.project_file_components.clone(),
+                indexed_sha256: prior.line_window.indexed_sha256.clone(),
+                observed_sha256: prior.line_window.observed_sha256.clone(),
+                anchor_line: prior.callsite_line,
+                byte_start: usize::try_from(prior.line_window.byte_start).unwrap(),
+                byte_end: usize::try_from(prior.line_window.byte_end).unwrap(),
+                text: prior.line_window.text.clone(),
+            },
+        };
+        let observed =
+            super::super::contracts::observed_receipt_from_task6(0, &task6_receipt, oracle)
+                .unwrap();
+        report["cases"][0]["receipt_evidence"]["observed_receipts"][0] =
+            serde_json::to_value(observed).unwrap();
+        super::super::thresholds::tests::refresh_results_digest(&mut report);
+
+        let parsed = QualificationSummaryV1::from_json(report).unwrap();
+        let corpus = CorpusV1::from_json(corpus).unwrap();
+        let thresholds = ThresholdsV1::from_json(thresholds).unwrap();
+        let summary = build_summary(
+            QualificationReportInputV1 {
+                qualification_id: parsed.qualification_id,
+                source_commit: parsed.provenance.source_commit,
+                source_tree: parsed.provenance.source_tree,
+                environment: parsed.environment,
+                inventory: parsed.inventory,
+                trails: parsed.trails,
+                cases: parsed.cases,
+                failure_funnel: parsed.failure_funnel,
+            },
+            &corpus,
+            &thresholds,
+        )
+        .unwrap();
+        summary
+            .validate_against_inputs(&corpus, &thresholds)
+            .unwrap();
+
+        let root = tempfile::tempdir().unwrap();
+        let destination = root.path().join(&summary.qualification_id);
+        let reservation = reserve_case_diagnostic(root.path(), &summary.qualification_id).unwrap();
+        build_and_publish(
+            &destination,
+            &summary,
+            &corpus,
+            &thresholds,
+            &PublicLeakPolicy::default(),
+            PublicArtifactDiagnosticContext::new(
+                &reservation,
+                &summary.qualification_id,
+                &summary.provenance.source_commit,
+                &summary.provenance.source_tree,
+            ),
+        )
+        .unwrap();
+
+        let cases = fs::read_to_string(destination.join("cases.json")).unwrap();
+        let summary = fs::read_to_string(destination.join("summary.json")).unwrap();
+        for raw in [SOURCE_CANONICAL_ID, TARGET_CANONICAL_ID] {
+            assert!(!cases.contains(raw));
+            assert!(!summary.contains(raw));
+        }
+        verify_published(
+            &destination,
+            &corpus,
+            &thresholds,
+            &path_files,
+            &PublicLeakPolicy::default(),
+        )
+        .unwrap();
+        assert_eq!(fs::read_dir(destination).unwrap().count(), 8);
+    }
+
+    #[cfg(all(
+        unix,
+        any(
+            target_os = "android",
+            target_os = "ios",
+            target_os = "linux",
+            target_os = "macos"
+        )
+    ))]
+    #[test]
+    fn builder_path_writes_a_non_receipt_path_failure_diagnostic() {
+        let (mut report, corpus, thresholds) =
+            super::super::thresholds::tests::accepted_fixture::values();
+        report["environment"]["build"]["rustc_vv"] = json!(format!(
+            "/private/compiler\n{}",
+            report["environment"]["build"]["rustc_vv"].as_str().unwrap()
+        ));
         super::super::thresholds::tests::refresh_results_digest(&mut report);
         let summary = QualificationSummaryV1::from_json(report).unwrap();
         let corpus = CorpusV1::from_json(corpus).unwrap();
@@ -2721,12 +2860,9 @@ mod tests {
         )
         .unwrap();
         assert_eq!(diagnostic["failure"]["reason"], "path_leak");
-        assert_eq!(diagnostic["failure"]["artifact"], "cases.json");
-        assert_eq!(diagnostic["failure"]["case_ordinal"], 0);
-        assert_eq!(
-            diagnostic["failure"]["json_pointer"],
-            "/0/receipt_evidence/observed_receipts/0/source/canonical_id"
-        );
+        assert_eq!(diagnostic["failure"]["artifact"], "environment.json");
+        assert!(diagnostic["failure"]["case_ordinal"].is_null());
+        assert_eq!(diagnostic["failure"]["json_pointer"], "/build/rustc_vv");
     }
 
     #[cfg(all(

--- a/crates/codestory-bench/src/bin/codestory_proof_availability/thresholds.rs
+++ b/crates/codestory-bench/src/bin/codestory_proof_availability/thresholds.rs
@@ -705,6 +705,10 @@ pub(crate) mod tests {
         pub(crate) fn values() -> (serde_json::Value, serde_json::Value, serde_json::Value) {
             (report(), corpus(), thresholds())
         }
+
+        pub(crate) fn oracle_path_file_values() -> Vec<serde_json::Value> {
+            path_files()
+        }
     }
 
     fn observed(full: u64, cohorts: [u64; 4]) -> Observations {

--- a/crates/codestory-bench/tests/proof_availability_contracts.rs
+++ b/crates/codestory-bench/tests/proof_availability_contracts.rs
@@ -823,19 +823,35 @@ pub(crate) fn report() -> Value {
                     });
                     let source_node_id = -(i64::try_from(step_index).expect("step index") + 1);
                     let target_node_id = source_node_id - 1;
+                    let source_canonical_id =
+                        format!("canonical-{case_index}-{source_node_id}");
+                    let target_canonical_id =
+                        format!("canonical-{case_index}-{target_node_id}");
+                    let source_pinned = contracts::PinnedNodeIdentityV1 {
+                        project_id: project_id.clone(),
+                        core_generation_id: core_generation_id.clone(),
+                        core_run_id: core_run_id.clone(),
+                        node_id: source_node_id.to_string(),
+                    };
+                    let target_pinned = contracts::PinnedNodeIdentityV1 {
+                        project_id: project_id.clone(),
+                        core_generation_id: core_generation_id.clone(),
+                        core_run_id: core_run_id.clone(),
+                        node_id: target_node_id.to_string(),
+                    };
                     json!({
                         "receipt_id":format!("indexed-call-edge:fixture-{case_index}-{step_index}"),
                         "step_index":step_index,
                         "edge_id":edge_id,
                         "source":{
                             "pinned":{"project_id":project_id,"core_generation_id":core_generation_id,"core_run_id":core_run_id,"node_id":source_node_id.to_string()},
-                            "canonical_id":format!("canonical-{case_index}-{source_node_id}"),
+                            "canonical_id_binding_sha256":contracts::resolved_canonical_id_binding_sha256(&source_pinned, &source_canonical_id).unwrap(),
                             "qualified_name":step["caller"]["symbol"],
                             "project_file_components":source_path.split('/').collect::<Vec<_>>()
                         },
                         "target":{
                             "pinned":{"project_id":project_id,"core_generation_id":core_generation_id,"core_run_id":core_run_id,"node_id":target_node_id.to_string()},
-                            "canonical_id":format!("canonical-{case_index}-{target_node_id}"),
+                            "canonical_id_binding_sha256":contracts::resolved_canonical_id_binding_sha256(&target_pinned, &target_canonical_id).unwrap(),
                             "qualified_name":step["target"]["symbol"],
                             "project_file_components":source_path.split('/').collect::<Vec<_>>()
                         },
@@ -903,7 +919,7 @@ pub(crate) fn report() -> Value {
         })
         .collect::<Vec<_>>();
     let mut report = json!({
-      "schema":"codestory.proof-availability-report/v1","qualification_id":"20260821T000000Z-bbbbbbbbbbbb",
+      "schema":"codestory.proof-availability-report/v2","qualification_id":"20260821T000000Z-bbbbbbbbbbbb",
       "provenance":{"source_commit":COMMIT,"source_tree":COMMIT,"binary_sha256":SHA,"corpus_sha256":corpus_hash,"thresholds_sha256":threshold_hash,"results_sha256":SHA},
       "environment":{"qualification_id":"20260821T000000Z-bbbbbbbbbbbb","environment_id":"macos-arm64","os":"macos","architecture":"aarch64","rust_host":"aarch64-apple-darwin","binary_sha256":SHA,"qualification_source_commit":COMMIT,"qualification_source_tree":COMMIT,"recorded_at":"2026-08-21T12:34:56Z","build":{"source_commit":COMMIT,"source_tree":COMMIT,"source_dirty":false,"rustc_vv":"rustc 1.91.0\nbinary: rustc\nhost: aarch64-apple-darwin\n","cargo_profile":"release","prescribed_argv":["cargo","build","--release","--locked","-p","codestory-bench","--bin","codestory-proof-availability"]},"invocation":{"binary_name":"codestory-proof-availability","operation":"run","profile":"local_core_only","corpus_sha256":corpus_hash,"thresholds_sha256":threshold_hash},"projects":frozen["cohorts"].as_array().unwrap().iter().map(|cohort|{let id=cohort["repository_id"].as_str().unwrap();json!({"repository_id":id,"source_head":cohort["commit"],"source_tree":SHA,"store_schema":"codestory-store/v1","file_count":10,"node_count":20,"edge_count":30,"freshness":"fresh","database_sha256":SHA,"core_generation":1,"identity":{"project_id":format!("project-{id}"),"core_generation_id":format!("generation-{id}"),"core_run_id":format!("run-{id}")}})}).collect::<Vec<_>>()},
       "inventory":cohort_ids.iter().map(|id|json!({"repository_id":id,"stored_call_rows":"10","effective_endpoint_rows":"10","exact_resolved_rows":"8","admitted_rows":"7","unresolved_placeholder_rows":"2"})).collect::<Vec<_>>(),
@@ -1067,6 +1083,216 @@ fn runtime_receipt_comparison_uses_the_oracle_file_hash_not_hash_self_agreement(
         ReceiptOracleComparisonV1::Mismatched { mismatches, .. }
             if mismatches == [contracts::ReceiptMismatchFieldV1::CallsiteWindow]
     ));
+}
+
+#[test]
+fn resolved_canonical_id_bindings_cover_host_paths_relative_ids_and_context() {
+    use codestory_agent::proof_qualification_support::{PinnedNodeIdentity, ResolvedNodeIdentity};
+
+    let raws = [
+        "/Users/private/worktree/src/caller.rs::caller",
+        r"C:\private\worktree\src\caller.rs::caller",
+        r"\\server\share\worktree\src\caller.rs::caller",
+        r"\\?\C:\private\worktree\src\caller.rs::caller",
+        "flask/app.py::dispatch_request",
+    ];
+    let public_pinned = |node_id: &str| contracts::PinnedNodeIdentityV1 {
+        project_id: "project".into(),
+        core_generation_id: "generation".into(),
+        core_run_id: "run".into(),
+        node_id: node_id.into(),
+    };
+    for raw in raws {
+        for node_id in ["-1", "-2"] {
+            let product = ResolvedNodeIdentity {
+                pinned: PinnedNodeIdentity {
+                    project_id: "project".into(),
+                    core_generation_id: "generation".into(),
+                    core_run_id: "run".into(),
+                    node_id: node_id.into(),
+                },
+                canonical_id: raw.into(),
+                qualified_name: "module::callable".into(),
+                project_file_components: vec!["src".into(), "caller.rs".into()],
+            };
+            let public = contracts::ResolvedNodeIdentityV1::try_from(&product).unwrap();
+            assert_eq!(public.canonical_id_binding_sha256.len(), 64);
+            assert!(
+                public
+                    .canonical_id_binding_sha256
+                    .bytes()
+                    .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+            );
+            assert!(!serde_json::to_string(&public).unwrap().contains(raw));
+        }
+    }
+
+    let same_value_first =
+        contracts::resolved_canonical_id_binding_sha256(&public_pinned("-1"), "same-canonical-id")
+            .unwrap();
+    let same_value_second =
+        contracts::resolved_canonical_id_binding_sha256(&public_pinned("-2"), "same-canonical-id")
+            .unwrap();
+    let different_value_same_pin = contracts::resolved_canonical_id_binding_sha256(
+        &public_pinned("-1"),
+        "different-canonical-id",
+    )
+    .unwrap();
+    assert_ne!(same_value_first, same_value_second);
+    assert_ne!(same_value_first, different_value_same_pin);
+
+    let empty = ResolvedNodeIdentity {
+        pinned: PinnedNodeIdentity {
+            project_id: "project".into(),
+            core_generation_id: "generation".into(),
+            core_run_id: "run".into(),
+            node_id: "-1".into(),
+        },
+        canonical_id: String::new(),
+        qualified_name: "module::callable".into(),
+        project_file_components: vec!["src".into(), "caller.rs".into()],
+    };
+    contracts::ResolvedNodeIdentityV1::try_from(&empty)
+        .expect_err("an empty raw canonical ID cannot produce a public binding");
+}
+
+#[test]
+fn canonical_selector_oracles_recompute_the_contextual_receipt_binding() {
+    use codestory_agent::proof_qualification_support::{
+        CallableContainmentEvidence, IndexedCallEdgeReceipt, IndexedLineWindow, PinnedNodeIdentity,
+        ReceiptRef, ResolvedNodeIdentity,
+    };
+    use codestory_contracts::graph::{NodeId, ResolutionCertainty};
+
+    let path_file =
+        CohortPathFileV1::from_json(cohort_path_file("codestory-rust")).expect("oracle path file");
+    let mut oracle = path_file.paths[0].oracle_steps[0].clone();
+    let source_raw = "flask/app.py::dispatch_request";
+    let target_raw = r"\\server\share\target.py::target";
+    oracle.caller.selector = ExactSymbolSelectorV1::CanonicalId {
+        canonical_id: source_raw.into(),
+    };
+    oracle.target.selector = ExactSymbolSelectorV1::CanonicalId {
+        canonical_id: target_raw.into(),
+    };
+    let identity = |node_id: &str, canonical_id: &str, qualified_name: &str| ResolvedNodeIdentity {
+        pinned: PinnedNodeIdentity {
+            project_id: "project".into(),
+            core_generation_id: "generation".into(),
+            core_run_id: "run".into(),
+            node_id: node_id.into(),
+        },
+        canonical_id: canonical_id.into(),
+        qualified_name: qualified_name.into(),
+        project_file_components: oracle
+            .receipt_line_window
+            .path
+            .split('/')
+            .map(ToOwned::to_owned)
+            .collect(),
+    };
+    let receipt = IndexedCallEdgeReceipt {
+        receipt: ReceiptRef {
+            receipt_id: "indexed-call-edge:canonical-selector".into(),
+            edge_id: "-42".into(),
+        },
+        source: identity("-1", source_raw, &oracle.caller.symbol),
+        target: identity("-2", target_raw, &oracle.target.symbol),
+        certainty: ResolutionCertainty::Certain,
+        callsite_identity: format!("-3:{}:0:-2|fixture", oracle.callsite_line),
+        containment: CallableContainmentEvidence {
+            file_node_id: NodeId(-3),
+            owner_node_id: NodeId(-1),
+            start_line: oracle.callsite_line,
+            end_line: oracle.callsite_line,
+        },
+        line_window: IndexedLineWindow {
+            kind: "indexed_line_v1",
+            project_file_components: oracle
+                .receipt_line_window
+                .path
+                .split('/')
+                .map(ToOwned::to_owned)
+                .collect(),
+            indexed_sha256: oracle.receipt_file_sha256.clone(),
+            observed_sha256: oracle.receipt_file_sha256.clone(),
+            anchor_line: oracle.callsite_line,
+            byte_start: usize::try_from(oracle.receipt_line_window.start_byte).unwrap(),
+            byte_end: usize::try_from(oracle.receipt_line_window.end_byte).unwrap(),
+            text: "call();\n".into(),
+        },
+    };
+
+    assert!(matches!(
+        contracts::compare_task6_receipt_to_oracle(0, &receipt, &oracle).unwrap(),
+        ReceiptOracleComparisonV1::Exact { .. }
+    ));
+    oracle.target.selector = ExactSymbolSelectorV1::CanonicalId {
+        canonical_id: format!("{target_raw}x"),
+    };
+    assert!(matches!(
+        contracts::compare_task6_receipt_to_oracle(0, &receipt, &oracle).unwrap(),
+        ReceiptOracleComparisonV1::Mismatched { mismatches, .. }
+            if mismatches == [contracts::ReceiptMismatchFieldV1::Target]
+    ));
+}
+
+#[test]
+fn resolved_receipt_bindings_reject_legacy_and_malformed_shapes_and_bind_results_digest() {
+    let base = report();
+    let base_digest = contracts::results_evidence_sha256_from_json(&base).unwrap();
+    let binding = base["cases"][0]["receipt_evidence"]["observed_receipts"][0]["source"]
+        ["canonical_id_binding_sha256"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+
+    let mut changed = base.clone();
+    let replacement = if binding.starts_with('a') { 'b' } else { 'a' };
+    changed["cases"][0]["receipt_evidence"]["observed_receipts"][0]["source"]["canonical_id_binding_sha256"] =
+        json!(format!("{replacement}{}", &binding[1..]));
+    assert_ne!(
+        contracts::results_evidence_sha256_from_json(&changed).unwrap(),
+        base_digest
+    );
+
+    let mut canonical_bound = base.clone();
+    canonical_bound["cases"][0]["receipt_evidence"]["observed_receipts"][0]["oracle_comparison"]
+        ["oracle_step"]["caller"]["selector"] =
+        json!({"kind":"canonical_id","canonical_id":"canonical-0--1"});
+    rebind_results_digest(&mut canonical_bound);
+    QualificationSummaryV1::from_json(canonical_bound.clone())
+        .expect("the exact frozen canonical selector recomputes the receipt commitment");
+    canonical_bound["cases"][0]["receipt_evidence"]["observed_receipts"][0]["source"]
+        ["canonical_id_binding_sha256"] = changed["cases"][0]["receipt_evidence"]
+        ["observed_receipts"][0]["source"]["canonical_id_binding_sha256"]
+        .clone();
+    rebind_results_digest(&mut canonical_bound);
+    QualificationSummaryV1::from_json(canonical_bound)
+        .expect_err("a one-byte commitment mutation cannot satisfy a frozen canonical selector");
+
+    for malformed in [String::new(), "A".repeat(64), "a".repeat(63)] {
+        let mut value = base.clone();
+        value["cases"][0]["receipt_evidence"]["observed_receipts"][0]["source"]["canonical_id_binding_sha256"] =
+            json!(malformed);
+        rebind_results_digest(&mut value);
+        QualificationSummaryV1::from_json(value)
+            .expect_err("malformed public canonical-ID commitments fail closed");
+    }
+
+    let mut legacy = base;
+    let source = legacy["cases"][0]["receipt_evidence"]["observed_receipts"][0]["source"]
+        .as_object_mut()
+        .unwrap();
+    source.remove("canonical_id_binding_sha256");
+    source.insert("canonical_id".into(), json!("legacy-raw-canonical-id"));
+    QualificationSummaryV1::from_json(legacy)
+        .expect_err("resolved receipt identities no longer accept a raw canonical_id field");
+
+    serde_json::from_value::<ExactSymbolSelectorV1>(
+        json!({"kind":"canonical_id","canonical_id":"frozen-oracle-value"}),
+    )
+    .expect("frozen oracle selectors continue to carry raw canonical IDs");
 }
 
 #[test]
@@ -2235,7 +2461,11 @@ fn producer_facade_conversions_preserve_task4_and_task6_semantics() {
     assert_eq!(observed.source.pinned.core_generation_id, "generation");
     assert_eq!(observed.source.pinned.core_run_id, "run");
     assert_eq!(observed.source.pinned.node_id, "-1");
-    assert_eq!(observed.source.canonical_id, "canonical--1");
+    assert_eq!(
+        observed.source.canonical_id_binding_sha256,
+        contracts::resolved_canonical_id_binding_sha256(&observed.source.pinned, "canonical--1")
+            .unwrap()
+    );
     assert_eq!(observed.source.qualified_name, "codestory-rust-l1-0::start");
     assert_eq!(
         observed.source.project_file_components,
@@ -2253,7 +2483,11 @@ fn producer_facade_conversions_preserve_task4_and_task6_semantics() {
     assert_eq!(observed.target.pinned.core_generation_id, "generation");
     assert_eq!(observed.target.pinned.core_run_id, "run");
     assert_eq!(observed.target.pinned.node_id, "-2");
-    assert_eq!(observed.target.canonical_id, "canonical--2");
+    assert_eq!(
+        observed.target.canonical_id_binding_sha256,
+        contracts::resolved_canonical_id_binding_sha256(&observed.target.pinned, "canonical--2")
+            .unwrap()
+    );
     assert_eq!(
         observed.target.qualified_name,
         "codestory-rust-l1-0::target_0"
@@ -2852,6 +3086,20 @@ fn schemas_have_semantic_constants_patterns_and_bounds() {
         6
     );
     let report_schema = contracts::schema_json(SchemaDocument::Report);
+    assert_eq!(
+        report_schema["$id"],
+        "codestory.proof-availability-report/v2"
+    );
+    assert_eq!(
+        report_schema["$defs"]["ResolvedNodeIdentityV1"]["properties"]["canonical_id_binding_sha256"]
+            ["pattern"],
+        "^[0-9a-f]{64}$"
+    );
+    assert!(
+        report_schema["$defs"]["ResolvedNodeIdentityV1"]["properties"]
+            .get("canonical_id")
+            .is_none()
+    );
     assert_eq!(
         report_schema["$defs"]["EnvironmentReportV1"]["properties"]["qualification_source_commit"]
             ["pattern"],

--- a/docs/testing/proof-availability-v1.md
+++ b/docs/testing/proof-availability-v1.md
@@ -111,6 +111,17 @@ contract digest with the digest produced by validating that frozen oracle path.
 Read-only verification recomputes the same expected digest from the frozen
 oracle, so a different well-formed SHA-256 fails before metrics are evaluated.
 
+Public report schema `codestory.proof-availability-report/v2` does not expose
+resolved runtime canonical IDs because those identities may contain host paths.
+Each resolved source and target instead carries
+`canonical_id_binding_sha256`, computed over RFC 8785 canonical JSON containing
+the complete pinned node identity and raw canonical ID with the domain
+`codestory.proof-availability-resolved-canonical-id/v1\0`. Frozen oracle
+selectors may still use raw canonical IDs; verification recomputes the same
+contextual binding from the selector and receipt pin. The v2 results-evidence
+digest binds these commitments under
+`codestory.proof-availability-results-evidence/v2\0`.
+
 A product finalization failure remains an `Invalid` case row rather than
 aborting the report. It retains the actual trace and both completed mutation
 rows, records every oracle step as missing, and carries no projection or receipt


### PR DESCRIPTION
## Context

The fresh non-evidence Task 13H run proved that qualification publication first failed because an observed receipt copied a path-bearing product canonical ID into `cases.json`. The public leak validator correctly rejected it.

This PR fixes only the closed benchmark evidence projection. Product, store, indexer, proof-kernel, corpus, thresholds, methodology, and public v3 routing are unchanged.

## What changed

- replace public resolved-receipt `canonical_id` with a contextual `canonical_id_binding_sha256`;
- bind the raw ID to the complete pinned node identity with RFC 8785 canonical JSON and a domain-separated SHA-256;
- recompute that binding for frozen canonical-selector oracle comparison;
- reject empty raw IDs and malformed/legacy public commitment shapes;
- move the report schema and results-evidence digest domain to v2;
- retain the fail-closed path validator, owner-private diagnostic, split reconstruction, offline verification, and exactly-eight artifact contract.

## Review

Review `contracts.rs` first for the commitment and oracle comparison, then `report.rs` for artifact validation and the diagnostic fixture, then the generated report schema. The exact reviewed commit is `9308c4df3982b9bbf4856809b7e036662d8e6e57`, tree `e3d302598e5d6c6a5b571fce5c64a24f16abea6e`.

Independent review found no Critical or Important defect.

## Verification

- contracts: 59 passed, 0 failed, 1 intentional ignore
- proof-availability suite: 130 passed, 0 failed, 2 intentional ignores
- `cargo check --locked -p codestory-bench`
- `cargo clippy --locked -p codestory-bench --all-targets -- -D warnings`
- `cargo fmt -p codestory-bench -- --check`
- docs links: 84 files, 316 links
- `git diff --check`

The real builder-path regression first failed with `proof_availability_public_artifact_build_failed`; after the change it publishes exactly eight synthetic artifacts, exposes neither raw source nor target ID, reconstructs split artifacts, and passes offline verification.

## Risk and nonclaims

The binding is intentionally publication-contextual, so it cannot imply equality across pins. This PR produces no Q2 result and makes no availability or activation claim. A wholly new binary, qualification ID, materialization, and run are required after merge.

Closes #2012
Refs #1985
Refs #1984
