### PR TITLE
Include native_binary_contract in the post-publish harness

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -4953,6 +4953,7 @@ function validatePostPublish(workflows, violations, graph) {
     ".github/scripts/install-codestory-marketplace-proof.mjs",
     ".github/scripts/marketplace-delivery-identity.mjs",
     ".github/scripts/check-packaged-agent-proof.py",
+    ".github/scripts/native_binary_contract.py",
     ".github/scripts/packaged_agent_proof",
     '| tar -x -C "$harness_root"',
     'echo "helper=$harness_root/.github/scripts/install-codestory-marketplace-proof.mjs" >> "$GITHUB_OUTPUT"',

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -5394,6 +5394,7 @@ function validatePostPublish(workflows, violations, graph) {
     "--engine-policy accelerated",
     '--expected-backend "$EXPECTED_BACKEND"',
     "--proof-tier installed_runtime",
+    "--measurement-protocol",
     "--server-behavior-only",
     "--installed-plugin-attestation",
     "--installed-plugin-data",

--- a/.github/scripts/packaged_agent_proof/installed_identity.py
+++ b/.github/scripts/packaged_agent_proof/installed_identity.py
@@ -16,8 +16,8 @@ from .marketplace_installation import (
 )
 
 
-def _reject_source_checkout(plugin_root: Path) -> None:
-    source_plugin_root = REPOSITORY_ROOT / "plugins" / "codestory"
+def _reject_source_checkout(plugin_root: Path, source_root: Path) -> None:
+    source_plugin_root = source_root / "plugins" / "codestory"
     require(
         not same_existing_path(plugin_root, source_plugin_root),
         "installed_runtime proof rejects the repository-source plugin root",
@@ -158,7 +158,8 @@ def installed_plugin_identity(
         and args.installed_plugin_data.is_dir(),
         "installed_runtime proof requires one attestation and its plugin data directory",
     )
-    _reject_source_checkout(plugin_root)
+    source_root = args.project.resolve() if args.project is not None else REPOSITORY_ROOT
+    _reject_source_checkout(plugin_root, source_root)
     attestation = _load_attestation(args.installed_plugin_attestation)
     # Each installer identity routes to exactly one accepted shape. A live public-catalog
     # install and a deferred candidate-pinned fixture are different states of the world, so
@@ -172,6 +173,7 @@ def installed_plugin_identity(
             args.installed_plugin_data,
             plugin_root,
             manifest,
+            source_root,
         )
     return _candidate_installed_plugin_identity(
         args,

--- a/.github/scripts/packaged_agent_proof/installed_identity.py
+++ b/.github/scripts/packaged_agent_proof/installed_identity.py
@@ -158,7 +158,8 @@ def installed_plugin_identity(
         and args.installed_plugin_data.is_dir(),
         "installed_runtime proof requires one attestation and its plugin data directory",
     )
-    source_root = args.project.resolve() if args.project is not None else REPOSITORY_ROOT
+    project = getattr(args, "project", None)
+    source_root = project.resolve() if project is not None else REPOSITORY_ROOT
     _reject_source_checkout(plugin_root, source_root)
     attestation = _load_attestation(args.installed_plugin_attestation)
     # Each installer identity routes to exactly one accepted shape. A live public-catalog

--- a/.github/scripts/packaged_agent_proof/marketplace_installation.py
+++ b/.github/scripts/packaged_agent_proof/marketplace_installation.py
@@ -443,7 +443,12 @@ def _validate_marketplace_checkout(
     return marketplace_commit
 
 
-def _validate_release_source(plugin: dict, plugin_root: Path, manifest: dict) -> str:
+def _validate_release_source(
+    plugin: dict,
+    plugin_root: Path,
+    manifest: dict,
+    source_root: Path,
+) -> str:
     package_sha256 = directory_contract_sha256(plugin_root)
     source_commit = plugin["source_commit"]
     require(
@@ -453,17 +458,17 @@ def _validate_release_source(plugin: dict, plugin_root: Path, manifest: dict) ->
         and plugin["package_sha256"] == package_sha256
         and isinstance(source_commit, str)
         and re.fullmatch(r"[0-9a-f]{40}", source_commit) is not None
-        and _git_output(REPOSITORY_ROOT, "rev-parse", f"{source_commit}^{{commit}}")
+        and _git_output(source_root, "rev-parse", f"{source_commit}^{{commit}}")
         == source_commit
-        and _git_output(REPOSITORY_ROOT, "rev-parse", f"{source_commit}^{{tree}}")
+        and _git_output(source_root, "rev-parse", f"{source_commit}^{{tree}}")
         == manifest["source"]["tree"]
-        and _git_output(REPOSITORY_ROOT, "rev-parse", "HEAD")
+        and _git_output(source_root, "rev-parse", "HEAD")
         == manifest["source"]["commit"]
-        and _git_output(REPOSITORY_ROOT, "rev-parse", "HEAD^{tree}")
+        and _git_output(source_root, "rev-parse", "HEAD^{tree}")
         == manifest["source"]["tree"],
         "marketplace install is not bound to the exact packaged release source",
     )
-    source_plugin_root = REPOSITORY_ROOT / "plugins" / "codestory"
+    source_plugin_root = source_root / "plugins" / "codestory"
     require(
         package_sha256 == directory_contract_sha256(source_plugin_root),
         "Codex-installed plugin bytes differ from the packaged release source tree",
@@ -477,6 +482,7 @@ def marketplace_installed_plugin_identity(
     installed_plugin_data: Path,
     plugin_root: Path,
     manifest: dict,
+    source_root: Path = REPOSITORY_ROOT,
 ) -> dict:
     codex_home, plugin, marketplace = _validate_attestation_paths(
         attestation,
@@ -504,7 +510,9 @@ def marketplace_installed_plugin_identity(
         plugin["source_commit"] == plugin_source_sha,
         "marketplace attestation source does not match the catalog pin",
     )
-    package_sha256 = _validate_release_source(plugin, plugin_root, manifest)
+    package_sha256 = _validate_release_source(
+        plugin, plugin_root, manifest, source_root
+    )
     return {
         "schema_version": 2,
         "installation_source": state.installation_source,

--- a/.github/workflows/post-publish-release-smoke.yml
+++ b/.github/workflows/post-publish-release-smoke.yml
@@ -136,6 +136,7 @@ jobs:
             .github/scripts/install-codestory-marketplace-proof.mjs \
             .github/scripts/marketplace-delivery-identity.mjs \
             .github/scripts/check-packaged-agent-proof.py \
+            .github/scripts/native_binary_contract.py \
             .github/scripts/packaged_agent_proof \
             | tar -x -C "$harness_root"
           echo "helper=$harness_root/.github/scripts/install-codestory-marketplace-proof.mjs" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/post-publish-release-smoke.yml
+++ b/.github/workflows/post-publish-release-smoke.yml
@@ -669,6 +669,7 @@ jobs:
             --checksum-file "$ASSET_CHECKSUM" \
             --expected-version "$RELEASE_VERSION" \
             --project "${{ github.workspace }}" \
+            --measurement-protocol "${{ github.workspace }}/crates/codestory-llama-sys/per-user-embedding-server-measurement-protocol.json" \
             --plugin-root "$INSTALLED_PLUGIN_ROOT" \
             --plugin-handoff \
             --engine-policy accelerated \


### PR DESCRIPTION
## Summary
- Post-publish smoke on v0.17.5 failed because the caller-bound harness archived `packaged_agent_proof` but not the sibling `native_binary_contract.py` it imports.
- Stage that file with the harness so a post-publication repair can re-prove the immutable v0.17.5 bytes without moving the tag.

## Test plan
- [x] `node --test` workflow policy tests
- [ ] Dispatched post-publish smoke for 0.17.5 from this ref


Made with [Cursor](https://cursor.com)