### PR TITLE
add exact Go proof receipts

### DIFF
--- a/crates/codestory-indexer/src/cache.rs
+++ b/crates/codestory-indexer/src/cache.rs
@@ -10,7 +10,7 @@ use std::path::{Component, Path, PathBuf};
 
 // Bumped to 6 because JavaScript joins the private proof adapter roster and
 // ECMAScript bindings are now collected with name-specific closure semantics.
-const INDEX_ARTIFACT_CACHE_VERSION: u32 = 9;
+const INDEX_ARTIFACT_CACHE_VERSION: u32 = 10;
 const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
 const FNV_PRIME: u64 = 0x00000100000001B3;
 
@@ -86,6 +86,22 @@ pub(crate) enum CachedResolutionBinding {
         constructor_record: bool,
         constructor_method: Option<String>,
     },
+    GoPackageFunction {
+        package_name: String,
+        name: String,
+    },
+    GoImplicitReceiver {
+        package_name: String,
+        owner_name: String,
+        receiver_is_pointer: bool,
+    },
+    GoExplicitReceiver {
+        package_name: String,
+        owner_name: String,
+        receiver_is_pointer: bool,
+        constructor: bool,
+        constructor_uses_builtin_new: bool,
+    },
     Ambiguous,
     MissingBinding,
     Unsupported,
@@ -132,6 +148,34 @@ pub(crate) struct CachedResolutionFile {
     pub rust_types: Vec<CachedRustType>,
     #[serde(default)]
     pub rust_uses: Vec<CachedRustUseBinding>,
+    #[serde(default)]
+    pub go_package: Option<CachedGoPackage>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct CachedGoPackage {
+    pub name: String,
+    pub build_constrained: bool,
+    pub generated: bool,
+    pub package_blockers: Vec<String>,
+    pub types: Vec<CachedGoType>,
+    pub methods: Vec<CachedGoMethod>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct CachedGoType {
+    pub name: String,
+    pub declaration: NodeId,
+    pub interface: bool,
+    pub generic: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct CachedGoMethod {
+    pub owner_name: String,
+    pub method_name: String,
+    pub declaration: NodeId,
+    pub pointer_receiver: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -243,7 +287,7 @@ impl CachedIndexArtifact {
         resolution_file: Option<CachedResolutionFile>,
     ) -> Self {
         Self {
-            resolution_input_schema_version: 7,
+            resolution_input_schema_version: 8,
             files: index_result.files,
             nodes: index_result.nodes,
             edges: index_result.edges,

--- a/crates/codestory-indexer/src/cache.rs
+++ b/crates/codestory-indexer/src/cache.rs
@@ -763,7 +763,10 @@ mod tests {
             )
         );
         assert!(
-            crate::proof_resolution::cached_resolution_inputs_are_current(&decoded, "go", "unused",)
+            !crate::proof_resolution::cached_resolution_inputs_are_current(
+                &decoded, "go", "unused",
+            ),
+            "a legacy cache without proof inputs cannot satisfy the installed Go adapter"
         );
     }
 }

--- a/crates/codestory-indexer/src/languages/go.rs
+++ b/crates/codestory-indexer/src/languages/go.rs
@@ -32,19 +32,42 @@
 //! sit in `lib.rs`, and `tests/language_extraction_snapshot.rs` pins the
 //! rendered projection of both Go fixtures so the move stays output-equal.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::OnceLock;
 
 use tree_sitter::{Node as TsNode, Tree};
+
+#[cfg(test)]
+thread_local! {
+    static GO_NAVIGATION_RESOLUTION_WORK: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[inline]
+fn count_go_navigation_resolution_work(amount: usize) {
+    #[cfg(test)]
+    GO_NAVIGATION_RESOLUTION_WORK.with(|work| work.set(work.get().saturating_add(amount)));
+    #[cfg(not(test))]
+    let _ = amount;
+}
+
+#[cfg(test)]
+fn reset_go_navigation_resolution_work() {
+    GO_NAVIGATION_RESOLUTION_WORK.with(|work| work.set(0));
+}
+
+#[cfg(test)]
+fn go_navigation_resolution_work() -> usize {
+    GO_NAVIGATION_RESOLUTION_WORK.with(std::cell::Cell::get)
+}
 
 use super::LanguageExtraction;
 use crate::{
     CompiledLanguageRules, LanguageRuleset, ManualMemberEdgeSpec, ManualReceiverCallSpec,
     ManualReceiverSource, OptionalReceiverOwnerBinding, ReceiverCallSiteKey, ReceiverOwnerBinding,
     collect_receiver_call_specs_in_callable, declaration_name, descendant_by_field_name,
-    enclosing_node_with_kind, member_call_method_col, node_is_same_or_ancestor,
-    normalize_parameter_name, normalized_receiver_variable, receiver_call_belongs_to_callable,
-    receiver_callsite_key, trimmed_node_text, ts_node_graph_span, walk_tree_nodes,
+    enclosing_node_with_kind, member_call_method_col, normalize_parameter_name,
+    normalized_receiver_variable, receiver_call_belongs_to_callable, receiver_callsite_key,
+    trimmed_node_text, ts_node_graph_span, walk_tree_nodes,
 };
 
 /// Callsite marker written onto edges produced from Go selector-call syntax.
@@ -185,22 +208,45 @@ fn go_receiver_owner_name(receiver_node: TsNode<'_>, source: &str) -> Option<Str
 }
 
 fn normalize_go_type_surface(raw: &str) -> Option<String> {
-    let mut surface = raw.trim();
-    while let Some(stripped) = surface.strip_prefix('*') {
-        surface = stripped.trim_start();
+    go_exact_type_surface(raw).map(|(_, owner)| owner)
+}
+
+fn go_exact_type_surface(raw: &str) -> Option<(Option<String>, String)> {
+    let surface = raw.trim();
+    let surface = if let Some(stripped) = surface.strip_prefix('*') {
+        let stripped = stripped.trim_start();
+        if stripped.starts_with('*') {
+            return None;
+        }
+        stripped
+    } else {
+        surface
+    };
+    if surface.contains(char::is_whitespace)
+        || surface.contains(['[', ']', '(', ')', '{', '}', '/', '&'])
+    {
+        return None;
     }
-    if let Some(stripped) = surface.strip_prefix("[]") {
-        surface = stripped.trim_start();
+    match surface.split_once('.') {
+        Some((qualifier, owner))
+            if !owner.contains('.')
+                && normalize_parameter_name(qualifier).as_deref() == Some(qualifier)
+                && normalize_parameter_name(owner).as_deref() == Some(owner) =>
+        {
+            Some((Some(qualifier.to_string()), owner.to_string()))
+        }
+        None if normalize_parameter_name(surface).as_deref() == Some(surface) => {
+            Some((None, surface.to_string()))
+        }
+        _ => None,
     }
-    let base = surface.split('[').next().unwrap_or(surface).trim();
-    let terminal = base.rsplit('.').next().unwrap_or(base).trim();
-    (!terminal.is_empty()).then(|| terminal.to_string())
 }
 
 pub(crate) fn receiver_call_specs(tree: &Tree, source: &str) -> Vec<ManualReceiverCallSpec> {
     let mut edges = Vec::new();
     let import_bindings = collect_go_import_bindings(source);
     walk_tree_nodes(tree.root_node(), &mut |callable| {
+        count_go_navigation_resolution_work(1);
         if !matches!(
             callable.kind(),
             "function_declaration" | "method_declaration"
@@ -281,39 +327,189 @@ fn collect_go_local_composite_receiver_call_specs(
     local_binding_callsites: &mut HashSet<ReceiverCallSiteKey>,
     edges: &mut Vec<ManualReceiverCallSpec>,
 ) {
+    let mut calls = Vec::new();
+    let mut intervals = Vec::new();
+    let builtin_new_unshadowed = !import_bindings.contains_key("new")
+        && !go_file_scope_name_is_shadowed(callable, "new", source)
+        && !go_callable_declares_name(callable, "new", source);
     walk_tree_nodes(callable, &mut |node| {
-        let Some((receiver_name, method_name)) = selector_call(node, source) else {
-            return;
-        };
+        count_go_navigation_resolution_work(1);
         if !receiver_call_belongs_to_callable(node, callable) {
             return;
         }
-        let Some(owner_name) = go_visible_local_composite_owner(
-            callable,
-            node,
-            &receiver_name,
-            source,
-            import_bindings,
-        ) else {
+        if let Some((receiver_name, method_name)) = selector_call(node, source) {
+            calls.push(GoNavigationCall {
+                node,
+                receiver_name,
+                method_name,
+            });
+        }
+        let Some((scope_end, scope_depth)) = go_navigation_binding_scope(node, callable) else {
             return;
         };
-        let method_col = member_call_method_col(node, source, &method_name);
+        match node.kind() {
+            "short_var_declaration" | "assignment_statement" => {
+                let left = node
+                    .child_by_field_name("left")
+                    .map(go_expression_list_items)
+                    .unwrap_or_default();
+                let right = node
+                    .child_by_field_name("right")
+                    .map(go_expression_list_items)
+                    .unwrap_or_default();
+                for (index, left) in left.into_iter().enumerate() {
+                    let Some(name) = normalized_receiver_variable(left, source) else {
+                        continue;
+                    };
+                    let owner = right.get(index).and_then(|value| {
+                        go_direct_composite_literal_owner(
+                            *value,
+                            source,
+                            import_bindings,
+                            builtin_new_unshadowed,
+                        )
+                    });
+                    intervals.push(GoNavigationBindingInterval {
+                        name,
+                        start_byte: node.end_byte(),
+                        end_byte: if node.kind() == "assignment_statement" {
+                            callable.end_byte()
+                        } else {
+                            scope_end
+                        },
+                        scope_depth: if node.kind() == "assignment_statement" {
+                            usize::MAX - 1
+                        } else {
+                            scope_depth
+                        },
+                        owner,
+                    });
+                }
+            }
+            "var_spec" => {
+                let Some(type_node) = node.child_by_field_name("type") else {
+                    return;
+                };
+                let owner = trimmed_node_text(type_node, source)
+                    .as_deref()
+                    .and_then(|raw_type| go_receiver_owner_from_type(raw_type, import_bindings));
+                let mut cursor = node.walk();
+                for name_node in node
+                    .named_children(&mut cursor)
+                    .take_while(|child| child.start_byte() < type_node.start_byte())
+                {
+                    let Some(name) = normalized_receiver_variable(name_node, source) else {
+                        continue;
+                    };
+                    intervals.push(GoNavigationBindingInterval {
+                        name,
+                        start_byte: node.end_byte(),
+                        end_byte: scope_end,
+                        scope_depth,
+                        owner: owner.clone(),
+                    });
+                }
+            }
+            "const_spec" | "type_spec" => {
+                for name in go_navigation_declared_names(node, source) {
+                    intervals.push(GoNavigationBindingInterval {
+                        name,
+                        start_byte: node.end_byte(),
+                        end_byte: scope_end,
+                        scope_depth,
+                        owner: None,
+                    });
+                }
+            }
+            "range_clause" | "receive_statement" | "type_switch_guard" => {
+                if let Some((names, end_byte, depth)) =
+                    go_navigation_special_binding(node, callable, source)
+                {
+                    for name in names {
+                        intervals.push(GoNavigationBindingInterval {
+                            name,
+                            start_byte: node.end_byte(),
+                            end_byte,
+                            scope_depth: depth,
+                            owner: None,
+                        });
+                    }
+                }
+            }
+            "type_switch_statement" => {
+                if let Some(header) = trimmed_node_text(node, source).and_then(|surface| {
+                    surface
+                        .split_once('{')
+                        .map(|(header, _)| header.trim().to_string())
+                }) {
+                    for name in go_navigation_special_names(
+                        header.strip_prefix("switch").unwrap_or(&header),
+                    ) {
+                        intervals.push(GoNavigationBindingInterval {
+                            name,
+                            start_byte: node.start_byte(),
+                            end_byte: node.end_byte(),
+                            scope_depth: scope_depth.saturating_add(1),
+                            owner: None,
+                        });
+                    }
+                }
+            }
+            "unary_expression" => {
+                let Some(surface) = trimmed_node_text(node, source) else {
+                    return;
+                };
+                let Some(name) = surface.strip_prefix('&').map(str::trim) else {
+                    return;
+                };
+                if normalize_parameter_name(name).as_deref() == Some(name) {
+                    intervals.push(GoNavigationBindingInterval {
+                        name: name.to_string(),
+                        start_byte: callable.start_byte(),
+                        end_byte: callable.end_byte(),
+                        scope_depth: usize::MAX,
+                        owner: None,
+                    });
+                }
+            }
+            _ => {}
+        }
+        if !go_navigation_node_is_captured(node, callable) || node.kind() != "identifier" {
+            return;
+        }
+        let Some(name) = normalized_receiver_variable(node, source) else {
+            return;
+        };
+        intervals.push(GoNavigationBindingInterval {
+            name,
+            start_byte: callable.start_byte(),
+            end_byte: callable.end_byte(),
+            scope_depth: usize::MAX,
+            owner: None,
+        });
+    });
+    let decisions = go_navigation_binding_decisions(source.len(), &intervals, &calls);
+    for call in calls {
+        let Some(owner) = decisions.get(&call.node.id()) else {
+            continue;
+        };
+        let method_col = member_call_method_col(call.node, source, &call.method_name);
         local_binding_callsites.insert(ReceiverCallSiteKey {
-            receiver_name: receiver_name.clone(),
-            method_name: method_name.clone(),
-            line: Some(node.start_position().row as u32 + 1),
+            receiver_name: call.receiver_name.clone(),
+            method_name: call.method_name.clone(),
+            line: Some(call.node.start_position().row as u32 + 1),
             method_col,
         });
-        if let Some((owner_name, owner_module)) = owner_name {
+        if let Some((owner_name, owner_module)) = owner {
             edges.push(ManualReceiverCallSpec {
                 source_name: call_source.name.to_string(),
                 source_span: call_source.span,
-                receiver_name,
-                owner_name,
-                owner_module,
-                method_name,
+                receiver_name: call.receiver_name,
+                owner_name: owner_name.clone(),
+                owner_module: owner_module.clone(),
+                method_name: call.method_name,
                 method_col,
-                line: Some(node.start_position().row as u32 + 1),
+                line: Some(call.node.start_position().row as u32 + 1),
                 allow_global_fallback: false,
                 binding_marker: None,
                 required_callsite_marker: None,
@@ -321,71 +517,223 @@ fn collect_go_local_composite_receiver_call_specs(
                 owner_is_syntactic: false,
             });
         }
-    });
+    }
 }
 
-fn go_visible_local_composite_owner(
-    callable: TsNode<'_>,
-    call_node: TsNode<'_>,
-    receiver_name: &str,
-    source: &str,
-    import_bindings: &HashMap<String, String>,
-) -> Option<OptionalReceiverOwnerBinding> {
-    let mut visible_bindings = Vec::new();
-    walk_tree_nodes(callable, &mut |node| {
-        if !matches!(
-            node.kind(),
-            "short_var_declaration" | "assignment_statement"
-        ) {
-            return;
+struct GoNavigationCall<'tree> {
+    node: TsNode<'tree>,
+    receiver_name: String,
+    method_name: String,
+}
+
+struct GoNavigationBindingInterval {
+    name: String,
+    start_byte: usize,
+    end_byte: usize,
+    scope_depth: usize,
+    owner: OptionalReceiverOwnerBinding,
+}
+
+#[derive(Clone, Copy)]
+enum GoNavigationEvent {
+    End(usize),
+    Start(usize),
+    Call(usize),
+}
+
+fn go_navigation_binding_decisions(
+    source_len: usize,
+    intervals: &[GoNavigationBindingInterval],
+    calls: &[GoNavigationCall<'_>],
+) -> HashMap<usize, OptionalReceiverOwnerBinding> {
+    let mut events = vec![Vec::new(); source_len.saturating_add(1)];
+    for (index, interval) in intervals.iter().enumerate() {
+        if interval.start_byte >= interval.end_byte || interval.end_byte > source_len {
+            continue;
         }
-        if !receiver_call_belongs_to_callable(node, callable)
-            || node.end_byte() > call_node.start_byte()
+        events[interval.start_byte].push(GoNavigationEvent::Start(index));
+        events[interval.end_byte].push(GoNavigationEvent::End(index));
+        count_go_navigation_resolution_work(2);
+    }
+    for (index, call) in calls.iter().enumerate() {
+        if call.node.start_byte() <= source_len {
+            events[call.node.start_byte()].push(GoNavigationEvent::Call(index));
+            count_go_navigation_resolution_work(1);
+        }
+    }
+    let mut active = HashMap::<String, BTreeMap<usize, HashSet<usize>>>::new();
+    let mut decisions = HashMap::new();
+    for bucket in events {
+        count_go_navigation_resolution_work(1);
+        for event in bucket
+            .iter()
+            .copied()
+            .filter(|event| matches!(event, GoNavigationEvent::End(_)))
         {
-            return;
+            let GoNavigationEvent::End(index) = event else {
+                unreachable!()
+            };
+            let interval = &intervals[index];
+            if let Some(depths) = active.get_mut(&interval.name) {
+                if let Some(entries) = depths.get_mut(&interval.scope_depth) {
+                    entries.remove(&index);
+                    if entries.is_empty() {
+                        depths.remove(&interval.scope_depth);
+                    }
+                }
+                if depths.is_empty() {
+                    active.remove(&interval.name);
+                }
+            }
+            count_go_navigation_resolution_work(1);
         }
-        if !go_local_binding_visible_at_call(node, call_node) {
-            return;
+        for event in bucket
+            .iter()
+            .copied()
+            .filter(|event| matches!(event, GoNavigationEvent::Start(_)))
+        {
+            let GoNavigationEvent::Start(index) = event else {
+                unreachable!()
+            };
+            let interval = &intervals[index];
+            active
+                .entry(interval.name.clone())
+                .or_default()
+                .entry(interval.scope_depth)
+                .or_default()
+                .insert(index);
+            count_go_navigation_resolution_work(1);
         }
-        let Some(owner_name) =
-            go_receiver_write_owner(node, receiver_name, source, import_bindings)
-        else {
-            return;
-        };
-        visible_bindings.push((node.end_byte(), owner_name));
-    });
-    visible_bindings.sort_by_key(|(end_byte, _)| *end_byte);
-    visible_bindings.pop().map(|(_, owner_name)| owner_name)
+        for event in bucket
+            .iter()
+            .copied()
+            .filter(|event| matches!(event, GoNavigationEvent::Call(_)))
+        {
+            let GoNavigationEvent::Call(index) = event else {
+                unreachable!()
+            };
+            let call = &calls[index];
+            let Some((_, entries)) = active
+                .get(&call.receiver_name)
+                .and_then(BTreeMap::last_key_value)
+            else {
+                continue;
+            };
+            let latest_start = entries
+                .iter()
+                .map(|index| intervals[*index].start_byte)
+                .max()
+                .expect("active binding set is non-empty");
+            let mut latest = entries
+                .iter()
+                .filter(|index| intervals[**index].start_byte == latest_start);
+            let owner = latest
+                .next()
+                .filter(|_| latest.next().is_none())
+                .and_then(|index| intervals[*index].owner.clone());
+            decisions.insert(call.node.id(), owner);
+            count_go_navigation_resolution_work(1);
+        }
+    }
+    decisions
 }
 
-fn go_receiver_write_owner(
+fn go_navigation_binding_scope(
+    mut node: TsNode<'_>,
+    callable: TsNode<'_>,
+) -> Option<(usize, usize)> {
+    let mut depth = 0usize;
+    loop {
+        if node.kind() == "block" {
+            return Some((node.end_byte(), depth.saturating_add(1)));
+        }
+        if node.id() == callable.id() {
+            return Some((callable.end_byte(), depth));
+        }
+        node = node.parent()?;
+        depth = depth.saturating_add(usize::from(node.kind() == "block"));
+    }
+}
+
+fn go_navigation_declared_names(node: TsNode<'_>, source: &str) -> Vec<String> {
+    let boundary = node
+        .child_by_field_name("type")
+        .or_else(|| node.child_by_field_name("value"))
+        .map(|child| child.start_byte())
+        .unwrap_or(usize::MAX);
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor)
+        .take_while(|child| child.start_byte() < boundary)
+        .filter_map(|child| normalized_receiver_variable(child, source))
+        .collect()
+}
+
+fn go_navigation_special_binding(
     node: TsNode<'_>,
-    receiver_name: &str,
+    callable: TsNode<'_>,
     source: &str,
-    import_bindings: &HashMap<String, String>,
-) -> Option<OptionalReceiverOwnerBinding> {
-    if !matches!(
-        node.kind(),
-        "short_var_declaration" | "assignment_statement"
-    ) {
+) -> Option<(Vec<String>, usize, usize)> {
+    let surface = trimmed_node_text(node, source)?;
+    let names = go_navigation_special_names(&surface);
+    if names.is_empty() {
         return None;
     }
-    let left_items = node
-        .child_by_field_name("left")
-        .map(go_expression_list_items)
+    let boundary_kind = match node.kind() {
+        "range_clause" => "for_statement",
+        "receive_statement" => "communication_case",
+        "type_switch_guard" => "type_switch_statement",
+        _ => return None,
+    };
+    let mut boundary = node;
+    while boundary.kind() != boundary_kind {
+        boundary = boundary.parent()?;
+        if boundary.id() == callable.id() {
+            return None;
+        }
+    }
+    let declaration = surface.contains(":=");
+    Some((
+        names,
+        if declaration {
+            boundary.end_byte()
+        } else {
+            callable.end_byte()
+        },
+        if declaration {
+            go_navigation_binding_scope(boundary, callable)?
+                .1
+                .saturating_add(1)
+        } else {
+            usize::MAX - 2
+        },
+    ))
+}
+
+fn go_navigation_special_names(surface: &str) -> Vec<String> {
+    let left = surface
+        .split_once(":=")
+        .or_else(|| surface.split_once('='))
+        .map(|(left, _)| left)
         .unwrap_or_default();
-    let receiver_index = left_items.iter().position(|left| {
-        normalized_receiver_variable(*left, source).as_deref() == Some(receiver_name)
-    })?;
-    let owner_name = node
-        .child_by_field_name("right")
-        .map(go_expression_list_items)
-        .and_then(|right_items| {
-            right_items.get(receiver_index).and_then(|right| {
-                go_direct_composite_literal_owner(*right, source, import_bindings)
-            })
-        });
-    Some(owner_name)
+    left.rsplit([';', '{', ':'])
+        .next()
+        .unwrap_or(left)
+        .split(',')
+        .filter_map(normalize_parameter_name)
+        .filter(|name| name != "_")
+        .collect()
+}
+
+fn go_navigation_node_is_captured(mut node: TsNode<'_>, callable: TsNode<'_>) -> bool {
+    let mut crossed_closure = false;
+    while node.id() != callable.id() {
+        crossed_closure |= node.kind() == "func_literal";
+        let Some(parent) = node.parent() else {
+            return false;
+        };
+        node = parent;
+    }
+    crossed_closure
 }
 
 fn go_expression_list_items(node: TsNode<'_>) -> Vec<TsNode<'_>> {
@@ -404,8 +752,10 @@ fn go_direct_composite_literal_owner(
     node: TsNode<'_>,
     source: &str,
     import_bindings: &HashMap<String, String>,
+    builtin_new_unshadowed: bool,
 ) -> OptionalReceiverOwnerBinding {
-    if let Some(owner) = go_builtin_new_owner(node, source, import_bindings) {
+    if let Some(owner) = go_builtin_new_owner(node, source, import_bindings, builtin_new_unshadowed)
+    {
         return Some(owner);
     }
     if node.kind() == "composite_literal" {
@@ -417,20 +767,37 @@ fn go_direct_composite_literal_owner(
                 go_composite_literal_owner_binding_from_type(type_surface, import_bindings)
             });
     }
-    trimmed_node_text(node, source)
-        .as_deref()
-        .and_then(|surface| go_direct_composite_literal_owner_surface(surface, import_bindings))
+    if node.kind() == "unary_expression"
+        && trimmed_node_text(node, source)
+            .as_deref()
+            .is_some_and(|surface| surface.trim_start().starts_with('&'))
+    {
+        let mut cursor = node.walk();
+        let children = node.named_children(&mut cursor).collect::<Vec<_>>();
+        let [literal] = children.as_slice() else {
+            return None;
+        };
+        if literal.kind() != "composite_literal" {
+            return None;
+        }
+        return literal
+            .child_by_field_name("type")
+            .and_then(|type_node| trimmed_node_text(type_node, source))
+            .as_deref()
+            .and_then(|type_surface| {
+                go_composite_literal_owner_binding_from_type(type_surface, import_bindings)
+            });
+    }
+    None
 }
 
 fn go_builtin_new_owner(
     node: TsNode<'_>,
     source: &str,
     import_bindings: &HashMap<String, String>,
+    builtin_new_unshadowed: bool,
 ) -> OptionalReceiverOwnerBinding {
-    if node.kind() != "call_expression"
-        || import_bindings.contains_key("new")
-        || go_builtin_name_is_shadowed(node, "new", source)
-    {
+    if node.kind() != "call_expression" || !builtin_new_unshadowed {
         return None;
     }
     let function = node.child_by_field_name("function")?;
@@ -449,19 +816,11 @@ fn go_builtin_new_owner(
     go_composite_literal_owner_binding_from_type(&raw_type, import_bindings)
 }
 
-fn go_builtin_name_is_shadowed(call: TsNode<'_>, name: &str, source: &str) -> bool {
-    if go_file_scope_name_is_shadowed(call, name, source) {
-        return true;
-    }
-    let Some(callable) = enclosing_node_with_kind(
-        call,
-        &["function_declaration", "method_declaration", "func_literal"],
-    ) else {
-        return false;
-    };
+fn go_callable_declares_name(callable: TsNode<'_>, name: &str, source: &str) -> bool {
     let mut shadowed = false;
     walk_tree_nodes(callable, &mut |node| {
-        if shadowed || node.start_byte() >= call.start_byte() {
+        count_go_navigation_resolution_work(1);
+        if shadowed {
             return;
         }
         match node.kind() {
@@ -477,9 +836,6 @@ fn go_builtin_name_is_shadowed(call: TsNode<'_>, name: &str, source: &str) -> bo
                 });
             }
             "short_var_declaration" | "assignment_statement" => {
-                if !go_local_binding_visible_at_call(node, call) {
-                    return;
-                }
                 shadowed = node
                     .child_by_field_name("left")
                     .map(go_expression_list_items)
@@ -489,15 +845,17 @@ fn go_builtin_name_is_shadowed(call: TsNode<'_>, name: &str, source: &str) -> bo
                         normalized_receiver_variable(left, source).as_deref() == Some(name)
                     });
             }
-            "var_spec" => {
-                if !go_local_binding_visible_at_call(node, call) {
-                    return;
-                }
-                let mut cursor = node.walk();
-                shadowed = node.named_children(&mut cursor).any(|child| {
-                    matches!(child.kind(), "identifier" | "field_identifier")
-                        && normalized_receiver_variable(child, source).as_deref() == Some(name)
-                });
+            "var_spec" | "const_spec" | "type_spec" => {
+                shadowed = go_navigation_declared_names(node, source)
+                    .iter()
+                    .any(|declared| declared == name);
+            }
+            "range_clause" | "receive_statement" | "type_switch_guard" => {
+                shadowed = trimmed_node_text(node, source)
+                    .map(|surface| go_navigation_special_names(&surface))
+                    .unwrap_or_default()
+                    .iter()
+                    .any(|declared| declared == name);
             }
             _ => {}
         }
@@ -544,35 +902,12 @@ fn go_file_scope_name_is_shadowed(call: TsNode<'_>, name: &str, source: &str) ->
         })
 }
 
-fn go_direct_composite_literal_owner_surface(
-    surface: &str,
-    import_bindings: &HashMap<String, String>,
-) -> OptionalReceiverOwnerBinding {
-    let surface = surface.trim().trim_start_matches('&').trim();
-    if !surface.contains('{') {
-        return None;
-    }
-    let type_surface = surface
-        .split_once('{')
-        .map(|(type_surface, _)| type_surface)
-        .unwrap_or(surface)
-        .trim();
-    go_composite_literal_owner_binding_from_type(type_surface, import_bindings)
-}
-
 fn go_composite_literal_owner_binding_from_type(
     type_surface: &str,
     import_bindings: &HashMap<String, String>,
 ) -> OptionalReceiverOwnerBinding {
-    let type_surface = type_surface.trim().trim_start_matches('&').trim();
-    if type_surface.contains('(')
-        || type_surface.contains(')')
-        || type_surface.starts_with("[]")
-        || type_surface.starts_with("map[")
-    {
-        return None;
-    }
-    let owner_name = normalize_go_type_surface(type_surface)?;
+    let type_surface = type_surface.trim();
+    let (qualifier, owner_name) = go_exact_type_surface(type_surface)?;
     if !owner_name
         .chars()
         .next()
@@ -580,28 +915,11 @@ fn go_composite_literal_owner_binding_from_type(
     {
         return None;
     }
-    if let Some(qualifier) = go_type_import_qualifier(type_surface) {
+    if let Some(qualifier) = qualifier {
         let module_name = import_bindings.get(&qualifier)?;
         return Some((owner_name, Some(module_name.clone())));
     }
-    if type_surface.contains('.') {
-        return None;
-    }
     Some((owner_name, None))
-}
-
-fn go_local_binding_visible_at_call(binding: TsNode<'_>, call_node: TsNode<'_>) -> bool {
-    let Some(binding_scope) = go_lexical_scope(binding) else {
-        return false;
-    };
-    let Some(call_scope) = go_lexical_scope(call_node) else {
-        return false;
-    };
-    node_is_same_or_ancestor(binding_scope, call_scope)
-}
-
-fn go_lexical_scope(node: TsNode<'_>) -> Option<TsNode<'_>> {
-    enclosing_node_with_kind(node, &["block"])
 }
 
 fn collect_go_method_receiver_bindings(
@@ -905,16 +1223,7 @@ fn collect_go_parameter_type_modules(
 }
 
 fn go_type_import_qualifier(raw_type: &str) -> Option<String> {
-    let mut surface = raw_type.trim();
-    while let Some(stripped) = surface.strip_prefix('*') {
-        surface = stripped.trim_start();
-    }
-    while let Some(stripped) = surface.strip_prefix("[]") {
-        surface = stripped.trim_start();
-    }
-    let base = surface.split('[').next().unwrap_or(surface).trim();
-    let (qualifier, _) = base.rsplit_once('.')?;
-    normalize_parameter_name(qualifier)
+    go_exact_type_surface(raw_type)?.0
 }
 
 fn selector_call(node: TsNode<'_>, source: &str) -> Option<(String, String)> {
@@ -931,4 +1240,52 @@ fn selector_call(node: TsNode<'_>, source: &str) -> Option<(String, String)> {
         normalized_receiver_variable(receiver, source)?,
         trimmed_node_text(method, source)?,
     ))
+}
+
+#[cfg(test)]
+mod complexity_tests {
+    use super::*;
+    use tree_sitter::Parser;
+
+    fn measured_receiver_work(binding_count: usize, call_count: usize) -> usize {
+        let mut source = String::from(
+            "package proof\ntype Worker struct{}\nfunc (*Worker) Run() {}\nfunc caller() {\n",
+        );
+        for index in 0..binding_count {
+            source.push_str(&format!("  worker{index} := &Worker{{}}\n"));
+        }
+        for index in 0..call_count {
+            source.push_str(&format!("  worker{}.Run()\n", index % binding_count.max(1)));
+        }
+        source.push_str("}\n");
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_go::LANGUAGE.into())
+            .expect("Go grammar must load");
+        let tree = parser.parse(&source, None).expect("Go source must parse");
+        reset_go_navigation_resolution_work();
+        let _ = receiver_call_specs(&tree, &source);
+        go_navigation_resolution_work()
+    }
+
+    #[test]
+    fn receiver_binding_preparation_and_lookup_work_is_independently_linear() {
+        let baseline = measured_receiver_work(32, 32);
+        let more_bindings = measured_receiver_work(64, 32);
+        let more_calls = measured_receiver_work(32, 64);
+        let combined = measured_receiver_work(64, 64);
+        assert!(baseline > 0, "Go navigation work was not counted");
+        assert!(
+            more_bindings <= baseline * 2 + 128,
+            "Go receiver binding preparation grew superlinearly: {baseline} -> {more_bindings}"
+        );
+        assert!(
+            more_calls <= baseline * 2 + 128,
+            "Go receiver lookup work grew superlinearly: {baseline} -> {more_calls}"
+        );
+        assert!(
+            combined <= baseline * 2 + 256,
+            "combined Go receiver work grew superlinearly: {baseline} -> {combined}"
+        );
+    }
 }

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -16457,6 +16457,7 @@ mod proof_resolution_cache_tests {
                 rust_modules: Vec::new(),
                 rust_types: Vec::new(),
                 rust_uses: Vec::new(),
+                go_package: None,
             }),
         };
 

--- a/crates/codestory-indexer/src/proof_resolution.rs
+++ b/crates/codestory-indexer/src/proof_resolution.rs
@@ -1,8 +1,9 @@
 use crate::cache::{
     CachedCallResolutionInput, CachedClassBinding, CachedClassDeclaration, CachedClassMethod,
-    CachedDeclarationKind, CachedDirectExport, CachedIndexArtifact, CachedInherentMethod,
-    CachedResolutionBinding, CachedResolutionFile, CachedRustFileModule, CachedRustModule,
-    CachedRustType, CachedRustUseBinding, CachedTopLevelDeclaration,
+    CachedDeclarationKind, CachedDirectExport, CachedGoMethod, CachedGoPackage, CachedGoType,
+    CachedIndexArtifact, CachedInherentMethod, CachedResolutionBinding, CachedResolutionFile,
+    CachedRustFileModule, CachedRustModule, CachedRustType, CachedRustUseBinding,
+    CachedTopLevelDeclaration,
 };
 use crate::source_content_hash;
 use anyhow::{Context, Result, anyhow};
@@ -25,6 +26,7 @@ use tree_sitter::{Node as TsNode, Tree};
 #[cfg(test)]
 thread_local! {
     static RUST_RESOLUTION_WORK: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static GO_RESOLUTION_WORK: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
 
 #[inline]
@@ -45,9 +47,28 @@ fn rust_resolution_work() -> usize {
     RUST_RESOLUTION_WORK.with(std::cell::Cell::get)
 }
 
-const ADAPTER_VERSION: &str = "reference-v9";
-const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 7;
+#[inline]
+fn count_go_resolution_work(amount: usize) {
+    #[cfg(test)]
+    GO_RESOLUTION_WORK.with(|work| work.set(work.get().saturating_add(amount)));
+    #[cfg(not(test))]
+    let _ = amount;
+}
+
+#[cfg(test)]
+fn reset_go_resolution_work() {
+    GO_RESOLUTION_WORK.with(|work| work.set(0));
+}
+
+#[cfg(test)]
+fn go_resolution_work() -> usize {
+    GO_RESOLUTION_WORK.with(std::cell::Cell::get)
+}
+
+const ADAPTER_VERSION: &str = "reference-v10";
+const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 8;
 const INSTALLED_ADAPTERS: &[(&str, &str)] = &[
+    ("go", ADAPTER_VERSION),
     ("javascript", ADAPTER_VERSION),
     ("rust", ADAPTER_VERSION),
     ("tsx", ADAPTER_VERSION),
@@ -80,6 +101,8 @@ pub(crate) fn collect_call_resolution_inputs(
         .then(|| JavascriptResolutionIndex::build(tree, source, file_id, nodes));
     let rust_index =
         (language == "rust").then(|| RustResolutionIndex::build(tree, source, file_id, nodes));
+    let go_index =
+        (language == "go").then(|| GoResolutionIndex::build(tree, source, file_id, nodes));
     let (direct_exports, export_poison_all, poisoned_export_names) =
         if let Some(index) = &javascript_index {
             index.collect_direct_exports(source)
@@ -93,6 +116,8 @@ pub(crate) fn collect_call_resolution_inputs(
         index.cached_top_level_declarations()
     } else if let Some(index) = &rust_index {
         index.declarations.clone()
+    } else if let Some(index) = &go_index {
+        index.declarations.clone()
     } else {
         Vec::new()
     };
@@ -102,55 +127,67 @@ pub(crate) fn collect_call_resolution_inputs(
         Vec::new()
     };
     let mut calls = Vec::new();
-    let mut emit_call = |callee: TsNode<'_>,
-                         form: CalleeForm,
-                         raw_target: String,
-                         rust_callable_id: Option<usize>| {
-        let mut callsite = ExactCallsite {
-            file_id: FileId(file_id.0),
-            source_sha256: source_sha256.clone(),
-            start_byte: callee.start_byte() as u64,
-            end_byte_exclusive: callee.end_byte() as u64,
-            line: callee.start_position().row as u32 + 1,
-            column: callee.start_position().column as u32 + 1,
-            callee_form: form,
-            raw_target: raw_target.clone(),
-        };
-        let (caller, mut binding) = if let Some(index) = &rust_index {
-            index.resolve_syntax_claim(source, callee, form, &raw_target, rust_callable_id)
-        } else if let Some(index) = &javascript_index {
-            index.resolve_syntax_claim(source, callee, form, &raw_target)
-        } else {
-            (None, CachedResolutionBinding::Unsupported)
-        };
-        if !lookup_input_complete {
-            binding = CachedResolutionBinding::IncompleteDomain;
-        }
-        if matches!(binding, CachedResolutionBinding::StaticImport { .. })
-            || matches!(
+    let mut emit_call =
+        |callee: TsNode<'_>, form: CalleeForm, raw_target: String, callable_id: Option<usize>| {
+            let mut callsite = ExactCallsite {
+                file_id: FileId(file_id.0),
+                source_sha256: source_sha256.clone(),
+                start_byte: callee.start_byte() as u64,
+                end_byte_exclusive: callee.end_byte() as u64,
+                line: callee.start_position().row as u32 + 1,
+                column: callee.start_position().column as u32 + 1,
+                callee_form: form,
+                raw_target: raw_target.clone(),
+            };
+            let (caller, mut binding) = if let Some(index) = &rust_index {
+                index.resolve_syntax_claim(source, callee, form, &raw_target, callable_id)
+            } else if let Some(index) = &go_index {
+                index.resolve_syntax_claim(source, callee, form, &raw_target, callable_id)
+            } else if let Some(index) = &javascript_index {
+                index.resolve_syntax_claim(source, callee, form, &raw_target)
+            } else {
+                (None, CachedResolutionBinding::Unsupported)
+            };
+            if !lookup_input_complete {
+                binding = CachedResolutionBinding::IncompleteDomain;
+            }
+            if matches!(binding, CachedResolutionBinding::GoImplicitReceiver { .. }) {
+                callsite.callee_form = CalleeForm::ImplicitReceiver;
+            }
+            if matches!(binding, CachedResolutionBinding::StaticImport { .. })
+                || matches!(
+                    binding,
+                    CachedResolutionBinding::RustPath {
+                        import: Some(_),
+                        ..
+                    }
+                ) && form == CalleeForm::Identifier
+            {
+                callsite.callee_form = CalleeForm::NamedImport;
+            }
+            calls.push(CachedCallResolutionInput {
+                callsite,
+                caller,
                 binding,
-                CachedResolutionBinding::RustPath {
-                    import: Some(_),
-                    ..
-                }
-            ) && form == CalleeForm::Identifier
-        {
-            callsite.callee_form = CalleeForm::NamedImport;
-        }
-        calls.push(CachedCallResolutionInput {
-            callsite,
-            caller,
-            binding,
-            language: language.to_string(),
-            adapter_version: ADAPTER_VERSION.to_string(),
-            parser_fingerprint: parser_fingerprint.to_string(),
-        });
-    };
+                language: language.to_string(),
+                adapter_version: ADAPTER_VERSION.to_string(),
+                parser_fingerprint: parser_fingerprint.to_string(),
+            });
+        };
     if let Some(index) = &javascript_index {
         for call in &index.calls {
             emit_call(call.callee, call.form, call.raw_target.clone(), None);
         }
     } else if let Some(index) = &rust_index {
+        for call in &index.calls {
+            emit_call(
+                call.callee,
+                call.form,
+                call.raw_target.clone(),
+                call.callable_id,
+            );
+        }
+    } else if let Some(index) = &go_index {
         for call in &index.calls {
             emit_call(
                 call.callee,
@@ -193,6 +230,7 @@ pub(crate) fn collect_call_resolution_inputs(
             rust_uses: rust_index
                 .as_ref()
                 .map_or_else(Vec::new, |index| index.uses.clone()),
+            go_package: go_index.as_ref().map(GoResolutionIndex::cached_package),
         }),
     }
 }
@@ -295,6 +333,1223 @@ fn classify_callee<'tree>(
             ))
         }
     }
+}
+
+#[derive(Debug, Clone)]
+struct IndexedGoCall<'tree> {
+    callee: TsNode<'tree>,
+    form: CalleeForm,
+    raw_target: String,
+    callable_id: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
+struct GoReceiverBinding {
+    owner_name: String,
+    pointer: bool,
+    constructor: bool,
+    constructor_uses_builtin_new: bool,
+    imported: bool,
+    implicit: bool,
+}
+
+struct GoResolutionIndex<'tree> {
+    calls: Vec<IndexedGoCall<'tree>>,
+    package_name: Option<String>,
+    declarations: Vec<CachedTopLevelDeclaration>,
+    types: Vec<CachedGoType>,
+    methods: Vec<CachedGoMethod>,
+    package_blockers: Vec<String>,
+    import_names: HashSet<String>,
+    import_domain_complete: bool,
+    callable_nodes: HashMap<usize, NodeId>,
+    binding_decisions: HashMap<(usize, usize, String), GoBindingDecision>,
+    build_constrained: bool,
+    generated: bool,
+}
+
+#[derive(Debug, Clone)]
+enum GoBindingDecision {
+    Receiver(GoReceiverBinding),
+    Blocked,
+}
+
+#[derive(Debug, Clone)]
+struct GoBindingInterval {
+    name: String,
+    callable_id: usize,
+    start_byte: usize,
+    end_byte: usize,
+    scope_depth: usize,
+    receiver: Option<GoReceiverBinding>,
+}
+
+impl<'tree> GoResolutionIndex<'tree> {
+    fn build(tree: &'tree Tree, source: &str, file_id: NodeId, nodes: &[Node]) -> Self {
+        let root = tree.root_node();
+        let package_name = go_package_name(root, source);
+        let graph_nodes = GoGraphNodeIndex::prepare(file_id, nodes);
+        let import_domain = go_import_domain(root, source);
+        let mut result = Self {
+            calls: Vec::new(),
+            package_name,
+            declarations: Vec::new(),
+            types: Vec::new(),
+            methods: Vec::new(),
+            package_blockers: Vec::new(),
+            import_names: import_domain.names,
+            import_domain_complete: import_domain.complete,
+            callable_nodes: HashMap::new(),
+            binding_decisions: HashMap::new(),
+            build_constrained: go_source_has_build_constraint(source),
+            generated: go_source_is_generated(root, source),
+        };
+        walk_nodes(root, &mut |node| {
+            count_go_resolution_work(1);
+            match node.kind() {
+                "function_declaration" => {
+                    let Some(name_node) = node.child_by_field_name("name") else {
+                        return;
+                    };
+                    let Some(name) = node_text(name_node, source).map(str::to_string) else {
+                        return;
+                    };
+                    if let Some(declaration) = graph_nodes.unique(
+                        NodeKind::FUNCTION,
+                        node.start_position().row as u32 + 1,
+                        &name,
+                    ) {
+                        result.callable_nodes.insert(node.id(), declaration);
+                        if node.parent().is_some_and(|parent| parent.id() == root.id()) {
+                            result.declarations.push(CachedTopLevelDeclaration {
+                                name,
+                                declaration,
+                                module_path: Vec::new(),
+                                cross_module_visible: false,
+                            });
+                        }
+                    }
+                }
+                "method_declaration" => {
+                    let Some(name_node) = node.child_by_field_name("name") else {
+                        return;
+                    };
+                    let Some(name) = node_text(name_node, source).map(str::to_string) else {
+                        return;
+                    };
+                    let Some(receiver) = node.child_by_field_name("receiver") else {
+                        return;
+                    };
+                    let Some((owner_name, pointer_receiver, _)) =
+                        go_receiver_declaration(receiver, source)
+                    else {
+                        return;
+                    };
+                    if let Some(declaration) = graph_nodes.unique(
+                        NodeKind::METHOD,
+                        node.start_position().row as u32 + 1,
+                        &name,
+                    ) {
+                        result.callable_nodes.insert(node.id(), declaration);
+                        result.methods.push(CachedGoMethod {
+                            owner_name,
+                            method_name: name,
+                            declaration,
+                            pointer_receiver,
+                        });
+                    }
+                }
+                "type_spec" => {
+                    if !go_spec_is_package_level(node, root) {
+                        return;
+                    }
+                    let Some(name_node) = node.child_by_field_name("name") else {
+                        return;
+                    };
+                    let Some(name) = node_text(name_node, source).map(str::to_string) else {
+                        return;
+                    };
+                    let declaration_node = node
+                        .parent()
+                        .filter(|parent| parent.kind() == "type_declaration")
+                        .unwrap_or(node);
+                    if let Some(declaration) = graph_nodes.unique(
+                        NodeKind::STRUCT,
+                        declaration_node.start_position().row as u32 + 1,
+                        &name,
+                    ) {
+                        let kind = node.child_by_field_name("type");
+                        result.types.push(CachedGoType {
+                            name,
+                            declaration,
+                            interface: kind.is_some_and(|kind| kind.kind() == "interface_type"),
+                            generic: node.child_by_field_name("type_parameters").is_some(),
+                        });
+                    }
+                }
+                "var_spec" | "const_spec" => {
+                    if go_spec_is_package_level(node, root) {
+                        go_declared_names(node, source, &mut result.package_blockers);
+                    }
+                }
+                "comment" => {
+                    if let Some(name) = go_linkname_local_name(node, source) {
+                        result.package_blockers.push(name);
+                    }
+                }
+                "call_expression" => {
+                    let Some(function) = node.child_by_field_name("function") else {
+                        return;
+                    };
+                    let callable_id = go_enclosing_callable(node).map(|callable| callable.id());
+                    match function.kind() {
+                        "identifier" => {
+                            if let Some(raw_target) = node_text(function, source) {
+                                result.calls.push(IndexedGoCall {
+                                    callee: function,
+                                    form: CalleeForm::Identifier,
+                                    raw_target: raw_target.to_string(),
+                                    callable_id,
+                                });
+                            }
+                        }
+                        "selector_expression" => {
+                            let Some(field) = function.child_by_field_name("field") else {
+                                return;
+                            };
+                            let Some(raw_target) = node_text(field, source) else {
+                                return;
+                            };
+                            result.calls.push(IndexedGoCall {
+                                callee: field,
+                                form: CalleeForm::ExplicitReceiver,
+                                raw_target: raw_target.to_string(),
+                                callable_id,
+                            });
+                        }
+                        _ => {
+                            let mut cursor = function.walk();
+                            let leaf = function
+                                .named_children(&mut cursor)
+                                .last()
+                                .unwrap_or(function);
+                            result.calls.push(IndexedGoCall {
+                                callee: leaf,
+                                form: CalleeForm::DynamicAccess,
+                                raw_target: node_text(leaf, source)
+                                    .unwrap_or(function.kind())
+                                    .to_string(),
+                                callable_id,
+                            });
+                        }
+                    }
+                }
+                _ => {}
+            }
+        });
+        result.declarations.sort_by(|left, right| {
+            left.name
+                .cmp(&right.name)
+                .then(left.declaration.cmp(&right.declaration))
+        });
+        result.types.sort_by(|left, right| {
+            left.name
+                .cmp(&right.name)
+                .then(left.declaration.cmp(&right.declaration))
+        });
+        result.methods.sort_by(|left, right| {
+            (&left.owner_name, &left.method_name, left.declaration).cmp(&(
+                &right.owner_name,
+                &right.method_name,
+                right.declaration,
+            ))
+        });
+        result.package_blockers.sort();
+        result.package_blockers.dedup();
+        result
+            .calls
+            .sort_by_key(|call| (call.callee.start_byte(), call.callee.end_byte()));
+        result.binding_decisions =
+            go_prepare_binding_decisions(root, source, &result.calls, &result.import_names);
+        result
+    }
+
+    fn cached_package(&self) -> CachedGoPackage {
+        CachedGoPackage {
+            name: self.package_name.clone().unwrap_or_default(),
+            build_constrained: self.build_constrained,
+            generated: self.generated,
+            package_blockers: self.package_blockers.clone(),
+            types: self.types.clone(),
+            methods: self.methods.clone(),
+        }
+    }
+
+    fn resolve_syntax_claim(
+        &self,
+        source: &str,
+        callee: TsNode<'tree>,
+        form: CalleeForm,
+        raw_target: &str,
+        callable_id: Option<usize>,
+    ) -> (Option<NodeId>, CachedResolutionBinding) {
+        let Some(callable_id) = callable_id else {
+            return (None, CachedResolutionBinding::MissingBinding);
+        };
+        let Some(caller) = self.callable_nodes.get(&callable_id).copied() else {
+            return (None, CachedResolutionBinding::Ambiguous);
+        };
+        let Some(package_name) = self.package_name.clone() else {
+            return (Some(caller), CachedResolutionBinding::IncompleteDomain);
+        };
+        if self.build_constrained {
+            return (Some(caller), CachedResolutionBinding::IncompleteDomain);
+        }
+        if self.generated {
+            return (Some(caller), CachedResolutionBinding::Unsupported);
+        }
+        if !self.import_domain_complete {
+            return (Some(caller), CachedResolutionBinding::IncompleteDomain);
+        }
+        match form {
+            CalleeForm::Identifier => {
+                if self.import_names.contains(raw_target)
+                    || self.binding_decisions.contains_key(&(
+                        callable_id,
+                        callee.start_byte(),
+                        raw_target.to_string(),
+                    ))
+                {
+                    return (Some(caller), CachedResolutionBinding::Unsupported);
+                }
+                (
+                    Some(caller),
+                    CachedResolutionBinding::GoPackageFunction {
+                        package_name,
+                        name: raw_target.to_string(),
+                    },
+                )
+            }
+            CalleeForm::ExplicitReceiver => {
+                let Some(call) = callee.parent().and_then(|selector| selector.parent()) else {
+                    return (Some(caller), CachedResolutionBinding::Unsupported);
+                };
+                let Some(selector) = call.child_by_field_name("function") else {
+                    return (Some(caller), CachedResolutionBinding::Unsupported);
+                };
+                let Some(receiver) = selector.child_by_field_name("operand") else {
+                    return (Some(caller), CachedResolutionBinding::Unsupported);
+                };
+                let Some(receiver_name) = go_simple_identifier(receiver, source) else {
+                    return (Some(caller), CachedResolutionBinding::Unsupported);
+                };
+                if self.import_names.contains(receiver_name) {
+                    return (Some(caller), CachedResolutionBinding::IncompleteDomain);
+                }
+                let binding = match self.binding_decisions.get(&(
+                    callable_id,
+                    callee.start_byte(),
+                    receiver_name.to_string(),
+                )) {
+                    Some(GoBindingDecision::Receiver(binding)) => binding.clone(),
+                    Some(GoBindingDecision::Blocked) | None => {
+                        return (Some(caller), CachedResolutionBinding::Unsupported);
+                    }
+                };
+                if binding.imported {
+                    return (Some(caller), CachedResolutionBinding::IncompleteDomain);
+                }
+                if binding.implicit {
+                    (
+                        Some(caller),
+                        CachedResolutionBinding::GoImplicitReceiver {
+                            package_name,
+                            owner_name: binding.owner_name,
+                            receiver_is_pointer: binding.pointer,
+                        },
+                    )
+                } else {
+                    (
+                        Some(caller),
+                        CachedResolutionBinding::GoExplicitReceiver {
+                            package_name,
+                            owner_name: binding.owner_name,
+                            receiver_is_pointer: binding.pointer,
+                            constructor: binding.constructor,
+                            constructor_uses_builtin_new: binding.constructor_uses_builtin_new,
+                        },
+                    )
+                }
+            }
+            _ => (Some(caller), CachedResolutionBinding::Unsupported),
+        }
+    }
+}
+
+struct GoGraphNodeIndex {
+    nodes: HashMap<(NodeKind, u32, String), Vec<NodeId>>,
+}
+
+impl GoGraphNodeIndex {
+    fn prepare(file_id: NodeId, nodes: &[Node]) -> Self {
+        let mut result = HashMap::<_, Vec<_>>::new();
+        for node in nodes
+            .iter()
+            .filter(|node| node.file_node_id == Some(file_id))
+        {
+            if let Some(line) = node.start_line {
+                result
+                    .entry((
+                        node.kind,
+                        line,
+                        graph_leaf_name(&node.serialized_name).to_string(),
+                    ))
+                    .or_default()
+                    .push(node.id);
+            }
+        }
+        Self { nodes: result }
+    }
+
+    fn unique(&self, kind: NodeKind, line: u32, name: &str) -> Option<NodeId> {
+        let values = self.nodes.get(&(kind, line, name.to_string()))?;
+        let [value] = values.as_slice() else {
+            return None;
+        };
+        Some(*value)
+    }
+}
+
+fn go_package_name(root: TsNode<'_>, source: &str) -> Option<String> {
+    let mut cursor = root.walk();
+    let clauses = root
+        .named_children(&mut cursor)
+        .filter(|node| node.kind() == "package_clause")
+        .collect::<Vec<_>>();
+    let [clause] = clauses.as_slice() else {
+        return None;
+    };
+    let mut cursor = clause.walk();
+    clause
+        .named_children(&mut cursor)
+        .find(|node| node.kind() == "package_identifier")
+        .and_then(|node| node_text(node, source))
+        .map(str::to_string)
+}
+
+fn go_spec_is_package_level(node: TsNode<'_>, root: TsNode<'_>) -> bool {
+    node.parent()
+        .and_then(|declaration| declaration.parent())
+        .is_some_and(|parent| parent.id() == root.id())
+}
+
+fn go_enclosing_callable(mut node: TsNode<'_>) -> Option<TsNode<'_>> {
+    loop {
+        if matches!(node.kind(), "function_declaration" | "method_declaration") {
+            return Some(node);
+        }
+        if node.kind() == "func_literal" {
+            return None;
+        }
+        node = node.parent()?;
+    }
+}
+
+fn go_receiver_declaration(receiver: TsNode<'_>, source: &str) -> Option<(String, bool, String)> {
+    let mut cursor = receiver.walk();
+    let parameters = receiver
+        .named_children(&mut cursor)
+        .filter(|node| node.kind() == "parameter_declaration")
+        .collect::<Vec<_>>();
+    let [parameter] = parameters.as_slice() else {
+        return None;
+    };
+    let type_node = parameter.child_by_field_name("type")?;
+    let binding = go_exact_type_node(type_node, source, &HashSet::new(), true)?;
+    if binding.imported {
+        return None;
+    }
+    let mut cursor = parameter.walk();
+    let names = parameter
+        .named_children(&mut cursor)
+        .take_while(|node| node.start_byte() < type_node.start_byte())
+        .filter_map(|node| go_simple_identifier(node, source).map(str::to_string))
+        .collect::<Vec<_>>();
+    let variable = match names.as_slice() {
+        [] => String::new(),
+        [name] => name.clone(),
+        _ => return None,
+    };
+    Some((binding.owner_name, binding.pointer, variable))
+}
+
+fn go_identifier(value: &str) -> bool {
+    let mut chars = value.chars();
+    chars
+        .next()
+        .is_some_and(|character| character == '_' || character.is_alphabetic())
+        && chars.all(|character| character == '_' || character.is_alphanumeric())
+}
+
+fn go_simple_identifier<'a>(node: TsNode<'_>, source: &'a str) -> Option<&'a str> {
+    (node.kind() == "identifier")
+        .then(|| node_text(node, source))
+        .flatten()
+        .filter(|name| go_identifier(name))
+}
+
+fn go_source_has_build_constraint(source: &str) -> bool {
+    source
+        .lines()
+        .take_while(|line| {
+            let trimmed = line.trim();
+            trimmed.is_empty() || trimmed.starts_with("//")
+        })
+        .any(|line| {
+            let trimmed = line.trim();
+            trimmed.starts_with("//go:build") || trimmed.starts_with("// +build")
+        })
+}
+
+fn go_source_is_generated(root: TsNode<'_>, source: &str) -> bool {
+    let package_start = {
+        let mut cursor = root.walk();
+        root.named_children(&mut cursor)
+            .find(|node| node.kind() == "package_clause")
+            .map(|node| node.start_byte())
+            .unwrap_or(usize::MAX)
+    };
+    let mut cursor = root.walk();
+    root.named_children(&mut cursor)
+        .take_while(|node| node.start_byte() < package_start)
+        .filter(|node| node.kind() == "comment")
+        .filter_map(|node| node_text(node, source))
+        .flat_map(str::lines)
+        .any(|line| {
+            let line = line
+                .trim()
+                .trim_start_matches("/*")
+                .trim_start_matches('*')
+                .trim_end_matches("*/")
+                .trim();
+            line.starts_with("// Code generated ") && line.ends_with(" DO NOT EDIT.")
+        })
+}
+
+fn go_linkname_local_name(node: TsNode<'_>, source: &str) -> Option<String> {
+    let text = node_text(node, source)?.trim();
+    let mut components = text.strip_prefix("//go:linkname")?.split_whitespace();
+    let local = components.next()?;
+    let remote = components.next()?;
+    (components.next().is_none() && go_identifier(local) && !remote.is_empty())
+        .then(|| local.to_string())
+}
+
+fn go_declared_names(node: TsNode<'_>, source: &str, names: &mut Vec<String>) {
+    let boundary = node
+        .child_by_field_name("type")
+        .or_else(|| node.child_by_field_name("value"))
+        .map(|node| node.start_byte())
+        .unwrap_or(usize::MAX);
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        if child.start_byte() >= boundary {
+            break;
+        }
+        if child.kind() == "identifier"
+            && let Some(name) = node_text(child, source)
+        {
+            names.push(name.to_string());
+        }
+    }
+}
+
+struct GoImportDomain {
+    names: HashSet<String>,
+    complete: bool,
+}
+
+fn go_import_domain(root: TsNode<'_>, source: &str) -> GoImportDomain {
+    let mut values = HashSet::new();
+    let mut complete = true;
+    walk_nodes(root, &mut |node| {
+        if node.kind() != "import_spec" {
+            return;
+        }
+        let Some(path) = node.child_by_field_name("path") else {
+            complete = false;
+            return;
+        };
+        let Some(path) = node_text(path, source).and_then(go_string_literal) else {
+            complete = false;
+            return;
+        };
+        let explicit_alias = node
+            .child_by_field_name("name")
+            .and_then(|node| node_text(node, source))
+            .map(str::to_string);
+        if explicit_alias.as_deref() == Some(".") {
+            complete = false;
+            return;
+        }
+        if explicit_alias.as_deref() == Some("_") {
+            return;
+        }
+        let alias = explicit_alias.or_else(|| path.rsplit('/').next().map(str::to_string));
+        let Some(alias) = alias.filter(|alias| !alias.is_empty() && go_identifier(alias)) else {
+            complete = false;
+            return;
+        };
+        if !values.insert(alias) {
+            complete = false;
+        }
+    });
+    GoImportDomain {
+        names: values,
+        complete,
+    }
+}
+
+fn go_string_literal(literal: &str) -> Option<&str> {
+    let literal = literal.trim();
+    let quote = literal.as_bytes().first().copied()?;
+    if !matches!(quote, b'"' | b'`') || literal.as_bytes().last().copied()? != quote {
+        return None;
+    }
+    let value = literal.get(1..literal.len().checked_sub(1)?)?;
+    (quote == b'`' || !value.contains('\\')).then_some(value)
+}
+
+fn go_expression_names(node: TsNode<'_>, source: &str) -> Vec<String> {
+    let mut result = Vec::new();
+    let mut cursor = node.walk();
+    if node.kind() == "expression_list" {
+        for child in node.named_children(&mut cursor) {
+            if let Some(name) = go_simple_identifier(child, source) {
+                result.push(name.to_string());
+            }
+        }
+    } else if let Some(name) = go_simple_identifier(node, source) {
+        result.push(name.to_string());
+    }
+    result
+}
+
+fn go_prepare_binding_decisions(
+    root: TsNode<'_>,
+    source: &str,
+    calls: &[IndexedGoCall<'_>],
+    import_names: &HashSet<String>,
+) -> HashMap<(usize, usize, String), GoBindingDecision> {
+    let shadowed_new = go_callables_declaring_name(root, source, "new");
+    let mut intervals = Vec::<GoBindingInterval>::new();
+    walk_nodes(root, &mut |node| {
+        count_go_resolution_work(1);
+        let Some(callable) = go_enclosing_callable(node) else {
+            return;
+        };
+        if node.id() == callable.id() {
+            if callable.kind() == "method_declaration"
+                && let Some(receiver) = callable.child_by_field_name("receiver")
+                && let Some((owner_name, pointer, variable)) =
+                    go_receiver_declaration(receiver, source)
+                && !variable.is_empty()
+            {
+                intervals.push(GoBindingInterval {
+                    name: variable,
+                    callable_id: callable.id(),
+                    start_byte: callable.start_byte(),
+                    end_byte: callable.end_byte(),
+                    scope_depth: 0,
+                    receiver: Some(GoReceiverBinding {
+                        owner_name,
+                        pointer,
+                        constructor: false,
+                        constructor_uses_builtin_new: false,
+                        imported: false,
+                        implicit: true,
+                    }),
+                });
+            }
+            return;
+        }
+        let Some((scope_start, scope_end, depth)) = go_binding_scope(node, callable) else {
+            return;
+        };
+        match node.kind() {
+            "parameter_declaration" | "variadic_parameter_declaration" => {
+                if callable.kind() == "method_declaration"
+                    && callable
+                        .child_by_field_name("receiver")
+                        .is_some_and(|receiver| {
+                            receiver.start_byte() <= node.start_byte()
+                                && node.end_byte() <= receiver.end_byte()
+                        })
+                {
+                    return;
+                }
+                let Some(type_node) = node.child_by_field_name("type") else {
+                    return;
+                };
+                let receiver = go_typed_receiver_binding(type_node, source, import_names);
+                let mut cursor = node.walk();
+                for name_node in node.named_children(&mut cursor) {
+                    if name_node.start_byte() >= type_node.start_byte() {
+                        break;
+                    }
+                    if let Some(name) = go_simple_identifier(name_node, source) {
+                        intervals.push(GoBindingInterval {
+                            name: name.to_string(),
+                            callable_id: callable.id(),
+                            start_byte: callable.start_byte(),
+                            end_byte: callable.end_byte(),
+                            scope_depth: 0,
+                            receiver: receiver.clone(),
+                        });
+                    }
+                }
+            }
+            "short_var_declaration" | "assignment_statement" => {
+                let names = node
+                    .child_by_field_name("left")
+                    .map(|left| go_expression_names(left, source))
+                    .unwrap_or_default();
+                let values = node
+                    .child_by_field_name("right")
+                    .map(go_expression_items)
+                    .unwrap_or_default();
+                for (index, name) in names.into_iter().enumerate() {
+                    let assignment = node.kind() == "assignment_statement";
+                    let receiver = (!assignment && !go_binding_uses_control_flow(node, callable))
+                        .then(|| {
+                            values.get(index).and_then(|value| {
+                                go_direct_constructor_binding_prepared(
+                                    *value,
+                                    source,
+                                    !shadowed_new.contains(&callable.id())
+                                        && !import_names.contains("new"),
+                                    import_names,
+                                )
+                            })
+                        })
+                        .flatten();
+                    intervals.push(GoBindingInterval {
+                        name,
+                        callable_id: callable.id(),
+                        start_byte: node.end_byte().max(scope_start),
+                        end_byte: if assignment {
+                            callable.end_byte()
+                        } else {
+                            scope_end
+                        },
+                        scope_depth: if assignment { usize::MAX - 1 } else { depth },
+                        receiver,
+                    });
+                }
+            }
+            "var_spec" => {
+                let Some(type_node) = node.child_by_field_name("type") else {
+                    return;
+                };
+                let receiver = (!go_binding_uses_control_flow(node, callable))
+                    .then(|| go_typed_receiver_binding(type_node, source, import_names))
+                    .flatten();
+                let mut names = Vec::new();
+                go_declared_names(node, source, &mut names);
+                for name in names {
+                    intervals.push(GoBindingInterval {
+                        name,
+                        callable_id: callable.id(),
+                        start_byte: node.end_byte().max(scope_start),
+                        end_byte: scope_end,
+                        scope_depth: depth,
+                        receiver: receiver.clone(),
+                    });
+                }
+            }
+            "const_spec" | "type_spec" => {
+                let mut names = Vec::new();
+                go_declared_names(node, source, &mut names);
+                if node.kind() == "type_spec"
+                    && let Some(name) = node
+                        .child_by_field_name("name")
+                        .and_then(|name| node_text(name, source))
+                {
+                    names.push(name.to_string());
+                }
+                for name in names {
+                    intervals.push(GoBindingInterval {
+                        name,
+                        callable_id: callable.id(),
+                        start_byte: node.end_byte().max(scope_start),
+                        end_byte: scope_end,
+                        scope_depth: depth,
+                        receiver: None,
+                    });
+                }
+            }
+            "range_clause" | "receive_statement" | "type_switch_guard" => {
+                let Some(special) = go_special_binding(node, callable, source) else {
+                    return;
+                };
+                for name in special.names {
+                    intervals.push(GoBindingInterval {
+                        name,
+                        callable_id: callable.id(),
+                        start_byte: node.end_byte(),
+                        end_byte: special.end_byte,
+                        scope_depth: special.scope_depth,
+                        receiver: None,
+                    });
+                }
+            }
+            "type_switch_statement" => {
+                let Some(special) = go_type_switch_binding(node, callable, source) else {
+                    return;
+                };
+                for name in special.names {
+                    intervals.push(GoBindingInterval {
+                        name,
+                        callable_id: callable.id(),
+                        start_byte: node.start_byte(),
+                        end_byte: special.end_byte,
+                        scope_depth: special.scope_depth,
+                        receiver: None,
+                    });
+                }
+            }
+            "unary_expression" => {
+                let Some(surface) = node_text(node, source).map(str::trim) else {
+                    return;
+                };
+                let Some(name) = surface.strip_prefix('&').map(str::trim) else {
+                    return;
+                };
+                if go_identifier(name) {
+                    intervals.push(GoBindingInterval {
+                        name: name.to_string(),
+                        callable_id: callable.id(),
+                        start_byte: callable.start_byte(),
+                        end_byte: callable.end_byte(),
+                        scope_depth: usize::MAX,
+                        receiver: None,
+                    });
+                }
+            }
+            _ => {}
+        }
+    });
+    walk_nodes(root, &mut |node| {
+        if node.kind() != "identifier" {
+            return;
+        }
+        let Some(callable) = go_outer_callable_for_captured_node(node) else {
+            return;
+        };
+        let Some(name) = node_text(node, source).filter(|name| go_identifier(name)) else {
+            return;
+        };
+        intervals.push(GoBindingInterval {
+            name: name.to_string(),
+            callable_id: callable.id(),
+            start_byte: callable.start_byte(),
+            end_byte: callable.end_byte(),
+            scope_depth: usize::MAX,
+            receiver: None,
+        });
+        count_go_resolution_work(1);
+    });
+    let mut intervals_by_name = HashMap::<(usize, String), Vec<GoBindingInterval>>::new();
+    for interval in intervals {
+        if interval.start_byte < interval.end_byte {
+            intervals_by_name
+                .entry((interval.callable_id, interval.name.clone()))
+                .or_default()
+                .push(interval);
+        }
+    }
+    let mut calls_by_name = HashMap::<(usize, String), Vec<usize>>::new();
+    for call in calls {
+        let Some(callable_id) = call.callable_id else {
+            continue;
+        };
+        let name = if call.form == CalleeForm::Identifier {
+            Some(call.raw_target.clone())
+        } else {
+            call.callee
+                .parent()
+                .and_then(|selector| selector.child_by_field_name("operand"))
+                .and_then(|receiver| go_simple_identifier(receiver, source))
+                .map(str::to_string)
+        };
+        if let Some(name) = name {
+            calls_by_name
+                .entry((callable_id, name))
+                .or_default()
+                .push(call.callee.start_byte());
+        }
+    }
+    let mut decisions = HashMap::new();
+    for (key, mut callsites) in calls_by_name {
+        let bindings = intervals_by_name.remove(&key).unwrap_or_default();
+        callsites.sort_unstable();
+        let mut events = Vec::with_capacity(bindings.len() * 2 + callsites.len());
+        for (index, binding) in bindings.iter().enumerate() {
+            events.push((binding.start_byte, 1_u8, index));
+            events.push((binding.end_byte, 0_u8, index));
+            count_go_resolution_work(2);
+        }
+        for (index, callsite) in callsites.iter().copied().enumerate() {
+            events.push((callsite, 2_u8, index));
+            count_go_resolution_work(1);
+        }
+        events.sort_unstable();
+        let mut active = BTreeMap::<usize, HashSet<usize>>::new();
+        for (byte, kind, index) in events {
+            count_go_resolution_work(1);
+            match kind {
+                0 => {
+                    let depth = bindings[index].scope_depth;
+                    if let Some(entries) = active.get_mut(&depth) {
+                        entries.remove(&index);
+                        if entries.is_empty() {
+                            active.remove(&depth);
+                        }
+                    }
+                }
+                1 => {
+                    active
+                        .entry(bindings[index].scope_depth)
+                        .or_default()
+                        .insert(index);
+                }
+                _ => {
+                    let Some((_, entries)) = active.last_key_value() else {
+                        continue;
+                    };
+                    let decision = if entries.len() == 1 {
+                        let binding = &bindings[*entries.iter().next().expect("one binding")];
+                        binding
+                            .receiver
+                            .clone()
+                            .map_or(GoBindingDecision::Blocked, GoBindingDecision::Receiver)
+                    } else {
+                        GoBindingDecision::Blocked
+                    };
+                    decisions.insert((key.0, byte, key.1.clone()), decision);
+                }
+            }
+        }
+    }
+    decisions
+}
+
+fn go_callables_declaring_name(root: TsNode<'_>, source: &str, wanted: &str) -> HashSet<usize> {
+    let mut result = HashSet::new();
+    walk_nodes(root, &mut |node| {
+        let Some(callable) = go_enclosing_callable(node) else {
+            return;
+        };
+        let declared = match node.kind() {
+            "parameter_declaration" | "variadic_parameter_declaration" => {
+                let boundary = node
+                    .child_by_field_name("type")
+                    .map(|node| node.start_byte())
+                    .unwrap_or(usize::MAX);
+                let mut cursor = node.walk();
+                node.named_children(&mut cursor).any(|child| {
+                    child.start_byte() < boundary
+                        && go_simple_identifier(child, source) == Some(wanted)
+                })
+            }
+            "short_var_declaration" | "assignment_statement" => {
+                node.child_by_field_name("left").is_some_and(|left| {
+                    go_expression_names(left, source)
+                        .iter()
+                        .any(|name| name == wanted)
+                })
+            }
+            "var_spec" | "const_spec" | "type_spec" => {
+                let mut names = Vec::new();
+                go_declared_names(node, source, &mut names);
+                if node.kind() == "type_spec"
+                    && let Some(name) = node
+                        .child_by_field_name("name")
+                        .and_then(|name| node_text(name, source))
+                {
+                    names.push(name.to_string());
+                }
+                names.iter().any(|name| name == wanted)
+            }
+            "range_clause" | "receive_statement" | "type_switch_guard" => {
+                go_special_binding_names(node_text(node, source).unwrap_or_default())
+                    .iter()
+                    .any(|name| name == wanted)
+            }
+            "type_switch_statement" => go_type_switch_header(node, source)
+                .map(go_special_binding_names)
+                .unwrap_or_default()
+                .iter()
+                .any(|name| name == wanted),
+            _ => false,
+        };
+        if declared {
+            result.insert(callable.id());
+        }
+    });
+    result
+}
+
+struct GoSpecialBinding {
+    names: Vec<String>,
+    end_byte: usize,
+    scope_depth: usize,
+}
+
+fn go_special_binding(
+    node: TsNode<'_>,
+    callable: TsNode<'_>,
+    source: &str,
+) -> Option<GoSpecialBinding> {
+    let surface = node_text(node, source)?;
+    let names = go_special_binding_names(surface);
+    if names.is_empty() {
+        return None;
+    }
+    let declaration = surface.contains(":=");
+    let boundary_kind = match node.kind() {
+        "range_clause" => "for_statement",
+        "receive_statement" => "communication_case",
+        "type_switch_guard" => "type_switch_statement",
+        _ => return None,
+    };
+    let mut boundary = node;
+    while boundary.kind() != boundary_kind {
+        boundary = boundary.parent()?;
+        if boundary.id() == callable.id() {
+            return None;
+        }
+    }
+    Some(GoSpecialBinding {
+        names,
+        end_byte: if declaration {
+            boundary.end_byte()
+        } else {
+            callable.end_byte()
+        },
+        scope_depth: if declaration {
+            go_scope_depth(boundary, callable).saturating_add(1)
+        } else {
+            usize::MAX - 2
+        },
+    })
+}
+
+fn go_type_switch_binding(
+    node: TsNode<'_>,
+    callable: TsNode<'_>,
+    source: &str,
+) -> Option<GoSpecialBinding> {
+    let names = go_type_switch_header(node, source).map(go_special_binding_names)?;
+    (!names.is_empty()).then(|| GoSpecialBinding {
+        names,
+        end_byte: node.end_byte(),
+        scope_depth: go_scope_depth(node, callable).saturating_add(1),
+    })
+}
+
+fn go_type_switch_header<'a>(node: TsNode<'_>, source: &'a str) -> Option<&'a str> {
+    let (header, _) = node_text(node, source)?.split_once('{')?;
+    header.trim().strip_prefix("switch").map(str::trim)
+}
+
+fn go_special_binding_names(surface: &str) -> Vec<String> {
+    let left = surface
+        .split_once(":=")
+        .or_else(|| surface.split_once('='))
+        .map(|(left, _)| left)
+        .unwrap_or_default();
+    left.rsplit([';', '{', ':'])
+        .next()
+        .unwrap_or(left)
+        .split(',')
+        .map(str::trim)
+        .filter(|name| *name != "_" && go_identifier(name))
+        .map(str::to_string)
+        .collect()
+}
+
+fn go_scope_depth(mut node: TsNode<'_>, callable: TsNode<'_>) -> usize {
+    let mut depth: usize = 0;
+    while node.id() != callable.id() {
+        depth = depth.saturating_add(usize::from(node.kind() == "block"));
+        let Some(parent) = node.parent() else {
+            break;
+        };
+        node = parent;
+    }
+    depth
+}
+
+fn go_binding_scope(node: TsNode<'_>, callable: TsNode<'_>) -> Option<(usize, usize, usize)> {
+    let mut current = node;
+    let mut depth = 0;
+    loop {
+        if current.kind() == "block" {
+            depth += 1;
+            return Some((current.start_byte(), current.end_byte(), depth));
+        }
+        if current.id() == callable.id() {
+            return Some((callable.start_byte(), callable.end_byte(), 0));
+        }
+        current = current.parent()?;
+    }
+}
+
+fn go_binding_uses_control_flow(mut node: TsNode<'_>, callable: TsNode<'_>) -> bool {
+    while node.id() != callable.id() {
+        if matches!(
+            node.kind(),
+            "if_statement"
+                | "for_statement"
+                | "expression_switch_statement"
+                | "type_switch_statement"
+                | "select_statement"
+        ) {
+            return true;
+        }
+        let Some(parent) = node.parent() else {
+            return true;
+        };
+        node = parent;
+    }
+    false
+}
+
+fn go_outer_callable_for_captured_node(mut node: TsNode<'_>) -> Option<TsNode<'_>> {
+    let mut crossed_closure = false;
+    loop {
+        crossed_closure |= node.kind() == "func_literal";
+        if crossed_closure && matches!(node.kind(), "function_declaration" | "method_declaration") {
+            return Some(node);
+        }
+        node = node.parent()?;
+    }
+}
+
+fn go_typed_receiver_binding(
+    type_node: TsNode<'_>,
+    source: &str,
+    import_names: &HashSet<String>,
+) -> Option<GoReceiverBinding> {
+    let mut binding = go_exact_type_node(type_node, source, import_names, true)?;
+    binding.constructor = false;
+    binding.constructor_uses_builtin_new = false;
+    binding.implicit = false;
+    Some(binding)
+}
+
+fn go_exact_type_node(
+    node: TsNode<'_>,
+    source: &str,
+    import_names: &HashSet<String>,
+    allow_pointer: bool,
+) -> Option<GoReceiverBinding> {
+    let (base, pointer) = if node.kind() == "pointer_type" && allow_pointer {
+        let mut cursor = node.walk();
+        let children = node.named_children(&mut cursor).collect::<Vec<_>>();
+        let [base] = children.as_slice() else {
+            return None;
+        };
+        if base.kind() == "pointer_type" {
+            return None;
+        }
+        (*base, true)
+    } else {
+        (node, false)
+    };
+    let surface = node_text(base, source)?.trim();
+    let (owner_name, imported) = match base.kind() {
+        "type_identifier" => {
+            if !go_identifier(surface) {
+                return None;
+            }
+            (surface, false)
+        }
+        "qualified_type" => {
+            let (qualifier, owner_name) = surface.split_once('.')?;
+            if owner_name.contains('.')
+                || !go_identifier(qualifier)
+                || !go_identifier(owner_name)
+                || !import_names.contains(qualifier)
+            {
+                return None;
+            }
+            (owner_name, true)
+        }
+        _ => return None,
+    };
+    Some(GoReceiverBinding {
+        owner_name: owner_name.to_string(),
+        pointer,
+        constructor: false,
+        constructor_uses_builtin_new: false,
+        imported,
+        implicit: false,
+    })
+}
+
+fn go_direct_constructor_binding_prepared(
+    value: TsNode<'_>,
+    source: &str,
+    builtin_new_unshadowed: bool,
+    import_names: &HashSet<String>,
+) -> Option<GoReceiverBinding> {
+    let (type_node, pointer, constructor_uses_builtin_new) = match value.kind() {
+        "composite_literal" => (value.child_by_field_name("type")?, false, false),
+        "unary_expression" => {
+            let surface = node_text(value, source)?.trim();
+            if !surface.starts_with('&') {
+                return None;
+            }
+            let mut cursor = value.walk();
+            let children = value.named_children(&mut cursor).collect::<Vec<_>>();
+            let [literal] = children.as_slice() else {
+                return None;
+            };
+            if literal.kind() != "composite_literal" {
+                return None;
+            }
+            (literal.child_by_field_name("type")?, true, false)
+        }
+        "call_expression" if builtin_new_unshadowed => {
+            let function = value.child_by_field_name("function")?;
+            if go_simple_identifier(function, source) != Some("new") {
+                return None;
+            }
+            let arguments = value.child_by_field_name("arguments")?;
+            let mut cursor = arguments.walk();
+            let arguments = arguments.named_children(&mut cursor).collect::<Vec<_>>();
+            let [type_node] = arguments.as_slice() else {
+                return None;
+            };
+            (*type_node, true, true)
+        }
+        _ => return None,
+    };
+    let mut binding = go_exact_type_node(type_node, source, import_names, false)?;
+    binding.pointer = pointer;
+    binding.constructor = true;
+    binding.constructor_uses_builtin_new = constructor_uses_builtin_new;
+    Some(binding)
+}
+
+fn go_expression_items(node: TsNode<'_>) -> Vec<TsNode<'_>> {
+    if node.kind() != "expression_list" {
+        return vec![node];
+    }
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor).collect()
 }
 
 #[derive(Debug, Clone)]
@@ -3903,6 +5158,7 @@ pub fn rematerialize_proof_resolution_projection(
         .map(|record| (record.file.file_id.0, record))
         .collect::<HashMap<_, _>>();
     let rust_projection_index = RustProjectionIndex::prepare(&records)?;
+    let go_projection_index = GoProjectionIndex::prepare(&records)?;
     let mut claims = inputs
         .into_iter()
         .map(|(source_record, input)| {
@@ -3910,6 +5166,7 @@ pub fn rematerialize_proof_resolution_projection(
                 &file_by_id,
                 &record_by_path,
                 &rust_projection_index,
+                &go_projection_index,
                 source_record,
                 input,
             )
@@ -4127,6 +5384,7 @@ struct ResolvedSyntaxClaim {
     reason: ProofResolutionReason,
     evidence_chain: Vec<ResolutionEvidence>,
     exact_node_file_expectations: Vec<(NodeId, FileId)>,
+    exact_dependency_files: Vec<FileId>,
 }
 
 #[derive(Default)]
@@ -4265,6 +5523,15 @@ impl ExactEvidenceValidationIndex {
                 *declaration == target && target_node.file_node_id == Some(source_file)
             }
             (
+                CalleeForm::Identifier,
+                [ResolutionEvidence::SamePackageDeclaration { declaration }],
+            ) => {
+                claim.input.language == "go"
+                    && *declaration == target
+                    && target_node.file_node_id.is_some()
+                    && target_node.file_node_id != Some(source_file)
+            }
+            (
                 CalleeForm::NamedImport,
                 [
                     ResolutionEvidence::StaticImportBinding {
@@ -4312,14 +5579,36 @@ impl ExactEvidenceValidationIndex {
                     ResolutionEvidence::SameFileDeclaration { declaration },
                 ],
             ) => {
-                *declaration == target
+                let local_shape = *declaration == target
                     && target_node.kind == NodeKind::METHOD
-                    && target_node.file_node_id == Some(source_file)
                     && nodes.get(owner).is_some_and(|owner_node| {
                         matches!(
                             owner_node.kind,
                             NodeKind::STRUCT | NodeKind::CLASS | NodeKind::ENUM
-                        ) && owner_node.file_node_id == Some(source_file)
+                        ) && if claim.input.language == "go" {
+                            owner_node.file_node_id.is_some() && target_node.file_node_id.is_some()
+                        } else {
+                            owner_node.file_node_id == Some(source_file)
+                                && target_node.file_node_id == Some(source_file)
+                        }
+                    });
+                local_shape
+                    && self.has_member(*owner, claim.caller)
+                    && self.has_member(*owner, target)
+            }
+            (
+                CalleeForm::ImplicitReceiver,
+                [
+                    ResolutionEvidence::ImplicitReceiver { owner },
+                    ResolutionEvidence::SamePackageDeclaration { declaration },
+                ],
+            ) => {
+                claim.input.language == "go"
+                    && *declaration == target
+                    && target_node.kind == NodeKind::METHOD
+                    && target_node.file_node_id.is_some()
+                    && nodes.get(owner).is_some_and(|owner_node| {
+                        owner_node.kind == NodeKind::STRUCT && owner_node.file_node_id.is_some()
                     })
                     && self.has_member(*owner, claim.caller)
                     && self.has_member(*owner, target)
@@ -4389,6 +5678,7 @@ impl ExactEvidenceValidationIndex {
                     ResolutionEvidence::SameFileDeclaration { declaration },
                 ],
             ) if *constructor == *receiver_type => self.local_receiver_is_correlated(
+                &claim.input.language,
                 source_file,
                 *constructor,
                 *declaration,
@@ -4403,6 +5693,7 @@ impl ExactEvidenceValidationIndex {
                     ResolutionEvidence::SameFileDeclaration { declaration },
                 ],
             ) => self.local_receiver_is_correlated(
+                &claim.input.language,
                 source_file,
                 *receiver_type,
                 *declaration,
@@ -4493,12 +5784,44 @@ impl ExactEvidenceValidationIndex {
                     target_node,
                     nodes,
                 ),
+            (
+                CalleeForm::ExplicitReceiver,
+                [
+                    ResolutionEvidence::ConstructorBinding { constructor },
+                    ResolutionEvidence::ExplicitReceiverType { receiver_type },
+                    ResolutionEvidence::SamePackageDeclaration { declaration },
+                ],
+            ) if *constructor == *receiver_type => self.local_receiver_is_correlated(
+                &claim.input.language,
+                source_file,
+                *constructor,
+                *declaration,
+                target,
+                target_node,
+                nodes,
+            ),
+            (
+                CalleeForm::ExplicitReceiver,
+                [
+                    ResolutionEvidence::ExplicitReceiverType { receiver_type },
+                    ResolutionEvidence::SamePackageDeclaration { declaration },
+                ],
+            ) => self.local_receiver_is_correlated(
+                &claim.input.language,
+                source_file,
+                *receiver_type,
+                *declaration,
+                target,
+                target_node,
+                nodes,
+            ),
             _ => false,
         }
     }
 
     fn local_receiver_is_correlated(
         &self,
+        language: &str,
         source_file: NodeId,
         owner: NodeId,
         declaration: NodeId,
@@ -4512,8 +5835,12 @@ impl ExactEvidenceValidationIndex {
                 matches!(
                     owner_node.kind,
                     NodeKind::CLASS | NodeKind::STRUCT | NodeKind::ENUM
-                ) && owner_node.file_node_id == Some(source_file)
-                    && owner_node.file_node_id == target_node.file_node_id
+                ) && if language == "go" {
+                    owner_node.file_node_id.is_some() && target_node.file_node_id.is_some()
+                } else {
+                    owner_node.file_node_id == Some(source_file)
+                        && owner_node.file_node_id == target_node.file_node_id
+                }
             })
             && self.has_member(owner, target)
     }
@@ -4544,7 +5871,7 @@ impl ExactEvidenceValidationIndex {
 
 fn proof_import_node_kind_is_literal(language: &str, kind: NodeKind) -> bool {
     match language {
-        "rust" => kind == NodeKind::MODULE,
+        "go" | "rust" => kind == NodeKind::MODULE,
         "javascript" | "typescript" | "tsx" => {
             matches!(kind, NodeKind::MODULE | NodeKind::UNKNOWN)
         }
@@ -5391,10 +6718,523 @@ fn rust_resolve_module_path<'a>(
     rust_index.resolve_module_path(source_record, relative_module, components)
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct GoPackageKey {
+    directory: WorkspacePathIdentity,
+    package_name: String,
+}
+
+struct GoPackageDeclaration<'a> {
+    declaration: NodeId,
+    record: &'a ResolutionCacheRecord,
+}
+
+struct GoPackageType<'a> {
+    value: &'a CachedGoType,
+    record: &'a ResolutionCacheRecord,
+}
+
+struct GoPackageMethod<'a> {
+    value: &'a CachedGoMethod,
+    record: &'a ResolutionCacheRecord,
+}
+
+struct GoCandidateSet<T> {
+    exact: Option<T>,
+    ambiguous: bool,
+    conditional: bool,
+    generated: bool,
+}
+
+impl<T> Default for GoCandidateSet<T> {
+    fn default() -> Self {
+        Self {
+            exact: None,
+            ambiguous: false,
+            conditional: false,
+            generated: false,
+        }
+    }
+}
+
+impl<T> GoCandidateSet<T> {
+    fn add(&mut self, value: T, conditional: bool, generated: bool) {
+        self.conditional |= conditional;
+        if conditional {
+            return;
+        }
+        if generated {
+            self.ambiguous |= self.generated || self.exact.is_some();
+            self.generated = true;
+            return;
+        }
+        self.ambiguous |= self.generated;
+        if self.exact.replace(value).is_some() {
+            self.ambiguous = true;
+        }
+    }
+}
+
+struct GoPackageDomain<'a> {
+    dependencies: Vec<FileId>,
+    complete: bool,
+    functions: HashMap<String, GoCandidateSet<GoPackageDeclaration<'a>>>,
+    blockers: HashMap<String, usize>,
+    conditional_blockers: HashSet<String>,
+    types: HashMap<String, GoCandidateSet<GoPackageType<'a>>>,
+    methods: HashMap<(String, String), GoCandidateSet<GoPackageMethod<'a>>>,
+}
+
+struct GoProjectionIndex<'a> {
+    keys_by_file: HashMap<i64, GoPackageKey>,
+    domains: HashMap<GoPackageKey, GoPackageDomain<'a>>,
+}
+
+enum GoFunctionResolution {
+    Exact {
+        declaration: NodeId,
+        declaration_file: FileId,
+        dependencies: Vec<FileId>,
+    },
+    Missing,
+    Ambiguous,
+    Incomplete,
+    Unsupported,
+}
+
+enum GoReceiverResolution {
+    Exact {
+        owner: NodeId,
+        owner_file: FileId,
+        declaration: NodeId,
+        declaration_file: FileId,
+        dependencies: Vec<FileId>,
+    },
+    Missing,
+    Ambiguous,
+    Incomplete,
+    Unsupported,
+}
+
+impl<'a> GoProjectionIndex<'a> {
+    fn prepare(records: &'a [ResolutionCacheRecord]) -> Result<Self> {
+        let go_records = records
+            .iter()
+            .filter(|record| record.file.language == "go")
+            .collect::<Vec<_>>();
+        let mut records_by_directory = HashMap::<WorkspacePathIdentity, Vec<_>>::new();
+        let mut records_by_identity = HashMap::<WorkspacePathIdentity, Vec<_>>::new();
+        for record in &go_records {
+            count_go_resolution_work(1);
+            let identity = workspace_path_identity(&record.path)?;
+            records_by_identity
+                .entry(identity)
+                .or_default()
+                .push(*record);
+            let directory = record
+                .path
+                .parent()
+                .ok_or_else(|| anyhow!("Go proof input has no package directory"))?;
+            records_by_directory
+                .entry(workspace_path_identity(directory)?)
+                .or_default()
+                .push(*record);
+        }
+        let mut directory_inventory_complete = HashMap::new();
+        for (identity, directory_records) in &records_by_directory {
+            count_go_resolution_work(1);
+            let Some(directory) = directory_records
+                .first()
+                .and_then(|record| record.path.parent())
+            else {
+                directory_inventory_complete.insert(identity.clone(), false);
+                continue;
+            };
+            let mut complete = true;
+            let entries = match std::fs::read_dir(directory) {
+                Ok(entries) => entries,
+                Err(_) => {
+                    directory_inventory_complete.insert(identity.clone(), false);
+                    continue;
+                }
+            };
+            for entry in entries {
+                count_go_resolution_work(1);
+                let Ok(entry) = entry else {
+                    complete = false;
+                    continue;
+                };
+                let path = entry.path();
+                if path.extension().and_then(|extension| extension.to_str()) != Some("go") {
+                    continue;
+                }
+                let Ok(file_type) = entry.file_type() else {
+                    complete = false;
+                    continue;
+                };
+                if !file_type.is_file() {
+                    complete = false;
+                    continue;
+                }
+                let Ok(file_identity) = workspace_path_identity(&path) else {
+                    complete = false;
+                    continue;
+                };
+                if records_by_identity.get(&file_identity).map(Vec::len) != Some(1) {
+                    complete = false;
+                }
+            }
+            directory_inventory_complete.insert(identity.clone(), complete);
+        }
+        let mut keys_by_file = HashMap::new();
+        let mut grouped = HashMap::<GoPackageKey, Vec<&ResolutionCacheRecord>>::new();
+        for record in go_records {
+            count_go_resolution_work(1);
+            let Some(package) = &record.file.go_package else {
+                continue;
+            };
+            if package.name.is_empty() {
+                continue;
+            }
+            let directory = workspace_path_identity(
+                record
+                    .path
+                    .parent()
+                    .ok_or_else(|| anyhow!("Go proof input has no package directory"))?,
+            )?;
+            let key = GoPackageKey {
+                directory,
+                package_name: package.name.clone(),
+            };
+            keys_by_file.insert(record.file.file_id.0, key.clone());
+            grouped.entry(key).or_default().push(record);
+        }
+        let package_names_by_directory = grouped.keys().fold(
+            HashMap::<WorkspacePathIdentity, Vec<String>>::new(),
+            |mut names, key| {
+                names
+                    .entry(key.directory.clone())
+                    .or_default()
+                    .push(key.package_name.clone());
+                names
+            },
+        );
+        let mut domains = HashMap::new();
+        for (key, mut package_records) in grouped {
+            count_go_resolution_work(1);
+            package_records.sort_by_key(|record| record.file.file_id);
+            let names = package_names_by_directory
+                .get(&key.directory)
+                .map(Vec::as_slice)
+                .unwrap_or_default();
+            let allowed_test_split = names.iter().all(|name| {
+                name == &key.package_name
+                    || name == &format!("{}_test", key.package_name)
+                    || key.package_name == format!("{name}_test")
+            });
+            let mut complete = directory_inventory_complete
+                .get(&key.directory)
+                .copied()
+                .unwrap_or(false)
+                && allowed_test_split;
+            let mut functions = HashMap::<String, GoCandidateSet<GoPackageDeclaration<'_>>>::new();
+            let mut blockers = HashMap::<String, usize>::new();
+            let mut conditional_blockers = HashSet::<String>::new();
+            let mut types = HashMap::<String, GoCandidateSet<GoPackageType<'_>>>::new();
+            let mut methods =
+                HashMap::<(String, String), GoCandidateSet<GoPackageMethod<'_>>>::new();
+            for record in &package_records {
+                count_go_resolution_work(1);
+                if go_test_file(&record.path) {
+                    continue;
+                }
+                let Some(package) = &record.file.go_package else {
+                    complete = false;
+                    continue;
+                };
+                let conditional = go_file_is_conditional(&record.path, package);
+                complete &= record.file.complete && record.file.lookup_input_complete;
+                for declaration in &record.file.top_level_declarations {
+                    count_go_resolution_work(1);
+                    functions.entry(declaration.name.clone()).or_default().add(
+                        GoPackageDeclaration {
+                            declaration: declaration.declaration,
+                            record,
+                        },
+                        conditional,
+                        package.generated,
+                    );
+                }
+                for blocker in &package.package_blockers {
+                    count_go_resolution_work(1);
+                    *blockers.entry(blocker.clone()).or_default() += 1;
+                    if conditional {
+                        conditional_blockers.insert(blocker.clone());
+                    }
+                }
+                for value in &package.types {
+                    count_go_resolution_work(1);
+                    types.entry(value.name.clone()).or_default().add(
+                        GoPackageType { value, record },
+                        conditional,
+                        package.generated,
+                    );
+                }
+                for value in &package.methods {
+                    count_go_resolution_work(1);
+                    methods
+                        .entry((value.owner_name.clone(), value.method_name.clone()))
+                        .or_default()
+                        .add(
+                            GoPackageMethod { value, record },
+                            conditional,
+                            package.generated,
+                        );
+                }
+            }
+            let dependencies = package_records
+                .iter()
+                .filter(|record| !go_test_file(&record.path))
+                .map(|record| {
+                    count_go_resolution_work(1);
+                    FileId(record.file.file_id.0)
+                })
+                .collect();
+            domains.insert(
+                key,
+                GoPackageDomain {
+                    dependencies,
+                    complete,
+                    functions,
+                    blockers,
+                    conditional_blockers,
+                    types,
+                    methods,
+                },
+            );
+        }
+        Ok(Self {
+            keys_by_file,
+            domains,
+        })
+    }
+
+    fn domain(
+        &self,
+        source_record: &ResolutionCacheRecord,
+        package_name: &str,
+    ) -> Option<&GoPackageDomain<'a>> {
+        count_go_resolution_work(1);
+        let key = self.keys_by_file.get(&source_record.file.file_id.0)?;
+        (key.package_name == package_name)
+            .then(|| self.domains.get(key))
+            .flatten()
+    }
+
+    fn resolve_function(
+        &self,
+        source_record: &ResolutionCacheRecord,
+        package_name: &str,
+        name: &str,
+    ) -> GoFunctionResolution {
+        let Some(domain) = self.domain(source_record, package_name) else {
+            return GoFunctionResolution::Incomplete;
+        };
+        if !domain.complete
+            || go_test_file(&source_record.path)
+            || source_record
+                .file
+                .go_package
+                .as_ref()
+                .is_none_or(|package| go_file_is_conditional(&source_record.path, package))
+        {
+            return GoFunctionResolution::Incomplete;
+        }
+        if domain.conditional_blockers.contains(name) {
+            return GoFunctionResolution::Incomplete;
+        }
+        if domain.blockers.get(name).copied().unwrap_or_default() > 0 {
+            return GoFunctionResolution::Ambiguous;
+        }
+        if let Some(types) = domain.types.get(name) {
+            if types.conditional {
+                return GoFunctionResolution::Incomplete;
+            }
+            return if types.ambiguous || types.exact.is_some() {
+                GoFunctionResolution::Ambiguous
+            } else {
+                GoFunctionResolution::Unsupported
+            };
+        }
+        let Some(declarations) = domain.functions.get(name) else {
+            return GoFunctionResolution::Missing;
+        };
+        count_go_resolution_work(1);
+        if declarations.conditional {
+            return GoFunctionResolution::Incomplete;
+        }
+        if declarations.ambiguous {
+            return GoFunctionResolution::Ambiguous;
+        }
+        match declarations.exact.as_ref() {
+            Some(declaration) => GoFunctionResolution::Exact {
+                declaration: declaration.declaration,
+                declaration_file: FileId(declaration.record.file.file_id.0),
+                dependencies: go_domain_dependencies(domain),
+            },
+            None if declarations.generated => GoFunctionResolution::Unsupported,
+            None => GoFunctionResolution::Missing,
+        }
+    }
+
+    fn resolve_receiver(
+        &self,
+        source_record: &ResolutionCacheRecord,
+        package_name: &str,
+        owner_name: &str,
+        method_name: &str,
+        receiver_is_pointer: bool,
+        constructor_uses_builtin_new: bool,
+    ) -> GoReceiverResolution {
+        let Some(domain) = self.domain(source_record, package_name) else {
+            return GoReceiverResolution::Incomplete;
+        };
+        if !domain.complete
+            || go_test_file(&source_record.path)
+            || source_record
+                .file
+                .go_package
+                .as_ref()
+                .is_none_or(|package| go_file_is_conditional(&source_record.path, package))
+        {
+            return GoReceiverResolution::Incomplete;
+        }
+        if constructor_uses_builtin_new {
+            let new_functions = domain.functions.get("new");
+            let new_types = domain.types.get("new");
+            if domain.conditional_blockers.contains("new")
+                || new_functions.is_some_and(|declarations| declarations.conditional)
+                || new_types.is_some_and(|declarations| declarations.conditional)
+            {
+                return GoReceiverResolution::Incomplete;
+            }
+            if domain.blockers.get("new").copied().unwrap_or_default() > 0
+                || new_functions.is_some()
+                || new_types.is_some()
+            {
+                return GoReceiverResolution::Unsupported;
+            }
+        }
+        if domain.conditional_blockers.contains(owner_name) {
+            return GoReceiverResolution::Incomplete;
+        }
+        if domain.blockers.get(owner_name).copied().unwrap_or_default() > 0 {
+            return GoReceiverResolution::Ambiguous;
+        }
+        let owners = domain.types.get(owner_name);
+        let methods = domain
+            .methods
+            .get(&(owner_name.to_string(), method_name.to_string()));
+        count_go_resolution_work(2);
+        if owners.is_some_and(|owners| owners.conditional)
+            || methods.is_some_and(|methods| methods.conditional)
+        {
+            return GoReceiverResolution::Incomplete;
+        }
+        if owners.is_some_and(|owners| owners.ambiguous)
+            || methods.is_some_and(|methods| methods.ambiguous)
+        {
+            return GoReceiverResolution::Ambiguous;
+        }
+        let (Some(owner), Some(method)) = (
+            owners.and_then(|owners| owners.exact.as_ref()),
+            methods.and_then(|methods| methods.exact.as_ref()),
+        ) else {
+            if owners.is_some_and(|owners| owners.generated)
+                || methods.is_some_and(|methods| methods.generated)
+            {
+                return GoReceiverResolution::Unsupported;
+            }
+            return GoReceiverResolution::Missing;
+        };
+        if owner.value.interface || owner.value.generic {
+            return GoReceiverResolution::Unsupported;
+        }
+        if !receiver_is_pointer && method.value.pointer_receiver {
+            return GoReceiverResolution::Unsupported;
+        }
+        GoReceiverResolution::Exact {
+            owner: owner.value.declaration,
+            owner_file: FileId(owner.record.file.file_id.0),
+            declaration: method.value.declaration,
+            declaration_file: FileId(method.record.file.file_id.0),
+            dependencies: go_domain_dependencies(domain),
+        }
+    }
+}
+
+fn go_test_file(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.ends_with("_test.go"))
+}
+
+fn go_file_is_conditional(path: &Path, package: &CachedGoPackage) -> bool {
+    package.build_constrained || go_filename_has_build_constraint(path)
+}
+
+fn go_filename_has_build_constraint(path: &Path) -> bool {
+    const GOOS: &[&str] = &[
+        "aix",
+        "android",
+        "darwin",
+        "dragonfly",
+        "freebsd",
+        "illumos",
+        "ios",
+        "js",
+        "linux",
+        "netbsd",
+        "openbsd",
+        "plan9",
+        "solaris",
+        "wasip1",
+        "windows",
+    ];
+    const GOARCH: &[&str] = &[
+        "386", "amd64", "arm", "arm64", "loong64", "mips", "mips64", "mips64le", "mipsle", "ppc64",
+        "ppc64le", "riscv64", "s390x", "wasm",
+    ];
+    let Some(mut stem) = path.file_stem().and_then(|stem| stem.to_str()) else {
+        return true;
+    };
+    if stem.starts_with('.') || stem.starts_with('_') {
+        return true;
+    }
+    if let Some(without_test) = stem.strip_suffix("_test") {
+        stem = without_test;
+    }
+    let components = stem.split('_').collect::<Vec<_>>();
+    let Some(last) = components.last().copied() else {
+        return false;
+    };
+    GOOS.contains(&last)
+        || GOARCH.contains(&last)
+        || components.len() >= 2
+            && GOOS.contains(&components[components.len() - 2])
+            && GOARCH.contains(&last)
+}
+
+fn go_domain_dependencies(domain: &GoPackageDomain<'_>) -> Vec<FileId> {
+    count_go_resolution_work(1);
+    domain.dependencies.clone()
+}
+
 fn resolve_syntax_claim(
     files: &HashMap<i64, &codestory_store::FileInfo>,
     records: &HashMap<WorkspacePathIdentity, &ResolutionCacheRecord>,
     rust_index: &RustProjectionIndex<'_>,
+    go_index: &GoProjectionIndex<'_>,
     source_record: &ResolutionCacheRecord,
     input: CachedCallResolutionInput,
 ) -> Result<ResolvedSyntaxClaim> {
@@ -5407,6 +7247,7 @@ fn resolve_syntax_claim(
     let mut evidence_chain = Vec::new();
     let caller = input.caller.unwrap_or(NodeId(input.callsite.file_id.0));
     let mut exact_node_file_expectations = vec![(caller, input.callsite.file_id)];
+    let mut exact_dependency_files = vec![input.callsite.file_id];
     match &input.binding {
         CachedResolutionBinding::SameFile { declaration } => {
             let declaration_is_recorded =
@@ -5783,6 +7624,158 @@ fn resolve_syntax_claim(
                 }
             }
         }
+        CachedResolutionBinding::GoPackageFunction { package_name, name } => {
+            match go_index.resolve_function(source_record, package_name, name) {
+                GoFunctionResolution::Exact {
+                    declaration,
+                    declaration_file,
+                    dependencies,
+                } => {
+                    status = ProofResolutionStatus::Exact;
+                    reason = ProofResolutionReason::ExactResolution;
+                    target = Some(declaration);
+                    if declaration_file == input.callsite.file_id {
+                        evidence_chain
+                            .push(ResolutionEvidence::SameFileDeclaration { declaration });
+                    } else {
+                        evidence_chain
+                            .push(ResolutionEvidence::SamePackageDeclaration { declaration });
+                    }
+                    exact_node_file_expectations.push((declaration, declaration_file));
+                    exact_dependency_files = dependencies;
+                }
+                GoFunctionResolution::Missing => {
+                    status = ProofResolutionStatus::MissingBinding;
+                    reason = ProofResolutionReason::MissingBinding;
+                }
+                GoFunctionResolution::Ambiguous => {
+                    status = ProofResolutionStatus::Ambiguous;
+                    reason = ProofResolutionReason::MultipleBindings;
+                }
+                GoFunctionResolution::Incomplete => {
+                    status = ProofResolutionStatus::IncompleteDomain;
+                    reason = ProofResolutionReason::LookupDomainIncomplete;
+                }
+                GoFunctionResolution::Unsupported => {
+                    status = ProofResolutionStatus::Unsupported;
+                    reason = ProofResolutionReason::UnsupportedConstruct;
+                }
+            }
+        }
+        CachedResolutionBinding::GoImplicitReceiver {
+            package_name,
+            owner_name,
+            receiver_is_pointer,
+        } => {
+            match go_index.resolve_receiver(
+                source_record,
+                package_name,
+                owner_name,
+                &input.callsite.raw_target,
+                *receiver_is_pointer,
+                false,
+            ) {
+                GoReceiverResolution::Exact {
+                    owner,
+                    owner_file,
+                    declaration,
+                    declaration_file,
+                    dependencies,
+                } => {
+                    status = ProofResolutionStatus::Exact;
+                    reason = ProofResolutionReason::ExactResolution;
+                    target = Some(declaration);
+                    evidence_chain.push(ResolutionEvidence::ImplicitReceiver { owner });
+                    if declaration_file == input.callsite.file_id {
+                        evidence_chain
+                            .push(ResolutionEvidence::SameFileDeclaration { declaration });
+                    } else {
+                        evidence_chain
+                            .push(ResolutionEvidence::SamePackageDeclaration { declaration });
+                    }
+                    exact_node_file_expectations.push((owner, owner_file));
+                    exact_node_file_expectations.push((declaration, declaration_file));
+                    exact_dependency_files = dependencies;
+                }
+                GoReceiverResolution::Missing => {
+                    status = ProofResolutionStatus::MissingBinding;
+                    reason = ProofResolutionReason::MissingBinding;
+                }
+                GoReceiverResolution::Ambiguous => {
+                    status = ProofResolutionStatus::Ambiguous;
+                    reason = ProofResolutionReason::MultipleBindings;
+                }
+                GoReceiverResolution::Incomplete => {
+                    status = ProofResolutionStatus::IncompleteDomain;
+                    reason = ProofResolutionReason::LookupDomainIncomplete;
+                }
+                GoReceiverResolution::Unsupported => {
+                    status = ProofResolutionStatus::Unsupported;
+                    reason = ProofResolutionReason::UnsupportedConstruct;
+                }
+            }
+        }
+        CachedResolutionBinding::GoExplicitReceiver {
+            package_name,
+            owner_name,
+            receiver_is_pointer,
+            constructor,
+            constructor_uses_builtin_new,
+        } => {
+            match go_index.resolve_receiver(
+                source_record,
+                package_name,
+                owner_name,
+                &input.callsite.raw_target,
+                *receiver_is_pointer,
+                *constructor_uses_builtin_new,
+            ) {
+                GoReceiverResolution::Exact {
+                    owner,
+                    owner_file,
+                    declaration,
+                    declaration_file,
+                    dependencies,
+                } => {
+                    status = ProofResolutionStatus::Exact;
+                    reason = ProofResolutionReason::ExactResolution;
+                    target = Some(declaration);
+                    if *constructor {
+                        evidence_chain
+                            .push(ResolutionEvidence::ConstructorBinding { constructor: owner });
+                    }
+                    evidence_chain.push(ResolutionEvidence::ExplicitReceiverType {
+                        receiver_type: owner,
+                    });
+                    if declaration_file == input.callsite.file_id {
+                        evidence_chain
+                            .push(ResolutionEvidence::SameFileDeclaration { declaration });
+                    } else {
+                        evidence_chain
+                            .push(ResolutionEvidence::SamePackageDeclaration { declaration });
+                    }
+                    exact_node_file_expectations.push((owner, owner_file));
+                    exact_node_file_expectations.push((declaration, declaration_file));
+                    exact_dependency_files = dependencies;
+                }
+                GoReceiverResolution::Missing => {
+                    status = ProofResolutionStatus::MissingBinding;
+                    reason = ProofResolutionReason::MissingBinding;
+                }
+                GoReceiverResolution::Ambiguous => {
+                    status = ProofResolutionStatus::Ambiguous;
+                    reason = ProofResolutionReason::MultipleBindings;
+                }
+                GoReceiverResolution::Incomplete => {
+                    status = ProofResolutionStatus::IncompleteDomain;
+                    reason = ProofResolutionReason::LookupDomainIncomplete;
+                }
+                GoReceiverResolution::Unsupported => {
+                    status = ProofResolutionStatus::Unsupported;
+                    reason = ProofResolutionReason::UnsupportedConstruct;
+                }
+            }
+        }
         CachedResolutionBinding::Ambiguous => {
             status = ProofResolutionStatus::Ambiguous;
             reason = ProofResolutionReason::MultipleBindings;
@@ -5830,6 +7823,7 @@ fn resolve_syntax_claim(
                             reason,
                             evidence_chain,
                             exact_node_file_expectations,
+                            exact_dependency_files,
                         });
                     }
                     (source_record, None, *owner)
@@ -5854,6 +7848,7 @@ fn resolve_syntax_claim(
                                     reason,
                                     evidence_chain,
                                     exact_node_file_expectations,
+                                    exact_dependency_files,
                                 });
                             }
                             RelativeImportResolution::Incomplete => {
@@ -5867,6 +7862,7 @@ fn resolve_syntax_claim(
                                     reason,
                                     evidence_chain,
                                     exact_node_file_expectations,
+                                    exact_dependency_files,
                                 });
                             }
                         };
@@ -5888,6 +7884,7 @@ fn resolve_syntax_claim(
                             reason,
                             evidence_chain,
                             exact_node_file_expectations,
+                            exact_dependency_files,
                         });
                     }
                     let owners = target_record
@@ -5919,6 +7916,7 @@ fn resolve_syntax_claim(
                             reason,
                             evidence_chain,
                             exact_node_file_expectations,
+                            exact_dependency_files,
                         });
                     };
                     (target_record, Some(*import), export.declaration)
@@ -5987,6 +7985,7 @@ fn resolve_syntax_claim(
         reason,
         evidence_chain,
         exact_node_file_expectations,
+        exact_dependency_files,
     })
 }
 
@@ -6003,7 +8002,12 @@ fn enforce_exact_dependency_eligibility(
         .filter(|claim| claim.status == ProofResolutionStatus::Exact)
     {
         let mut eligible = true;
-        let mut expected_file_ids = HashSet::from([claim.input.callsite.file_id.0]);
+        let mut expected_file_ids = claim
+            .exact_dependency_files
+            .iter()
+            .map(|file| file.0)
+            .collect::<HashSet<_>>();
+        expected_file_ids.insert(claim.input.callsite.file_id.0);
         for (node_id, expected_file_id) in &claim.exact_node_file_expectations {
             expected_file_ids.insert(expected_file_id.0);
             let node = nodes.get(node_id).ok_or_else(|| {
@@ -6117,6 +8121,14 @@ fn seal_resolved_claim(
     };
     let input = &claim.input;
     let mut dependency_ids = HashSet::from([NodeId(input.callsite.file_id.0)]);
+    if status == ProofResolutionStatus::Exact {
+        dependency_ids.extend(
+            claim
+                .exact_dependency_files
+                .iter()
+                .map(|file| NodeId(file.0)),
+        );
+    }
     for node_id in evidence_chain
         .iter()
         .flat_map(ResolutionEvidence::node_ids)
@@ -6330,6 +8342,7 @@ mod rust_complexity_tests {
                 rust_modules: modules,
                 rust_types: types,
                 rust_uses: imports,
+                go_package: None,
             },
             calls: Vec::new(),
         };
@@ -6380,6 +8393,134 @@ mod rust_complexity_tests {
         assert!(
             large <= small * 2 + 128,
             "projection work grew superlinearly: {small} -> {large}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod go_complexity_tests {
+    use super::*;
+    use tree_sitter::Parser;
+
+    fn go_source(count: usize) -> String {
+        let mut source = String::from(
+            "package proof\ntype Worker struct{}\nfunc (w *Worker) Run() {}\nfunc caller() {\n",
+        );
+        for index in 0..count {
+            source.push_str(&format!(
+                "  worker{index} := &Worker{{}}\n  worker{index}.Run()\n"
+            ));
+        }
+        source.push_str("}\n");
+        source
+    }
+
+    fn measured_source_work(count: usize) -> usize {
+        let source = go_source(count);
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_go::LANGUAGE.into())
+            .expect("Go grammar must load");
+        let tree = parser.parse(&source, None).expect("source must parse");
+        reset_go_resolution_work();
+        let _ = GoResolutionIndex::build(&tree, &source, NodeId(1), &[]);
+        go_resolution_work()
+    }
+
+    fn measured_package_work(file_count: usize, lookup_count: usize) -> usize {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut records = Vec::new();
+        for index in 0..file_count {
+            let path = temp.path().join(format!("file_{index}.go"));
+            std::fs::write(&path, "package proof\n").expect("write Go source");
+            records.push(ResolutionCacheRecord {
+                path,
+                file: CachedResolutionFile {
+                    file_id: NodeId(index as i64 + 1),
+                    source_sha256: "0".repeat(64),
+                    language: "go".to_string(),
+                    adapter_version: ADAPTER_VERSION.to_string(),
+                    parser_fingerprint: "parser".to_string(),
+                    complete: true,
+                    lookup_input_complete: true,
+                    typescript_module: false,
+                    top_level_declarations: vec![CachedTopLevelDeclaration {
+                        name: "Target".to_string(),
+                        declaration: NodeId(10_000 + index as i64),
+                        module_path: Vec::new(),
+                        cross_module_visible: false,
+                    }],
+                    inherent_methods: Vec::new(),
+                    classes: Vec::new(),
+                    direct_exports: Vec::new(),
+                    export_poison_all: false,
+                    poisoned_export_names: Vec::new(),
+                    rust_modules: Vec::new(),
+                    rust_types: Vec::new(),
+                    rust_uses: Vec::new(),
+                    go_package: Some(CachedGoPackage {
+                        name: "proof".to_string(),
+                        build_constrained: false,
+                        generated: false,
+                        package_blockers: Vec::new(),
+                        types: Vec::new(),
+                        methods: Vec::new(),
+                    }),
+                },
+                calls: Vec::new(),
+            });
+        }
+        reset_go_resolution_work();
+        let index = GoProjectionIndex::prepare(&records).expect("Go package projection");
+        for _ in 0..lookup_count {
+            let _ = index.resolve_function(&records[0], "proof", "Target");
+        }
+        go_resolution_work()
+    }
+
+    #[test]
+    fn go_source_resolution_work_is_linear_for_bindings_and_calls() {
+        let small = measured_source_work(64);
+        let large = measured_source_work(128);
+        assert!(small > 0, "Go source work was not instrumented");
+        assert!(
+            large <= small * 2 + 128,
+            "Go source work grew superlinearly: {small} -> {large}"
+        );
+    }
+
+    #[test]
+    fn go_package_projection_work_is_linear() {
+        let small = measured_package_work(64, 64);
+        let large = measured_package_work(128, 128);
+        assert!(small >= 64, "Go package work was not instrumented: {small}");
+        assert!(
+            large <= small * 2 + 128,
+            "Go package work grew superlinearly: {small} -> {large}"
+        );
+    }
+
+    #[test]
+    fn go_package_files_and_call_lookups_are_independently_counted_and_linear() {
+        let baseline = measured_package_work(64, 64);
+        assert!(
+            baseline >= 64 * 8,
+            "Go package dependency preparation/lookups were not fully counted: {baseline}"
+        );
+        let more_files = measured_package_work(128, 64);
+        let more_calls = measured_package_work(64, 128);
+        let combined = measured_package_work(128, 128);
+        assert!(
+            more_files <= baseline * 2 + 128,
+            "Go file preparation grew superlinearly: {baseline} -> {more_files}"
+        );
+        assert!(
+            more_calls <= baseline * 2 + 128,
+            "Go call lookup work grew superlinearly: {baseline} -> {more_calls}"
+        );
+        assert!(
+            combined <= baseline * 2 + 256,
+            "combined Go package/call work grew superlinearly: {baseline} -> {combined}"
         );
     }
 }

--- a/crates/codestory-indexer/src/proof_resolution.rs
+++ b/crates/codestory-indexer/src/proof_resolution.rs
@@ -487,10 +487,8 @@ impl<'tree> GoResolutionIndex<'tree> {
                         });
                     }
                 }
-                "var_spec" | "const_spec" => {
-                    if go_spec_is_package_level(node, root) {
-                        go_declared_names(node, source, &mut result.package_blockers);
-                    }
+                "var_spec" | "const_spec" if go_spec_is_package_level(node, root) => {
+                    go_declared_names(node, source, &mut result.package_blockers);
                 }
                 "comment" => {
                     if let Some(name) = go_linkname_local_name(node, source) {
@@ -5819,6 +5817,9 @@ impl ExactEvidenceValidationIndex {
         }
     }
 
+    // Keeping every proof-correlation input explicit makes accidental endpoint
+    // substitution visible at the call sites.
+    #[allow(clippy::too_many_arguments)]
     fn local_receiver_is_correlated(
         &self,
         language: &str,

--- a/crates/codestory-indexer/tests/call_resolution_common_methods.rs
+++ b/crates/codestory-indexer/tests/call_resolution_common_methods.rs
@@ -15609,6 +15609,46 @@ func build() {
 }
 
 #[test]
+fn test_go_navigation_accepts_only_closed_type_and_constructor_ast_shapes() -> anyhow::Result<()> {
+    let source = r#"
+package proof
+
+type A struct { B B }
+type B struct{}
+func (*A) Run() {}
+func (*B) Run() {}
+
+func nestedSelector() {
+    x := A{B: B{}}.B
+    x.Run()
+}
+
+func doublePointer(x **A) {
+    x.Run()
+}
+
+func indexedComposite() {
+    x := []A{{}}[0]
+    x.Run()
+}
+"#;
+    let (nodes, edges) = index_files(&[("main.go", source)])?;
+    for caller in ["nestedSelector", "doublePointer", "indexedComposite"] {
+        for owner in ["A", "B"] {
+            assert_no_resolved_call_to_method_owner(
+                "Go non-closed type/constructor AST",
+                &nodes,
+                &edges,
+                caller,
+                owner,
+                "Run",
+            );
+        }
+    }
+    Ok(())
+}
+
+#[test]
 fn test_projection_regression_dart_arrow_and_initializer_calls_are_typed() -> anyhow::Result<()> {
     let request = r#"
 class BaseRequest {

--- a/crates/codestory-indexer/tests/proof_resolution.rs
+++ b/crates/codestory-indexer/tests/proof_resolution.rs
@@ -960,14 +960,14 @@ fn go_lexical_shadowing_is_callsite_specific() -> anyhow::Result<()> {
     index_files(
         project.path(),
         &mut store,
-        &[((
+        &[(
             "main.go",
             concat!(
                 "package proof\n",
                 "func target() {}\n",
                 "func caller() { target(); { target := func() {}; target() }; target() }\n",
             ),
-        ))],
+        )],
     )?;
     rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
     let matching = store

--- a/crates/codestory-indexer/tests/proof_resolution.rs
+++ b/crates/codestory-indexer/tests/proof_resolution.rs
@@ -1,7 +1,7 @@
 use codestory_contracts::events::EventBus;
 use codestory_contracts::graph::{EdgeId, EdgeKind, Node, NodeId, NodeKind};
 use codestory_contracts::proof_resolution::{
-    ProofResolutionStatus, ResolutionEvidence, ResolutionEvidenceKind,
+    ProofResolutionReason, ProofResolutionStatus, ResolutionEvidence, ResolutionEvidenceKind,
 };
 use codestory_indexer::{WorkspaceIndexer, rematerialize_proof_resolution_projection};
 use codestory_store::{FileInfo, FileRole, IndexPublicationMode, IndexPublicationRecord, Store};
@@ -442,6 +442,918 @@ fn typescript_and_rust_reference_calls_rematerialize_exact_facts() -> anyhow::Re
                 && row.counts.authoritative_receipts == 0
                 && row.counts.complete_proofs == 0)
     );
+    Ok(())
+}
+
+#[test]
+fn go_closed_exact_subset_authorizes_package_functions_and_concrete_receivers() -> anyhow::Result<()>
+{
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(
+        project.path(),
+        &mut store,
+        &[
+            ("go.mod", "module example.com/proof\n\ngo 1.24\n"),
+            (
+                "worker.go",
+                concat!(
+                    "package proof\n\n",
+                    "type Worker struct{}\n",
+                    "type ValueWorker struct{}\n",
+                    "func localTarget() {}\n",
+                    "func (w *Worker) implicit() { w.step() }\n",
+                    "func (w *Worker) step() {}\n",
+                    "func (w ValueWorker) valueStep() {}\n",
+                    "func parameter(w *Worker) { w.step() }\n",
+                    "func constructed() {\n",
+                    "  a := ValueWorker{}\n",
+                    "  a.valueStep()\n",
+                    "  b := &Worker{}\n",
+                    "  b.step()\n",
+                    "  c := new(Worker)\n",
+                    "  c.step()\n",
+                    "}\n",
+                    "func sameFile() { localTarget() }\n",
+                ),
+            ),
+            (
+                "cross.go",
+                "package proof\n\nfunc crossFile() { localTarget() }\n",
+            ),
+        ],
+    )?;
+
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    store.validate_proof_resolution_publication(&publication(1))?;
+    let facts = store.get_proof_resolution_facts()?;
+    let exact = facts
+        .iter()
+        .filter(|fact| fact.provenance.language_adapter == "go")
+        .filter(|fact| fact.status == ProofResolutionStatus::Exact)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        exact
+            .iter()
+            .filter(|fact| fact.callsite.raw_target == "localTarget")
+            .count(),
+        2,
+        "same-file and cross-file package functions: {facts:#?}"
+    );
+    assert_eq!(
+        exact
+            .iter()
+            .filter(|fact| matches!(fact.callsite.raw_target.as_str(), "step" | "valueStep"))
+            .count(),
+        5,
+        "implicit, typed, value, pointer, and builtin-new receivers: {facts:#?}"
+    );
+    assert!(exact.iter().all(|fact| {
+        fact.provenance.dependency_file_hashes.len() == 2
+            && fact.edge_id.is_some()
+            && fact.target.is_some()
+    }));
+    Ok(())
+}
+
+#[test]
+fn go_explicit_typed_local_receiver_is_exact_without_reassignment() -> anyhow::Result<()> {
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(
+        project.path(),
+        &mut store,
+        &[(
+            "main.go",
+            concat!(
+                "package proof\n",
+                "type Worker struct{}\n",
+                "func (*Worker) Run() {}\n",
+                "func caller() { var worker *Worker; worker.Run() }\n",
+            ),
+        )],
+    )?;
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    let fact = store
+        .get_proof_resolution_facts()?
+        .into_iter()
+        .find(|fact| fact.callsite.raw_target == "Run")
+        .expect("typed local fact");
+    assert_eq!(fact.status, ProofResolutionStatus::Exact, "{fact:#?}");
+    assert!(matches!(
+        fact.evidence_chain.as_slice(),
+        [
+            ResolutionEvidence::ExplicitReceiverType { .. },
+            ResolutionEvidence::SameFileDeclaration { .. }
+        ]
+    ));
+    Ok(())
+}
+
+#[test]
+fn go_type_and_constructor_authority_requires_closed_ast_shapes() -> anyhow::Result<()> {
+    let cases = [
+        (
+            "nested_selector.go",
+            concat!(
+                "package proof\n",
+                "type A struct { B B }\n",
+                "type B struct{}\n",
+                "func (*A) Run() {}\n",
+                "func (*B) Run() {}\n",
+                "func caller() { x := A{B: B{}}.B; x.Run() }\n",
+            ),
+        ),
+        (
+            "double_pointer.go",
+            concat!(
+                "package proof\n",
+                "type A struct{}\n",
+                "func (*A) Run() {}\n",
+                "func caller(x **A) { x.Run() }\n",
+            ),
+        ),
+        (
+            "parenthesized.go",
+            concat!(
+                "package proof\n",
+                "type A struct{}\n",
+                "func (*A) Run() {}\n",
+                "func caller(x (A)) { x.Run() }\n",
+            ),
+        ),
+        (
+            "arbitrary_expression.go",
+            concat!(
+                "package proof\n",
+                "type A struct{}\n",
+                "func (*A) Run() {}\n",
+                "func caller() { x := A{}; y := []A{x}[0]; y.Run() }\n",
+            ),
+        ),
+    ];
+    for (path, source) in cases {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(project.path(), &mut store, &[(path, source)])?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        let run = store
+            .get_proof_resolution_facts()?
+            .into_iter()
+            .find(|fact| fact.callsite.raw_target == "Run")
+            .unwrap_or_else(|| panic!("missing hostile constructor fact for {path}"));
+        assert_ne!(
+            run.status,
+            ProofResolutionStatus::Exact,
+            "non-closed Go type/constructor surface became Exact for {path}: {run:#?}"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn go_relevant_range_select_and_type_switch_bindings_poison_outer_authority() -> anyhow::Result<()>
+{
+    let cases = [
+        (
+            "range_declare.go",
+            concat!(
+                "package proof\n",
+                "type A struct{}\n",
+                "type B struct{}\n",
+                "func (*A) Run() {}\n",
+                "func (*B) Run() {}\n",
+                "func caller(a *A, xs []*B) { for _, a := range xs { a.Run() } }\n",
+            ),
+        ),
+        (
+            "range_assign.go",
+            concat!(
+                "package proof\n",
+                "type A struct{}\n",
+                "type B struct{}\n",
+                "func (*A) Run() {}\n",
+                "func (*B) Run() {}\n",
+                "func caller(a *A, xs []*B) { for _, a = range xs { a.Run() } }\n",
+            ),
+        ),
+        (
+            "select_receive.go",
+            concat!(
+                "package proof\n",
+                "type A struct{}\n",
+                "type B struct{}\n",
+                "func (*A) Run() {}\n",
+                "func (*B) Run() {}\n",
+                "func caller(a *A, ch <-chan *B) { select { case a := <-ch: a.Run() } }\n",
+            ),
+        ),
+        (
+            "type_switch.go",
+            concat!(
+                "package proof\n",
+                "type A struct{}\n",
+                "type B struct{}\n",
+                "func (*A) Run() {}\n",
+                "func (*B) Run() {}\n",
+                "func caller(a *A, value any) { switch a := value.(type) { case *B: a.Run() } }\n",
+            ),
+        ),
+    ];
+    for (path, source) in cases {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(project.path(), &mut store, &[(path, source)])?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        let run = store
+            .get_proof_resolution_facts()?
+            .into_iter()
+            .find(|fact| fact.callsite.raw_target == "Run")
+            .unwrap_or_else(|| panic!("missing hostile lexical fact for {path}"));
+        assert_ne!(
+            run.status,
+            ProofResolutionStatus::Exact,
+            "incomplete Go lexical closure retained outer authority for {path}: {run:#?}"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn go_source_and_owner_closure_rejects_generated_linkname_and_owner_competitors()
+-> anyhow::Result<()> {
+    let leading_comments = (0..21)
+        .map(|index| format!("// leading comment {index}\n"))
+        .collect::<String>();
+    let generated = format!(
+        "{leading_comments}// Code generated by fixture. DO NOT EDIT.\npackage proof\nfunc target() {{}}\nfunc caller() {{ target() }}\n"
+    );
+    let cases = [
+        (
+            vec![("generated.go", generated.as_str())],
+            "target",
+            "generated marker after line 20",
+        ),
+        (
+            vec![(
+                "linkname.go",
+                concat!(
+                    "package proof\n",
+                    "import _ \"unsafe\"\n",
+                    "//go:linkname target runtime.target\n",
+                    "func target() {}\n",
+                    "func caller() { target() }\n",
+                ),
+            )],
+            "target",
+            "go:linkname",
+        ),
+        (
+            vec![
+                (
+                    "main.go",
+                    concat!(
+                        "package proof\n",
+                        "type Worker struct{}\n",
+                        "func (*Worker) Run() {}\n",
+                        "func caller(worker *Worker) { worker.Run() }\n",
+                    ),
+                ),
+                (
+                    "conditional.go",
+                    "//go:build linux\n\npackage proof\nvar Worker = 1\n",
+                ),
+            ],
+            "Run",
+            "conditional owner-name competitor",
+        ),
+    ];
+    for (files, target, label) in cases {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(project.path(), &mut store, &files)?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        let fact = store
+            .get_proof_resolution_facts()?
+            .into_iter()
+            .find(|fact| fact.callsite.raw_target == target)
+            .unwrap_or_else(|| panic!("missing source-closure fact for {label}"));
+        assert_ne!(
+            fact.status,
+            ProofResolutionStatus::Exact,
+            "{label} became Exact: {fact:#?}"
+        );
+    }
+
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(
+        project.path(),
+        &mut store,
+        &[(
+            "string.go",
+            concat!(
+                "package proof\n",
+                "const marker = \"// Code generated by fixture. DO NOT EDIT.\"\n",
+                "func target() {}\n",
+                "func caller() { target() }\n",
+            ),
+        )],
+    )?;
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    let target = store
+        .get_proof_resolution_facts()?
+        .into_iter()
+        .find(|fact| fact.callsite.raw_target == "target")
+        .expect("string non-marker fact");
+    assert_eq!(target.status, ProofResolutionStatus::Exact, "{target:#?}");
+    Ok(())
+}
+
+#[test]
+fn go_unsupported_shadowed_and_open_domains_never_authorize_exact_receipts() -> anyhow::Result<()> {
+    let cases = [
+        (
+            "shadow.go",
+            concat!(
+                "package proof\n",
+                "func target() {}\n",
+                "func caller(target func()) { target() }\n",
+            ),
+            "target",
+        ),
+        (
+            "interface.go",
+            concat!(
+                "package proof\n",
+                "type Runner interface { Run() }\n",
+                "func caller(r Runner) { r.Run() }\n",
+            ),
+            "Run",
+        ),
+        (
+            "embedded.go",
+            concat!(
+                "package proof\n",
+                "type Base struct{}\n",
+                "func (Base) Run() {}\n",
+                "type Child struct { Base }\n",
+                "func caller(c Child) { c.Run() }\n",
+            ),
+            "Run",
+        ),
+        (
+            "rebound.go",
+            concat!(
+                "package proof\n",
+                "type Worker struct{}\n",
+                "func (*Worker) Run() {}\n",
+                "func caller(w *Worker) { w = &Worker{}; w.Run() }\n",
+            ),
+            "Run",
+        ),
+        (
+            "pointer_promotion.go",
+            concat!(
+                "package proof\n",
+                "type Worker struct{}\n",
+                "func (*Worker) Run() {}\n",
+                "func caller(w Worker) { w.Run() }\n",
+            ),
+            "Run",
+        ),
+        (
+            "captured.go",
+            concat!(
+                "package proof\n",
+                "type Worker struct{}\n",
+                "func (*Worker) Run() {}\n",
+                "func caller(w *Worker) { func() { w = &Worker{} }(); w.Run() }\n",
+            ),
+            "Run",
+        ),
+        (
+            "branch_write.go",
+            concat!(
+                "package proof\n",
+                "type Worker struct{}\n",
+                "func (*Worker) Run() {}\n",
+                "func caller(w *Worker, condition bool) { if condition { w = &Worker{} }; w.Run() }\n",
+            ),
+            "Run",
+        ),
+        (
+            "branch_binding.go",
+            concat!(
+                "package proof\n",
+                "type Worker struct{}\n",
+                "func (*Worker) Run() {}\n",
+                "func caller(condition bool) { if condition { w := &Worker{}; w.Run() } }\n",
+            ),
+            "Run",
+        ),
+        (
+            "shadowed_new.go",
+            concat!(
+                "package proof\n",
+                "type Worker struct{}\n",
+                "func (*Worker) Run() {}\n",
+                "func caller(new func(Worker) *Worker) { w := new(Worker{}); w.Run() }\n",
+            ),
+            "Run",
+        ),
+        (
+            "package_new.go",
+            concat!(
+                "package proof\n",
+                "type Worker struct{}\n",
+                "func (*Worker) Run() {}\n",
+                "func new(Worker) *Worker { return &Worker{} }\n",
+                "func caller() { w := new(Worker{}); w.Run() }\n",
+            ),
+            "Run",
+        ),
+        (
+            "generic_receiver.go",
+            concat!(
+                "package proof\n",
+                "type Worker[T any] struct{}\n",
+                "func (*Worker[T]) Run() {}\n",
+                "func caller(w *Worker[int]) { w.Run() }\n",
+            ),
+            "Run",
+        ),
+        (
+            "local_const_shadow.go",
+            concat!(
+                "package proof\n",
+                "func target() {}\n",
+                "func caller() { const target = 1; target() }\n",
+            ),
+            "target",
+        ),
+        (
+            "local_type_shadow.go",
+            concat!(
+                "package proof\n",
+                "func target() {}\n",
+                "func caller() { type target int; target() }\n",
+            ),
+            "target",
+        ),
+        (
+            "local_function_shadow.go",
+            concat!(
+                "package proof\n",
+                "func target() {}\n",
+                "func caller() { target := func() {}; target() }\n",
+            ),
+            "target",
+        ),
+        (
+            "import_shadow.go",
+            concat!(
+                "package proof\n",
+                "import target \"example.com/other\"\n",
+                "func target() {}\n",
+                "func caller() { target() }\n",
+            ),
+            "target",
+        ),
+        (
+            "dot_import.go",
+            concat!(
+                "package proof\n",
+                "import . \"example.com/other\"\n",
+                "func target() {}\n",
+                "func caller() { target() }\n",
+            ),
+            "target",
+        ),
+    ];
+    for (path, source, target) in cases {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(project.path(), &mut store, &[(path, source)])?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        let matching = store
+            .get_proof_resolution_facts()?
+            .into_iter()
+            .filter(|fact| fact.provenance.language_adapter == "go")
+            .filter(|fact| fact.callsite.raw_target == target)
+            .collect::<Vec<_>>();
+        assert!(!matching.is_empty(), "missing Go fact for {path}");
+        assert!(
+            matching
+                .iter()
+                .all(|fact| fact.status != ProofResolutionStatus::Exact),
+            "unsupported Go case became Exact for {path}: {matching:#?}"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn go_lexical_shadowing_is_callsite_specific() -> anyhow::Result<()> {
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(
+        project.path(),
+        &mut store,
+        &[((
+            "main.go",
+            concat!(
+                "package proof\n",
+                "func target() {}\n",
+                "func caller() { target(); { target := func() {}; target() }; target() }\n",
+            ),
+        ))],
+    )?;
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    let matching = store
+        .get_proof_resolution_facts()?
+        .into_iter()
+        .filter(|fact| fact.callsite.raw_target == "target")
+        .collect::<Vec<_>>();
+    assert_eq!(matching.len(), 3, "{matching:#?}");
+    assert_ne!(matching[0].status, ProofResolutionStatus::Unsupported);
+    assert_eq!(matching[1].status, ProofResolutionStatus::Unsupported);
+    assert_ne!(matching[2].status, ProofResolutionStatus::Unsupported);
+    assert!(
+        matching
+            .iter()
+            .all(|fact| fact.status != ProofResolutionStatus::Exact)
+    );
+    Ok(())
+}
+
+#[test]
+fn go_filename_selected_callers_and_competing_declarations_are_incomplete() -> anyhow::Result<()> {
+    for files in [
+        vec![(
+            "main_linux.go",
+            "package proof\nfunc target() {}\nfunc caller() { target() }\n",
+        )],
+        vec![
+            (
+                "main.go",
+                "package proof\nfunc target() {}\nfunc caller() { target() }\n",
+            ),
+            (
+                "target_windows_amd64.go",
+                "package proof\nfunc target() {}\n",
+            ),
+        ],
+    ] {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(project.path(), &mut store, &files)?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        let target = store
+            .get_proof_resolution_facts()?
+            .into_iter()
+            .find(|fact| fact.callsite.raw_target == "target")
+            .expect("target fact");
+        assert_eq!(
+            target.status,
+            ProofResolutionStatus::IncompleteDomain,
+            "{target:#?}"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn go_package_closure_and_imports_fail_closed_without_complete_authenticated_domains()
+-> anyhow::Result<()> {
+    for (files, target) in [
+        (
+            vec![
+                ("a.go", "package proof\nfunc target() {}\n"),
+                (
+                    "b.go",
+                    "package proof\nfunc target() {}\nfunc caller() { target() }\n",
+                ),
+            ],
+            "target",
+        ),
+        (
+            vec![
+                (
+                    "a.go",
+                    "package proof\nfunc target() {}\nfunc caller() { target() }\n",
+                ),
+                (
+                    "conditional.go",
+                    "//go:build linux\n\npackage proof\nfunc target() {}\n",
+                ),
+            ],
+            "target",
+        ),
+        (
+            vec![
+                ("go.mod", "module example.com/proof\n\ngo 1.24\n"),
+                ("dep/dep.go", "package dep\nfunc Target() {}\n"),
+                (
+                    "main.go",
+                    "package proof\nimport alias \"example.com/proof/dep\"\nfunc caller() { alias.Target() }\n",
+                ),
+            ],
+            "Target",
+        ),
+    ] {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(project.path(), &mut store, &files)?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        let matching = store
+            .get_proof_resolution_facts()?
+            .into_iter()
+            .filter(|fact| fact.provenance.language_adapter == "go")
+            .filter(|fact| fact.callsite.raw_target == target)
+            .collect::<Vec<_>>();
+        assert!(!matching.is_empty(), "missing Go closure fact for {target}");
+        assert!(
+            matching
+                .iter()
+                .all(|fact| fact.status != ProofResolutionStatus::Exact),
+            "open Go package/import domain became Exact: {matching:#?}"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn go_imported_receivers_are_incomplete_without_an_authenticated_module_domain()
+-> anyhow::Result<()> {
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(
+        project.path(),
+        &mut store,
+        &[
+            ("go.mod", "module example.com/proof\n\ngo 1.24\n"),
+            (
+                "dep/dep.go",
+                "package dep\ntype Worker struct{}\nfunc (*Worker) Run() {}\n",
+            ),
+            (
+                "main.go",
+                concat!(
+                    "package proof\n",
+                    "import dep \"example.com/proof/dep\"\n",
+                    "func parameter(worker *dep.Worker) { worker.Run() }\n",
+                    "func constructed() { worker := &dep.Worker{}; worker.Run() }\n",
+                ),
+            ),
+        ],
+    )?;
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    let matching = store
+        .get_proof_resolution_facts()?
+        .into_iter()
+        .filter(|fact| fact.callsite.raw_target == "Run")
+        .collect::<Vec<_>>();
+    assert_eq!(matching.len(), 2, "{matching:#?}");
+    assert!(matching.iter().all(|fact| {
+        fact.status == ProofResolutionStatus::IncompleteDomain
+            && fact.reason == ProofResolutionReason::LookupDomainIncomplete
+    }));
+    Ok(())
+}
+
+#[test]
+fn go_noncompeting_conditional_and_test_siblings_preserve_the_exact_package_domain()
+-> anyhow::Result<()> {
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(
+        project.path(),
+        &mut store,
+        &[
+            (
+                "main.go",
+                "package proof\nfunc target() {}\nfunc caller() { target() }\n",
+            ),
+            (
+                "conditional.go",
+                "//go:build linux\n\npackage proof\nfunc unrelated() {}\n",
+            ),
+            ("main_test.go", "package proof_test\nfunc testOnly() {}\n"),
+            ("same_package_test.go", "package proof\nfunc target() {}\n"),
+        ],
+    )?;
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    let target = store
+        .get_proof_resolution_facts()?
+        .into_iter()
+        .find(|fact| {
+            fact.provenance.language_adapter == "go" && fact.callsite.raw_target == "target"
+        })
+        .expect("target fact");
+    assert_eq!(target.status, ProofResolutionStatus::Exact, "{target:#?}");
+    assert_eq!(target.provenance.dependency_file_hashes.len(), 2);
+    assert!(
+        target
+            .provenance
+            .dependency_file_hashes
+            .iter()
+            .all(|dependency| dependency.file_id != target.callsite.file_id
+                || dependency.source_sha256 == target.callsite.source_sha256)
+    );
+    Ok(())
+}
+
+#[test]
+fn go_missing_cache_coverage_and_parser_error_siblings_make_the_package_incomplete()
+-> anyhow::Result<()> {
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(
+        project.path(),
+        &mut store,
+        &[(
+            "main.go",
+            "package proof\nfunc target() {}\nfunc caller() { target() }\n",
+        )],
+    )?;
+    fs::write(
+        project.path().join("not_indexed.go"),
+        "package proof\nfunc unrelated() {}\n",
+    )?;
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    let missing = store
+        .get_proof_resolution_facts()?
+        .into_iter()
+        .find(|fact| fact.callsite.raw_target == "target")
+        .expect("missing-coverage target fact");
+    assert_eq!(missing.status, ProofResolutionStatus::IncompleteDomain);
+
+    let parse_project = tempfile::tempdir()?;
+    let mut parse_store = Store::new_in_memory()?;
+    index_files(
+        parse_project.path(),
+        &mut parse_store,
+        &[
+            (
+                "main.go",
+                "package proof\nfunc target() {}\nfunc caller() { target() }\n",
+            ),
+            ("broken.go", "package proof\nfunc broken( {\n"),
+        ],
+    )?;
+    rematerialize_proof_resolution_projection(&mut parse_store, &publication(1))?;
+    let parser_error = parse_store
+        .get_proof_resolution_facts()?
+        .into_iter()
+        .find(|fact| fact.callsite.raw_target == "target")
+        .expect("parser-error target fact");
+    assert_eq!(parser_error.status, ProofResolutionStatus::IncompleteDomain);
+    Ok(())
+}
+
+#[test]
+fn go_generated_targets_and_same_named_other_owners_stay_non_authoritative() -> anyhow::Result<()> {
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(
+        project.path(),
+        &mut store,
+        &[
+            (
+                "types.go",
+                concat!(
+                    "package proof\n",
+                    "type A struct{}\n",
+                    "type B struct{}\n",
+                    "func (*A) Run() {}\n",
+                    "func (*B) Run() {}\n",
+                    "func caller(a *A) { a.Run() }\n",
+                ),
+            ),
+            (
+                "generated.go",
+                "// Code generated by fixture. DO NOT EDIT.\npackage proof\nfunc generatedTarget() {}\nfunc generatedCaller() { generatedTarget() }\n",
+            ),
+        ],
+    )?;
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    let facts = store.get_proof_resolution_facts()?;
+    let run = facts
+        .iter()
+        .find(|fact| fact.callsite.raw_target == "Run")
+        .expect("owner-specific method fact");
+    assert_eq!(
+        run.status,
+        ProofResolutionStatus::Exact,
+        "the exact receiver owner must disambiguate same-spelled methods: {run:#?}"
+    );
+    assert!(matches!(
+        run.evidence_chain.as_slice(),
+        [
+            ResolutionEvidence::ExplicitReceiverType { .. },
+            ResolutionEvidence::SameFileDeclaration { .. }
+        ]
+    ));
+    let generated = facts
+        .iter()
+        .find(|fact| fact.callsite.raw_target == "generatedTarget")
+        .expect("generated target fact");
+    assert_ne!(generated.status, ProofResolutionStatus::Exact);
+    Ok(())
+}
+
+#[test]
+fn go_repeated_callsites_and_utf8_crlf_coordinates_are_source_bound_and_distinct()
+-> anyhow::Result<()> {
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    let source =
+        "package proof\r\n// λλ\r\nfunc target() {}\r\nfunc caller() { target(); target() }\r\n";
+    index_files(project.path(), &mut store, &[("main.go", source)])?;
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    let mut facts = store
+        .get_proof_resolution_facts()?
+        .into_iter()
+        .filter(|fact| fact.callsite.raw_target == "target")
+        .collect::<Vec<_>>();
+    facts.sort_by_key(|fact| fact.callsite.start_byte);
+    assert_eq!(facts.len(), 2, "{facts:#?}");
+    assert!(
+        facts
+            .iter()
+            .all(|fact| fact.status == ProofResolutionStatus::Exact)
+    );
+    assert_ne!(facts[0].edge_id, facts[1].edge_id);
+    assert_ne!(
+        facts[0].raw_callsite_identity,
+        facts[1].raw_callsite_identity
+    );
+    for fact in &facts {
+        assert_eq!(
+            &source.as_bytes()
+                [fact.callsite.start_byte as usize..fact.callsite.end_byte_exclusive as usize],
+            b"target"
+        );
+        assert_eq!(fact.callsite.line, 4);
+    }
+    assert!(facts[0].callsite.column < facts[1].callsite.column);
+    Ok(())
+}
+
+#[test]
+fn go_wrong_effective_target_never_becomes_exact_even_with_certain_navigation_metadata()
+-> anyhow::Result<()> {
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(
+        project.path(),
+        &mut store,
+        &[(
+            "main.go",
+            concat!(
+                "package proof\n",
+                "type A struct{}\n",
+                "type B struct{}\n",
+                "func (*A) Run() {}\n",
+                "func (*B) Run() {}\n",
+                "func caller(a *A) { a.Run() }\n",
+            ),
+        )],
+    )?;
+    let nodes = store.get_nodes()?;
+    let wrong_target = nodes
+        .iter()
+        .filter(|node| node.kind == NodeKind::METHOD && node.serialized_name.ends_with("B.Run"))
+        .map(|node| node.id)
+        .next()
+        .or_else(|| {
+            nodes
+                .iter()
+                .filter(|node| {
+                    node.kind == NodeKind::METHOD && node.serialized_name.ends_with("Run")
+                })
+                .nth(1)
+                .map(|node| node.id)
+        })
+        .expect("B.Run target");
+    let call = store
+        .get_edges()?
+        .into_iter()
+        .find(|edge| edge.kind == EdgeKind::CALL && edge.line == Some(6))
+        .expect("receiver CALL edge");
+    store.get_connection().execute(
+        "UPDATE edge SET resolved_target_node_id = ?1, certainty = 1, confidence = 1.0 WHERE id = ?2",
+        (wrong_target.0, call.id.0),
+    )?;
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    let fact = store
+        .get_proof_resolution_facts()?
+        .into_iter()
+        .find(|fact| fact.callsite.raw_target == "Run")
+        .expect("mutated Run fact");
+    assert_ne!(fact.status, ProofResolutionStatus::Exact, "{fact:#?}");
+    assert!(fact.edge_id.is_none());
     Ok(())
 }
 
@@ -2747,7 +3659,7 @@ fn complete_projection_requires_cache_coverage_but_empty_and_unsupported_reposit
     let mut empty = Store::new_in_memory()?;
     let empty_receipt = rematerialize_proof_resolution_projection(&mut empty, &publication(1))?;
     assert_eq!(empty_receipt.fact_count, 0);
-    assert_eq!(empty_receipt.adapter_roster.len(), 4);
+    assert_eq!(empty_receipt.adapter_roster.len(), 5);
 
     let project = tempfile::tempdir()?;
     let mut unsupported = Store::new_in_memory()?;
@@ -2762,7 +3674,7 @@ fn complete_projection_requires_cache_coverage_but_empty_and_unsupported_reposit
     let unsupported_receipt =
         rematerialize_proof_resolution_projection(&mut unsupported, &publication(1))?;
     assert_eq!(unsupported_receipt.fact_count, 0);
-    assert_eq!(unsupported_receipt.adapter_roster.len(), 4);
+    assert_eq!(unsupported_receipt.adapter_roster.len(), 5);
 
     let governed_project = tempfile::tempdir()?;
     let mut governed = Store::new_in_memory()?;
@@ -2990,7 +3902,7 @@ fn complete_projection_rejects_cache_schema_adapter_and_language_mismatch() -> a
             .expect_err("cache provenance mismatch must reject the complete projection");
         let message = error.to_string();
         assert!(
-            ["stale", "schema-v7", "adapter", "language"]
+            ["stale", "schema-v8", "adapter", "language"]
                 .iter()
                 .any(|needle| message.contains(needle)),
             "{mutation}: {error}"

--- a/crates/codestory-runtime/src/tests.rs
+++ b/crates/codestory-runtime/src/tests.rs
@@ -4698,6 +4698,16 @@ fn semantic_projection_republish_uses_stored_core_after_source_is_removed() {
             .expect("read republished core"),
         Some(outcome.publication.clone())
     );
+    let proof = storage
+        .get_proof_resolution_publication()
+        .expect("read rebound proof publication")
+        .expect("stored proof publication remains present");
+    assert_eq!(proof.core_generation_id, outcome.publication.generation_id);
+    assert_eq!(proof.core_run_id, outcome.publication.run_id);
+    assert_eq!(
+        proof.published_at_epoch_ms,
+        outcome.publication.published_at_epoch_ms
+    );
     storage
         .validate_dense_anchor_publication(&outcome.publication)
         .expect("dense publication is coherent");
@@ -4745,6 +4755,37 @@ fn semantic_projection_republish_uses_stored_core_after_source_is_removed() {
     assert_eq!(
         Storage::database_complete_index_publication(&storage_path)
             .expect("read publication after rejected source policy"),
+        Some(outcome.publication.clone())
+    );
+    assert_no_staged_publication_artifacts(&storage_path);
+
+    let tampered = rusqlite::Connection::open(&storage_path).expect("open rebound core");
+    let go_edge_id = tampered
+        .query_row(
+            "SELECT edge_id FROM proof_resolution_fact
+             WHERE status = 'exact' AND language_adapter = 'go'
+             ORDER BY edge_id LIMIT 1",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .expect("stored fixture has one exact Go edge");
+    tampered
+        .execute(
+            "UPDATE edge SET line = line + 1 WHERE id = ?1",
+            [go_edge_id],
+        )
+        .expect("tamper stored Go correlation");
+    drop(tampered);
+    let error = controller
+        .republish_semantic_projections_at_blocking(
+            workspace.path().to_path_buf(),
+            storage_path.clone(),
+        )
+        .expect_err("stored-graph tamper must reject source-free proof rebind");
+    assert!(error.message.contains("proof resolution"), "{error:?}");
+    assert_eq!(
+        Storage::database_complete_index_publication(&storage_path)
+            .expect("read publication after rejected proof rebind"),
         Some(outcome.publication)
     );
     assert_no_staged_publication_artifacts(&storage_path);

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -1094,7 +1094,7 @@ fn read_proof_resolution_rollback_identity(
         )));
     };
     let receipt = storage
-        .validate_proof_resolution_publication(publication)
+        .validate_stored_proof_resolution_publication(publication)
         .map_err(|error| {
             promotion_error(format!(
                 "Proof resolution rollback identity does not match {}: {error}",

--- a/crates/codestory-store/src/storage_impl/proof_resolution.rs
+++ b/crates/codestory-store/src/storage_impl/proof_resolution.rs
@@ -311,14 +311,16 @@ fn go_package_dependency_ids(
         .ok_or_else(|| proof_error("Go authenticated package closure is missing"))
 }
 
-fn prepare_go_package_closure(
-    file_by_id: &HashMap<i64, FileInfo>,
-    file_content_hash_by_id: &HashMap<i64, String>,
-) -> (
+type PreparedGoPackageClosure = (
     HashMap<i64, GoPackageIdentity>,
     HashMap<GoPackageIdentity, BTreeSet<FileId>>,
     HashMap<i64, String>,
-) {
+);
+
+fn prepare_go_package_closure(
+    file_by_id: &HashMap<i64, FileInfo>,
+    file_content_hash_by_id: &HashMap<i64, String>,
+) -> PreparedGoPackageClosure {
     let mut identity_by_file = HashMap::new();
     let mut dependencies_by_package = HashMap::<GoPackageIdentity, BTreeSet<FileId>>::new();
     let mut errors = HashMap::new();

--- a/crates/codestory-store/src/storage_impl/proof_resolution.rs
+++ b/crates/codestory-store/src/storage_impl/proof_resolution.rs
@@ -212,6 +212,7 @@ struct ProofResolutionValidationContext {
     go_package_identity_by_file: HashMap<i64, GoPackageIdentity>,
     go_dependency_ids_by_package: HashMap<GoPackageIdentity, BTreeSet<FileId>>,
     go_attestation_error_by_file: HashMap<i64, String>,
+    live_go_sources_authenticated: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -309,6 +310,47 @@ fn go_package_dependency_ids(
         .get(source_identity)
         .cloned()
         .ok_or_else(|| proof_error("Go authenticated package closure is missing"))
+}
+
+fn stored_go_package_dependency_ids(
+    source_file_id: FileId,
+    required_evidence_ids: &BTreeSet<FileId>,
+    stored_fact_ids: &BTreeSet<FileId>,
+    context: &ProofResolutionValidationContext,
+) -> Result<BTreeSet<FileId>, StorageError> {
+    if !required_evidence_ids.is_subset(stored_fact_ids) {
+        return Err(proof_error(
+            "stored Go dependency receipt omits source or typed evidence files",
+        ));
+    }
+    let source_file = context
+        .file_by_id
+        .get(&source_file_id.0)
+        .ok_or_else(|| proof_error("stored Go source dependency file is missing"))?;
+    let source_parent = source_file
+        .path
+        .parent()
+        .ok_or_else(|| proof_error("stored Go source path has no package directory"))?;
+    for file_id in stored_fact_ids {
+        count_go_store_replay_work(1);
+        let file = context
+            .file_by_id
+            .get(&file_id.0)
+            .ok_or_else(|| proof_error("stored Go dependency file is missing"))?;
+        if file.language != "go"
+            || file.path.parent() != Some(source_parent)
+            || file
+                .path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.ends_with("_test.go"))
+        {
+            return Err(proof_error(
+                "stored Go dependency receipt crosses its authenticated package domain",
+            ));
+        }
+    }
+    Ok(stored_fact_ids.clone())
 }
 
 type PreparedGoPackageClosure = (
@@ -480,6 +522,7 @@ mod go_replay_complexity_tests {
             go_package_identity_by_file,
             go_dependency_ids_by_package,
             go_attestation_error_by_file,
+            live_go_sources_authenticated: true,
         };
         for _ in 0..lookup_count {
             go_package_dependency_ids(FileId(1), &BTreeSet::from([FileId(1)]), &context)
@@ -564,7 +607,10 @@ impl ProofRelationState {
 }
 
 impl ProofResolutionValidationContext {
-    fn prepare(storage: &Storage) -> Result<Self, StorageError> {
+    fn prepare(
+        storage: &Storage,
+        authenticate_live_go_sources: bool,
+    ) -> Result<Self, StorageError> {
         let file_by_id = storage
             .get_files()?
             .into_iter()
@@ -575,7 +621,11 @@ impl ProofResolutionValidationContext {
             go_package_identity_by_file,
             go_dependency_ids_by_package,
             go_attestation_error_by_file,
-        ) = prepare_go_package_closure(&file_by_id, &file_content_hash_by_id);
+        ) = if authenticate_live_go_sources {
+            prepare_go_package_closure(&file_by_id, &file_content_hash_by_id)
+        } else {
+            (HashMap::new(), HashMap::new(), HashMap::new())
+        };
         let node_by_id: HashMap<NodeId, Node> = storage
             .get_nodes()?
             .into_iter()
@@ -668,6 +718,7 @@ impl ProofResolutionValidationContext {
             go_package_identity_by_file,
             go_dependency_ids_by_package,
             go_attestation_error_by_file,
+            live_go_sources_authenticated: authenticate_live_go_sources,
         })
     }
 
@@ -849,11 +900,13 @@ impl Storage {
     fn validate_facts_against_graph(
         &self,
         facts: &[CallResolutionFact],
+        authenticate_live_go_sources: bool,
     ) -> Result<(), StorageError> {
         for fact in facts {
             validate_fact_seal(fact)?;
         }
-        let context = ProofResolutionValidationContext::prepare(self)?;
+        let context =
+            ProofResolutionValidationContext::prepare(self, authenticate_live_go_sources)?;
         let exact_fact_indices = facts
             .iter()
             .enumerate()
@@ -1039,11 +1092,16 @@ impl Storage {
                     "Go exact import evidence has no authenticated module-domain receipt",
                 ));
             }
-            required_dependency_ids = go_package_dependency_ids(
-                fact.callsite.file_id,
-                &required_dependency_ids,
-                context,
-            )?;
+            required_dependency_ids = if context.live_go_sources_authenticated {
+                go_package_dependency_ids(fact.callsite.file_id, &required_dependency_ids, context)?
+            } else {
+                stored_go_package_dependency_ids(
+                    fact.callsite.file_id,
+                    &required_dependency_ids,
+                    &dependency_file_ids(fact),
+                    context,
+                )?
+            };
         }
         let observed_dependency_ids = dependency_file_ids(fact);
         if observed_dependency_ids != required_dependency_ids {
@@ -1695,7 +1753,7 @@ impl Storage {
                     right.fact_id.as_str(),
                 ))
         });
-        self.validate_facts_against_graph(&facts)?;
+        self.validate_facts_against_graph(&facts, true)?;
         if facts.windows(2).any(|pair| {
             pair[0].callsite.file_id == pair[1].callsite.file_id
                 && pair[0].callsite.start_byte == pair[1].callsite.start_byte
@@ -1854,6 +1912,24 @@ impl Storage {
         &self,
         publication: &IndexPublicationRecord,
     ) -> Result<ProofResolutionPublication, StorageError> {
+        let (manifest, facts) = self.validate_proof_resolution_receipt(publication)?;
+        self.validate_facts_against_graph(&facts, true)?;
+        Ok(manifest)
+    }
+
+    pub(crate) fn validate_stored_proof_resolution_publication(
+        &self,
+        publication: &IndexPublicationRecord,
+    ) -> Result<ProofResolutionPublication, StorageError> {
+        let (manifest, facts) = self.validate_proof_resolution_receipt(publication)?;
+        self.validate_facts_against_graph(&facts, false)?;
+        Ok(manifest)
+    }
+
+    fn validate_proof_resolution_receipt(
+        &self,
+        publication: &IndexPublicationRecord,
+    ) -> Result<(ProofResolutionPublication, Vec<CallResolutionFact>), StorageError> {
         let manifest = self
             .get_proof_resolution_publication()?
             .ok_or_else(|| proof_error("complete publication receipt is missing"))?;
@@ -1878,8 +1954,10 @@ impl Storage {
                 "fact rows do not match their publication digest",
             ));
         }
-        self.validate_facts_against_graph(&facts)?;
-        Ok(manifest)
+        for fact in &facts {
+            validate_fact_seal(fact)?;
+        }
+        Ok((manifest, facts))
     }
 
     /// Rebind an already authenticated proof projection to a semantic-only
@@ -1893,7 +1971,11 @@ impl Storage {
         if self.get_proof_resolution_publication()?.is_none() {
             return Ok(None);
         }
-        self.validate_proof_resolution_publication(previous)?;
+        // A semantic-only republish is allowed to operate from the stored core
+        // after working-tree sources disappear. The previous publication was
+        // graph-validated before promotion; rebind authenticates its immutable
+        // fact rows and receipt without consulting live source bytes.
+        self.validate_stored_proof_resolution_publication(previous)?;
         if next.generation_id.trim().is_empty()
             || next.run_id.trim().is_empty()
             || next.published_at_epoch_ms < 0
@@ -1921,7 +2003,8 @@ impl Storage {
             ));
         }
         tx.commit()?;
-        self.validate_proof_resolution_publication(next).map(Some)
+        self.validate_stored_proof_resolution_publication(next)
+            .map(Some)
     }
 }
 

--- a/crates/codestory-store/src/storage_impl/proof_resolution.rs
+++ b/crates/codestory-store/src/storage_impl/proof_resolution.rs
@@ -13,6 +13,29 @@ const EVIDENCE_DIGEST_DOMAIN: &[u8] = b"codestory-proof-resolution-evidence-v1\0
 const FACT_ID_DOMAIN: &[u8] = b"codestory-proof-resolution-fact-id-v1\0";
 const PUBLICATION_DIGEST_DOMAIN: &[u8] = b"codestory-proof-resolution-publication-v1\0";
 
+#[cfg(test)]
+thread_local! {
+    static GO_STORE_REPLAY_WORK: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[inline]
+fn count_go_store_replay_work(amount: usize) {
+    #[cfg(test)]
+    GO_STORE_REPLAY_WORK.with(|work| work.set(work.get().saturating_add(amount)));
+    #[cfg(not(test))]
+    let _ = amount;
+}
+
+#[cfg(test)]
+fn reset_go_store_replay_work() {
+    GO_STORE_REPLAY_WORK.with(|work| work.set(0));
+}
+
+#[cfg(test)]
+fn go_store_replay_work() -> usize {
+    GO_STORE_REPLAY_WORK.with(std::cell::Cell::get)
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProofResolutionPublication {
     pub core_generation_id: String,
@@ -182,8 +205,348 @@ struct ProofResolutionValidationContext {
     node_by_id: HashMap<NodeId, Node>,
     edges: Vec<Edge>,
     edge_index_by_id: HashMap<EdgeId, usize>,
+    ordinary_call_edge_indices: Vec<usize>,
+    parsed_callsite_identity_by_edge: HashMap<EdgeId, StoredCanonicalCallsiteIdentity>,
     import_relations: HashMap<(NodeId, NodeId, NodeId), ProofRelationState>,
     member_relations: HashMap<(NodeId, NodeId), ProofRelationState>,
+    go_package_identity_by_file: HashMap<i64, GoPackageIdentity>,
+    go_dependency_ids_by_package: HashMap<GoPackageIdentity, BTreeSet<FileId>>,
+    go_attestation_error_by_file: HashMap<i64, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct GoPackageIdentity {
+    native_directory: PathBuf,
+    package_name: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct StoredCanonicalCallsiteIdentity {
+    file_id: FileId,
+    line: u32,
+    column_or_ordinal: u32,
+    raw_target: NodeId,
+}
+
+fn parse_stored_callsite_identity(identity: &str) -> Option<StoredCanonicalCallsiteIdentity> {
+    let mut fields = identity.split('|').next()?.split(':');
+    let parsed = StoredCanonicalCallsiteIdentity {
+        file_id: FileId(fields.next()?.parse().ok()?),
+        line: fields.next()?.parse().ok()?,
+        column_or_ordinal: fields.next()?.parse().ok()?,
+        raw_target: NodeId(fields.next()?.parse().ok()?),
+    };
+    (fields.next().is_none() && parsed.column_or_ordinal > 0).then_some(parsed)
+}
+
+fn prepare_call_edge_correlation_index(
+    edges: &[Edge],
+    node_by_id: &HashMap<NodeId, Node>,
+) -> (Vec<usize>, HashMap<EdgeId, StoredCanonicalCallsiteIdentity>) {
+    let mut indices = Vec::new();
+    let mut identities = HashMap::new();
+    for (index, edge) in edges.iter().enumerate() {
+        count_go_store_replay_work(1);
+        if edge.kind != EdgeKind::CALL || !node_by_id.contains_key(&edge.target) {
+            continue;
+        }
+        indices.push(index);
+        if let Some(identity) = edge
+            .callsite_identity
+            .as_deref()
+            .and_then(parse_stored_callsite_identity)
+        {
+            identities.insert(edge.id, identity);
+        }
+    }
+    (indices, identities)
+}
+
+fn go_package_dependency_ids(
+    source_file_id: FileId,
+    evidence_ids: &BTreeSet<FileId>,
+    context: &ProofResolutionValidationContext,
+) -> Result<BTreeSet<FileId>, StorageError> {
+    let source_file = context
+        .file_by_id
+        .get(&source_file_id.0)
+        .ok_or_else(|| proof_error("Go source dependency file is missing"))?;
+    if source_file
+        .path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.ends_with("_test.go"))
+    {
+        return Err(proof_error(
+            "Go production proof cannot originate in a test file",
+        ));
+    }
+    if let Some(error) = context.go_attestation_error_by_file.get(&source_file_id.0) {
+        return Err(proof_error(format!(
+            "Go source dependency is not publication-authenticated: {error}"
+        )));
+    }
+    let source_identity = context
+        .go_package_identity_by_file
+        .get(&source_file_id.0)
+        .ok_or_else(|| proof_error("Go source dependency has no authenticated package clause"))?;
+    for file_id in evidence_ids {
+        count_go_store_replay_work(1);
+        if let Some(error) = context.go_attestation_error_by_file.get(&file_id.0) {
+            return Err(proof_error(format!(
+                "Go evidence dependency is not publication-authenticated: {error}"
+            )));
+        }
+        if context.go_package_identity_by_file.get(&file_id.0) != Some(source_identity) {
+            return Err(proof_error(
+                "Go exact evidence crosses its authenticated native package identity",
+            ));
+        }
+    }
+    count_go_store_replay_work(1);
+    context
+        .go_dependency_ids_by_package
+        .get(source_identity)
+        .cloned()
+        .ok_or_else(|| proof_error("Go authenticated package closure is missing"))
+}
+
+fn prepare_go_package_closure(
+    file_by_id: &HashMap<i64, FileInfo>,
+    file_content_hash_by_id: &HashMap<i64, String>,
+) -> (
+    HashMap<i64, GoPackageIdentity>,
+    HashMap<GoPackageIdentity, BTreeSet<FileId>>,
+    HashMap<i64, String>,
+) {
+    let mut identity_by_file = HashMap::new();
+    let mut dependencies_by_package = HashMap::<GoPackageIdentity, BTreeSet<FileId>>::new();
+    let mut errors = HashMap::new();
+    for file in file_by_id.values().filter(|file| file.language == "go") {
+        count_go_store_replay_work(1);
+        match attest_go_file(file, file_content_hash_by_id) {
+            Ok(identity) => {
+                if !file
+                    .path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.ends_with("_test.go"))
+                {
+                    dependencies_by_package
+                        .entry(identity.clone())
+                        .or_default()
+                        .insert(FileId(file.id));
+                }
+                identity_by_file.insert(file.id, identity);
+            }
+            Err(error) => {
+                errors.insert(file.id, error);
+            }
+        }
+    }
+    (identity_by_file, dependencies_by_package, errors)
+}
+
+fn attest_go_file(
+    file: &FileInfo,
+    file_content_hash_by_id: &HashMap<i64, String>,
+) -> Result<GoPackageIdentity, String> {
+    let expected_hash = file_content_hash_by_id
+        .get(&file.id)
+        .ok_or_else(|| "stored source hash is missing".to_owned())?;
+    let bytes =
+        fs::read(&file.path).map_err(|error| format!("source bytes cannot be read: {error}"))?;
+    count_go_store_replay_work(bytes.len().saturating_add(1));
+    let observed_hash = format!("{:x}", Sha256::digest(&bytes));
+    if &observed_hash != expected_hash {
+        return Err("source bytes do not match the stored source hash".to_owned());
+    }
+    let source =
+        std::str::from_utf8(&bytes).map_err(|_| "source bytes are not strict UTF-8".to_owned())?;
+    let package_name = go_package_clause_from_source(source)
+        .ok_or_else(|| "source has no exact package clause".to_owned())?;
+    let parent = file
+        .path
+        .parent()
+        .ok_or_else(|| "source path has no package directory".to_owned())?;
+    let native_directory = fs::canonicalize(parent)
+        .map_err(|error| format!("package directory has no native identity: {error}"))?;
+    Ok(GoPackageIdentity {
+        native_directory,
+        package_name,
+    })
+}
+
+fn go_package_clause_from_source(source: &str) -> Option<String> {
+    let mut block_comment = false;
+    for raw_line in source.lines() {
+        let mut line = raw_line.trim();
+        loop {
+            if block_comment {
+                if let Some((_, rest)) = line.split_once("*/") {
+                    block_comment = false;
+                    line = rest.trim_start();
+                    continue;
+                }
+                break;
+            }
+            if line.is_empty() || line.starts_with("//") {
+                break;
+            }
+            if let Some(rest) = line.strip_prefix("/*") {
+                if let Some((_, trailing)) = rest.split_once("*/") {
+                    line = trailing.trim_start();
+                    continue;
+                }
+                block_comment = true;
+                break;
+            }
+            let rest = line.strip_prefix("package")?;
+            if rest
+                .chars()
+                .next()
+                .is_none_or(|character| !character.is_whitespace())
+            {
+                return None;
+            }
+            let mut components = rest.split_whitespace();
+            let name = components.next()?;
+            let trailing = components.collect::<Vec<_>>().join(" ");
+            if !go_package_identifier(name) || (!trailing.is_empty() && !trailing.starts_with("//"))
+            {
+                return None;
+            }
+            return Some(name.to_owned());
+        }
+    }
+    None
+}
+
+fn go_package_identifier(value: &str) -> bool {
+    let mut chars = value.chars();
+    chars
+        .next()
+        .is_some_and(|character| character == '_' || character.is_alphabetic())
+        && chars.all(|character| character == '_' || character.is_alphanumeric())
+}
+
+#[cfg(test)]
+mod go_replay_complexity_tests {
+    use super::*;
+
+    fn measured_package_replay_work(file_count: usize, lookup_count: usize) -> usize {
+        let temp = tempfile::tempdir().expect("Go replay tempdir");
+        let mut file_by_id = HashMap::new();
+        let mut file_content_hash_by_id = HashMap::new();
+        let source = b"package proof\n";
+        let source_hash = format!("{:x}", Sha256::digest(source));
+        for index in 0..file_count {
+            let id = i64::try_from(index + 1).expect("file id");
+            let path = temp.path().join(format!("file_{index}.go"));
+            fs::write(&path, source).expect("write Go replay source");
+            file_by_id.insert(
+                id,
+                FileInfo {
+                    id,
+                    path,
+                    language: "go".to_owned(),
+                    modification_time: 0,
+                    indexed: true,
+                    complete: true,
+                    line_count: 1,
+                    file_role: FileRole::Source,
+                },
+            );
+            file_content_hash_by_id.insert(id, source_hash.clone());
+        }
+        reset_go_store_replay_work();
+        let (
+            go_package_identity_by_file,
+            go_dependency_ids_by_package,
+            go_attestation_error_by_file,
+        ) = prepare_go_package_closure(&file_by_id, &file_content_hash_by_id);
+        let context = ProofResolutionValidationContext {
+            file_by_id,
+            file_content_hash_by_id,
+            node_by_id: HashMap::new(),
+            edges: Vec::new(),
+            edge_index_by_id: HashMap::new(),
+            ordinary_call_edge_indices: Vec::new(),
+            parsed_callsite_identity_by_edge: HashMap::new(),
+            import_relations: HashMap::new(),
+            member_relations: HashMap::new(),
+            go_package_identity_by_file,
+            go_dependency_ids_by_package,
+            go_attestation_error_by_file,
+        };
+        for _ in 0..lookup_count {
+            go_package_dependency_ids(FileId(1), &BTreeSet::from([FileId(1)]), &context)
+                .expect("package closure");
+        }
+        go_store_replay_work()
+    }
+
+    #[test]
+    fn package_file_preparation_and_fact_replay_are_independently_linear() {
+        let baseline = measured_package_replay_work(32, 32);
+        let more_files = measured_package_replay_work(64, 32);
+        let more_facts = measured_package_replay_work(32, 64);
+        let combined = measured_package_replay_work(64, 64);
+        assert!(baseline > 0, "Go store replay work was not counted");
+        assert!(
+            more_files <= baseline * 2 + 64,
+            "Go store file preparation grew superlinearly: {baseline} -> {more_files}"
+        );
+        assert!(
+            more_facts <= baseline * 2 + 64,
+            "Go store fact replay grew superlinearly: {baseline} -> {more_facts}"
+        );
+        assert!(
+            combined <= baseline * 2 + 128,
+            "combined Go store replay grew superlinearly: {baseline} -> {combined}"
+        );
+    }
+
+    fn measured_repeated_callsite_index_work(count: usize) -> usize {
+        let node_by_id = HashMap::from([(
+            NodeId(4),
+            Node {
+                id: NodeId(4),
+                kind: NodeKind::UNKNOWN,
+                serialized_name: "target".to_owned(),
+                ..Default::default()
+            },
+        )]);
+        let edges = (0..count)
+            .map(|index| Edge {
+                id: EdgeId(i64::try_from(index + 1).expect("edge id")),
+                source: NodeId(2),
+                target: NodeId(4),
+                kind: EdgeKind::CALL,
+                file_node_id: Some(NodeId(1)),
+                line: Some(2),
+                resolved_target: Some(NodeId(3)),
+                callsite_identity: Some(format!("1:2:{}:4", index + 1)),
+                ..Default::default()
+            })
+            .collect::<Vec<_>>();
+        reset_go_store_replay_work();
+        let (indices, identities) = prepare_call_edge_correlation_index(&edges, &node_by_id);
+        assert_eq!(indices.len(), count);
+        assert_eq!(identities.len(), count);
+        go_store_replay_work()
+    }
+
+    #[test]
+    fn repeated_same_line_correlation_identity_index_work_is_linear() {
+        let small = measured_repeated_callsite_index_work(64);
+        let large = measured_repeated_callsite_index_work(128);
+        assert!(small >= 64, "callsite index work was not counted: {small}");
+        assert!(
+            large <= small * 2 + 64,
+            "same-line callsite identity indexing grew superlinearly: {small} -> {large}"
+        );
+    }
 }
 
 #[derive(Default)]
@@ -206,12 +569,19 @@ impl ProofResolutionValidationContext {
             .map(|file| (file.id, file))
             .collect();
         let file_content_hash_by_id = storage.get_file_content_hashes()?;
+        let (
+            go_package_identity_by_file,
+            go_dependency_ids_by_package,
+            go_attestation_error_by_file,
+        ) = prepare_go_package_closure(&file_by_id, &file_content_hash_by_id);
         let node_by_id: HashMap<NodeId, Node> = storage
             .get_nodes()?
             .into_iter()
             .map(|node| (node.id, node))
             .collect();
         let edges = storage.get_edges()?;
+        let (ordinary_call_edge_indices, parsed_callsite_identity_by_edge) =
+            prepare_call_edge_correlation_index(&edges, &node_by_id);
         let mut edge_index_by_id = HashMap::with_capacity(edges.len());
         let mut import_relations = HashMap::<_, ProofRelationState>::new();
         let mut member_relations = HashMap::<_, ProofRelationState>::new();
@@ -289,8 +659,13 @@ impl ProofResolutionValidationContext {
             node_by_id,
             edges,
             edge_index_by_id,
+            ordinary_call_edge_indices,
+            parsed_callsite_identity_by_edge,
             import_relations,
             member_relations,
+            go_package_identity_by_file,
+            go_dependency_ids_by_package,
+            go_attestation_error_by_file,
         })
     }
 
@@ -539,14 +914,11 @@ impl Storage {
             )
             .collect::<BTreeSet<_>>();
         let ordinary_edge_indices = context
-            .edges
+            .ordinary_call_edge_indices
             .iter()
-            .enumerate()
-            .filter_map(|(index, edge)| {
-                (edge.kind == EdgeKind::CALL
-                    && context.node_by_id.contains_key(&edge.target)
-                    && !constructor_evidence_nodes.contains(&edge.effective_target()))
-                .then_some(index)
+            .copied()
+            .filter(|index| {
+                !constructor_evidence_nodes.contains(&context.edges[*index].effective_target())
             })
             .collect::<Vec<_>>();
         let edge_inputs = ordinary_edge_indices
@@ -575,7 +947,16 @@ impl Storage {
                     raw_target: graph_leaf_name(&raw.serialized_name),
                     callsite_identity: edge.callsite_identity.as_deref(),
                     semantic_exact: edge.resolved_target == Some(edge.effective_target())
-                        && edge.candidate_targets.is_empty(),
+                        && edge.candidate_targets.is_empty()
+                        && context
+                            .parsed_callsite_identity_by_edge
+                            .get(&edge.id)
+                            .is_some_and(|identity| {
+                                Some(identity.file_id)
+                                    == edge.file_node_id.map(|file| FileId(file.0))
+                                    && Some(identity.line) == edge.line
+                                    && identity.raw_target == edge.target
+                            }),
                 }
             })
             .collect::<Vec<_>>();
@@ -646,10 +1027,28 @@ impl Storage {
                 required_dependency_ids.insert(FileId(file_id.0));
             }
         }
-        if dependency_file_ids(fact) != required_dependency_ids {
-            return Err(proof_error(
-                "dependency hashes do not exactly cover source, import, package, and target files",
-            ));
+        if fact.status == ProofResolutionStatus::Exact && fact.provenance.language_adapter == "go" {
+            if fact
+                .evidence_chain
+                .iter()
+                .any(|evidence| matches!(evidence, ResolutionEvidence::StaticImportBinding { .. }))
+            {
+                return Err(proof_error(
+                    "Go exact import evidence has no authenticated module-domain receipt",
+                ));
+            }
+            required_dependency_ids = go_package_dependency_ids(
+                fact.callsite.file_id,
+                &required_dependency_ids,
+                context,
+            )?;
+        }
+        let observed_dependency_ids = dependency_file_ids(fact);
+        if observed_dependency_ids != required_dependency_ids {
+            return Err(proof_error(format!(
+                "dependency hashes do not exactly cover source, import, package, and target files for {}: observed={observed_dependency_ids:?} required={required_dependency_ids:?}",
+                fact.provenance.language_adapter
+            )));
         }
         for dependency in &fact.provenance.dependency_file_hashes {
             let dependency_file = context
@@ -697,6 +1096,22 @@ impl Storage {
             .ok_or_else(|| proof_error("exact target node is missing"))?;
         if target_node.file_node_id.is_none() {
             return Err(proof_error("exact target has no indexed dependency file"));
+        }
+        if fact.provenance.language_adapter == "go"
+            && (!matches!(caller.kind, NodeKind::FUNCTION | NodeKind::METHOD)
+                || !matches!(target_node.kind, NodeKind::FUNCTION | NodeKind::METHOD))
+        {
+            return Err(proof_error(
+                "Go exact caller and target must be source-level callables",
+            ));
+        }
+        if fact.provenance.language_adapter == "go"
+            && fact.callsite.callee_form == CalleeForm::Identifier
+            && target_node.kind != NodeKind::FUNCTION
+        {
+            return Err(proof_error(
+                "Go identifier evidence target is not a FUNCTION graph node",
+            ));
         }
         for evidence in &fact.evidence_chain {
             let ResolutionEvidence::StaticImportBinding { import, .. } = evidence else {
@@ -767,6 +1182,18 @@ impl Storage {
                 }
             }
             (
+                CalleeForm::Identifier,
+                [ResolutionEvidence::SamePackageDeclaration { declaration }],
+            ) if fact.provenance.language_adapter == "go" && *declaration == target => {
+                if target_node.file_node_id.is_none()
+                    || target_node.file_node_id == Some(NodeId(fact.callsite.file_id.0))
+                {
+                    return Err(proof_error(
+                        "SamePackageDeclaration is not an exact cross-file Go target",
+                    ));
+                }
+            }
+            (
                 CalleeForm::NamedImport,
                 [
                     ResolutionEvidence::StaticImportBinding {
@@ -830,16 +1257,44 @@ impl Storage {
                     .node_by_id
                     .get(owner)
                     .ok_or_else(|| proof_error("implicit receiver owner is missing"))?;
+                let go_owner = fact.provenance.language_adapter == "go";
                 if !matches!(
                     owner_node.kind,
                     NodeKind::STRUCT | NodeKind::CLASS | NodeKind::ENUM
-                ) || owner_node.file_node_id != Some(NodeId(fact.callsite.file_id.0))
-                    || target_node.file_node_id != Some(NodeId(fact.callsite.file_id.0))
-                    || !context.has_member(*owner, fact.caller)
+                ) || if go_owner {
+                    owner_node.file_node_id.is_none()
+                        || target_node.file_node_id != Some(NodeId(fact.callsite.file_id.0))
+                } else {
+                    owner_node.file_node_id != Some(NodeId(fact.callsite.file_id.0))
+                        || target_node.file_node_id != Some(NodeId(fact.callsite.file_id.0))
+                } || !context.has_member(*owner, fact.caller)
                     || !context.has_member(*owner, target)
                 {
                     return Err(proof_error(
                         "ImplicitReceiver does not own caller and target through inherent membership",
+                    ));
+                }
+            }
+            (
+                CalleeForm::ImplicitReceiver,
+                [
+                    ResolutionEvidence::ImplicitReceiver { owner },
+                    ResolutionEvidence::SamePackageDeclaration { declaration },
+                ],
+            ) if fact.provenance.language_adapter == "go" && *declaration == target => {
+                let owner_node = context
+                    .node_by_id
+                    .get(owner)
+                    .ok_or_else(|| proof_error("Go implicit receiver owner is missing"))?;
+                if owner_node.kind != NodeKind::STRUCT
+                    || owner_node.file_node_id.is_none()
+                    || target_node.file_node_id.is_none()
+                    || target_node.file_node_id == Some(NodeId(fact.callsite.file_id.0))
+                    || !context.has_member(*owner, fact.caller)
+                    || !context.has_member(*owner, target)
+                {
+                    return Err(proof_error(
+                        "Go ImplicitReceiver does not own caller and target through direct membership",
                     ));
                 }
             }
@@ -937,9 +1392,13 @@ impl Storage {
                 if !matches!(
                     owner_node.kind,
                     NodeKind::CLASS | NodeKind::STRUCT | NodeKind::ENUM
-                ) || owner_node.file_node_id != Some(NodeId(fact.callsite.file_id.0))
-                    || owner_node.file_node_id != target_node.file_node_id
-                    || !context.has_member(owner, target)
+                ) || if fact.provenance.language_adapter == "go" {
+                    owner_node.file_node_id.is_none()
+                        || target_node.file_node_id != Some(NodeId(fact.callsite.file_id.0))
+                } else {
+                    owner_node.file_node_id != Some(NodeId(fact.callsite.file_id.0))
+                        || owner_node.file_node_id != target_node.file_node_id
+                } || !context.has_member(owner, target)
                 {
                     return Err(proof_error(
                         "ConstructorBinding and ExplicitReceiverType do not name the unique target owner/member",
@@ -961,14 +1420,52 @@ impl Storage {
                 if !matches!(
                     owner_node.kind,
                     NodeKind::CLASS | NodeKind::STRUCT | NodeKind::ENUM
-                ) || owner_node.file_node_id != Some(NodeId(fact.callsite.file_id.0))
-                    || owner_node.file_node_id != target_node.file_node_id
-                    || !context.has_member(owner, target)
+                ) || if fact.provenance.language_adapter == "go" {
+                    owner_node.file_node_id.is_none()
+                        || target_node.file_node_id != Some(NodeId(fact.callsite.file_id.0))
+                } else {
+                    owner_node.file_node_id != Some(NodeId(fact.callsite.file_id.0))
+                        || owner_node.file_node_id != target_node.file_node_id
+                } || !context.has_member(owner, target)
                 {
                     return Err(proof_error(
                         "ExplicitReceiverType does not name the unique target owner/member",
                     ));
                 }
+            }
+            (
+                CalleeForm::ExplicitReceiver,
+                [
+                    ResolutionEvidence::ConstructorBinding { constructor },
+                    ResolutionEvidence::ExplicitReceiverType { receiver_type },
+                    ResolutionEvidence::SamePackageDeclaration { declaration },
+                ],
+            ) if fact.provenance.language_adapter == "go"
+                && *constructor == *receiver_type
+                && *declaration == target =>
+            {
+                Self::validate_go_package_receiver(
+                    context,
+                    fact.callsite.file_id,
+                    *constructor,
+                    target,
+                    target_node,
+                )?;
+            }
+            (
+                CalleeForm::ExplicitReceiver,
+                [
+                    ResolutionEvidence::ExplicitReceiverType { receiver_type },
+                    ResolutionEvidence::SamePackageDeclaration { declaration },
+                ],
+            ) if fact.provenance.language_adapter == "go" && *declaration == target => {
+                Self::validate_go_package_receiver(
+                    context,
+                    fact.callsite.file_id,
+                    *receiver_type,
+                    target,
+                    target_node,
+                )?;
             }
             (
                 CalleeForm::ExplicitReceiver,
@@ -1133,6 +1630,30 @@ impl Storage {
         {
             return Err(proof_error(
                 "imported receiver evidence does not name one IMPORT owner and one MEMBER target",
+            ));
+        }
+        Ok(())
+    }
+
+    fn validate_go_package_receiver(
+        context: &ProofResolutionValidationContext,
+        source_file: FileId,
+        owner: NodeId,
+        target: NodeId,
+        target_node: &Node,
+    ) -> Result<(), StorageError> {
+        let owner_node = context
+            .node_by_id
+            .get(&owner)
+            .ok_or_else(|| proof_error("Go receiver owner is missing"))?;
+        if owner_node.kind != NodeKind::STRUCT
+            || owner_node.file_node_id.is_none()
+            || target_node.file_node_id.is_none()
+            || target_node.file_node_id == Some(NodeId(source_file.0))
+            || !context.has_member(owner, target)
+        {
+            return Err(proof_error(
+                "Go receiver evidence does not name one direct owner/member",
             ));
         }
         Ok(())

--- a/crates/codestory-store/tests/proof_resolution.rs
+++ b/crates/codestory-store/tests/proof_resolution.rs
@@ -11,6 +11,9 @@ use codestory_store::{
     seal_call_resolution_fact,
 };
 use rusqlite::hooks::{AuthAction, AuthContext, Authorization};
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::Path;
 use std::sync::{
     Arc,
     atomic::{AtomicUsize, Ordering},
@@ -118,6 +121,35 @@ fn projection(facts: Vec<CallResolutionFact>) -> ProofResolutionProjection {
     }
 }
 
+fn go_projection(fact: CallResolutionFact) -> ProofResolutionProjection {
+    let mut result = projection(vec![fact.clone()]);
+    result.adapter_roster = vec![ProofResolutionAdapter {
+        language: "go".to_owned(),
+        adapter_version: "reference-v10".to_owned(),
+    }];
+    result.funnel[0].language = "go".to_owned();
+    result.funnel[0].callee_form = Some(fact.callsite.callee_form);
+    result.funnel[0].evidence_kind = fact.evidence_chain.first().map(ResolutionEvidence::kind);
+    result
+}
+
+fn go_exact_fact(dependencies: &[(i64, String)]) -> CallResolutionFact {
+    let mut fact = exact_fact(EdgeId(7));
+    fact.provenance.language_adapter = "go".to_owned();
+    fact.provenance.language_adapter_version = "reference-v10".to_owned();
+    if let Some((_, source_hash)) = dependencies.iter().find(|(file_id, _)| *file_id == 1) {
+        fact.callsite.source_sha256 = source_hash.clone();
+    }
+    fact.provenance.dependency_file_hashes = dependencies
+        .iter()
+        .map(|(file_id, hash)| DependencyFileHash {
+            file_id: FileId(*file_id),
+            source_sha256: hash.clone(),
+        })
+        .collect();
+    seal_call_resolution_fact(fact).expect("seal Go exact fact")
+}
+
 fn incomplete_domain_projection() -> ProofResolutionProjection {
     ProofResolutionProjection {
         adapter_roster: vec![ProofResolutionAdapter {
@@ -217,6 +249,181 @@ fn seed_exact_graph(store: &mut Store) {
             ..Default::default()
         })
         .expect("edge");
+}
+
+fn seed_go_exact_graph(
+    store: &mut Store,
+    sibling: bool,
+) -> (tempfile::TempDir, Vec<(i64, String)>) {
+    seed_exact_graph(store);
+    let temp = tempfile::tempdir().expect("Go exact graph tempdir");
+    let package = temp.path().join("src");
+    fs::create_dir_all(&package).expect("create Go exact package");
+    let source_bytes = b"package proof\nfunc caller() { callee() }\n";
+    let source_path = package.join("main.go");
+    fs::write(&source_path, source_bytes).expect("write Go exact source");
+    let source_hash = sha256_bytes(source_bytes);
+    let source = FileInfo {
+        id: 1,
+        path: source_path,
+        language: "go".to_owned(),
+        modification_time: 0,
+        indexed: true,
+        complete: true,
+        line_count: 2,
+        file_role: FileRole::Source,
+    };
+    store.insert_file(&source).expect("Go source file");
+    store
+        .update_file_metadata(&source, Some(&source_hash))
+        .expect("Go source hash");
+    let mut dependencies = vec![(1, source_hash)];
+    if sibling {
+        let sibling_bytes = b"package proof\nfunc helper() {}\n";
+        let sibling_path = package.join("helper.go");
+        fs::write(&sibling_path, sibling_bytes).expect("write Go exact sibling");
+        let sibling_hash = sha256_bytes(sibling_bytes);
+        let sibling = FileInfo {
+            id: 5,
+            path: sibling_path,
+            language: "go".to_owned(),
+            modification_time: 0,
+            indexed: true,
+            complete: true,
+            line_count: 1,
+            file_role: FileRole::Source,
+        };
+        store.insert_file(&sibling).expect("Go sibling file");
+        store
+            .update_file_metadata(&sibling, Some(&sibling_hash))
+            .expect("Go sibling hash");
+        dependencies.push((5, sibling_hash));
+    }
+    (temp, dependencies)
+}
+
+fn sha256_bytes(source: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(source))
+}
+
+fn seed_authenticated_go_cross_file_graph(
+    store: &mut Store,
+    root: &Path,
+    source_package: &str,
+    target_package: &str,
+    target_path_uses_native_alias: bool,
+) -> CallResolutionFact {
+    let package = root.join("package");
+    fs::create_dir_all(&package).expect("create Go package");
+    let source_path = package.join("main.go");
+    let target_path = package.join("target.go");
+    let source = format!("package {source_package}\nfunc caller() {{ callee() }}\n");
+    let target = format!("package {target_package}\nfunc callee() {{}}\n");
+    fs::write(&source_path, source.as_bytes()).expect("write Go source");
+    fs::write(&target_path, target.as_bytes()).expect("write Go target");
+    let recorded_target_path = if target_path_uses_native_alias {
+        package.join("..").join("package").join("target.go")
+    } else {
+        target_path
+    };
+    let source_sha256 = sha256_bytes(source.as_bytes());
+    let target_sha256 = sha256_bytes(target.as_bytes());
+    for (id, path, hash) in [
+        (1, source_path, source_sha256.clone()),
+        (5, recorded_target_path, target_sha256.clone()),
+    ] {
+        let file = FileInfo {
+            id,
+            path,
+            language: "go".to_owned(),
+            modification_time: 0,
+            indexed: true,
+            complete: true,
+            line_count: 2,
+            file_role: FileRole::Source,
+        };
+        store.insert_file(&file).expect("Go file");
+        store
+            .update_file_metadata(&file, Some(&hash))
+            .expect("Go source hash");
+    }
+    for node in [
+        Node {
+            id: NodeId(1),
+            kind: NodeKind::FILE,
+            serialized_name: "main.go".to_owned(),
+            ..Default::default()
+        },
+        Node {
+            id: NodeId(5),
+            kind: NodeKind::FILE,
+            serialized_name: "target.go".to_owned(),
+            ..Default::default()
+        },
+        Node {
+            id: NodeId(2),
+            kind: NodeKind::FUNCTION,
+            serialized_name: "caller".to_owned(),
+            file_node_id: Some(NodeId(1)),
+            start_line: Some(2),
+            end_line: Some(2),
+            ..Default::default()
+        },
+        Node {
+            id: NodeId(3),
+            kind: NodeKind::FUNCTION,
+            serialized_name: "callee".to_owned(),
+            file_node_id: Some(NodeId(5)),
+            start_line: Some(2),
+            end_line: Some(2),
+            ..Default::default()
+        },
+        Node {
+            id: NodeId(4),
+            kind: NodeKind::UNKNOWN,
+            serialized_name: "callee".to_owned(),
+            file_node_id: Some(NodeId(1)),
+            start_line: Some(2),
+            start_col: Some(15),
+            end_line: Some(2),
+            end_col: Some(21),
+            ..Default::default()
+        },
+    ] {
+        store.insert_node(&node).expect("Go graph node");
+    }
+    store
+        .insert_edge(&Edge {
+            id: EdgeId(7),
+            source: NodeId(2),
+            target: NodeId(4),
+            kind: EdgeKind::CALL,
+            file_node_id: Some(NodeId(1)),
+            line: Some(2),
+            resolved_target: Some(NodeId(3)),
+            callsite_identity: Some("1:2:1:4".to_owned()),
+            ..Default::default()
+        })
+        .expect("Go CALL edge");
+
+    let mut fact = exact_fact(EdgeId(7));
+    fact.callsite.source_sha256 = source_sha256.clone();
+    fact.evidence_chain = vec![ResolutionEvidence::SamePackageDeclaration {
+        declaration: NodeId(3),
+    }];
+    fact.provenance.dependency_file_hashes = vec![
+        DependencyFileHash {
+            file_id: FileId(1),
+            source_sha256,
+        },
+        DependencyFileHash {
+            file_id: FileId(5),
+            source_sha256: target_sha256,
+        },
+    ];
+    fact.provenance.language_adapter = "go".to_owned();
+    fact.provenance.language_adapter_version = "reference-v10".to_owned();
+    seal_call_resolution_fact(fact).expect("seal authenticated Go fact")
 }
 
 fn receiver_projection(fact: CallResolutionFact) -> ProofResolutionProjection {
@@ -726,6 +933,127 @@ fn exact_projection_round_trips_with_matching_raw_call_and_deterministic_digest(
         first,
         store.get_proof_resolution_publication().unwrap().unwrap()
     );
+}
+
+#[test]
+fn go_exact_projection_requires_the_complete_package_dependency_set() {
+    let mut accepted = Store::new_in_memory().unwrap();
+    let (_accepted_files, accepted_dependencies) = seed_go_exact_graph(&mut accepted, true);
+    accepted
+        .replace_proof_resolution_projection(
+            &publication(),
+            &go_projection(go_exact_fact(&accepted_dependencies)),
+        )
+        .expect("complete Go package closure must validate");
+
+    let mut missing = Store::new_in_memory().unwrap();
+    let (_missing_files, missing_dependencies) = seed_go_exact_graph(&mut missing, true);
+    missing
+        .replace_proof_resolution_projection(
+            &publication(),
+            &go_projection(go_exact_fact(&missing_dependencies[..1])),
+        )
+        .expect_err("missing Go package dependency must fail closed");
+
+    let mut extra = Store::new_in_memory().unwrap();
+    let (_extra_files, mut extra_dependencies) = seed_go_exact_graph(&mut extra, true);
+    let unrelated = FileInfo {
+        id: 6,
+        path: "other/unrelated.go".into(),
+        language: "go".to_owned(),
+        modification_time: 0,
+        indexed: true,
+        complete: true,
+        line_count: 1,
+        file_role: FileRole::Source,
+    };
+    extra.insert_file(&unrelated).unwrap();
+    extra
+        .update_file_metadata(&unrelated, Some(&"c".repeat(64)))
+        .unwrap();
+    extra_dependencies.push((6, "c".repeat(64)));
+    extra
+        .replace_proof_resolution_projection(
+            &publication(),
+            &go_projection(go_exact_fact(&extra_dependencies)),
+        )
+        .expect_err("extra Go package dependency must fail closed");
+}
+
+#[test]
+fn go_store_rejects_evidence_scope_swaps_and_unauthenticated_imports() {
+    for mutate in [
+        (|fact: &mut CallResolutionFact| {
+            fact.evidence_chain = vec![ResolutionEvidence::SamePackageDeclaration {
+                declaration: NodeId(3),
+            }];
+        }) as fn(&mut CallResolutionFact),
+        |fact: &mut CallResolutionFact| {
+            fact.evidence_chain = vec![ResolutionEvidence::StaticImportBinding {
+                import: NodeId(4),
+                declaration: NodeId(3),
+            }];
+        },
+    ] {
+        let mut store = Store::new_in_memory().unwrap();
+        let (_files, dependencies) = seed_go_exact_graph(&mut store, false);
+        let mut fact = go_exact_fact(&dependencies);
+        mutate(&mut fact);
+        let fact = seal_call_resolution_fact(fact).unwrap();
+        store
+            .replace_proof_resolution_projection(&publication(), &go_projection(fact))
+            .expect_err("forged Go evidence must fail closed");
+    }
+}
+
+#[test]
+fn go_store_replay_requires_exact_package_clause_and_native_directory_identity() {
+    let crossed = tempfile::tempdir().expect("crossed package tempdir");
+    let mut crossed_store = Store::new_in_memory().unwrap();
+    let crossed_fact = seed_authenticated_go_cross_file_graph(
+        &mut crossed_store,
+        crossed.path(),
+        "proof",
+        "other",
+        false,
+    );
+    crossed_store
+        .replace_proof_resolution_projection(&publication(), &go_projection(crossed_fact))
+        .expect_err("resealed cross-package-clause Go evidence must fail closed");
+
+    let aliased = tempfile::tempdir().expect("native alias tempdir");
+    let mut aliased_store = Store::new_in_memory().unwrap();
+    let aliased_fact = seed_authenticated_go_cross_file_graph(
+        &mut aliased_store,
+        aliased.path(),
+        "proof",
+        "proof",
+        true,
+    );
+    aliased_store
+        .replace_proof_resolution_projection(&publication(), &go_projection(aliased_fact))
+        .expect("native aliases of one authenticated Go package directory must agree");
+}
+
+#[test]
+fn go_store_replay_rejects_identifier_authority_over_a_method_target() {
+    let mut store = Store::new_in_memory().unwrap();
+    let (_files, dependencies) = seed_go_exact_graph(&mut store, false);
+    store
+        .get_connection()
+        .execute("UPDATE node SET kind = 14 WHERE id = 3", [])
+        .unwrap();
+    let stored_kind: i32 = store
+        .get_connection()
+        .query_row("SELECT kind FROM node WHERE id = 3", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(stored_kind, NodeKind::METHOD as i32);
+    store
+        .replace_proof_resolution_projection(
+            &publication(),
+            &go_projection(go_exact_fact(&dependencies)),
+        )
+        .expect_err("Go identifier evidence must authorize only a FUNCTION target");
 }
 
 #[test]


### PR DESCRIPTION
## Context

Go had 66/78 expected positive steps reaching the exact-fact gate but no proof-authoritative resolution facts. This PR implements the closed matrix published in #2034 without changing navigation authority, public routes, packet/context/search contracts, or the 0.17 lane.

Closes #2034
Refs #2023

Base: `dev/codestory-0.18@dd261949e6b10d4c0bc17c35d5a10f409d4ffc1d`

Accepted source head: `aafd46964f3afe22586a6ae07dbe1d0186d79b22`

Accepted tree: `c0cf9a83eda457df37436ac5c4cff8398c04c9fe`

## What changed

- emits exact Go receipts for the frozen same-package, same-file, concrete-receiver, and implicit-receiver subsets;
- keeps imports and every open or dynamic lookup domain non-exact;
- authenticates parser provenance, source hashes, package closure, native file identity, graph/fact correlation, callsite coordinates, and typed evidence;
- correlates repeated callsites in deterministic source order without edge reuse;
- validates and rematerializes the proof overlay in linear time while leaving ordinary navigation edges unchanged;
- preserves semantic-only republish from a stored core after sources disappear, while rejecting stored graph tampering;
- keeps the exact-resolution overlay production-unreachable and one-way.

The implementation was frozen once for one consolidated adversarial review over language closure, parser provenance, graph/fact correlation, repeated callsites, source coordinates, native ordering, storage integrity, and complexity. Its five retained soundness/complexity classes were corrected in one batch. No second stylistic review round was used.

## How to review

1. Start with `crates/codestory-indexer/src/proof_resolution.rs` and the closed Go matrix tests in `crates/codestory-indexer/tests/proof_resolution.rs`.
2. Check the compact Go parser-cache inputs in `crates/codestory-indexer/src/languages/go.rs` and `cache.rs`.
3. Review storage replay and source-free semantic rebind in `crates/codestory-store/src/storage_impl/proof_resolution.rs`.
4. Confirm the runtime remains dark and retrieval consumers cannot read proof facts through the architecture contracts.

## Verification

Focused accepted-head checks:

- indexer proof resolution: 67 passed;
- exact-resolution availability: 5 passed;
- Go navigation: 7 passed;
- store proof resolution: 20 passed;
- semantic republish matrix: 11 passed;
- one-way overlay architecture: passed;
- production-unreachable architecture: passed;
- focused clippy with warnings denied: passed.

Broad serial accepted-head checks:

- direct rustfmt check over every changed Rust file: passed;
- `cargo check --locked --workspace`: passed;
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`: passed;
- `cargo nextest run --locked --workspace --no-fail-fast`: 3,984 passed, 1 failed, 34 skipped. The sole failure is the inherited Python test `test_python_constructor_local_visibility_and_shadows_fail_closed`; every Go/proof/storage/runtime test passed;
- `cargo test --locked --workspace --doc`: passed;
- indexer fidelity: 8 passed;
- language coverage: 13 passed;
- stdio protocol contracts: 63 passed;
- `git diff --check`: passed.

Local qualification used locked release binary SHA-256 `705bfc8e78161da0e70b9a6b550ad1234b7e3d7b6b25db677e448c1cbbf1f06a` and qualification ID `20260824T062751Z-aafd46964f3a`. Materialize, run, and read-only verify all passed against the unchanged corpus and thresholds.

- hard gates: all zero;
- Go: 18/30 complete proofs;
- combined: 50/120 complete proofs;
- Rust: 12/30;
- TypeScript/JavaScript: 20/30;
- Python: 0/30;
- decision: keep proof dark.

## Risk and nonclaims

The main risk is conservative availability: external imports, interfaces, reflection, generated-only semantics, incomplete packages, shadowing, rebinding, and other open domains remain non-exact. This PR does not register `prove_call_path`, change public transport, alter packet/context/search, add a dependency index, touch release versions, or claim Q2 passage.
