### PR TITLE
add exact Python proof receipts

### DIFF
--- a/crates/codestory-indexer/src/cache.rs
+++ b/crates/codestory-indexer/src/cache.rs
@@ -8,9 +8,8 @@ use codestory_store::FileInfo;
 use serde::{Deserialize, Serialize};
 use std::path::{Component, Path, PathBuf};
 
-// Bumped to 6 because JavaScript joins the private proof adapter roster and
-// ECMAScript bindings are now collected with name-specific closure semantics.
-const INDEX_ARTIFACT_CACHE_VERSION: u32 = 11;
+// Versioned with proof-input semantics so older parser artifacts fail closed.
+const INDEX_ARTIFACT_CACHE_VERSION: u32 = 12;
 const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
 const FNV_PRIME: u64 = 0x00000100000001B3;
 
@@ -287,7 +286,7 @@ impl CachedIndexArtifact {
         resolution_file: Option<CachedResolutionFile>,
     ) -> Self {
         Self {
-            resolution_input_schema_version: 9,
+            resolution_input_schema_version: 10,
             files: index_result.files,
             nodes: index_result.nodes,
             edges: index_result.edges,

--- a/crates/codestory-indexer/src/cache.rs
+++ b/crates/codestory-indexer/src/cache.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::path::{Component, Path, PathBuf};
 
 // Versioned with proof-input semantics so older parser artifacts fail closed.
-const INDEX_ARTIFACT_CACHE_VERSION: u32 = 12;
+const INDEX_ARTIFACT_CACHE_VERSION: u32 = 13;
 const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
 const FNV_PRIME: u64 = 0x00000100000001B3;
 
@@ -286,7 +286,7 @@ impl CachedIndexArtifact {
         resolution_file: Option<CachedResolutionFile>,
     ) -> Self {
         Self {
-            resolution_input_schema_version: 10,
+            resolution_input_schema_version: 11,
             files: index_result.files,
             nodes: index_result.nodes,
             edges: index_result.edges,

--- a/crates/codestory-indexer/src/cache.rs
+++ b/crates/codestory-indexer/src/cache.rs
@@ -10,7 +10,7 @@ use std::path::{Component, Path, PathBuf};
 
 // Bumped to 6 because JavaScript joins the private proof adapter roster and
 // ECMAScript bindings are now collected with name-specific closure semantics.
-const INDEX_ARTIFACT_CACHE_VERSION: u32 = 10;
+const INDEX_ARTIFACT_CACHE_VERSION: u32 = 11;
 const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
 const FNV_PRIME: u64 = 0x00000100000001B3;
 
@@ -287,7 +287,7 @@ impl CachedIndexArtifact {
         resolution_file: Option<CachedResolutionFile>,
     ) -> Self {
         Self {
-            resolution_input_schema_version: 8,
+            resolution_input_schema_version: 9,
             files: index_result.files,
             nodes: index_result.nodes,
             edges: index_result.edges,

--- a/crates/codestory-indexer/src/languages/python.rs
+++ b/crates/codestory-indexer/src/languages/python.rs
@@ -50,10 +50,10 @@ use crate::{
     ManualMemberEdgeSpec, ManualReceiverCallSpec, ManualReceiverSource,
     OptionalReceiverOwnerBinding, ReceiverCallSiteKey, collect_colon_parameter_types,
     collect_receiver_call_specs_in_callable, declaration_name, enclosing_node_with_kind,
-    first_descendant_with_kind, member_call_method_col, node_source_text, normalize_parameter_name,
+    member_call_method_col, node_source_text, normalize_parameter_name,
     normalized_receiver_variable, parameter_name_before_colon, receiver_call_belongs_to_callable,
     receiver_callsite_key, same_ts_span, signature_parameter_surface, split_top_level_parameters,
-    surface_member_call, trimmed_node_text, ts_node_graph_span, walk_tree_nodes,
+    trimmed_node_text, ts_node_graph_span, walk_tree_nodes,
 };
 
 /// Callsite marker written onto edges produced from Python attribute-call
@@ -1012,7 +1012,7 @@ fn python_property_constructor_receiver_owner(
     let owner_name = node
         .child_by_field_name("right")
         .and_then(|right_node| python_direct_constructor_call_type(right_node, source))?;
-    if python_visible_local_type_name(method, node, &owner_name, source) {
+    if let Some(owner_name) = python_visible_local_type_name(method, node, &owner_name, source) {
         return Some((owner_name, None));
     }
     if python_callable_has_local_binding_name(method, &owner_name, source) {
@@ -1131,10 +1131,14 @@ fn python_constructor_receiver_owner(
     source: &str,
     imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
 ) -> OptionalReceiverOwnerBinding {
-    let owner_name = node
-        .child_by_field_name("right")
-        .and_then(|right_node| python_direct_constructor_call_type(right_node, source))?;
-    if python_visible_local_type_name(callable, node, &owner_name, source) {
+    let owner_name = match node.child_by_field_name("right") {
+        Some(right) => python_direct_constructor_call_type(right, source)?,
+        None => node
+            .child_by_field_name("type")
+            .and_then(|annotation| trimmed_node_text(annotation, source))
+            .and_then(|name| normalize_parameter_name(&name))?,
+    };
+    if let Some(owner_name) = python_visible_local_type_name(callable, node, &owner_name, source) {
         return Some((owner_name, None));
     }
     if python_callable_has_local_binding_name(callable, &owner_name, source) {
@@ -1169,10 +1173,10 @@ fn python_visible_local_type_name(
     before_node: TsNode<'_>,
     owner_name: &str,
     source: &str,
-) -> bool {
-    let mut found = false;
+) -> Option<String> {
+    let mut found = None;
     walk_tree_nodes(callable, &mut |node| {
-        if found
+        if found.is_some()
             || node.kind() != "class_definition"
             || !receiver_call_belongs_to_callable(node, callable)
             || node.end_byte() > before_node.start_byte()
@@ -1180,7 +1184,8 @@ fn python_visible_local_type_name(
             return;
         }
         if declaration_name(node, source).as_deref() == Some(owner_name) {
-            found = true;
+            found = declaration_name(callable, source)
+                .map(|callable_name| format!("{callable_name}.{owner_name}"));
         }
     });
     found
@@ -1674,12 +1679,16 @@ fn python_attribute_call_nodes<'tree>(
     if node.kind() != "call" {
         return None;
     }
-    let function = node.child_by_field_name("function")?;
-    let attribute = if function.kind() == "attribute" {
-        function
-    } else {
-        first_descendant_with_kind(function, "attribute")?
-    };
+    let mut function = node.child_by_field_name("function")?;
+    while function.kind() == "parenthesized_expression" {
+        let mut cursor = function.walk();
+        let children = function.named_children(&mut cursor).collect::<Vec<_>>();
+        let [child] = children.as_slice() else {
+            return None;
+        };
+        function = *child;
+    }
+    let attribute = (function.kind() == "attribute").then_some(function)?;
     Some((
         attribute.child_by_field_name("object")?,
         attribute.child_by_field_name("attribute")?,
@@ -1699,14 +1708,9 @@ pub(crate) fn attribute_method_col(
 }
 
 fn member_call(node: TsNode<'_>, source: &str) -> Option<(String, String)> {
-    if node.kind() != "call" {
-        return None;
-    }
-    if let Some((receiver, method)) = python_attribute_call_nodes(node) {
-        return Some((
-            normalized_receiver_variable(receiver, source)?,
-            trimmed_node_text(method, source)?,
-        ));
-    }
-    surface_member_call(node, source)
+    let (receiver, method) = python_attribute_call_nodes(node)?;
+    Some((
+        normalized_receiver_variable(receiver, source)?,
+        trimmed_node_text(method, source)?,
+    ))
 }

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -37,6 +37,29 @@ use tree_sitter_graph::ast::File as GraphFile;
 use tree_sitter_graph::functions::Functions;
 use tree_sitter_graph::{ExecutionConfig, NoCancellation, Variables};
 
+#[cfg(test)]
+thread_local! {
+    static MANUAL_RECEIVER_LOOKUP_WORK: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[inline]
+fn count_manual_receiver_lookup_work(amount: usize) {
+    #[cfg(test)]
+    MANUAL_RECEIVER_LOOKUP_WORK.with(|work| work.set(work.get().saturating_add(amount)));
+    #[cfg(not(test))]
+    let _ = amount;
+}
+
+#[cfg(test)]
+fn reset_manual_receiver_lookup_work() {
+    MANUAL_RECEIVER_LOOKUP_WORK.with(|work| work.set(0));
+}
+
+#[cfg(test)]
+fn manual_receiver_lookup_work() -> usize {
+    MANUAL_RECEIVER_LOOKUP_WORK.with(std::cell::Cell::get)
+}
+
 mod cache;
 pub mod cancellation;
 pub mod compilation_database;
@@ -8504,6 +8527,9 @@ fn append_manual_receiver_call_edges(
     } else {
         HashSet::new()
     };
+    let member_targets = PreparedMemberTargetIndex::prepare(unique_nodes, result_edges);
+    let python_local_owner_lines =
+        (language_name == "python").then(|| PythonLocalOwnerLineIndex::prepare(tree, source));
 
     for spec in language_receiver_call_specs(language_name, tree, source) {
         let extra_callsite_marker = context_manager_alias_callsites
@@ -8702,13 +8728,15 @@ fn append_manual_receiver_call_edges(
             continue;
         }
 
-        let Some(target_id) = member_target_id_by_owner_and_method(
-            unique_nodes,
-            result_edges,
+        let python_local_owner_line = python_local_owner_lines
+            .as_ref()
+            .and_then(|index| index.unique_line(&spec.owner_name));
+        let Some(target_id) = member_targets.target(
             &spec.owner_name,
             &spec.method_name,
             file_id,
             spec.allow_global_fallback,
+            python_local_owner_line,
         ) else {
             let should_annotate = match language_name {
                 "python" => !languages::python::is_implicit_receiver(&spec.receiver_name),
@@ -9474,81 +9502,216 @@ fn callsite_has_receiver_annotation(callsite_identity: Option<&str>) -> bool {
     })
 }
 
-fn member_target_id_by_owner_and_method(
-    nodes: &HashMap<NodeId, Node>,
-    edges: &[Edge],
-    owner_name: &str,
-    method_name: &str,
-    file_id: NodeId,
-    allow_global_fallback: bool,
-) -> Option<NodeId> {
-    let mut owners = nodes
-        .values()
-        .filter(|node| is_type_like_kind(node.kind))
-        .filter(|node| node_matches_name(node, owner_name))
-        .collect::<Vec<_>>();
-    owners.sort_by(|left, right| {
-        left.start_line
-            .unwrap_or(u32::MAX)
-            .cmp(&right.start_line.unwrap_or(u32::MAX))
-            .then_with(|| node_span_width(right).cmp(&node_span_width(left)))
-            .then_with(|| left.id.cmp(&right.id))
-    });
+#[derive(Clone, Copy)]
+struct PreparedMemberOwner {
+    id: NodeId,
+    file_node_id: Option<NodeId>,
+    start_line: Option<u32>,
+    span_width: u32,
+}
 
-    let mut candidates = Vec::new();
-    for owner in owners {
-        let mut targets = edges
+#[derive(Clone, Copy)]
+struct PreparedMemberTarget {
+    file_node_id: Option<NodeId>,
+    id: NodeId,
+    start_line: Option<u32>,
+}
+
+#[derive(Default)]
+struct PreparedMemberTargetIndex {
+    owners_by_name: HashMap<String, Vec<PreparedMemberOwner>>,
+    targets_by_owner_and_name: HashMap<(NodeId, String), Vec<PreparedMemberTarget>>,
+}
+
+impl PreparedMemberTargetIndex {
+    fn prepare(nodes: &HashMap<NodeId, Node>, edges: &[Edge]) -> Self {
+        let mut index = Self::default();
+        for node in nodes.values() {
+            count_manual_receiver_lookup_work(1);
+            if !is_type_like_kind(node.kind) {
+                continue;
+            }
+            let owner = PreparedMemberOwner {
+                id: node.id,
+                file_node_id: node.file_node_id,
+                start_line: node.start_line,
+                span_width: node_span_width(node),
+            };
+            for name in prepared_node_names(node, true) {
+                index.owners_by_name.entry(name).or_default().push(owner);
+            }
+        }
+        for edge in edges {
+            count_manual_receiver_lookup_work(1);
+            if edge.kind != EdgeKind::MEMBER {
+                continue;
+            }
+            let Some(target) = nodes.get(&edge.target) else {
+                continue;
+            };
+            if !matches!(target.kind, NodeKind::FUNCTION | NodeKind::METHOD) {
+                continue;
+            }
+            let prepared = PreparedMemberTarget {
+                file_node_id: target.file_node_id,
+                id: target.id,
+                start_line: target.start_line,
+            };
+            for name in prepared_node_names(target, false) {
+                index
+                    .targets_by_owner_and_name
+                    .entry((edge.source, name))
+                    .or_default()
+                    .push(prepared);
+            }
+        }
+        for owners in index.owners_by_name.values_mut() {
+            owners.sort_by(|left, right| {
+                left.start_line
+                    .unwrap_or(u32::MAX)
+                    .cmp(&right.start_line.unwrap_or(u32::MAX))
+                    .then_with(|| right.span_width.cmp(&left.span_width))
+                    .then_with(|| left.id.cmp(&right.id))
+            });
+            owners.dedup_by_key(|owner| owner.id);
+        }
+        for targets in index.targets_by_owner_and_name.values_mut() {
+            targets.sort_by_key(|target| (target.start_line.unwrap_or(u32::MAX), target.id));
+            targets.dedup_by_key(|target| target.id);
+        }
+        index
+    }
+
+    fn target(
+        &self,
+        owner_name: &str,
+        method_name: &str,
+        file_id: NodeId,
+        allow_global_fallback: bool,
+        owner_start_line: Option<u32>,
+    ) -> Option<NodeId> {
+        count_manual_receiver_lookup_work(1);
+        let owner_lookup_name = owner_start_line
+            .and_then(|_| owner_name.rsplit_once('.').map(|(_, name)| name))
+            .unwrap_or(owner_name);
+        let owners = self
+            .owners_by_name
+            .get(owner_lookup_name)
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        let mut candidates = Vec::new();
+        for owner in owners {
+            count_manual_receiver_lookup_work(1);
+            if owner_start_line.is_some_and(|line| owner.start_line != Some(line)) {
+                continue;
+            }
+            if let Some(targets) = self
+                .targets_by_owner_and_name
+                .get(&(owner.id, method_name.to_owned()))
+            {
+                for target in targets {
+                    count_manual_receiver_lookup_work(1);
+                    candidates.push((owner.file_node_id, target.file_node_id, target.id));
+                }
+            }
+        }
+        let mut same_file_matches = candidates
             .iter()
-            .filter(|edge| edge.kind == EdgeKind::MEMBER && edge.source == owner.id)
-            .filter_map(|edge| nodes.get(&edge.target))
-            .filter(|node| {
-                matches!(node.kind, NodeKind::FUNCTION | NodeKind::METHOD)
-                    && node_matches_name(node, method_name)
+            .filter_map(|(owner_file_id, target_file_id, target_id)| {
+                (owner_file_id.is_none()
+                    || target_file_id.is_none()
+                    || *owner_file_id == Some(file_id)
+                    || *target_file_id == Some(file_id))
+                .then_some(*target_id)
             })
             .collect::<Vec<_>>();
-        targets.sort_by(|left, right| {
-            left.start_line
-                .unwrap_or(u32::MAX)
-                .cmp(&right.start_line.unwrap_or(u32::MAX))
-                .then_with(|| left.id.cmp(&right.id))
-        });
-        for target in targets {
-            candidates.push((owner.file_node_id, target.file_node_id, target.id));
+        same_file_matches.sort_unstable();
+        same_file_matches.dedup();
+        match same_file_matches.as_slice() {
+            [target] => return Some(*target),
+            [] => {}
+            _ => return None,
+        }
+        if !allow_global_fallback {
+            return None;
+        }
+        let mut global_matches = candidates
+            .into_iter()
+            .map(|(_, _, target_id)| target_id)
+            .collect::<Vec<_>>();
+        global_matches.sort_unstable();
+        global_matches.dedup();
+        match global_matches.as_slice() {
+            [target] => Some(*target),
+            _ => None,
         }
     }
+}
 
-    let mut same_file_matches = candidates
-        .iter()
-        .filter_map(|(owner_file_id, target_file_id, target_id)| {
-            (owner_file_id.is_none()
-                || target_file_id.is_none()
-                || *owner_file_id == Some(file_id)
-                || *target_file_id == Some(file_id))
-            .then_some(*target_id)
-        })
-        .collect::<Vec<_>>();
-    same_file_matches.sort_unstable();
-    same_file_matches.dedup();
-    if same_file_matches.len() == 1 {
-        return Some(same_file_matches[0]);
+fn prepared_node_names(node: &Node, include_qualified_suffixes: bool) -> Vec<String> {
+    let mut names = vec![
+        node.serialized_name.clone(),
+        short_member_name(&node.serialized_name).to_owned(),
+    ];
+    if let Some(qualified) = node.qualified_name.as_deref() {
+        names.push(qualified.to_owned());
+        names.push(short_member_name(qualified).to_owned());
+        if include_qualified_suffixes {
+            names.extend(
+                qualified
+                    .match_indices('.')
+                    .map(|(index, _)| qualified[index + 1..].to_owned()),
+            );
+        }
     }
-    if same_file_matches.len() > 1 {
-        return None;
-    }
-    if !allow_global_fallback {
-        return None;
+    names.sort();
+    names.dedup();
+    names
+}
+
+#[derive(Default)]
+struct PythonLocalOwnerLineIndex {
+    lines_by_owner: HashMap<String, Vec<u32>>,
+}
+
+impl PythonLocalOwnerLineIndex {
+    fn prepare(tree: &Tree, source: &str) -> Self {
+        let mut index = Self::default();
+        walk_tree_nodes(tree.root_node(), &mut |node| {
+            count_manual_receiver_lookup_work(1);
+            if node.kind() != "class_definition" {
+                return;
+            }
+            let Some(class_name) = declaration_name(node, source) else {
+                return;
+            };
+            let Some(callable) = enclosing_node_with_kind(node, &["function_definition"]) else {
+                return;
+            };
+            let Some(callable_name) = declaration_name(callable, source) else {
+                return;
+            };
+            index
+                .lines_by_owner
+                .entry(format!("{callable_name}.{class_name}"))
+                .or_default()
+                .push(node.start_position().row as u32 + 1);
+        });
+        for lines in index.lines_by_owner.values_mut() {
+            lines.sort_unstable();
+            lines.dedup();
+        }
+        index
     }
 
-    let mut global_matches = candidates
-        .into_iter()
-        .map(|(_, _, target_id)| target_id)
-        .collect::<Vec<_>>();
-    global_matches.sort_unstable();
-    global_matches.dedup();
-    if global_matches.len() == 1 {
-        Some(global_matches[0])
-    } else {
-        None
+    fn unique_line(&self, owner_name: &str) -> Option<u32> {
+        count_manual_receiver_lookup_work(1);
+        self.lines_by_owner
+            .get(owner_name)
+            .and_then(|lines| match lines.as_slice() {
+                [line] => Some(*line),
+                _ => None,
+            })
     }
 }
 
@@ -10023,27 +10186,6 @@ fn normalize_js_ts_private_receiver_surface(receiver: &str) -> String {
         .map(|segment| segment.strip_prefix('#').unwrap_or(segment))
         .collect::<Vec<_>>()
         .join(".")
-}
-
-fn surface_member_call(node: TsNode<'_>, source: &str) -> Option<(String, String)> {
-    let text = trimmed_node_text(node, source)?;
-    let callable = text
-        .split('(')
-        .next()
-        .unwrap_or(text.as_str())
-        .trim()
-        .trim_end_matches(';')
-        .trim();
-    let separator = callable.rfind('.')?;
-    let receiver = callable[..separator].trim().trim_end_matches('?').trim();
-    let method = callable[separator + 1..]
-        .trim()
-        .trim_start_matches('?')
-        .trim();
-    Some((
-        normalized_receiver_surface(receiver)?,
-        normalize_parameter_name(method)?,
-    ))
 }
 
 fn normalized_receiver_surface(raw: &str) -> Option<String> {

--- a/crates/codestory-indexer/src/proof_resolution.rs
+++ b/crates/codestory-indexer/src/proof_resolution.rs
@@ -27,6 +27,7 @@ use tree_sitter::{Node as TsNode, Tree};
 thread_local! {
     static RUST_RESOLUTION_WORK: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
     static GO_RESOLUTION_WORK: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static PYTHON_RESOLUTION_WORK: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
 
 #[inline]
@@ -65,11 +66,30 @@ fn go_resolution_work() -> usize {
     GO_RESOLUTION_WORK.with(std::cell::Cell::get)
 }
 
-const ADAPTER_VERSION: &str = "reference-v10";
-const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 8;
+#[inline]
+fn count_python_resolution_work(amount: usize) {
+    #[cfg(test)]
+    PYTHON_RESOLUTION_WORK.with(|work| work.set(work.get().saturating_add(amount)));
+    #[cfg(not(test))]
+    let _ = amount;
+}
+
+#[cfg(test)]
+fn reset_python_resolution_work() {
+    PYTHON_RESOLUTION_WORK.with(|work| work.set(0));
+}
+
+#[cfg(test)]
+fn python_resolution_work() -> usize {
+    PYTHON_RESOLUTION_WORK.with(std::cell::Cell::get)
+}
+
+const ADAPTER_VERSION: &str = "reference-v11";
+const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 9;
 const INSTALLED_ADAPTERS: &[(&str, &str)] = &[
     ("go", ADAPTER_VERSION),
     ("javascript", ADAPTER_VERSION),
+    ("python", ADAPTER_VERSION),
     ("rust", ADAPTER_VERSION),
     ("tsx", ADAPTER_VERSION),
     ("typescript", ADAPTER_VERSION),
@@ -103,9 +123,17 @@ pub(crate) fn collect_call_resolution_inputs(
         (language == "rust").then(|| RustResolutionIndex::build(tree, source, file_id, nodes));
     let go_index =
         (language == "go").then(|| GoResolutionIndex::build(tree, source, file_id, nodes));
+    let python_index =
+        (language == "python").then(|| PythonResolutionIndex::build(tree, source, file_id, nodes));
     let (direct_exports, export_poison_all, poisoned_export_names) =
         if let Some(index) = &javascript_index {
             index.collect_direct_exports(source)
+        } else if let Some(index) = &python_index {
+            (
+                Vec::new(),
+                index.module_dynamic,
+                index.poisoned_export_names(),
+            )
         } else {
             (Vec::new(), false, Vec::new())
         };
@@ -117,6 +145,8 @@ pub(crate) fn collect_call_resolution_inputs(
     } else if let Some(index) = &rust_index {
         index.declarations.clone()
     } else if let Some(index) = &go_index {
+        index.declarations.clone()
+    } else if let Some(index) = &python_index {
         index.declarations.clone()
     } else {
         Vec::new()
@@ -143,6 +173,8 @@ pub(crate) fn collect_call_resolution_inputs(
                 index.resolve_syntax_claim(source, callee, form, &raw_target, callable_id)
             } else if let Some(index) = &go_index {
                 index.resolve_syntax_claim(source, callee, form, &raw_target, callable_id)
+            } else if let Some(index) = &python_index {
+                index.resolve_syntax_claim(source, callee, form, &raw_target)
             } else if let Some(index) = &javascript_index {
                 index.resolve_syntax_claim(source, callee, form, &raw_target)
             } else {
@@ -196,6 +228,10 @@ pub(crate) fn collect_call_resolution_inputs(
                 call.callable_id,
             );
         }
+    } else if let Some(index) = &python_index {
+        for call in &index.calls {
+            emit_call(call.callee, call.form, call.raw_target.clone(), None);
+        }
     } else {
         collect_calls(tree.root_node(), source, &mut |callee, form, raw_target| {
             emit_call(callee, form, raw_target, None);
@@ -215,9 +251,14 @@ pub(crate) fn collect_call_resolution_inputs(
             typescript_module,
             top_level_declarations,
             inherent_methods,
-            classes: javascript_index
-                .as_ref()
-                .map_or_else(Vec::new, |index| index.cached_classes()),
+            classes: javascript_index.as_ref().map_or_else(
+                || {
+                    python_index
+                        .as_ref()
+                        .map_or_else(Vec::new, |index| index.classes.clone())
+                },
+                |index| index.cached_classes(),
+            ),
             direct_exports,
             export_poison_all,
             poisoned_export_names,
@@ -1548,6 +1589,1141 @@ fn go_expression_items(node: TsNode<'_>) -> Vec<TsNode<'_>> {
     }
     let mut cursor = node.walk();
     node.named_children(&mut cursor).collect()
+}
+
+#[derive(Debug, Clone)]
+struct IndexedPythonCall<'tree> {
+    callee: TsNode<'tree>,
+    form: CalleeForm,
+    raw_target: String,
+}
+
+#[derive(Debug, Clone)]
+enum PythonNameBinding {
+    Receiver {
+        class_binding: CachedClassBinding,
+        constructor: bool,
+        type_name: String,
+    },
+    Other,
+}
+
+#[derive(Debug, Clone)]
+struct PythonBindingEvent {
+    at: usize,
+    binding: PythonNameBinding,
+}
+
+#[derive(Debug, Clone)]
+struct PythonFunctionInfo {
+    graph_id: Option<NodeId>,
+    direct_method: bool,
+    owner: Option<(NodeId, String)>,
+    plain_self: bool,
+}
+
+#[derive(Debug, Clone)]
+struct PythonImportBinding {
+    import: Option<NodeId>,
+    module_specifier: String,
+    imported_name: String,
+}
+
+struct PythonResolutionIndex<'tree> {
+    calls: Vec<IndexedPythonCall<'tree>>,
+    declarations: Vec<CachedTopLevelDeclaration>,
+    classes: Vec<CachedClassDeclaration>,
+    functions: HashMap<usize, PythonFunctionInfo>,
+    bindings: HashMap<usize, HashMap<String, Vec<PythonBindingEvent>>>,
+    imports: HashMap<String, Vec<PythonImportBinding>>,
+    module_blockers: HashMap<String, usize>,
+    module_dynamic: bool,
+    dynamic_functions: HashSet<usize>,
+    declarations_by_name: HashMap<String, Vec<NodeId>>,
+    classes_by_name: HashMap<String, Vec<CachedClassDeclaration>>,
+    class_owner_by_syntax_id: HashMap<usize, NodeId>,
+    closed_class_owners: HashSet<NodeId>,
+    dynamic_class_owners: HashSet<NodeId>,
+    methods_by_owner_and_name: HashMap<(NodeId, String), Vec<NodeId>>,
+    method_blockers_by_owner_and_name: HashSet<(NodeId, String)>,
+    global_names_by_function: HashMap<usize, HashSet<String>>,
+    writes_by_function: HashMap<usize, HashSet<String>>,
+}
+
+impl<'tree> PythonResolutionIndex<'tree> {
+    fn build(tree: &'tree Tree, source: &str, file_id: NodeId, nodes: &[Node]) -> Self {
+        let root = tree.root_node();
+        let mut callable_nodes = HashMap::<(u32, String), Vec<NodeId>>::new();
+        let mut class_nodes = HashMap::<(u32, String), Vec<NodeId>>::new();
+        let mut import_nodes = HashMap::<(u32, u32, String), Vec<NodeId>>::new();
+        for node in nodes
+            .iter()
+            .filter(|node| node.file_node_id == Some(file_id))
+        {
+            count_python_resolution_work(1);
+            let Some(line) = node.start_line else {
+                continue;
+            };
+            let name = graph_leaf_name(&node.serialized_name).to_string();
+            if matches!(node.kind, NodeKind::FUNCTION | NodeKind::METHOD) {
+                callable_nodes
+                    .entry((line, name.clone()))
+                    .or_default()
+                    .push(node.id);
+            } else if node.kind == NodeKind::CLASS {
+                class_nodes
+                    .entry((line, name.clone()))
+                    .or_default()
+                    .push(node.id);
+            }
+            if let Some(column) = node.start_col {
+                import_nodes
+                    .entry((line, column, name))
+                    .or_default()
+                    .push(node.id);
+            }
+        }
+
+        let mut result = Self {
+            calls: Vec::new(),
+            declarations: Vec::new(),
+            classes: Vec::new(),
+            functions: HashMap::new(),
+            bindings: HashMap::new(),
+            imports: HashMap::new(),
+            module_blockers: HashMap::new(),
+            module_dynamic: false,
+            dynamic_functions: HashSet::new(),
+            declarations_by_name: HashMap::new(),
+            classes_by_name: HashMap::new(),
+            class_owner_by_syntax_id: HashMap::new(),
+            closed_class_owners: HashSet::new(),
+            dynamic_class_owners: HashSet::new(),
+            methods_by_owner_and_name: HashMap::new(),
+            method_blockers_by_owner_and_name: HashSet::new(),
+            global_names_by_function: HashMap::new(),
+            writes_by_function: HashMap::new(),
+        };
+
+        walk_nodes(root, &mut |node| {
+            count_python_resolution_work(1);
+            match node.kind() {
+                "function_definition" => {
+                    result.collect_function(node, root, source, &callable_nodes, &class_nodes);
+                }
+                "class_definition" => {
+                    result.collect_class(node, root, source, &class_nodes, &callable_nodes);
+                }
+                "import_from_statement" => {
+                    result.collect_import(node, root, source, &import_nodes);
+                    if python_enclosing_function(node).is_some() {
+                        result.collect_local_binding_node(node, source);
+                    }
+                }
+                "call" => {
+                    result.collect_call(node, source);
+                    if python_direct_call_name(node, source)
+                        .is_some_and(|name| matches!(name, "exec" | "eval" | "globals"))
+                    {
+                        if let Some(function) = python_enclosing_function(node) {
+                            result.dynamic_functions.insert(function.id());
+                        } else {
+                            result.module_dynamic = true;
+                        }
+                    }
+                }
+                "assignment" | "augmented_assignment" => result.collect_assignment(node, source),
+                "parameters" => result.collect_parameter_bindings(node, source),
+                "for_statement"
+                | "with_item"
+                | "except_clause"
+                | "named_expression"
+                | "global_statement"
+                | "nonlocal_statement"
+                | "delete_statement"
+                | "case_pattern"
+                | "list_comprehension"
+                | "set_comprehension"
+                | "dictionary_comprehension"
+                | "generator_expression"
+                | "import_statement" => result.collect_local_binding_node(node, source),
+                _ => {}
+            }
+        });
+        result.collect_module_class_member_mutations(root, source);
+        for (function, global_names) in &result.global_names_by_function {
+            if let Some(writes) = result.writes_by_function.get(function) {
+                for name in global_names.intersection(writes) {
+                    *result.module_blockers.entry(name.clone()).or_default() += 1;
+                }
+            }
+        }
+        for events in result.bindings.values_mut().flat_map(HashMap::values_mut) {
+            events.sort_by_key(|event| event.at);
+        }
+        result
+            .calls
+            .sort_by_key(|call| (call.callee.start_byte(), call.callee.end_byte()));
+        result.declarations.sort_by(|left, right| {
+            left.name
+                .cmp(&right.name)
+                .then(left.declaration.cmp(&right.declaration))
+        });
+        result.classes.sort_by(|left, right| {
+            left.name
+                .cmp(&right.name)
+                .then(left.declaration.cmp(&right.declaration))
+        });
+        for declaration in &result.declarations {
+            result
+                .declarations_by_name
+                .entry(declaration.name.clone())
+                .or_default()
+                .push(declaration.declaration);
+        }
+        for class in &result.classes {
+            for method in &class.methods {
+                result
+                    .methods_by_owner_and_name
+                    .entry((class.declaration, method.name.clone()))
+                    .or_default()
+                    .push(method.declaration);
+            }
+        }
+        result
+    }
+
+    fn poisoned_export_names(&self) -> Vec<String> {
+        let mut names = self.module_blockers.keys().cloned().collect::<HashSet<_>>();
+        names.extend(self.imports.keys().cloned());
+        for class in &self.classes {
+            if self
+                .method_blockers_by_owner_and_name
+                .iter()
+                .any(|(owner, _)| *owner == class.declaration)
+            {
+                names.insert(class.name.clone());
+            }
+        }
+        let mut names = names.into_iter().collect::<Vec<_>>();
+        names.sort();
+        names
+    }
+
+    fn collect_function(
+        &mut self,
+        node: TsNode<'tree>,
+        root: TsNode<'tree>,
+        source: &str,
+        callable_nodes: &HashMap<(u32, String), Vec<NodeId>>,
+        class_nodes: &HashMap<(u32, String), Vec<NodeId>>,
+    ) {
+        let Some(name) = declaration_name(node, source).map(str::to_string) else {
+            return;
+        };
+        let graph_id = python_unique_graph_node(callable_nodes, node, &name);
+        let direct_module = python_direct_child_of(node, root)
+            && node
+                .parent()
+                .is_some_and(|parent| parent.kind() != "decorated_definition");
+        let owner_node = python_direct_enclosing_class(node);
+        let owner = owner_node.and_then(|owner_node| {
+            let owner_name = declaration_name(owner_node, source)?.to_string();
+            let owner = python_unique_graph_node(class_nodes, owner_node, &owner_name)?;
+            Some((owner, owner_name))
+        });
+        let direct_method = owner_node
+            .is_some_and(|owner| python_direct_function_in_class(node, owner))
+            && node
+                .parent()
+                .is_some_and(|parent| parent.kind() != "decorated_definition");
+        if let Some((owner, _)) = &owner
+            && (!direct_method || graph_id.is_none())
+        {
+            self.method_blockers_by_owner_and_name
+                .insert((*owner, name.clone()));
+        }
+        if let Some((owner, _)) = &owner
+            && matches!(
+                name.as_str(),
+                "__getattribute__" | "__getattr__" | "__setattr__" | "__delattr__"
+            )
+        {
+            self.dynamic_class_owners.insert(*owner);
+        }
+        self.functions.insert(
+            node.id(),
+            PythonFunctionInfo {
+                graph_id,
+                direct_method,
+                owner,
+                plain_self: direct_method && python_plain_self_parameter(node, source),
+            },
+        );
+        if direct_module {
+            if let Some(declaration) = graph_id {
+                self.declarations.push(CachedTopLevelDeclaration {
+                    name: name.clone(),
+                    declaration,
+                    module_path: Vec::new(),
+                    cross_module_visible: true,
+                });
+            } else {
+                *self.module_blockers.entry(name.clone()).or_default() += 1;
+            }
+        } else if python_enclosing_function(node).is_none() && owner_node.is_none() {
+            *self.module_blockers.entry(name.clone()).or_default() += 1;
+        }
+        if let Some(enclosing) = python_enclosing_function(node)
+            && enclosing.id() != node.id()
+        {
+            self.push_binding(enclosing, name, node.start_byte(), PythonNameBinding::Other);
+        }
+    }
+
+    fn collect_class(
+        &mut self,
+        node: TsNode<'tree>,
+        root: TsNode<'tree>,
+        source: &str,
+        class_nodes: &HashMap<(u32, String), Vec<NodeId>>,
+        callable_nodes: &HashMap<(u32, String), Vec<NodeId>>,
+    ) {
+        let Some(name) = declaration_name(node, source).map(str::to_string) else {
+            return;
+        };
+        let direct_module = python_direct_child_of(node, root)
+            && node
+                .parent()
+                .is_some_and(|parent| parent.kind() != "decorated_definition");
+        let closed = direct_module
+            && node.child_by_field_name("superclasses").is_none()
+            && node.child_by_field_name("type_parameters").is_none()
+            && node
+                .child_by_field_name("body")
+                .and_then(|body| source.get(node.start_byte()..body.start_byte()))
+                .is_some_and(|header| !header.contains('(') && !header.contains('['));
+        if closed && let Some(owner) = python_unique_graph_node(class_nodes, node, &name) {
+            self.class_owner_by_syntax_id.insert(node.id(), owner);
+            let mut methods = Vec::new();
+            if let Some(body) = node.child_by_field_name("body") {
+                let mut cursor = body.walk();
+                for method in body.named_children(&mut cursor) {
+                    count_python_resolution_work(1);
+                    if method.kind() != "function_definition"
+                        || method
+                            .parent()
+                            .is_some_and(|parent| parent.kind() == "decorated_definition")
+                    {
+                        continue;
+                    }
+                    let Some(method_name) = declaration_name(method, source) else {
+                        continue;
+                    };
+                    if let Some(declaration) =
+                        python_unique_graph_node(callable_nodes, method, method_name)
+                    {
+                        methods.push(CachedClassMethod {
+                            name: method_name.to_string(),
+                            declaration,
+                        });
+                    }
+                }
+            }
+            let class = CachedClassDeclaration {
+                name: name.clone(),
+                declaration: owner,
+                methods,
+            };
+            self.classes_by_name
+                .entry(name.clone())
+                .or_default()
+                .push(class.clone());
+            self.closed_class_owners.insert(owner);
+            self.classes.push(class);
+        } else if python_enclosing_function(node).is_none() {
+            *self.module_blockers.entry(name.clone()).or_default() += 1;
+        }
+        if let Some(function) = python_enclosing_function(node) {
+            self.push_binding(function, name, node.start_byte(), PythonNameBinding::Other);
+        }
+    }
+
+    fn collect_import(
+        &mut self,
+        node: TsNode<'tree>,
+        root: TsNode<'tree>,
+        source: &str,
+        import_nodes: &HashMap<(u32, u32, String), Vec<NodeId>>,
+    ) {
+        let direct = python_direct_child_of(node, root);
+        let module = node
+            .child_by_field_name("module_name")
+            .and_then(|module| node_text(module, source))
+            .map(str::trim)
+            .unwrap_or_default();
+        let mut cursor = node.walk();
+        let names = node
+            .children_by_field_name("name", &mut cursor)
+            .collect::<Vec<_>>();
+        if !direct || !python_exact_relative_module(module) || names.len() != 1 {
+            if direct
+                && (names.iter().any(|name| name.kind() == "wildcard_import")
+                    || node_text(node, source).is_some_and(|surface| surface.contains('*')))
+            {
+                self.module_dynamic = true;
+            }
+            let binding_names = python_binding_names(node, source);
+            if let Some(owner) = self.enclosing_class_owner(node) {
+                self.poison_class_members(owner, binding_names);
+            } else {
+                for name in binding_names {
+                    *self.module_blockers.entry(name).or_default() += 1;
+                }
+            }
+            return;
+        }
+        let imported = names[0];
+        let (imported_name_node, local_node) = if imported.kind() == "aliased_import" {
+            let Some(name) = imported.child_by_field_name("name") else {
+                return;
+            };
+            let Some(alias) = imported.child_by_field_name("alias") else {
+                return;
+            };
+            (name, alias)
+        } else {
+            (imported, imported)
+        };
+        let Some(imported_name) = node_text(imported_name_node, source)
+            .map(str::trim)
+            .filter(|name| python_identifier(name))
+        else {
+            return;
+        };
+        let Some(local_name) = node_text(local_node, source)
+            .map(str::trim)
+            .filter(|name| python_identifier(name))
+        else {
+            return;
+        };
+        let key = (
+            local_node.start_position().row as u32 + 1,
+            local_node.start_position().column as u32 + 1,
+            local_name.to_string(),
+        );
+        let import = import_nodes
+            .get(&key)
+            .and_then(|nodes| match nodes.as_slice() {
+                [node] => Some(*node),
+                _ => None,
+            });
+        self.imports
+            .entry(local_name.to_string())
+            .or_default()
+            .push(PythonImportBinding {
+                import,
+                module_specifier: module.to_string(),
+                imported_name: imported_name.to_string(),
+            });
+    }
+
+    fn collect_call(&mut self, node: TsNode<'tree>, source: &str) {
+        let Some(function) = node.child_by_field_name("function") else {
+            return;
+        };
+        let (callee, form, raw_target) = match function.kind() {
+            "identifier" => (
+                function,
+                CalleeForm::Identifier,
+                node_text(function, source).unwrap_or_default().to_string(),
+            ),
+            "attribute" => {
+                let Some(attribute) = function.child_by_field_name("attribute") else {
+                    return;
+                };
+                let Some(object) = function.child_by_field_name("object") else {
+                    return;
+                };
+                let form = if node_text(object, source).is_some_and(|value| value == "self") {
+                    CalleeForm::ImplicitReceiver
+                } else if object.kind() == "identifier" {
+                    CalleeForm::ExplicitReceiver
+                } else {
+                    CalleeForm::DynamicAccess
+                };
+                (
+                    attribute,
+                    form,
+                    node_text(attribute, source).unwrap_or_default().to_string(),
+                )
+            }
+            _ => (
+                function,
+                CalleeForm::DynamicAccess,
+                node_text(function, source)
+                    .unwrap_or_default()
+                    .trim()
+                    .to_string(),
+            ),
+        };
+        self.calls.push(IndexedPythonCall {
+            callee,
+            form,
+            raw_target,
+        });
+        if python_direct_call_name(node, source)
+            .is_some_and(|name| matches!(name, "getattr" | "setattr" | "delattr"))
+            && let Some(function) = python_enclosing_function(node)
+        {
+            self.dynamic_functions.insert(function.id());
+        }
+    }
+
+    fn collect_assignment(&mut self, node: TsNode<'tree>, source: &str) {
+        let Some(function) = python_enclosing_function(node) else {
+            if let Some(left) = node.child_by_field_name("left") {
+                let names = python_binding_names(left, source);
+                if let Some(owner) = self.enclosing_class_owner(node) {
+                    self.poison_class_members(owner, names);
+                } else {
+                    for name in names {
+                        *self.module_blockers.entry(name).or_default() += 1;
+                    }
+                }
+            }
+            return;
+        };
+        let Some(left) = node.child_by_field_name("left") else {
+            return;
+        };
+        let names = python_binding_names(left, source);
+        self.writes_by_function
+            .entry(function.id())
+            .or_default()
+            .extend(names.iter().cloned());
+        if let Some((owner, _)) = self
+            .functions
+            .get(&function.id())
+            .and_then(|info| info.owner.as_ref())
+            .cloned()
+        {
+            self.poison_class_members(owner, python_self_member_binding_names(left, source));
+        }
+        let direct_block = python_direct_statement_in_function(node, function);
+        let receiver = if names.len() == 1 && left.kind() == "identifier" && direct_block {
+            let class_name = match node.child_by_field_name("right") {
+                Some(right) => {
+                    python_direct_constructor_name(right, source).map(|name| (name, true))
+                }
+                None => node
+                    .child_by_field_name("type")
+                    .and_then(|annotation| python_exact_annotation(annotation, source))
+                    .map(|name| (name, false)),
+            };
+            class_name.and_then(|(class_name, constructor)| {
+                self.resolve_class_binding(&class_name)
+                    .map(|class_binding| PythonNameBinding::Receiver {
+                        class_binding,
+                        constructor,
+                        type_name: class_name,
+                    })
+            })
+        } else {
+            None
+        };
+        for name in names {
+            self.push_binding(
+                function,
+                name,
+                node.start_byte(),
+                receiver.clone().unwrap_or(PythonNameBinding::Other),
+            );
+        }
+    }
+
+    fn collect_parameter_bindings(&mut self, node: TsNode<'tree>, source: &str) {
+        let Some(function) = node
+            .parent()
+            .filter(|parent| parent.kind() == "function_definition")
+        else {
+            return;
+        };
+        let plain_self = self
+            .functions
+            .get(&function.id())
+            .is_some_and(|info| info.plain_self);
+        for name in python_binding_names(node, source) {
+            if plain_self && name == "self" {
+                continue;
+            }
+            self.push_binding(function, name, node.start_byte(), PythonNameBinding::Other);
+        }
+    }
+
+    fn collect_module_class_member_mutations(&mut self, root: TsNode<'tree>, source: &str) {
+        walk_nodes(root, &mut |node| {
+            count_python_resolution_work(1);
+            if !matches!(
+                node.kind(),
+                "assignment" | "augmented_assignment" | "delete_statement"
+            ) {
+                return;
+            }
+            let direct_module = node.parent().is_some_and(|parent| parent.id() == root.id())
+                || node.parent().is_some_and(|parent| {
+                    parent.kind() == "expression_statement"
+                        && parent
+                            .parent()
+                            .is_some_and(|grandparent| grandparent.id() == root.id())
+                });
+            if !direct_module {
+                return;
+            }
+
+            let mut targets = Vec::new();
+            if node.kind() == "delete_statement" {
+                let mut cursor = node.walk();
+                targets.extend(node.named_children(&mut cursor));
+            } else if let Some(left) = node.child_by_field_name("left") {
+                targets.push(left);
+            }
+            for target in targets {
+                if target.kind() != "attribute" {
+                    continue;
+                }
+                let Some(class_name) = target
+                    .child_by_field_name("object")
+                    .filter(|object| object.kind() == "identifier")
+                    .and_then(|object| node_text(object, source))
+                    .filter(|name| python_identifier(name))
+                else {
+                    continue;
+                };
+                let Some(member) = target
+                    .child_by_field_name("attribute")
+                    .filter(|attribute| attribute.kind() == "identifier")
+                    .and_then(|attribute| node_text(attribute, source))
+                    .filter(|name| python_identifier(name))
+                else {
+                    continue;
+                };
+                let owner = match self
+                    .classes_by_name
+                    .get(class_name)
+                    .map(Vec::as_slice)
+                    .unwrap_or_default()
+                {
+                    [class] => class.declaration,
+                    _ => continue,
+                };
+                self.method_blockers_by_owner_and_name
+                    .insert((owner, member.to_string()));
+            }
+        });
+    }
+
+    fn collect_local_binding_node(&mut self, node: TsNode<'tree>, source: &str) {
+        let names = python_binding_names(node, source);
+        if let Some(function) = python_enclosing_function(node) {
+            if node.kind() == "global_statement" {
+                self.global_names_by_function
+                    .entry(function.id())
+                    .or_default()
+                    .extend(names.iter().cloned());
+            } else {
+                self.writes_by_function
+                    .entry(function.id())
+                    .or_default()
+                    .extend(names.iter().cloned());
+            }
+            if let Some((owner, _)) = self
+                .functions
+                .get(&function.id())
+                .and_then(|info| info.owner.as_ref())
+                .cloned()
+            {
+                self.poison_class_members(owner, python_self_member_binding_names(node, source));
+            }
+            for name in names {
+                self.push_binding(function, name, node.start_byte(), PythonNameBinding::Other);
+            }
+        } else if let Some(owner) = self.enclosing_class_owner(node) {
+            self.poison_class_members(owner, names);
+        } else {
+            for name in names {
+                *self.module_blockers.entry(name).or_default() += 1;
+            }
+        }
+    }
+
+    fn enclosing_class_owner(&self, node: TsNode<'tree>) -> Option<NodeId> {
+        python_direct_enclosing_class(node)
+            .and_then(|class| self.class_owner_by_syntax_id.get(&class.id()).copied())
+    }
+
+    fn poison_class_members(&mut self, owner: NodeId, names: impl IntoIterator<Item = String>) {
+        self.method_blockers_by_owner_and_name
+            .extend(names.into_iter().map(|name| (owner, name)));
+    }
+
+    fn push_binding(
+        &mut self,
+        function: TsNode<'tree>,
+        name: String,
+        at: usize,
+        binding: PythonNameBinding,
+    ) {
+        self.bindings
+            .entry(function.id())
+            .or_default()
+            .entry(name)
+            .or_default()
+            .push(PythonBindingEvent { at, binding });
+    }
+
+    fn resolve_class_binding(&self, name: &str) -> Option<CachedClassBinding> {
+        if self.module_dynamic || self.module_blockers.contains_key(name) {
+            return None;
+        }
+        let classes = self
+            .classes_by_name
+            .get(name)
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        if let [class] = classes {
+            return Some(CachedClassBinding::SameFile {
+                owner: class.declaration,
+                owner_name: class.name.clone(),
+            });
+        }
+        let imports = self.imports.get(name)?;
+        let [import] = imports.as_slice() else {
+            return None;
+        };
+        Some(CachedClassBinding::StaticImport {
+            import: import.import?,
+            module_specifier: import.module_specifier.clone(),
+            imported_name: import.imported_name.clone(),
+            is_default: false,
+        })
+    }
+
+    fn resolve_syntax_claim(
+        &self,
+        source: &str,
+        callee: TsNode<'tree>,
+        form: CalleeForm,
+        raw_target: &str,
+    ) -> (Option<NodeId>, CachedResolutionBinding) {
+        let Some(call) = callee.parent().and_then(|parent| {
+            if parent.kind() == "call" {
+                Some(parent)
+            } else {
+                parent
+                    .parent()
+                    .filter(|grandparent| grandparent.kind() == "call")
+            }
+        }) else {
+            return (None, CachedResolutionBinding::Unsupported);
+        };
+        let Some(function) = python_enclosing_function(call) else {
+            return (None, CachedResolutionBinding::Unsupported);
+        };
+        let Some(info) = self.functions.get(&function.id()) else {
+            return (None, CachedResolutionBinding::Unsupported);
+        };
+        let Some(caller) = info.graph_id else {
+            return (None, CachedResolutionBinding::IncompleteDomain);
+        };
+        if python_enclosing_function(function).is_some() {
+            return (Some(caller), CachedResolutionBinding::Unsupported);
+        }
+        if python_has_enclosing_lambda(call, function) {
+            return (Some(caller), CachedResolutionBinding::Unsupported);
+        }
+        if self.dynamic_functions.contains(&function.id()) {
+            return (Some(caller), CachedResolutionBinding::Unsupported);
+        }
+        let binding = match form {
+            CalleeForm::Identifier => {
+                if self.module_dynamic
+                    || self
+                        .bindings
+                        .get(&function.id())
+                        .and_then(|bindings| bindings.get(raw_target))
+                        .is_some()
+                    || self
+                        .module_blockers
+                        .get(raw_target)
+                        .copied()
+                        .unwrap_or_default()
+                        > 0
+                {
+                    CachedResolutionBinding::Unsupported
+                } else if let Some(imports) = self.imports.get(raw_target) {
+                    match imports.as_slice() {
+                        [import] if import.import.is_some() => {
+                            CachedResolutionBinding::StaticImport {
+                                import: import.import.expect("checked"),
+                                module_specifier: import.module_specifier.clone(),
+                                imported_name: import.imported_name.clone(),
+                                is_default: false,
+                            }
+                        }
+                        [_] => CachedResolutionBinding::IncompleteDomain,
+                        _ => CachedResolutionBinding::Ambiguous,
+                    }
+                } else {
+                    let declarations = self
+                        .declarations_by_name
+                        .get(raw_target)
+                        .map(Vec::as_slice)
+                        .unwrap_or_default();
+                    if let [declaration] = declarations {
+                        CachedResolutionBinding::SameFile {
+                            declaration: *declaration,
+                        }
+                    } else if declarations.len() > 1 {
+                        CachedResolutionBinding::Ambiguous
+                    } else if self.classes_by_name.contains_key(raw_target) {
+                        CachedResolutionBinding::Unsupported
+                    } else {
+                        CachedResolutionBinding::MissingBinding
+                    }
+                }
+            }
+            CalleeForm::ImplicitReceiver => {
+                let owner = info.owner.as_ref();
+                let valid = info.direct_method
+                    && info.plain_self
+                    && !self
+                        .bindings
+                        .get(&function.id())
+                        .and_then(|bindings| bindings.get("self"))
+                        .is_some_and(|events| {
+                            events.iter().any(|event| event.at > function.start_byte())
+                        });
+                if !valid {
+                    CachedResolutionBinding::Unsupported
+                } else if let Some((owner, owner_name)) = owner {
+                    if !self.closed_class_owners.contains(owner)
+                        || self.dynamic_class_owners.contains(owner)
+                        || self
+                            .method_blockers_by_owner_and_name
+                            .contains(&(*owner, raw_target.to_owned()))
+                    {
+                        return (Some(caller), CachedResolutionBinding::Unsupported);
+                    }
+                    let methods = self
+                        .methods_by_owner_and_name
+                        .get(&(*owner, raw_target.to_string()))
+                        .map(Vec::as_slice)
+                        .unwrap_or_default();
+                    if let [method] = methods {
+                        CachedResolutionBinding::ImplicitReceiver {
+                            owner: *owner,
+                            declaration: *method,
+                            owner_name: owner_name.clone(),
+                        }
+                    } else if methods.len() > 1 {
+                        CachedResolutionBinding::Ambiguous
+                    } else {
+                        CachedResolutionBinding::MissingBinding
+                    }
+                } else {
+                    CachedResolutionBinding::Unsupported
+                }
+            }
+            CalleeForm::ExplicitReceiver => {
+                if !python_direct_statement_in_function(call, function) {
+                    return (Some(caller), CachedResolutionBinding::Unsupported);
+                }
+                let receiver = callee
+                    .parent()
+                    .and_then(|attribute| attribute.child_by_field_name("object"))
+                    .and_then(|receiver| (receiver.kind() == "identifier").then_some(receiver))
+                    .and_then(|receiver| node_text(receiver, source));
+                let events =
+                    receiver.and_then(|receiver| self.bindings.get(&function.id())?.get(receiver));
+                match events.map(Vec::as_slice) {
+                    Some(
+                        [
+                            PythonBindingEvent {
+                                at,
+                                binding:
+                                    PythonNameBinding::Receiver {
+                                        class_binding,
+                                        constructor,
+                                        type_name,
+                                    },
+                            },
+                        ],
+                    ) if *at < call.start_byte()
+                        && !self
+                            .bindings
+                            .get(&function.id())
+                            .is_some_and(|bindings| bindings.contains_key(type_name)) =>
+                    {
+                        if let CachedClassBinding::SameFile { owner, .. } = class_binding
+                            && (self.dynamic_class_owners.contains(owner)
+                                || self
+                                    .method_blockers_by_owner_and_name
+                                    .contains(&(*owner, raw_target.to_owned())))
+                        {
+                            return (Some(caller), CachedResolutionBinding::Unsupported);
+                        }
+                        if *constructor {
+                            CachedResolutionBinding::ConstructorBinding {
+                                class_binding: class_binding.clone(),
+                                method_name: raw_target.to_string(),
+                            }
+                        } else {
+                            CachedResolutionBinding::ExplicitReceiverType {
+                                class_binding: class_binding.clone(),
+                                method_name: raw_target.to_string(),
+                            }
+                        }
+                    }
+                    Some(_) => CachedResolutionBinding::Unsupported,
+                    None => CachedResolutionBinding::Unsupported,
+                }
+            }
+            _ => CachedResolutionBinding::Unsupported,
+        };
+        (Some(caller), binding)
+    }
+}
+
+fn python_unique_graph_node(
+    nodes: &HashMap<(u32, String), Vec<NodeId>>,
+    syntax: TsNode<'_>,
+    name: &str,
+) -> Option<NodeId> {
+    nodes
+        .get(&(syntax.start_position().row as u32 + 1, name.to_string()))
+        .and_then(|matches| match matches.as_slice() {
+            [node] => Some(*node),
+            _ => None,
+        })
+}
+
+fn python_direct_child_of(node: TsNode<'_>, owner: TsNode<'_>) -> bool {
+    node.parent()
+        .is_some_and(|parent| parent.id() == owner.id())
+        || node.parent().is_some_and(|parent| {
+            parent.kind() == "decorated_definition"
+                && parent
+                    .parent()
+                    .is_some_and(|grandparent| grandparent.id() == owner.id())
+        })
+}
+
+fn python_direct_function_in_class(function: TsNode<'_>, class: TsNode<'_>) -> bool {
+    class.child_by_field_name("body").is_some_and(|body| {
+        function
+            .parent()
+            .is_some_and(|parent| parent.id() == body.id())
+            || function.parent().is_some_and(|parent| {
+                parent.kind() == "decorated_definition"
+                    && parent
+                        .parent()
+                        .is_some_and(|grandparent| grandparent.id() == body.id())
+            })
+    })
+}
+
+fn python_direct_enclosing_class(mut node: TsNode<'_>) -> Option<TsNode<'_>> {
+    while let Some(parent) = node.parent() {
+        if parent.kind() == "function_definition" {
+            return None;
+        }
+        if parent.kind() == "class_definition" {
+            return Some(parent);
+        }
+        node = parent;
+    }
+    None
+}
+
+fn python_enclosing_function(mut node: TsNode<'_>) -> Option<TsNode<'_>> {
+    while let Some(parent) = node.parent() {
+        if parent.kind() == "function_definition" {
+            return Some(parent);
+        }
+        node = parent;
+    }
+    None
+}
+
+fn python_has_enclosing_lambda(mut node: TsNode<'_>, function: TsNode<'_>) -> bool {
+    while let Some(parent) = node.parent() {
+        if parent.id() == function.id() {
+            return false;
+        }
+        if parent.kind() == "lambda" {
+            return true;
+        }
+        node = parent;
+    }
+    false
+}
+
+fn python_plain_self_parameter(function: TsNode<'_>, source: &str) -> bool {
+    let Some(parameters) = function.child_by_field_name("parameters") else {
+        return false;
+    };
+    let mut cursor = parameters.walk();
+    let params = parameters.named_children(&mut cursor).collect::<Vec<_>>();
+    params.first().is_some_and(|parameter| {
+        parameter.kind() == "identifier" && node_text(*parameter, source) == Some("self")
+    })
+}
+
+fn python_direct_statement_in_function(node: TsNode<'_>, function: TsNode<'_>) -> bool {
+    function.child_by_field_name("body").is_some_and(|body| {
+        node.parent().is_some_and(|parent| parent.id() == body.id())
+            || node.parent().is_some_and(|parent| {
+                parent.kind() == "expression_statement"
+                    && parent
+                        .parent()
+                        .is_some_and(|grandparent| grandparent.id() == body.id())
+            })
+    })
+}
+
+fn python_direct_constructor_name(node: TsNode<'_>, source: &str) -> Option<String> {
+    if node.kind() != "call" {
+        return None;
+    }
+    let function = node.child_by_field_name("function")?;
+    let name = (function.kind() == "identifier").then(|| node_text(function, source))??;
+    python_identifier(name).then(|| name.to_string())
+}
+
+fn python_exact_annotation(node: TsNode<'_>, source: &str) -> Option<String> {
+    let surface = node_text(node, source)?.trim();
+    python_identifier(surface).then(|| surface.to_string())
+}
+
+fn python_direct_call_name<'a>(node: TsNode<'_>, source: &'a str) -> Option<&'a str> {
+    let function = node.child_by_field_name("function")?;
+    (function.kind() == "identifier").then(|| node_text(function, source))?
+}
+
+fn python_exact_relative_module(module: &str) -> bool {
+    module.starts_with('.')
+        && !module.starts_with("..")
+        && module[1..].split('.').all(python_identifier)
+        && module.len() > 1
+}
+
+fn python_identifier(name: &str) -> bool {
+    let mut chars = name.chars();
+    chars
+        .next()
+        .is_some_and(|ch| ch == '_' || ch.is_ascii_alphabetic())
+        && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+}
+
+fn python_binding_names(node: TsNode<'_>, source: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    match node.kind() {
+        "assignment" | "augmented_assignment" => {
+            if let Some(left) = node.child_by_field_name("left") {
+                python_binding_target_names(left, source, &mut names);
+            }
+        }
+        "for_statement"
+        | "list_comprehension"
+        | "set_comprehension"
+        | "dictionary_comprehension"
+        | "generator_expression" => {
+            if let Some(left) = node.child_by_field_name("left") {
+                python_binding_target_names(left, source, &mut names);
+            }
+        }
+        "named_expression" => {
+            if let Some(name) = node.child_by_field_name("name") {
+                python_binding_target_names(name, source, &mut names);
+            }
+        }
+        "with_item" => {
+            if let Some(alias) = node.child_by_field_name("alias") {
+                python_binding_target_names(alias, source, &mut names);
+            }
+        }
+        "except_clause" => {
+            if let Some(name) = node.child_by_field_name("name") {
+                python_binding_target_names(name, source, &mut names);
+            }
+        }
+        "parameters"
+        | "global_statement"
+        | "nonlocal_statement"
+        | "delete_statement"
+        | "case_pattern"
+        | "import_statement"
+        | "import_from_statement" => {
+            python_binding_target_names(node, source, &mut names);
+        }
+        _ => python_binding_target_names(node, source, &mut names),
+    }
+    names.sort();
+    names.dedup();
+    names
+}
+
+fn python_binding_target_names(node: TsNode<'_>, source: &str, names: &mut Vec<String>) {
+    count_python_resolution_work(1);
+    if node.kind() == "identifier" {
+        if let Some(name) = node_text(node, source).filter(|name| python_identifier(name)) {
+            names.push(name.to_string());
+        }
+        return;
+    }
+    if node.kind() == "attribute" {
+        return;
+    }
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        python_binding_target_names(child, source, names);
+    }
+}
+
+fn python_self_member_binding_names(node: TsNode<'_>, source: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    python_collect_self_member_binding_names(node, source, &mut names);
+    names.sort();
+    names.dedup();
+    names
+}
+
+fn python_collect_self_member_binding_names(
+    node: TsNode<'_>,
+    source: &str,
+    names: &mut Vec<String>,
+) {
+    count_python_resolution_work(1);
+    if node.kind() == "attribute"
+        && node
+            .child_by_field_name("object")
+            .and_then(|object| node_text(object, source))
+            == Some("self")
+    {
+        if let Some(name) = node
+            .child_by_field_name("attribute")
+            .and_then(|attribute| node_text(attribute, source))
+            .filter(|name| python_identifier(name))
+        {
+            names.push(name.to_string());
+        }
+        return;
+    }
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        python_collect_self_member_binding_names(child, source, names);
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -4924,21 +6100,60 @@ fn cache_entry_identity_for_indexed_file(
     })
 }
 
-fn cache_entry_matches_any_governed_file(
-    cache_path: &Path,
-    governed: &[&codestory_store::FileInfo],
-    governed_identities: &HashMap<i64, WorkspacePathIdentity>,
-) -> Result<bool> {
-    for file in governed {
-        let observed = cache_entry_identity_for_indexed_file(cache_path, &file.path)?;
-        if governed_identities
-            .get(&file.id)
-            .is_some_and(|identity| *identity == observed)
-        {
-            return Ok(true);
+struct PreparedGovernedCachePaths {
+    relative_suffixes: HashSet<PathBuf>,
+    absolute_identities: HashSet<WorkspacePathIdentity>,
+}
+
+impl PreparedGovernedCachePaths {
+    fn prepare(
+        governed: &[&codestory_store::FileInfo],
+        governed_identities: &HashMap<i64, WorkspacePathIdentity>,
+    ) -> Self {
+        let mut relative_suffixes = HashSet::new();
+        for file in governed {
+            let components = file
+                .path
+                .components()
+                .filter_map(|component| match component {
+                    Component::Normal(component) => Some(component),
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+            for start in 0..components.len() {
+                count_python_resolution_work(1);
+                relative_suffixes.insert(components[start..].iter().copied().collect());
+            }
+        }
+        Self {
+            relative_suffixes,
+            absolute_identities: governed_identities.values().cloned().collect(),
         }
     }
-    Ok(false)
+
+    fn contains(&self, cache_path: &Path) -> Result<bool> {
+        count_python_resolution_work(1);
+        if cache_path.is_absolute() {
+            let observed = workspace_path_identity(cache_path).with_context(|| {
+                format!(
+                    "proof resolution native identity is unavailable for parser cache path {}",
+                    cache_path.display()
+                )
+            })?;
+            return Ok(self.absolute_identities.contains(&observed));
+        }
+        if cache_path.as_os_str().is_empty()
+            || cache_path
+                .components()
+                .any(|component| !matches!(component, Component::Normal(_)))
+        {
+            return Err(anyhow!(
+                "proof resolution parser cache path is not a portable project path: {}",
+                cache_path.display()
+            ));
+        }
+        Ok(self.relative_suffixes.contains(cache_path))
+    }
 }
 
 pub fn rematerialize_proof_resolution_projection(
@@ -4990,16 +6205,13 @@ pub fn rematerialize_proof_resolution_projection(
         }
         governed_identities.insert(file.id, identity);
     }
+    let governed_cache_paths = PreparedGovernedCachePaths::prepare(&governed, &governed_identities);
     let mut records_by_id = HashMap::<i64, Vec<ResolutionCacheRecord>>::new();
     for entry in store.get_index_artifact_cache_entries()? {
         let artifact: CachedIndexArtifact = match serde_json::from_slice(&entry.artifact_blob) {
             Ok(artifact) => artifact,
             Err(error) => {
-                if cache_entry_matches_any_governed_file(
-                    &entry.file_path,
-                    &governed,
-                    &governed_identities,
-                )? {
+                if governed_cache_paths.contains(&entry.file_path)? {
                     return Err(anyhow!(
                         "proof resolution parser cache is corrupt for {}: {error}",
                         entry.file_path.display()
@@ -5009,11 +6221,7 @@ pub fn rematerialize_proof_resolution_projection(
             }
         };
         let Some(file) = artifact.resolution_file else {
-            if cache_entry_matches_any_governed_file(
-                &entry.file_path,
-                &governed,
-                &governed_identities,
-            )? {
+            if governed_cache_paths.contains(&entry.file_path)? {
                 return Err(anyhow!(
                     "proof resolution parser cache has no file coverage for {}",
                     entry.file_path.display()
@@ -5157,6 +6365,7 @@ pub fn rematerialize_proof_resolution_projection(
         .collect::<HashMap<_, _>>();
     let rust_projection_index = RustProjectionIndex::prepare(&records)?;
     let go_projection_index = GoProjectionIndex::prepare(&records)?;
+    let python_projection_index = PythonProjectionIndex::prepare(&records, &record_by_path)?;
     let mut claims = inputs
         .into_iter()
         .map(|(source_record, input)| {
@@ -5165,6 +6374,7 @@ pub fn rematerialize_proof_resolution_projection(
                 &record_by_path,
                 &rust_projection_index,
                 &go_projection_index,
+                &python_projection_index,
                 source_record,
                 input,
             )
@@ -5226,7 +6436,8 @@ pub fn rematerialize_proof_resolution_projection(
             let edge = &edges[*index];
             let raw = node_by_id[&edge.target];
             let direct_member_edge = edge.target == edge.effective_target()
-                && (raw.kind == NodeKind::METHOD || raw.file_node_id != edge.file_node_id);
+                && (matches!(raw.kind, NodeKind::FUNCTION | NodeKind::METHOD)
+                    || raw.file_node_id != edge.file_node_id);
             OrdinaryCallEdgeCorrelationInput {
                 file_id: edge.file_node_id.map(|file| FileId(file.0)),
                 line: edge.line,
@@ -5294,6 +6505,278 @@ enum RelativeImportResolution<'a> {
     Unique(&'a ResolutionCacheRecord),
     Missing,
     Incomplete,
+}
+
+struct PythonRelativeImportResolution<'a> {
+    target: RelativeImportResolution<'a>,
+    dependencies: Vec<FileId>,
+}
+
+#[derive(Default)]
+struct PythonProjectionIndex {
+    complete_directories: HashSet<WorkspacePathIdentity>,
+    declarations_by_file_and_name: HashMap<(i64, String), Vec<NodeId>>,
+    classes_by_file_and_name: HashMap<(i64, String), Vec<NodeId>>,
+    methods_by_file_owner_and_name: HashMap<(i64, NodeId, String), Vec<NodeId>>,
+}
+
+impl PythonProjectionIndex {
+    fn prepare(
+        records: &[ResolutionCacheRecord],
+        records_by_path: &HashMap<WorkspacePathIdentity, &ResolutionCacheRecord>,
+    ) -> Result<Self> {
+        let mut index = Self::default();
+        let mut directories = HashMap::<WorkspacePathIdentity, PathBuf>::new();
+        for record in records
+            .iter()
+            .filter(|record| record.file.language == "python")
+        {
+            count_python_resolution_work(1);
+            let directory = record.path.parent().ok_or_else(|| {
+                anyhow!(
+                    "Python proof resolution source has no package directory: {}",
+                    record.path.display()
+                )
+            })?;
+            let identity = workspace_path_identity(directory).map_err(|error| {
+                anyhow!(
+                    "Python proof resolution package directory has no native identity ({}): {error}",
+                    directory.display()
+                )
+            })?;
+            directories
+                .entry(identity)
+                .or_insert_with(|| directory.to_path_buf());
+            for declaration in &record.file.top_level_declarations {
+                count_python_resolution_work(1);
+                index
+                    .declarations_by_file_and_name
+                    .entry((record.file.file_id.0, declaration.name.clone()))
+                    .or_default()
+                    .push(declaration.declaration);
+            }
+            for class in &record.file.classes {
+                count_python_resolution_work(1);
+                index
+                    .classes_by_file_and_name
+                    .entry((record.file.file_id.0, class.name.clone()))
+                    .or_default()
+                    .push(class.declaration);
+                for method in &class.methods {
+                    count_python_resolution_work(1);
+                    index
+                        .methods_by_file_owner_and_name
+                        .entry((
+                            record.file.file_id.0,
+                            class.declaration,
+                            method.name.clone(),
+                        ))
+                        .or_default()
+                        .push(method.declaration);
+                }
+            }
+        }
+        for (identity, directory) in directories {
+            let mut complete = true;
+            let entries = match std::fs::read_dir(&directory) {
+                Ok(entries) => entries,
+                Err(_) => {
+                    continue;
+                }
+            };
+            for entry in entries {
+                count_python_resolution_work(1);
+                let Ok(entry) = entry else {
+                    complete = false;
+                    break;
+                };
+                let path = entry.path();
+                if path.extension().and_then(|extension| extension.to_str()) != Some("py") {
+                    continue;
+                }
+                if entry.file_type().map_or(true, |kind| kind.is_symlink()) {
+                    complete = false;
+                    break;
+                }
+                let Ok(entry_identity) = workspace_path_identity(&path) else {
+                    complete = false;
+                    break;
+                };
+                if !records_by_path.contains_key(&entry_identity) {
+                    complete = false;
+                    break;
+                }
+            }
+            if complete {
+                index.complete_directories.insert(identity);
+            }
+        }
+        Ok(index)
+    }
+
+    fn directory_is_complete(&self, directory: &Path) -> bool {
+        count_python_resolution_work(1);
+        workspace_path_identity(directory)
+            .ok()
+            .is_some_and(|identity| self.complete_directories.contains(&identity))
+    }
+
+    fn classes(&self, file_id: FileId, name: &str) -> &[NodeId] {
+        count_python_resolution_work(1);
+        self.classes_by_file_and_name
+            .get(&(file_id.0, name.to_owned()))
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+    }
+
+    fn declarations(&self, file_id: FileId, name: &str) -> &[NodeId] {
+        count_python_resolution_work(1);
+        self.declarations_by_file_and_name
+            .get(&(file_id.0, name.to_owned()))
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+    }
+
+    fn methods(&self, file_id: FileId, owner: NodeId, name: &str) -> &[NodeId] {
+        count_python_resolution_work(1);
+        self.methods_by_file_owner_and_name
+            .get(&(file_id.0, owner, name.to_owned()))
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+    }
+}
+
+fn resolve_python_relative_import<'a>(
+    source_record: &ResolutionCacheRecord,
+    module_specifier: &str,
+    records: &'a HashMap<WorkspacePathIdentity, &ResolutionCacheRecord>,
+    python_index: &PythonProjectionIndex,
+) -> Result<PythonRelativeImportResolution<'a>> {
+    if !python_exact_relative_module(module_specifier) {
+        return Ok(PythonRelativeImportResolution {
+            target: RelativeImportResolution::Missing,
+            dependencies: Vec::new(),
+        });
+    }
+    let Some(source_directory) = source_record.path.parent() else {
+        return Ok(PythonRelativeImportResolution {
+            target: RelativeImportResolution::Missing,
+            dependencies: Vec::new(),
+        });
+    };
+    let mut dependency_records = Vec::new();
+    let source_marker = source_directory.join("__init__.py");
+    let source_marker_identity = match workspace_path_identity(&source_marker) {
+        Ok(identity) => identity,
+        Err(_) => {
+            return Ok(PythonRelativeImportResolution {
+                target: RelativeImportResolution::Incomplete,
+                dependencies: Vec::new(),
+            });
+        }
+    };
+    let Some(source_marker_record) = records.get(&source_marker_identity).copied() else {
+        return Ok(PythonRelativeImportResolution {
+            target: RelativeImportResolution::Incomplete,
+            dependencies: Vec::new(),
+        });
+    };
+    dependency_records.push(source_marker_record);
+
+    let components = module_specifier[1..].split('.').collect::<Vec<_>>();
+    let mut base = source_directory.to_path_buf();
+    for component in &components[..components.len().saturating_sub(1)] {
+        base.push(component);
+        let marker = base.join("__init__.py");
+        let identity = match workspace_path_identity(&marker) {
+            Ok(identity) => identity,
+            Err(_) => {
+                return Ok(PythonRelativeImportResolution {
+                    target: RelativeImportResolution::Incomplete,
+                    dependencies: Vec::new(),
+                });
+            }
+        };
+        let Some(record) = records.get(&identity).copied() else {
+            return Ok(PythonRelativeImportResolution {
+                target: RelativeImportResolution::Incomplete,
+                dependencies: Vec::new(),
+            });
+        };
+        dependency_records.push(record);
+    }
+    let leaf = components
+        .last()
+        .expect("exact relative module has a component");
+    let file_candidate = base.join(leaf).with_extension("py");
+    let package_candidate = base.join(leaf).join("__init__.py");
+    let mut matches: Vec<&ResolutionCacheRecord> = Vec::new();
+    let mut uncovered = false;
+    for candidate in [&file_candidate, &package_candidate] {
+        match std::fs::symlink_metadata(candidate) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                uncovered = true;
+                continue;
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(_) => {
+                uncovered = true;
+                continue;
+            }
+        }
+        let identity = match workspace_path_identity(candidate) {
+            Ok(identity) => identity,
+            Err(_) => {
+                uncovered = true;
+                continue;
+            }
+        };
+        if let Some(record) = records.get(&identity) {
+            matches.push(*record);
+        } else {
+            uncovered = true;
+        }
+    }
+    matches.sort_by_key(|record| record.file.file_id);
+    matches.dedup_by_key(|record| record.file.file_id);
+    if uncovered || matches.len() != 1 {
+        return Ok(PythonRelativeImportResolution {
+            target: if matches.is_empty() && !uncovered {
+                RelativeImportResolution::Missing
+            } else {
+                RelativeImportResolution::Incomplete
+            },
+            dependencies: Vec::new(),
+        });
+    }
+    let target = matches[0];
+    if package_candidate == target.path {
+        dependency_records.push(target);
+    }
+    if [
+        source_directory,
+        target.path.parent().unwrap_or(source_directory),
+    ]
+    .into_iter()
+    .any(|directory| !python_index.directory_is_complete(directory))
+    {
+        return Ok(PythonRelativeImportResolution {
+            target: RelativeImportResolution::Incomplete,
+            dependencies: Vec::new(),
+        });
+    }
+    let mut dependencies = dependency_records
+        .into_iter()
+        .map(|record| FileId(record.file.file_id.0))
+        .chain(std::iter::once(FileId(target.file.file_id.0)))
+        .collect::<Vec<_>>();
+    dependencies.sort();
+    dependencies.dedup();
+    Ok(PythonRelativeImportResolution {
+        target: RelativeImportResolution::Unique(target),
+        dependencies,
+    })
 }
 
 fn resolve_relative_import<'a>(
@@ -5400,12 +6883,43 @@ impl ProofRelationState {
 struct ExactEvidenceValidationIndex {
     import_relations: HashMap<(NodeId, NodeId, NodeId), ProofRelationState>,
     member_relations: HashMap<(NodeId, NodeId), ProofRelationState>,
+    python_import_paths: HashMap<(NodeId, NodeId, String), Vec<Vec<NodeId>>>,
+    python_import_path_counts: HashMap<(NodeId, NodeId, Vec<NodeId>), usize>,
+}
+
+fn python_raw_import_marker_is_admissible(edge: &Edge, nodes: &HashMap<NodeId, &Node>) -> bool {
+    if edge.kind != EdgeKind::IMPORT
+        || edge.effective_source() != edge.source
+        || !edge.candidate_targets.is_empty()
+    {
+        return false;
+    }
+    let Some(file_id) = edge.file_node_id else {
+        return false;
+    };
+    let raw_markers_are_local = [edge.source, edge.target].into_iter().all(|node_id| {
+        nodes.get(&node_id).is_some_and(|node| {
+            node.file_node_id == Some(file_id)
+                && matches!(node.kind, NodeKind::UNKNOWN | NodeKind::MODULE)
+        })
+    });
+    let target_relation_is_consistent = match edge.resolved_target {
+        None => edge.effective_target() == edge.target,
+        Some(resolved) => {
+            edge.effective_target() == resolved
+                && resolved != edge.source
+                && resolved != edge.target
+                && nodes.contains_key(&resolved)
+        }
+    };
+    raw_markers_are_local && target_relation_is_consistent
 }
 
 impl ExactEvidenceValidationIndex {
     fn prepare(edges: &[Edge], nodes: &HashMap<NodeId, &Node>) -> Self {
         let mut import_relations = HashMap::<_, ProofRelationState>::new();
         let mut member_relations = HashMap::<_, ProofRelationState>::new();
+        let mut python_import_edges = HashMap::<NodeId, Vec<NodeId>>::new();
         for edge in edges {
             if edge.kind == EdgeKind::IMPORT
                 && let (Some(file_id), Some(target)) = (edge.file_node_id, edge.resolved_target)
@@ -5436,6 +6950,12 @@ impl ExactEvidenceValidationIndex {
                     state.conflicting += 1;
                 }
             }
+            if python_raw_import_marker_is_admissible(edge, nodes) {
+                python_import_edges
+                    .entry(edge.source)
+                    .or_default()
+                    .push(edge.target);
+            }
             if edge.kind == EdgeKind::MEMBER {
                 let owner = nodes.get(&edge.source);
                 let member = nodes.get(&edge.target);
@@ -5454,10 +6974,8 @@ impl ExactEvidenceValidationIndex {
                                         | NodeKind::CLASS
                                         | NodeKind::ENUM
                                 )
-                            ) | (
-                                NodeKind::STRUCT | NodeKind::CLASS | NodeKind::ENUM,
-                                Some(NodeKind::METHOD)
-                            )
+                            ) | (NodeKind::STRUCT | NodeKind::ENUM, Some(NodeKind::METHOD))
+                                | (NodeKind::CLASS, Some(NodeKind::METHOD | NodeKind::FUNCTION))
                         )
                     })
                     && member.is_some_and(|member| {
@@ -5473,9 +6991,53 @@ impl ExactEvidenceValidationIndex {
                 }
             }
         }
+        for targets in python_import_edges.values_mut() {
+            targets.sort();
+            targets.dedup();
+        }
+        let python_import_targets = python_import_edges
+            .values()
+            .flatten()
+            .copied()
+            .collect::<HashSet<_>>();
+        let mut python_import_paths = HashMap::<_, Vec<Vec<NodeId>>>::new();
+        let mut python_import_path_counts = HashMap::<_, usize>::new();
+        for &source in python_import_edges
+            .keys()
+            .filter(|source| !python_import_targets.contains(source))
+        {
+            let Some(file_id) = nodes.get(&source).and_then(|node| node.file_node_id) else {
+                continue;
+            };
+            let mut path = vec![source];
+            let mut visited = HashSet::from([source]);
+            let mut current = source;
+            while let Some([next]) = python_import_edges.get(&current).map(Vec::as_slice) {
+                if !visited.insert(*next) {
+                    break;
+                }
+                path.push(*next);
+                let Some(node) = nodes.get(next) else {
+                    break;
+                };
+                if node.kind == NodeKind::MODULE {
+                    python_import_paths
+                        .entry((file_id, source, node.serialized_name.clone()))
+                        .or_default()
+                        .push(path.clone());
+                    *python_import_path_counts
+                        .entry((file_id, source, path))
+                        .or_default() += 1;
+                    break;
+                }
+                current = *next;
+            }
+        }
         Self {
             import_relations,
             member_relations,
+            python_import_paths,
+            python_import_path_counts,
         }
     }
 
@@ -5489,6 +7051,27 @@ impl ExactEvidenceValidationIndex {
         self.member_relations
             .get(&(owner, member))
             .is_some_and(ProofRelationState::is_unique)
+    }
+
+    fn python_import_path(
+        &self,
+        file: NodeId,
+        import: NodeId,
+        module_specifier: &str,
+    ) -> Option<&[NodeId]> {
+        self.python_import_paths
+            .get(&(file, import, module_specifier.to_string()))
+            .and_then(|paths| match paths.as_slice() {
+                [path] => Some(path.as_slice()),
+                _ => None,
+            })
+    }
+
+    fn has_python_import_path(&self, file: NodeId, import: NodeId, components: &[NodeId]) -> bool {
+        self.python_import_path_counts
+            .get(&(file, import, components.to_vec()))
+            .copied()
+            == Some(1)
     }
 
     fn claim_has_literal_corroboration(
@@ -5556,19 +7139,33 @@ impl ExactEvidenceValidationIndex {
                     ResolutionEvidence::QualifiedPath { components },
                 ],
             ) => {
-                *declaration == target
+                let python_relative = claim.input.language == "python"
+                    && components.first() == Some(import)
                     && components.last() == Some(&target)
-                    && components.len() >= 2
                     && nodes.get(import).is_some_and(|import_node| {
-                        import_node.kind == NodeKind::MODULE
+                        import_node.kind == NodeKind::UNKNOWN
                             && import_node.file_node_id == Some(source_file)
                             && graph_leaf_name(&import_node.serialized_name)
                                 == claim.input.callsite.raw_target
                     })
-                    && self.has_import(source_file, *import, target)
-                    && components
-                        .windows(2)
-                        .all(|pair| self.has_member(pair[0], pair[1]))
+                    && components.len() >= 3
+                    && nodes
+                        .get(&components[components.len() - 2])
+                        .is_some_and(|node| node.kind == NodeKind::MODULE);
+                python_relative
+                    || (*declaration == target
+                        && components.last() == Some(&target)
+                        && components.len() >= 2
+                        && nodes.get(import).is_some_and(|import_node| {
+                            import_node.kind == NodeKind::MODULE
+                                && import_node.file_node_id == Some(source_file)
+                                && graph_leaf_name(&import_node.serialized_name)
+                                    == claim.input.callsite.raw_target
+                        })
+                        && self.has_import(source_file, *import, target)
+                        && components
+                            .windows(2)
+                            .all(|pair| self.has_member(pair[0], pair[1])))
             }
             (
                 CalleeForm::ImplicitReceiver,
@@ -5578,7 +7175,11 @@ impl ExactEvidenceValidationIndex {
                 ],
             ) => {
                 let local_shape = *declaration == target
-                    && target_node.kind == NodeKind::METHOD
+                    && if claim.input.language == "python" {
+                        target_node.kind == NodeKind::FUNCTION
+                    } else {
+                        target_node.kind == NodeKind::METHOD
+                    }
                     && nodes.get(owner).is_some_and(|owner_node| {
                         matches!(
                             owner_node.kind,
@@ -5710,19 +7311,17 @@ impl ExactEvidenceValidationIndex {
                     ResolutionEvidence::ExplicitReceiverType { receiver_type },
                     ResolutionEvidence::QualifiedPath { components },
                 ],
-            ) if *owner == *constructor
-                && *owner == *receiver_type
-                && components.as_slice() == [*owner, target] =>
-            {
-                self.imported_receiver_is_correlated(
+            ) if *owner == *constructor && *owner == *receiver_type => self
+                .imported_receiver_is_correlated(
+                    &claim.input.language,
                     source_file,
                     *import,
                     *owner,
                     target,
                     target_node,
+                    components,
                     nodes,
-                )
-            }
+                ),
             (
                 CalleeForm::ExplicitReceiver,
                 [
@@ -5733,15 +7332,16 @@ impl ExactEvidenceValidationIndex {
                     ResolutionEvidence::ExplicitReceiverType { receiver_type },
                     ResolutionEvidence::QualifiedPath { components },
                 ],
-            ) if *owner == *receiver_type && components.as_slice() == [*owner, target] => self
-                .imported_receiver_is_correlated(
-                    source_file,
-                    *import,
-                    *owner,
-                    target,
-                    target_node,
-                    nodes,
-                ),
+            ) if *owner == *receiver_type => self.imported_receiver_is_correlated(
+                &claim.input.language,
+                source_file,
+                *import,
+                *owner,
+                target,
+                target_node,
+                components,
+                nodes,
+            ),
             (
                 CalleeForm::ExplicitReceiver,
                 [
@@ -5755,11 +7355,13 @@ impl ExactEvidenceValidationIndex {
                 ],
             ) if *owner == *constructor && *owner == *receiver_type && *declaration == target => {
                 self.imported_receiver_is_correlated(
+                    &claim.input.language,
                     source_file,
                     *import,
                     *owner,
                     target,
                     target_node,
+                    &[],
                     nodes,
                 )
             }
@@ -5775,11 +7377,13 @@ impl ExactEvidenceValidationIndex {
                 ],
             ) if *owner == *receiver_type && *declaration == target => self
                 .imported_receiver_is_correlated(
+                    &claim.input.language,
                     source_file,
                     *import,
                     *owner,
                     target,
                     target_node,
+                    &[],
                     nodes,
                 ),
             (
@@ -5831,7 +7435,11 @@ impl ExactEvidenceValidationIndex {
         nodes: &HashMap<NodeId, &Node>,
     ) -> bool {
         declaration == target
-            && target_node.kind == NodeKind::METHOD
+            && if language == "python" {
+                target_node.kind == NodeKind::FUNCTION
+            } else {
+                target_node.kind == NodeKind::METHOD
+            }
             && nodes.get(&owner).is_some_and(|owner_node| {
                 matches!(
                     owner_node.kind,
@@ -5846,26 +7454,42 @@ impl ExactEvidenceValidationIndex {
             && self.has_member(owner, target)
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn imported_receiver_is_correlated(
         &self,
+        language: &str,
         source_file: NodeId,
         import: NodeId,
         owner: NodeId,
         target: NodeId,
         target_node: &Node,
+        components: &[NodeId],
         nodes: &HashMap<NodeId, &Node>,
     ) -> bool {
-        target_node.kind == NodeKind::METHOD
-            && nodes
-                .get(&import)
-                .is_some_and(|import_node| import_node.file_node_id == Some(source_file))
+        let python_path = language == "python"
+            && components.len() >= 4
+            && components[components.len() - 2] == owner
+            && components.last() == Some(&target)
+            && self.has_python_import_path(
+                source_file,
+                import,
+                &components[..components.len() - 2],
+            );
+        (if language == "python" {
+            target_node.kind == NodeKind::FUNCTION && python_path
+        } else {
+            target_node.kind == NodeKind::METHOD
+                && (components.is_empty() || components == [owner, target])
+        }) && nodes
+            .get(&import)
+            .is_some_and(|import_node| import_node.file_node_id == Some(source_file))
             && nodes.get(&owner).is_some_and(|owner_node| {
                 matches!(
                     owner_node.kind,
                     NodeKind::CLASS | NodeKind::STRUCT | NodeKind::ENUM
                 ) && owner_node.file_node_id == target_node.file_node_id
             })
-            && self.has_import(source_file, import, owner)
+            && (python_path || self.has_import(source_file, import, owner))
             && self.has_member(owner, target)
     }
 }
@@ -5873,7 +7497,7 @@ impl ExactEvidenceValidationIndex {
 fn proof_import_node_kind_is_literal(language: &str, kind: NodeKind) -> bool {
     match language {
         "go" | "rust" => kind == NodeKind::MODULE,
-        "javascript" | "typescript" | "tsx" => {
+        "javascript" | "typescript" | "tsx" | "python" => {
             matches!(kind, NodeKind::MODULE | NodeKind::UNKNOWN)
         }
         _ => false,
@@ -5889,6 +7513,71 @@ fn enforce_exact_evidence_corroboration(
         .iter_mut()
         .filter(|claim| claim.status == ProofResolutionStatus::Exact)
     {
+        let python_import = match &claim.input.binding {
+            CachedResolutionBinding::StaticImport {
+                import,
+                module_specifier,
+                ..
+            } => Some((*import, module_specifier.as_str())),
+            CachedResolutionBinding::ConstructorBinding {
+                class_binding:
+                    CachedClassBinding::StaticImport {
+                        import,
+                        module_specifier,
+                        ..
+                    },
+                ..
+            }
+            | CachedResolutionBinding::ExplicitReceiverType {
+                class_binding:
+                    CachedClassBinding::StaticImport {
+                        import,
+                        module_specifier,
+                        ..
+                    },
+                ..
+            } => Some((*import, module_specifier.as_str())),
+            _ => None,
+        };
+        if claim.input.language == "python"
+            && let Some((import, module_specifier)) = python_import
+            && let Some(path) = validation.python_import_path(
+                NodeId(claim.input.callsite.file_id.0),
+                import,
+                module_specifier,
+            )
+        {
+            let mut components = path.to_vec();
+            for evidence in &claim.evidence_chain {
+                match evidence {
+                    ResolutionEvidence::StaticImportBinding { declaration, .. }
+                        if components.last() != Some(declaration) =>
+                    {
+                        components.push(*declaration);
+                    }
+                    ResolutionEvidence::ExplicitReceiverType { receiver_type }
+                        if components.last() != Some(receiver_type) =>
+                    {
+                        components.push(*receiver_type);
+                    }
+                    _ => {}
+                }
+            }
+            if let Some(target) = claim.target
+                && components.last() != Some(&target)
+            {
+                components.push(target);
+            }
+            if let Some(ResolutionEvidence::QualifiedPath {
+                components: evidence_components,
+            }) = claim
+                .evidence_chain
+                .iter_mut()
+                .find(|evidence| matches!(evidence, ResolutionEvidence::QualifiedPath { .. }))
+            {
+                *evidence_components = components;
+            }
+        }
         if !validation.claim_has_literal_corroboration(claim, nodes) {
             claim.status = ProofResolutionStatus::IncompleteDomain;
             claim.reason = ProofResolutionReason::LookupDomainIncomplete;
@@ -7236,6 +8925,7 @@ fn resolve_syntax_claim(
     records: &HashMap<WorkspacePathIdentity, &ResolutionCacheRecord>,
     rust_index: &RustProjectionIndex<'_>,
     go_index: &GoProjectionIndex<'_>,
+    python_index: &PythonProjectionIndex,
     source_record: &ResolutionCacheRecord,
     input: CachedCallResolutionInput,
 ) -> Result<ResolvedSyntaxClaim> {
@@ -7251,7 +8941,12 @@ fn resolve_syntax_claim(
     let mut exact_dependency_files = vec![input.callsite.file_id];
     match &input.binding {
         CachedResolutionBinding::SameFile { declaration } => {
-            let declaration_is_recorded =
+            let declaration_is_recorded = if source_record.file.language == "python" {
+                python_index
+                    .declarations(input.callsite.file_id, &input.callsite.raw_target)
+                    .iter()
+                    .any(|candidate| candidate == declaration)
+            } else {
                 source_record
                     .file
                     .top_level_declarations
@@ -7259,7 +8954,8 @@ fn resolve_syntax_claim(
                     .any(|binding| {
                         binding.name == input.callsite.raw_target
                             && binding.declaration == *declaration
-                    });
+                    })
+            };
             let typescript_script =
                 matches!(source_record.file.language.as_str(), "typescript" | "tsx")
                     && !source_record.file.typescript_module;
@@ -7295,6 +8991,12 @@ fn resolve_syntax_claim(
                             && method.declaration == *declaration
                     })
                     .count()
+            } else if source_record.file.language == "python" {
+                python_index
+                    .methods(input.callsite.file_id, *owner, &input.callsite.raw_target)
+                    .iter()
+                    .filter(|method| **method == *declaration)
+                    .count()
             } else {
                 source_record
                     .file
@@ -7329,61 +9031,130 @@ fn resolve_syntax_claim(
             imported_name,
             is_default,
         } => {
-            let target_resolution =
-                resolve_relative_import(source_record, module_specifier, records)?;
-            let target_record = match target_resolution {
-                RelativeImportResolution::Unique(record) => Some(record),
-                RelativeImportResolution::Missing | RelativeImportResolution::Incomplete => None,
-            };
-            let target_domain_poisoned = target_record.is_some_and(|record| {
-                record.file.export_poison_all
-                    || record
-                        .file
-                        .poisoned_export_names
-                        .iter()
-                        .any(|name| name == imported_name)
-            });
-            let declarations = target_record
-                .filter(|record| record.file.lookup_input_complete && !target_domain_poisoned)
-                .into_iter()
-                .flat_map(|record| record.file.direct_exports.iter())
-                .filter(|export| {
-                    export.is_default == *is_default
-                        && export.exported_name == *imported_name
-                        && export.declaration_kind == CachedDeclarationKind::Callable
-                })
-                .collect::<Vec<_>>();
-            if target_domain_poisoned {
-                status = ProofResolutionStatus::IncompleteDomain;
-                reason = ProofResolutionReason::LookupDomainIncomplete;
-            } else if let [declaration] = declarations.as_slice() {
-                let target_file_id = FileId(
-                    target_record
-                        .expect("one direct export requires a resolved target record")
-                        .file
-                        .file_id
-                        .0,
-                );
-                status = ProofResolutionStatus::Exact;
-                reason = ProofResolutionReason::ExactResolution;
-                target = Some(declaration.declaration);
-                evidence_chain.push(ResolutionEvidence::StaticImportBinding {
-                    import: *import,
-                    declaration: declaration.declaration,
+            if source_record.file.language == "python" {
+                let resolution = resolve_python_relative_import(
+                    source_record,
+                    module_specifier,
+                    records,
+                    python_index,
+                )?;
+                let target_record = match resolution.target {
+                    RelativeImportResolution::Unique(record) => Some(record),
+                    RelativeImportResolution::Missing | RelativeImportResolution::Incomplete => {
+                        None
+                    }
+                };
+                let target_domain_unsupported = target_record.is_some_and(|record| {
+                    record.file.export_poison_all
+                        || record
+                            .file
+                            .poisoned_export_names
+                            .iter()
+                            .any(|name| name == imported_name)
                 });
-                exact_node_file_expectations.push((*import, input.callsite.file_id));
-                exact_node_file_expectations.push((declaration.declaration, target_file_id));
-            } else if matches!(target_resolution, RelativeImportResolution::Incomplete)
-                || target_record.is_some_and(|record| !record.file.lookup_input_complete)
-            {
-                status = ProofResolutionStatus::IncompleteDomain;
-                reason = ProofResolutionReason::LookupDomainIncomplete;
-            } else if declarations.len() > 1 {
-                status = ProofResolutionStatus::Ambiguous;
-                reason = ProofResolutionReason::MultipleBindings;
+                let declarations = target_record
+                    .filter(|record| {
+                        record.file.lookup_input_complete && !target_domain_unsupported
+                    })
+                    .map(|record| {
+                        python_index.declarations(FileId(record.file.file_id.0), imported_name)
+                    })
+                    .unwrap_or_default();
+                if target_domain_unsupported {
+                    status = ProofResolutionStatus::Unsupported;
+                    reason = ProofResolutionReason::UnsupportedConstruct;
+                } else if let [declaration] = declarations {
+                    let target_file_id = FileId(
+                        target_record
+                            .expect("one Python declaration requires a target record")
+                            .file
+                            .file_id
+                            .0,
+                    );
+                    status = ProofResolutionStatus::Exact;
+                    reason = ProofResolutionReason::ExactResolution;
+                    target = Some(*declaration);
+                    evidence_chain.push(ResolutionEvidence::StaticImportBinding {
+                        import: *import,
+                        declaration: *declaration,
+                    });
+                    evidence_chain.push(ResolutionEvidence::QualifiedPath {
+                        components: vec![*import, *declaration],
+                    });
+                    exact_node_file_expectations.push((*import, input.callsite.file_id));
+                    exact_node_file_expectations.push((*declaration, target_file_id));
+                    exact_dependency_files = resolution.dependencies;
+                } else if matches!(resolution.target, RelativeImportResolution::Incomplete)
+                    || target_record.is_some_and(|record| !record.file.lookup_input_complete)
+                {
+                    status = ProofResolutionStatus::IncompleteDomain;
+                    reason = ProofResolutionReason::LookupDomainIncomplete;
+                } else if declarations.len() > 1 {
+                    status = ProofResolutionStatus::Ambiguous;
+                    reason = ProofResolutionReason::MultipleBindings;
+                } else {
+                    status = ProofResolutionStatus::MissingBinding;
+                    reason = ProofResolutionReason::MissingBinding;
+                }
             } else {
-                status = ProofResolutionStatus::MissingBinding;
-                reason = ProofResolutionReason::MissingBinding;
+                let target_resolution =
+                    resolve_relative_import(source_record, module_specifier, records)?;
+                let target_record = match target_resolution {
+                    RelativeImportResolution::Unique(record) => Some(record),
+                    RelativeImportResolution::Missing | RelativeImportResolution::Incomplete => {
+                        None
+                    }
+                };
+                let target_domain_poisoned = target_record.is_some_and(|record| {
+                    record.file.export_poison_all
+                        || record
+                            .file
+                            .poisoned_export_names
+                            .iter()
+                            .any(|name| name == imported_name)
+                });
+                let declarations = target_record
+                    .filter(|record| record.file.lookup_input_complete && !target_domain_poisoned)
+                    .into_iter()
+                    .flat_map(|record| record.file.direct_exports.iter())
+                    .filter(|export| {
+                        export.is_default == *is_default
+                            && export.exported_name == *imported_name
+                            && export.declaration_kind == CachedDeclarationKind::Callable
+                    })
+                    .collect::<Vec<_>>();
+                if target_domain_poisoned {
+                    status = ProofResolutionStatus::IncompleteDomain;
+                    reason = ProofResolutionReason::LookupDomainIncomplete;
+                } else if let [declaration] = declarations.as_slice() {
+                    let target_file_id = FileId(
+                        target_record
+                            .expect("one direct export requires a resolved target record")
+                            .file
+                            .file_id
+                            .0,
+                    );
+                    status = ProofResolutionStatus::Exact;
+                    reason = ProofResolutionReason::ExactResolution;
+                    target = Some(declaration.declaration);
+                    evidence_chain.push(ResolutionEvidence::StaticImportBinding {
+                        import: *import,
+                        declaration: declaration.declaration,
+                    });
+                    exact_node_file_expectations.push((*import, input.callsite.file_id));
+                    exact_node_file_expectations.push((declaration.declaration, target_file_id));
+                } else if matches!(target_resolution, RelativeImportResolution::Incomplete)
+                    || target_record.is_some_and(|record| !record.file.lookup_input_complete)
+                {
+                    status = ProofResolutionStatus::IncompleteDomain;
+                    reason = ProofResolutionReason::LookupDomainIncomplete;
+                } else if declarations.len() > 1 {
+                    status = ProofResolutionStatus::Ambiguous;
+                    reason = ProofResolutionReason::MultipleBindings;
+                } else {
+                    status = ProofResolutionStatus::MissingBinding;
+                    reason = ProofResolutionReason::MissingBinding;
+                }
             }
         }
         CachedResolutionBinding::RustPath {
@@ -7807,13 +9578,23 @@ fn resolve_syntax_claim(
             );
             let (target_record, import, owner) = match class_binding {
                 CachedClassBinding::SameFile { owner, owner_name } => {
-                    let matches = source_record
-                        .file
-                        .classes
-                        .iter()
-                        .filter(|class| class.declaration == *owner && class.name == *owner_name)
-                        .collect::<Vec<_>>();
-                    if matches.len() != 1 {
+                    let match_count = if source_record.file.language == "python" {
+                        python_index
+                            .classes(input.callsite.file_id, owner_name)
+                            .iter()
+                            .filter(|candidate| **candidate == *owner)
+                            .count()
+                    } else {
+                        source_record
+                            .file
+                            .classes
+                            .iter()
+                            .filter(|class| {
+                                class.declaration == *owner && class.name == *owner_name
+                            })
+                            .count()
+                    };
+                    if match_count != 1 {
                         status = ProofResolutionStatus::Ambiguous;
                         reason = ProofResolutionReason::MultipleBindings;
                         return Ok(ResolvedSyntaxClaim {
@@ -7835,48 +9616,69 @@ fn resolve_syntax_claim(
                     imported_name,
                     is_default,
                 } => {
-                    let target_record =
-                        match resolve_relative_import(source_record, module_specifier, records)? {
-                            RelativeImportResolution::Unique(record) => record,
-                            RelativeImportResolution::Missing => {
-                                status = ProofResolutionStatus::MissingBinding;
-                                reason = ProofResolutionReason::MissingBinding;
-                                return Ok(ResolvedSyntaxClaim {
-                                    input,
-                                    caller,
-                                    target,
-                                    status,
-                                    reason,
-                                    evidence_chain,
-                                    exact_node_file_expectations,
-                                    exact_dependency_files,
-                                });
-                            }
-                            RelativeImportResolution::Incomplete => {
-                                status = ProofResolutionStatus::IncompleteDomain;
-                                reason = ProofResolutionReason::LookupDomainIncomplete;
-                                return Ok(ResolvedSyntaxClaim {
-                                    input,
-                                    caller,
-                                    target,
-                                    status,
-                                    reason,
-                                    evidence_chain,
-                                    exact_node_file_expectations,
-                                    exact_dependency_files,
-                                });
-                            }
-                        };
-                    if target_record.file.export_poison_all
+                    let python_resolution = (source_record.file.language == "python")
+                        .then(|| {
+                            resolve_python_relative_import(
+                                source_record,
+                                module_specifier,
+                                records,
+                                python_index,
+                            )
+                        })
+                        .transpose()?;
+                    let target_resolution = if let Some(resolution) = &python_resolution {
+                        resolution.target
+                    } else {
+                        resolve_relative_import(source_record, module_specifier, records)?
+                    };
+                    let target_record = match target_resolution {
+                        RelativeImportResolution::Unique(record) => record,
+                        RelativeImportResolution::Missing => {
+                            status = ProofResolutionStatus::MissingBinding;
+                            reason = ProofResolutionReason::MissingBinding;
+                            return Ok(ResolvedSyntaxClaim {
+                                input,
+                                caller,
+                                target,
+                                status,
+                                reason,
+                                evidence_chain,
+                                exact_node_file_expectations,
+                                exact_dependency_files,
+                            });
+                        }
+                        RelativeImportResolution::Incomplete => {
+                            status = ProofResolutionStatus::IncompleteDomain;
+                            reason = ProofResolutionReason::LookupDomainIncomplete;
+                            return Ok(ResolvedSyntaxClaim {
+                                input,
+                                caller,
+                                target,
+                                status,
+                                reason,
+                                evidence_chain,
+                                exact_node_file_expectations,
+                                exact_dependency_files,
+                            });
+                        }
+                    };
+                    let target_domain_poisoned = target_record.file.export_poison_all
                         || target_record
                             .file
                             .poisoned_export_names
                             .iter()
                             .any(|name| name == imported_name)
-                        || !target_record.file.lookup_input_complete
-                    {
-                        status = ProofResolutionStatus::IncompleteDomain;
-                        reason = ProofResolutionReason::LookupDomainIncomplete;
+                        || !target_record.file.lookup_input_complete;
+                    if target_domain_poisoned {
+                        if source_record.file.language == "python"
+                            && target_record.file.lookup_input_complete
+                        {
+                            status = ProofResolutionStatus::Unsupported;
+                            reason = ProofResolutionReason::UnsupportedConstruct;
+                        } else {
+                            status = ProofResolutionStatus::IncompleteDomain;
+                            reason = ProofResolutionReason::LookupDomainIncomplete;
+                        }
                         return Ok(ResolvedSyntaxClaim {
                             input,
                             caller,
@@ -7888,17 +9690,24 @@ fn resolve_syntax_claim(
                             exact_dependency_files,
                         });
                     }
-                    let owners = target_record
-                        .file
-                        .direct_exports
-                        .iter()
-                        .filter(|export| {
-                            export.is_default == *is_default
-                                && export.exported_name == *imported_name
-                                && export.declaration_kind == CachedDeclarationKind::Class
-                        })
-                        .collect::<Vec<_>>();
-                    let [export] = owners.as_slice() else {
+                    let owners = if source_record.file.language == "python" {
+                        python_index
+                            .classes(FileId(target_record.file.file_id.0), imported_name)
+                            .to_vec()
+                    } else {
+                        target_record
+                            .file
+                            .direct_exports
+                            .iter()
+                            .filter(|export| {
+                                export.is_default == *is_default
+                                    && export.exported_name == *imported_name
+                                    && export.declaration_kind == CachedDeclarationKind::Class
+                            })
+                            .map(|export| export.declaration)
+                            .collect::<Vec<_>>()
+                    };
+                    let [owner] = owners.as_slice() else {
                         status = if owners.is_empty() {
                             ProofResolutionStatus::MissingBinding
                         } else {
@@ -7920,9 +9729,15 @@ fn resolve_syntax_claim(
                             exact_dependency_files,
                         });
                     };
-                    (target_record, Some(*import), export.declaration)
+                    if let Some(resolution) = python_resolution {
+                        exact_dependency_files = resolution.dependencies;
+                    }
+                    (target_record, Some(*import), *owner)
                 }
             };
+            let python_methods = (source_record.file.language == "python").then(|| {
+                python_index.methods(FileId(target_record.file.file_id.0), owner, method_name)
+            });
             let methods = target_record
                 .file
                 .classes
@@ -7931,11 +9746,14 @@ fn resolve_syntax_claim(
                 .flat_map(|class| class.methods.iter())
                 .filter(|method| method.name == *method_name)
                 .collect::<Vec<_>>();
-            if let [method] = methods.as_slice() {
+            let method_declarations = python_methods
+                .map(|methods| methods.to_vec())
+                .unwrap_or_else(|| methods.iter().map(|method| method.declaration).collect());
+            if let [method] = method_declarations.as_slice() {
                 let target_file_id = FileId(target_record.file.file_id.0);
                 status = ProofResolutionStatus::Exact;
                 reason = ProofResolutionReason::ExactResolution;
-                target = Some(method.declaration);
+                target = Some(*method);
                 if let Some(import) = import {
                     evidence_chain.push(ResolutionEvidence::StaticImportBinding {
                         import,
@@ -7950,18 +9768,24 @@ fn resolve_syntax_claim(
                 evidence_chain.push(ResolutionEvidence::ExplicitReceiverType {
                     receiver_type: owner,
                 });
-                evidence_chain.push(ResolutionEvidence::SameFileDeclaration {
-                    declaration: method.declaration,
-                });
+                if import.is_some() && source_record.file.language == "python" {
+                    evidence_chain.push(ResolutionEvidence::QualifiedPath {
+                        components: vec![owner, *method],
+                    });
+                } else {
+                    evidence_chain.push(ResolutionEvidence::SameFileDeclaration {
+                        declaration: *method,
+                    });
+                }
                 exact_node_file_expectations.push((owner, target_file_id));
-                exact_node_file_expectations.push((method.declaration, target_file_id));
+                exact_node_file_expectations.push((*method, target_file_id));
             } else {
-                status = if methods.is_empty() {
+                status = if method_declarations.is_empty() {
                     ProofResolutionStatus::MissingBinding
                 } else {
                     ProofResolutionStatus::Ambiguous
                 };
-                reason = if methods.is_empty() {
+                reason = if method_declarations.is_empty() {
                     ProofResolutionReason::MissingBinding
                 } else {
                     ProofResolutionReason::MultipleBindings
@@ -8522,6 +10346,212 @@ mod go_complexity_tests {
         assert!(
             combined <= baseline * 2 + 256,
             "combined Go package/call work grew superlinearly: {baseline} -> {combined}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod python_complexity_tests {
+    use super::*;
+    use tree_sitter::Parser;
+
+    fn python_record(path: PathBuf, file_id: i64) -> ResolutionCacheRecord {
+        ResolutionCacheRecord {
+            path,
+            file: CachedResolutionFile {
+                file_id: NodeId(file_id),
+                source_sha256: "0".repeat(64),
+                language: "python".to_owned(),
+                adapter_version: ADAPTER_VERSION.to_owned(),
+                parser_fingerprint: "parser".to_owned(),
+                complete: true,
+                lookup_input_complete: true,
+                typescript_module: false,
+                top_level_declarations: vec![CachedTopLevelDeclaration {
+                    name: "target".to_owned(),
+                    declaration: NodeId(10_000 + file_id),
+                    module_path: Vec::new(),
+                    cross_module_visible: false,
+                }],
+                inherent_methods: Vec::new(),
+                classes: vec![CachedClassDeclaration {
+                    name: "Worker".to_owned(),
+                    declaration: NodeId(20_000 + file_id),
+                    methods: vec![CachedClassMethod {
+                        name: "run".to_owned(),
+                        declaration: NodeId(30_000 + file_id),
+                    }],
+                }],
+                direct_exports: Vec::new(),
+                export_poison_all: false,
+                poisoned_export_names: Vec::new(),
+                rust_modules: Vec::new(),
+                rust_types: Vec::new(),
+                rust_uses: Vec::new(),
+                go_package: None,
+            },
+            calls: Vec::new(),
+        }
+    }
+
+    fn measured_source_work(call_count: usize) -> usize {
+        let mut source = String::from(
+            "class Worker:\n    def run(self):\n        pass\n\ndef target():\n    pass\n\ndef caller():\n",
+        );
+        for index in 0..call_count {
+            source.push_str(&format!(
+                "    worker_{index} = Worker()\n    worker_{index}.run()\n    target()\n"
+            ));
+        }
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_python::LANGUAGE.into())
+            .expect("Python grammar must load");
+        let tree = parser.parse(&source, None).expect("source must parse");
+        reset_python_resolution_work();
+        let _ = PythonResolutionIndex::build(&tree, &source, NodeId(1), &[]);
+        python_resolution_work()
+    }
+
+    fn measured_projection_work(file_count: usize, lookup_count: usize) -> usize {
+        let temp = tempfile::tempdir().expect("Python projection tempdir");
+        let package = temp.path().join("proof");
+        std::fs::create_dir(&package).expect("create Python package");
+        let mut records = Vec::new();
+        for index in 0..file_count {
+            let name = if index == 0 {
+                "__init__.py".to_owned()
+            } else {
+                format!("module_{index}.py")
+            };
+            let path = package.join(name);
+            std::fs::write(&path, "def target():\n    pass\n").expect("write Python source");
+            records.push(python_record(path, index as i64 + 1));
+        }
+        let source = &records[0];
+        let records_by_path = records
+            .iter()
+            .map(|record| {
+                (
+                    workspace_path_identity(&record.path).expect("Python file identity"),
+                    record,
+                )
+            })
+            .collect::<HashMap<_, _>>();
+        reset_python_resolution_work();
+        let index = PythonProjectionIndex::prepare(&records, &records_by_path)
+            .expect("Python projection index");
+        for _ in 0..lookup_count {
+            let resolution =
+                resolve_python_relative_import(source, ".module_1", &records_by_path, &index)
+                    .expect("relative import resolution");
+            assert!(matches!(
+                resolution.target,
+                RelativeImportResolution::Unique(_)
+            ));
+            let _ = index.declarations(FileId(2), "target");
+            let owners = index.classes(FileId(2), "Worker");
+            assert_eq!(owners.len(), 1);
+            let _ = index.methods(FileId(2), owners[0], "run");
+        }
+        python_resolution_work()
+    }
+
+    #[test]
+    fn python_source_index_work_is_counted_and_linear() {
+        let small = measured_source_work(64);
+        let large = measured_source_work(128);
+        assert!(small > 0, "Python source work was not counted");
+        assert!(
+            large <= small * 2 + 256,
+            "Python source work grew superlinearly: {small} -> {large}"
+        );
+    }
+
+    #[test]
+    fn python_package_projection_preparation_and_lookups_are_independently_linear() {
+        let baseline = measured_projection_work(32, 32);
+        let more_files = measured_projection_work(64, 32);
+        let more_calls = measured_projection_work(32, 64);
+        let combined = measured_projection_work(64, 64);
+        assert!(
+            baseline >= 64,
+            "Python projection work was not counted: {baseline}"
+        );
+        assert!(
+            more_files <= baseline * 2 + 64,
+            "Python package preparation grew superlinearly: {baseline} -> {more_files}"
+        );
+        assert!(
+            more_calls <= baseline * 2 + 64,
+            "Python projection lookup grew superlinearly: {baseline} -> {more_calls}"
+        );
+        assert!(
+            combined <= baseline * 2 + 128,
+            "combined Python package/lookup work grew superlinearly: {baseline} -> {combined}"
+        );
+    }
+
+    fn measured_hostile_cache_lookup_work(file_count: usize, lookup_count: usize) -> usize {
+        let temp = tempfile::tempdir().expect("hostile cache tempdir");
+        let files = (0..file_count)
+            .map(|index| {
+                let path = temp.path().join(format!("pkg_{index}/module.py"));
+                std::fs::create_dir_all(path.parent().expect("cache parent"))
+                    .expect("create cache parent");
+                std::fs::write(&path, "def target():\n    pass\n").expect("write cache source");
+                codestory_store::FileInfo {
+                    id: index as i64 + 1,
+                    path,
+                    language: "python".to_owned(),
+                    modification_time: 0,
+                    indexed: true,
+                    complete: true,
+                    line_count: 2,
+                    file_role: codestory_store::FileRole::Source,
+                }
+            })
+            .collect::<Vec<_>>();
+        let governed = files.iter().collect::<Vec<_>>();
+        let identities = files
+            .iter()
+            .map(|file| {
+                (
+                    file.id,
+                    workspace_path_identity(&file.path).expect("cache identity"),
+                )
+            })
+            .collect::<HashMap<_, _>>();
+        reset_python_resolution_work();
+        let prepared = PreparedGovernedCachePaths::prepare(&governed, &identities);
+        for index in 0..lookup_count {
+            assert!(
+                prepared
+                    .contains(Path::new(&format!("pkg_{}/module.py", index % file_count)))
+                    .expect("hostile cache lookup")
+            );
+        }
+        python_resolution_work()
+    }
+
+    #[test]
+    fn hostile_cache_preparation_and_lookup_work_are_independently_linear() {
+        let baseline = measured_hostile_cache_lookup_work(32, 32);
+        let more_files = measured_hostile_cache_lookup_work(64, 32);
+        let more_lookups = measured_hostile_cache_lookup_work(32, 64);
+        let combined = measured_hostile_cache_lookup_work(64, 64);
+        assert!(baseline > 0, "hostile cache work was not counted");
+        assert!(
+            more_files <= baseline * 2 + 64,
+            "cache files: {baseline} -> {more_files}"
+        );
+        assert!(
+            more_lookups <= baseline * 2 + 64,
+            "cache lookups: {baseline} -> {more_lookups}"
+        );
+        assert!(
+            combined <= baseline * 2 + 128,
+            "cache combined: {baseline} -> {combined}"
         );
     }
 }

--- a/crates/codestory-indexer/src/proof_resolution.rs
+++ b/crates/codestory-indexer/src/proof_resolution.rs
@@ -84,8 +84,8 @@ fn python_resolution_work() -> usize {
     PYTHON_RESOLUTION_WORK.with(std::cell::Cell::get)
 }
 
-const ADAPTER_VERSION: &str = "reference-v11";
-const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 9;
+const ADAPTER_VERSION: &str = "reference-v12";
+const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 10;
 const INSTALLED_ADAPTERS: &[(&str, &str)] = &[
     ("go", ADAPTER_VERSION),
     ("javascript", ADAPTER_VERSION),
@@ -1643,6 +1643,7 @@ struct PythonResolutionIndex<'tree> {
     classes_by_name: HashMap<String, Vec<CachedClassDeclaration>>,
     class_owner_by_syntax_id: HashMap<usize, NodeId>,
     closed_class_owners: HashSet<NodeId>,
+    simple_base_class_owners: HashSet<NodeId>,
     dynamic_class_owners: HashSet<NodeId>,
     methods_by_owner_and_name: HashMap<(NodeId, String), Vec<NodeId>>,
     method_blockers_by_owner_and_name: HashSet<(NodeId, String)>,
@@ -1698,6 +1699,7 @@ impl<'tree> PythonResolutionIndex<'tree> {
             classes_by_name: HashMap::new(),
             class_owner_by_syntax_id: HashMap::new(),
             closed_class_owners: HashSet::new(),
+            simple_base_class_owners: HashSet::new(),
             dynamic_class_owners: HashSet::new(),
             methods_by_owner_and_name: HashMap::new(),
             method_blockers_by_owner_and_name: HashSet::new(),
@@ -1896,15 +1898,24 @@ impl<'tree> PythonResolutionIndex<'tree> {
             && node
                 .parent()
                 .is_some_and(|parent| parent.kind() != "decorated_definition");
+        let simple_base = python_single_simple_base(node, source);
+        let header_supported = node
+            .child_by_field_name("body")
+            .and_then(|body| source.get(node.start_byte()..body.start_byte()))
+            .is_some_and(|header| {
+                !header.contains('[')
+                    && (simple_base
+                        || (node.child_by_field_name("superclasses").is_none()
+                            && !header.contains('(')))
+            });
         let closed = direct_module
-            && node.child_by_field_name("superclasses").is_none()
             && node.child_by_field_name("type_parameters").is_none()
-            && node
-                .child_by_field_name("body")
-                .and_then(|body| source.get(node.start_byte()..body.start_byte()))
-                .is_some_and(|header| !header.contains('(') && !header.contains('['));
+            && header_supported;
         if closed && let Some(owner) = python_unique_graph_node(class_nodes, node, &name) {
             self.class_owner_by_syntax_id.insert(node.id(), owner);
+            if simple_base {
+                self.simple_base_class_owners.insert(owner);
+            }
             let mut methods = Vec::new();
             if let Some(body) = node.child_by_field_name("body") {
                 let mut cursor = body.walk();
@@ -2428,6 +2439,8 @@ impl<'tree> PythonResolutionIndex<'tree> {
                         }
                     } else if methods.len() > 1 {
                         CachedResolutionBinding::Ambiguous
+                    } else if self.simple_base_class_owners.contains(owner) {
+                        CachedResolutionBinding::Unsupported
                     } else {
                         CachedResolutionBinding::MissingBinding
                     }
@@ -2531,6 +2544,28 @@ fn python_direct_function_in_class(function: TsNode<'_>, class: TsNode<'_>) -> b
                         .is_some_and(|grandparent| grandparent.id() == body.id())
             })
     })
+}
+
+fn python_single_simple_base(class: TsNode<'_>, source: &str) -> bool {
+    let Some(superclasses) = class.child_by_field_name("superclasses") else {
+        return false;
+    };
+    let mut cursor = superclasses.walk();
+    let bases = superclasses.named_children(&mut cursor).collect::<Vec<_>>();
+    let [base] = bases.as_slice() else {
+        return false;
+    };
+    let Some(base_name) = (base.kind() == "identifier")
+        .then(|| node_text(*base, source))
+        .flatten()
+        .filter(|name| python_identifier(name))
+    else {
+        return false;
+    };
+    node_text(superclasses, source)
+        .and_then(|surface| surface.strip_prefix('('))
+        .and_then(|surface| surface.strip_suffix(')'))
+        .is_some_and(|surface| surface.trim() == base_name)
 }
 
 fn python_direct_enclosing_class(mut node: TsNode<'_>) -> Option<TsNode<'_>> {

--- a/crates/codestory-indexer/src/proof_resolution.rs
+++ b/crates/codestory-indexer/src/proof_resolution.rs
@@ -84,8 +84,8 @@ fn python_resolution_work() -> usize {
     PYTHON_RESOLUTION_WORK.with(std::cell::Cell::get)
 }
 
-const ADAPTER_VERSION: &str = "reference-v12";
-const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 10;
+const ADAPTER_VERSION: &str = "reference-v13";
+const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 11;
 const INSTALLED_ADAPTERS: &[(&str, &str)] = &[
     ("go", ADAPTER_VERSION),
     ("javascript", ADAPTER_VERSION),
@@ -1899,15 +1899,7 @@ impl<'tree> PythonResolutionIndex<'tree> {
                 .parent()
                 .is_some_and(|parent| parent.kind() != "decorated_definition");
         let simple_base = python_single_simple_base(node, source);
-        let header_supported = node
-            .child_by_field_name("body")
-            .and_then(|body| source.get(node.start_byte()..body.start_byte()))
-            .is_some_and(|header| {
-                !header.contains('[')
-                    && (simple_base
-                        || (node.child_by_field_name("superclasses").is_none()
-                            && !header.contains('(')))
-            });
+        let header_supported = simple_base || node.child_by_field_name("superclasses").is_none();
         let closed = direct_module
             && node.child_by_field_name("type_parameters").is_none()
             && header_supported;

--- a/crates/codestory-indexer/src/tests/mod.rs
+++ b/crates/codestory-indexer/src/tests/mod.rs
@@ -16,6 +16,126 @@ use rusqlite::types::Value;
 use std::collections::HashSet;
 use tempfile::tempdir;
 
+fn measured_manual_receiver_index_work(owner_count: usize, lookup_count: usize) -> usize {
+    let file_id = NodeId(1);
+    let mut nodes = HashMap::new();
+    let mut edges = Vec::new();
+    for index in 0..owner_count {
+        let owner_id = NodeId(i64::try_from(index * 2 + 2).expect("owner id"));
+        let target_id = NodeId(i64::try_from(index * 2 + 3).expect("target id"));
+        nodes.insert(
+            owner_id,
+            Node {
+                id: owner_id,
+                kind: NodeKind::CLASS,
+                serialized_name: format!("Owner{index}"),
+                qualified_name: Some(format!("module.Owner{index}")),
+                file_node_id: Some(file_id),
+                start_line: Some(u32::try_from(index + 1).expect("owner line")),
+                end_line: Some(u32::try_from(index + 2).expect("owner end line")),
+                ..Default::default()
+            },
+        );
+        nodes.insert(
+            target_id,
+            Node {
+                id: target_id,
+                kind: NodeKind::METHOD,
+                serialized_name: "run".to_owned(),
+                qualified_name: Some(format!("module.Owner{index}.run")),
+                file_node_id: Some(file_id),
+                start_line: Some(u32::try_from(index + 2).expect("method line")),
+                ..Default::default()
+            },
+        );
+        edges.push(Edge {
+            source: owner_id,
+            target: target_id,
+            kind: EdgeKind::MEMBER,
+            ..Default::default()
+        });
+    }
+    reset_manual_receiver_lookup_work();
+    let prepared = PreparedMemberTargetIndex::prepare(&nodes, &edges);
+    for index in 0..lookup_count {
+        let owner_index = index % owner_count;
+        assert_eq!(
+            prepared.target(&format!("Owner{owner_index}"), "run", file_id, false, None,),
+            Some(NodeId(
+                i64::try_from(owner_index * 2 + 3).expect("target id")
+            ))
+        );
+    }
+    manual_receiver_lookup_work()
+}
+
+#[test]
+fn prepared_manual_receiver_members_and_lookups_are_independently_linear() {
+    let baseline = measured_manual_receiver_index_work(64, 64);
+    let more_members = measured_manual_receiver_index_work(128, 64);
+    let more_lookups = measured_manual_receiver_index_work(64, 128);
+    let combined = measured_manual_receiver_index_work(128, 128);
+    assert!(baseline >= 64, "manual receiver work was not counted");
+    assert!(
+        more_members <= baseline * 2 + 64,
+        "member preparation: {baseline} -> {more_members}"
+    );
+    assert!(
+        more_lookups <= baseline * 2 + 64,
+        "member lookups: {baseline} -> {more_lookups}"
+    );
+    assert!(
+        combined <= baseline * 2 + 128,
+        "combined work: {baseline} -> {combined}"
+    );
+}
+
+fn measured_python_local_owner_line_work(owner_count: usize, lookup_count: usize) -> usize {
+    let mut source = String::new();
+    for index in 0..owner_count {
+        source.push_str(&format!(
+            "def caller_{index}():\n    class Owner{index}:\n        pass\n\n"
+        ));
+    }
+    let mut parser = Parser::new();
+    parser
+        .set_language(&tree_sitter_python::LANGUAGE.into())
+        .expect("Python parser language");
+    let tree = parser.parse(&source, None).expect("Python syntax tree");
+    reset_manual_receiver_lookup_work();
+    let prepared = PythonLocalOwnerLineIndex::prepare(&tree, &source);
+    for index in 0..lookup_count {
+        let owner_index = index % owner_count;
+        assert!(
+            prepared
+                .unique_line(&format!("caller_{owner_index}.Owner{owner_index}"))
+                .is_some()
+        );
+    }
+    manual_receiver_lookup_work()
+}
+
+#[test]
+fn python_local_owner_lines_are_prepared_once_and_looked_up_linearly() {
+    let baseline = measured_python_local_owner_line_work(64, 64);
+    let more_owners = measured_python_local_owner_line_work(128, 64);
+    let more_lookups = measured_python_local_owner_line_work(64, 128);
+    let combined = measured_python_local_owner_line_work(128, 128);
+    assert!(baseline >= 64, "Python owner-line work was not counted");
+    assert!(
+        more_owners <= baseline * 2 + 128,
+        "owner preparation: {baseline} -> {more_owners}"
+    );
+    assert!(
+        more_lookups <= baseline * 2 + 64,
+        "owner lookups: {baseline} -> {more_lookups}"
+    );
+    assert!(
+        combined <= baseline * 2 + 192,
+        "combined work: {baseline} -> {combined}"
+    );
+}
+
 /// A file whose only structural node is a position-derived one: a shape
 /// several collectors produce today, because `structural_node_id` mixes the
 /// declaration's line and column into the id.

--- a/crates/codestory-indexer/tests/call_resolution_common_methods.rs
+++ b/crates/codestory-indexer/tests/call_resolution_common_methods.rs
@@ -2293,6 +2293,101 @@ def outer(repo: Repository):
 }
 
 #[test]
+fn test_python_returned_call_projects_one_inner_member_call() -> anyhow::Result<()> {
+    let source = r#"
+class App:
+    def ensure_sync(self, function):
+        return function
+
+    def dispatch(self):
+        pass
+
+    def caller(self):
+        return self.ensure_sync(self.dispatch)()
+"#;
+
+    let (nodes, edges) = index_single_file("app.py", source)?;
+    let ensure_sync = nodes
+        .iter()
+        .find(|node| is_matching_owned_method(&node.serialized_name, "App", "ensure_sync"))
+        .expect("ensure_sync declaration");
+    let projected = edges
+        .iter()
+        .filter(|edge| {
+            edge.kind == EdgeKind::CALL
+                && edge.line == Some(10)
+                && edge.effective_target() == ensure_sync.id
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        projected.len(),
+        1,
+        "duplicate returned-call projection: {projected:#?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_python_parenthesized_member_call_is_transparent_but_returned_call_is_not()
+-> anyhow::Result<()> {
+    let source = r#"
+class App:
+    def run(self):
+        pass
+
+    def ensure_sync(self, function):
+        return function
+
+    def caller(self):
+        (self.run)()
+        return self.ensure_sync(self.run)()
+"#;
+
+    let (nodes, edges) = index_single_file("app.py", source)?;
+    let run = nodes
+        .iter()
+        .find(|node| is_matching_owned_method(&node.serialized_name, "App", "run"))
+        .expect("run declaration");
+    let ensure_sync = nodes
+        .iter()
+        .find(|node| is_matching_owned_method(&node.serialized_name, "App", "ensure_sync"))
+        .expect("ensure_sync declaration");
+
+    let parenthesized = edges
+        .iter()
+        .filter(|edge| {
+            edge.kind == EdgeKind::CALL
+                && edge.line == Some(10)
+                && edge.effective_target() == run.id
+        })
+        .count();
+    assert_eq!(parenthesized, 1, "parenthesized member call: {edges:#?}");
+
+    let returned = edges
+        .iter()
+        .filter(|edge| edge.kind == EdgeKind::CALL && edge.line == Some(11))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        returned
+            .iter()
+            .filter(|edge| edge.effective_target() == ensure_sync.id)
+            .count(),
+        1,
+        "returned-call inner member must project once: {returned:#?}"
+    );
+    assert_eq!(
+        returned
+            .iter()
+            .filter(|edge| edge.effective_target() == run.id)
+            .count(),
+        0,
+        "callable-return invocation must not project as the argument member: {returned:#?}"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_go_imported_receiver_uses_qualified_import_owner() -> anyhow::Result<()> {
     let notifier_source = r#"
 package notifier

--- a/crates/codestory-indexer/tests/proof_resolution.rs
+++ b/crates/codestory-indexer/tests/proof_resolution.rs
@@ -624,6 +624,42 @@ fn python_single_simple_base_authorizes_a_direct_same_class_method() -> anyhow::
     Ok(())
 }
 
+#[test]
+fn python_class_header_comments_do_not_change_direct_method_semantics() -> anyhow::Result<()> {
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(
+        project.path(),
+        &mut store,
+        &[(
+            "main.py",
+            concat!(
+                "class Worker(dict):  # type: ignore[type-arg]\n",
+                "    def target(self):\n        return True\n",
+                "    def caller(self):\n        return self.target()\n",
+            ),
+        )],
+    )?;
+
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    let facts = store.get_proof_resolution_facts()?;
+    let fact = facts
+        .iter()
+        .find(|fact| {
+            fact.provenance.language_adapter == "python" && fact.callsite.raw_target == "target"
+        })
+        .unwrap_or_else(|| panic!("missing Python target fact: {facts:#?}"));
+    assert_eq!(fact.status, ProofResolutionStatus::Exact, "{fact:#?}");
+    assert!(matches!(
+        fact.evidence_chain.as_slice(),
+        [
+            ResolutionEvidence::ImplicitReceiver { .. },
+            ResolutionEvidence::SameFileDeclaration { .. }
+        ]
+    ));
+    Ok(())
+}
+
 fn assert_python_target_has_closed_status(
     files: &[(&str, &str)],
     raw_target: &str,
@@ -4801,7 +4837,7 @@ fn complete_projection_rejects_cache_schema_adapter_and_language_mismatch() -> a
             .expect_err("cache provenance mismatch must reject the complete projection");
         let message = error.to_string();
         assert!(
-            ["stale", "schema-v10", "adapter", "language"]
+            ["stale", "schema-v11", "adapter", "language"]
                 .iter()
                 .any(|needle| message.contains(needle)),
             "{mutation}: {error}"

--- a/crates/codestory-indexer/tests/proof_resolution.rs
+++ b/crates/codestory-indexer/tests/proof_resolution.rs
@@ -1,12 +1,18 @@
 use codestory_contracts::events::EventBus;
 use codestory_contracts::graph::{EdgeId, EdgeKind, Node, NodeId, NodeKind};
 use codestory_contracts::proof_resolution::{
-    ProofResolutionReason, ProofResolutionStatus, ResolutionEvidence, ResolutionEvidenceKind,
+    DependencyFileHash, FileId, ProofResolutionProjection, ProofResolutionReason,
+    ProofResolutionStatus, ResolutionEvidence, ResolutionEvidenceKind,
 };
-use codestory_indexer::{WorkspaceIndexer, rematerialize_proof_resolution_projection};
-use codestory_store::{FileInfo, FileRole, IndexPublicationMode, IndexPublicationRecord, Store};
+use codestory_indexer::{
+    WorkspaceIndexer, build_proof_resolution_funnel, rematerialize_proof_resolution_projection,
+};
+use codestory_store::{
+    FileInfo, FileRole, IndexPublicationMode, IndexPublicationRecord, Store,
+    seal_call_resolution_fact,
+};
 use codestory_workspace::{BuildMode, RefreshInfo};
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::fs;
 use std::path::PathBuf;
 
@@ -513,6 +519,862 @@ fn go_closed_exact_subset_authorizes_package_functions_and_concrete_receivers() 
             && fact.edge_id.is_some()
             && fact.target.is_some()
     }));
+    Ok(())
+}
+
+#[test]
+fn python_closed_exact_subset_authorizes_s1_through_s4() -> anyhow::Result<()> {
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(
+        project.path(),
+        &mut store,
+        &[
+            ("pkg/__init__.py", ""),
+            (
+                "pkg/target.py",
+                "def imported_target():\n    pass\n\nclass ImportedWorker:\n    def run(self):\n        pass\n",
+            ),
+            (
+                "pkg/main.py",
+                concat!(
+                    "from .target import imported_target\n",
+                    "from .target import ImportedWorker\n\n",
+                    "def local_target():\n    pass\n\n",
+                    "class Worker:\n",
+                    "    def run(self):\n        pass\n",
+                    "    def caller(self):\n        self.run()\n\n",
+                    "def local_caller():\n    local_target()\n\n",
+                    "def import_caller():\n    imported_target()\n\n",
+                    "def constructed_caller():\n",
+                    "    local = Worker()\n",
+                    "    local.run()\n",
+                    "    imported: ImportedWorker\n",
+                    "    imported.run()\n",
+                ),
+            ),
+        ],
+    )?;
+
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    store.validate_proof_resolution_publication(&publication(1))?;
+    let facts = store
+        .get_proof_resolution_facts()?
+        .into_iter()
+        .filter(|fact| fact.provenance.language_adapter == "python")
+        .collect::<Vec<_>>();
+    for target in ["local_target", "imported_target"] {
+        let fact = facts
+            .iter()
+            .find(|fact| fact.callsite.raw_target == target)
+            .unwrap_or_else(|| panic!("missing Python fact for {target}: {facts:#?}"));
+        assert_eq!(fact.status, ProofResolutionStatus::Exact, "{fact:#?}");
+    }
+    assert_eq!(
+        facts
+            .iter()
+            .filter(|fact| fact.callsite.raw_target == "run"
+                && fact.status == ProofResolutionStatus::Exact)
+            .count(),
+        3,
+        "self, constructor, and explicit annotation receivers: {facts:#?}"
+    );
+    assert!(
+        facts
+            .iter()
+            .all(|fact| fact.callsite.start_byte < fact.callsite.end_byte_exclusive)
+    );
+    Ok(())
+}
+
+fn assert_python_target_has_closed_status(
+    files: &[(&str, &str)],
+    raw_target: &str,
+    expected: ProofResolutionStatus,
+) -> anyhow::Result<()> {
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(project.path(), &mut store, files)?;
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    let facts = store
+        .get_proof_resolution_facts()?
+        .into_iter()
+        .filter(|fact| {
+            fact.provenance.language_adapter == "python" && fact.callsite.raw_target == raw_target
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        !facts.is_empty(),
+        "missing closed Python fact for {raw_target}"
+    );
+    assert!(
+        facts.iter().any(|fact| fact.status == expected),
+        "missing {expected:?} Python fact for {raw_target}: {facts:#?}"
+    );
+    assert!(
+        facts.iter().all(|fact| {
+            fact.status != ProofResolutionStatus::Exact
+                && fact.reason.matches_status(fact.status)
+                && fact.evidence_chain.is_empty()
+        }),
+        "unsupported Python family became authoritative: {facts:#?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn python_closed_statuses_distinguish_unsupported_missing_ambiguous_and_incomplete()
+-> anyhow::Result<()> {
+    assert_python_target_has_closed_status(
+        &[("main.py", "def caller():\n    missing()\n")],
+        "missing",
+        ProofResolutionStatus::MissingBinding,
+    )?;
+    assert_python_target_has_closed_status(
+        &[(
+            "main.py",
+            "def target():\n    pass\ndef target():\n    pass\ndef caller():\n    target()\n",
+        )],
+        "target",
+        ProofResolutionStatus::Ambiguous,
+    )?;
+    assert_python_target_has_closed_status(
+        &[("main.py", "def caller(:\n    target()\n")],
+        "target",
+        ProofResolutionStatus::IncompleteDomain,
+    )?;
+    assert_python_target_has_closed_status(
+        &[("main.py", "def caller(target):\n    target()\n")],
+        "target",
+        ProofResolutionStatus::Unsupported,
+    )?;
+    Ok(())
+}
+
+#[test]
+fn python_dispatch_and_dynamic_language_families_are_closed_unsupported() -> anyhow::Result<()> {
+    for source in [
+        "class Base:\n    def target(self):\n        pass\nclass Child(Base):\n    def caller(self):\n        self.target()\n",
+        "class Left:\n    pass\nclass Right:\n    pass\nclass Child(Left, Right):\n    def target(self):\n        pass\n    def caller(self):\n        self.target()\n",
+        "class Base:\n    def target(self):\n        pass\nclass Child(Base):\n    def caller(self):\n        super().target()\n",
+        "class Worker:\n    def target(self):\n        pass\n    @classmethod\n    def caller(cls):\n        cls.target()\n",
+        "class Worker:\n    @staticmethod\n    def target():\n        pass\n    def caller(self):\n        self.target()\n",
+        "class Worker:\n    @property\n    def target(self):\n        return 1\n    def caller(self):\n        self.target()\n",
+        "def decorate(value):\n    return value\nclass Worker:\n    @decorate\n    def target(self):\n        pass\n    def caller(self):\n        self.target()\n",
+        "class Meta(type):\n    pass\nclass Worker(metaclass=Meta):\n    def target(self):\n        pass\n    def caller(self):\n        self.target()\n",
+        "class Worker[T]:\n    def target(self):\n        pass\n    def caller(self):\n        self.target()\n",
+        "class Worker:\n    def target(self):\n        pass\ndef caller(worker):\n    worker.target()\n",
+        "class Worker:\n    def target(self):\n        pass\ndef factory():\n    return Worker()\ndef caller():\n    factory().target()\n",
+        "class Worker:\n    def target(self):\n        pass\ndef caller(wrapper):\n    wrapper.worker.target()\n",
+        "class Worker:\n    def target(self):\n        pass\ndef caller():\n    worker = Worker()\n    setattr(worker, 'target', lambda: None)\n    worker.target()\n",
+        "def target():\n    pass\ndef caller():\n    eval('target = None')\n    target()\n",
+    ] {
+        assert_python_target_has_closed_status(
+            &[("main.py", source)],
+            "target",
+            ProofResolutionStatus::Unsupported,
+        )?;
+    }
+    for mutation in [
+        "Worker.target = lambda self: None",
+        "Worker.target: object = lambda self: None",
+        "Worker.target += other",
+        "del Worker.target",
+    ] {
+        let source = format!(
+            "class Worker:\n    def target(self):\n        pass\n{mutation}\ndef caller():\n    worker: Worker\n    worker.target()\n"
+        );
+        assert_python_target_has_closed_status(
+            &[("main.py", source.as_str())],
+            "target",
+            ProofResolutionStatus::Unsupported,
+        )?;
+    }
+    Ok(())
+}
+
+#[test]
+fn python_namespace_closure_hostiles_never_become_exact() -> anyhow::Result<()> {
+    let single_file_cases = [
+        concat!(
+            "class Worker:\n",
+            "    def target(self):\n        pass\n",
+            "    target = lambda self: None\n",
+            "    def caller(self):\n        self.target()\n",
+        ),
+        concat!(
+            "class Descriptor:\n    def __get__(self, instance, owner):\n        return lambda: None\n",
+            "class Worker:\n",
+            "    def target(self):\n        pass\n",
+            "    target = Descriptor()\n",
+            "    def caller(self):\n        self.target()\n",
+        ),
+        concat!(
+            "class Worker:\n",
+            "    def target(self):\n        pass\n",
+            "    del target\n",
+            "    def caller(self):\n        self.target()\n",
+        ),
+        concat!(
+            "class Worker:\n",
+            "    def target(self):\n        pass\n",
+            "    from other import target\n",
+            "    def caller(self):\n        self.target()\n",
+        ),
+        concat!(
+            "class Worker:\n",
+            "    def target(self):\n        pass\n",
+            "    def mutate(self):\n        self.target = lambda: None\n",
+            "    def caller(self):\n        self.target()\n",
+        ),
+        concat!(
+            "class Worker:\n",
+            "    def target(self):\n        pass\n",
+            "    def __getattribute__(self, name):\n        return object.__getattribute__(self, name)\n",
+            "    def caller(self):\n        self.target()\n",
+        ),
+        concat!(
+            "def target():\n    pass\n",
+            "def caller():\n    target += other\n    target()\n",
+        ),
+        concat!(
+            "def target():\n    pass\n",
+            "def caller():\n    callback = lambda: target()\n    callback()\n",
+        ),
+        concat!(
+            "def target():\n    pass\n",
+            "def mutate():\n    global target\n    target = other\n",
+            "def caller():\n    target()\n",
+        ),
+        concat!(
+            "class Worker:\n    def target(self):\n        pass\n",
+            "def caller():\n",
+            "    Worker = make_factory()\n",
+            "    worker = Worker()\n",
+            "    worker.target()\n",
+        ),
+        concat!(
+            "class Worker:\n    def target(self):\n        pass\n",
+            "def caller():\n",
+            "    worker: Worker\n",
+            "    Worker = Other\n",
+            "    worker.target()\n",
+        ),
+    ];
+    for source in single_file_cases {
+        assert_python_target_has_closed_status(
+            &[("main.py", source)],
+            "target",
+            ProofResolutionStatus::Unsupported,
+        )?;
+    }
+
+    assert_python_target_has_closed_status(
+        &[
+            ("pkg/__init__.py", ""),
+            ("pkg/target.py", "def target():\n    pass\n"),
+            (
+                "pkg/main.py",
+                concat!(
+                    "from .target import target\n",
+                    "target = replacement\n",
+                    "def caller():\n    target()\n",
+                ),
+            ),
+        ],
+        "target",
+        ProofResolutionStatus::Unsupported,
+    )?;
+
+    Ok(())
+}
+
+#[test]
+fn python_import_and_annotation_families_are_closed_non_exact() -> anyhow::Result<()> {
+    for source in [
+        "from external import target\ndef caller():\n    target()\n",
+        "import external\ndef caller():\n    external.target()\n",
+        "from external import *\ndef caller():\n    target()\n",
+        "import importlib\ndef caller():\n    importlib.import_module('external').target()\n",
+        "if enabled:\n    from .target import target\ndef caller():\n    target()\n",
+        "try:\n    from .target import target\nexcept ImportError:\n    pass\ndef caller():\n    target()\n",
+        "if TYPE_CHECKING:\n    from .target import target\ndef caller():\n    target()\n",
+    ] {
+        assert_python_target_has_closed_status(
+            &[("main.py", source)],
+            "target",
+            ProofResolutionStatus::Unsupported,
+        )?;
+    }
+
+    for annotation in ["'Worker'", "Worker | None", "list[Worker]", "Unknown"] {
+        let source = format!(
+            "class Worker:\n    def target(self):\n        pass\ndef caller():\n    worker: {annotation}\n    worker.target()\n"
+        );
+        assert_python_target_has_closed_status(
+            &[("main.py", source.as_str())],
+            "target",
+            ProofResolutionStatus::Unsupported,
+        )?;
+    }
+
+    assert_python_target_has_closed_status(
+        &[
+            ("pkg/__init__.py", ""),
+            ("pkg/reexport.py", "from .actual import target\n"),
+            ("pkg/actual.py", "def target():\n    pass\n"),
+            (
+                "pkg/main.py",
+                "from .reexport import target\ndef caller():\n    target()\n",
+            ),
+        ],
+        "target",
+        ProofResolutionStatus::Unsupported,
+    )?;
+    assert_python_target_has_closed_status(
+        &[
+            ("pkg/__init__.py", ""),
+            (
+                "pkg/main.py",
+                "from .stubs import target\ndef caller():\n    target()\n",
+            ),
+            ("pkg/stubs.pyi", "def target() -> None: ...\n"),
+        ],
+        "target",
+        ProofResolutionStatus::MissingBinding,
+    )?;
+    Ok(())
+}
+
+#[test]
+fn python_constructor_calls_and_non_straight_line_receivers_never_gain_authority()
+-> anyhow::Result<()> {
+    assert_python_target_has_closed_status(
+        &[(
+            "main.py",
+            "class Worker:\n    def target(self):\n        pass\ndef caller():\n    worker = Worker()\n    if enabled:\n        worker.target()\n",
+        )],
+        "target",
+        ProofResolutionStatus::Unsupported,
+    )?;
+    assert_python_target_has_closed_status(
+        &[(
+            "main.py",
+            "class Worker:\n    def __init__(self):\n        pass\ndef caller():\n    Worker()\n",
+        )],
+        "Worker",
+        ProofResolutionStatus::Unsupported,
+    )?;
+    Ok(())
+}
+
+#[test]
+fn python_unsupported_and_lexical_hostiles_receive_closed_non_exact_facts() -> anyhow::Result<()> {
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(
+        project.path(),
+        &mut store,
+        &[(
+            "main.py",
+            concat!(
+                "def target():\n    pass\n\n",
+                "class Base:\n    def method(self):\n        pass\n\n",
+                "class Child(Base):\n",
+                "    @classmethod\n    def class_call(cls):\n        cls.method()\n",
+                "    def inherited(self):\n        self.method()\n",
+                "    def parent(self):\n        super().method()\n\n",
+                "def parameter(target):\n    target()\n\n",
+                "def future_assignment():\n    target()\n    target = lambda: None\n\n",
+                "def destructuring():\n    target, other = values\n    target()\n\n",
+                "def control_flow():\n    for target in values:\n        target()\n\n",
+                "def dynamic(receiver):\n    getattr(receiver, 'method')()\n\n",
+                "def chained(factory):\n    factory().method()\n\n",
+                "def computed(receiver):\n    receiver['method']()\n\n",
+                "def nested():\n    def inner():\n        target()\n    inner()\n",
+            ),
+        )],
+    )?;
+
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    let facts = store
+        .get_proof_resolution_facts()?
+        .into_iter()
+        .filter(|fact| fact.provenance.language_adapter == "python")
+        .collect::<Vec<_>>();
+    assert!(
+        facts.len() >= 12,
+        "every Python syntax call must be closed: {facts:#?}"
+    );
+    assert!(
+        facts.iter().all(|fact| {
+            fact.status != ProofResolutionStatus::Exact
+                && fact.reason.matches_status(fact.status)
+                && fact.evidence_chain.is_empty()
+        }),
+        "hostile Python fact became authoritative: {facts:#?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn python_calls_preserve_utf8_crlf_and_repeated_terminal_coordinates() -> anyhow::Result<()> {
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    let source = "def target():\r\n    pass\r\n\r\ndef caller():\r\n    note = 'é'\r\n    target(); target()\r\n";
+    index_files(project.path(), &mut store, &[("main.py", source)])?;
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    let mut facts = store
+        .get_proof_resolution_facts()?
+        .into_iter()
+        .filter(|fact| fact.provenance.language_adapter == "python")
+        .filter(|fact| fact.callsite.raw_target == "target")
+        .collect::<Vec<_>>();
+    facts.sort_by_key(|fact| fact.callsite.start_byte);
+    assert_eq!(facts.len(), 2, "{facts:#?}");
+    assert!(
+        facts
+            .iter()
+            .all(|fact| fact.status == ProofResolutionStatus::Exact)
+    );
+    assert_eq!(facts[0].callsite.line, 6);
+    assert_eq!(facts[0].callsite.column, 5);
+    assert_eq!(facts[1].callsite.column, 15);
+    assert_eq!(
+        &source.as_bytes()
+            [facts[0].callsite.start_byte as usize..facts[0].callsite.end_byte_exclusive as usize],
+        b"target"
+    );
+    assert_ne!(facts[0].edge_id, facts[1].edge_id);
+    Ok(())
+}
+
+#[test]
+fn python_exact_fact_replay_rejects_graph_correlation_mutations() -> anyhow::Result<()> {
+    for mutation in ["target", "file", "line", "candidate", "identity"] {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(
+            project.path(),
+            &mut store,
+            &[(
+                "main.py",
+                "def target():\n    pass\n\ndef caller():\n    target()\n",
+            )],
+        )?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        let fact = store
+            .get_proof_resolution_facts()?
+            .into_iter()
+            .find(|fact| fact.callsite.raw_target == "target")
+            .expect("Python exact fact");
+        assert_eq!(fact.status, ProofResolutionStatus::Exact, "{fact:#?}");
+        let edge_id = fact.edge_id.expect("linked raw CALL").0;
+        match mutation {
+            "target" => {
+                store.get_connection().execute(
+                    "UPDATE edge SET resolved_target_node_id = source_node_id WHERE id = ?1",
+                    [edge_id],
+                )?;
+            }
+            "file" => {
+                store.get_connection().execute(
+                    "UPDATE edge SET file_node_id = target_node_id WHERE id = ?1",
+                    [edge_id],
+                )?;
+            }
+            "line" => {
+                store
+                    .get_connection()
+                    .execute("UPDATE edge SET line = 99 WHERE id = ?1", [edge_id])?;
+            }
+            "candidate" => {
+                store.get_connection().execute(
+                    "UPDATE edge SET candidate_target_node_ids = ?1 WHERE id = ?2",
+                    (format!("[{}]", fact.target.unwrap().0), edge_id),
+                )?;
+            }
+            "identity" => {
+                store.get_connection().execute(
+                    "UPDATE edge SET callsite_identity = 'opaque' WHERE id = ?1",
+                    [edge_id],
+                )?;
+            }
+            _ => unreachable!(),
+        }
+        let error = store
+            .validate_proof_resolution_publication(&publication(1))
+            .expect_err("resealed Python graph mutation must reject the exact fact");
+        assert!(!error.to_string().is_empty(), "{mutation}");
+    }
+    Ok(())
+}
+
+#[test]
+fn python_exact_fact_replay_rejects_resealed_file_row_move() -> anyhow::Result<()> {
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    let paths = index_files(
+        project.path(),
+        &mut store,
+        &[(
+            "main.py",
+            "def target():\n    pass\n\ndef caller():\n    target()\n",
+        )],
+    )?;
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    let source = paths.into_iter().next().expect("Python source path");
+    let moved = project.path().join("moved.py");
+    fs::rename(&source, &moved)?;
+    store.get_connection().execute(
+        "UPDATE file SET path = ?1 WHERE language = 'python'",
+        [moved.to_string_lossy().into_owned()],
+    )?;
+    let error = store
+        .validate_proof_resolution_publication(&publication(1))
+        .expect_err("resealed Python file-row move must reject the exact fact");
+    assert!(
+        error.to_string().contains("canonical file node id"),
+        "{error}"
+    );
+    Ok(())
+}
+
+#[test]
+fn python_relative_import_domain_fails_closed_for_missing_and_colliding_modules()
+-> anyhow::Result<()> {
+    for files in [
+        vec![
+            (
+                "pkg/main.py",
+                "from .target import target\ndef caller():\n    target()\n",
+            ),
+            ("pkg/target.py", "def target():\n    pass\n"),
+        ],
+        vec![
+            ("pkg/__init__.py", ""),
+            (
+                "pkg/main.py",
+                "from .target import target\ndef caller():\n    target()\n",
+            ),
+            ("pkg/target.py", "def target():\n    pass\n"),
+            ("pkg/target/__init__.py", "def target():\n    pass\n"),
+        ],
+        vec![
+            ("pkg/__init__.py", ""),
+            (
+                "pkg/main.py",
+                "from target import target\ndef caller():\n    target()\n",
+            ),
+            ("pkg/target.py", "def target():\n    pass\n"),
+        ],
+        vec![
+            ("pkg/__init__.py", ""),
+            (
+                "pkg/main.py",
+                "from .sub.target import target\ndef caller():\n    target()\n",
+            ),
+            ("pkg/sub/target.py", "def target():\n    pass\n"),
+        ],
+        vec![
+            ("pkg/__init__.py", ""),
+            ("pkg/sub/__init__.py", ""),
+            (
+                "pkg/main.py",
+                "from .sub.target import target\ndef caller():\n    target()\n",
+            ),
+            ("pkg/sub/target.py", "def target():\n    pass\n"),
+            ("pkg/sub/target/__init__.py", "def target():\n    pass\n"),
+        ],
+    ] {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(project.path(), &mut store, &files)?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        let fact = store
+            .get_proof_resolution_facts()?
+            .into_iter()
+            .find(|fact| {
+                fact.provenance.language_adapter == "python" && fact.callsite.raw_target == "target"
+            })
+            .expect("closed import call fact");
+        assert_ne!(fact.status, ProofResolutionStatus::Exact, "{fact:#?}");
+    }
+    Ok(())
+}
+
+#[test]
+fn python_raw_import_marker_hostiles_never_corroborate_exact_evidence() -> anyhow::Result<()> {
+    for mutation in [
+        "wrong_source",
+        "candidate",
+        "cross_file",
+        "non_marker",
+        "inconsistent_resolved",
+    ] {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(
+            project.path(),
+            &mut store,
+            &[
+                ("pkg/__init__.py", ""),
+                ("pkg/target.py", "def target():\n    pass\n"),
+                (
+                    "pkg/main.py",
+                    "from .target import target\ndef caller():\n    target()\n",
+                ),
+            ],
+        )?;
+        let marker = store
+            .get_edges()?
+            .into_iter()
+            .find(|edge| {
+                edge.kind == EdgeKind::IMPORT
+                    && store
+                        .get_node(edge.target)
+                        .ok()
+                        .flatten()
+                        .is_some_and(|node| node.kind == NodeKind::MODULE)
+            })
+            .expect("raw Python import marker edge");
+        match mutation {
+            "wrong_source" => {
+                store.get_connection().execute(
+                    "UPDATE edge SET resolved_source_node_id = target_node_id WHERE id = ?1",
+                    [marker.id.0],
+                )?;
+            }
+            "candidate" => {
+                store.get_connection().execute(
+                    "UPDATE edge SET candidate_target_node_ids = ?1 WHERE id = ?2",
+                    (format!("[{}]", marker.target.0), marker.id.0),
+                )?;
+            }
+            "cross_file" => {
+                let target_file = store
+                    .get_nodes()?
+                    .into_iter()
+                    .find(|node| {
+                        node.kind == NodeKind::FUNCTION && node.serialized_name == "target"
+                    })
+                    .and_then(|node| node.file_node_id)
+                    .expect("imported target file");
+                store.get_connection().execute(
+                    "UPDATE node SET file_node_id = ?1 WHERE id = ?2",
+                    (target_file.0, marker.target.0),
+                )?;
+            }
+            "non_marker" => {
+                store.get_connection().execute(
+                    "UPDATE node SET kind = ?1 WHERE id = ?2",
+                    (NodeKind::FUNCTION as i32, marker.target.0),
+                )?;
+            }
+            "inconsistent_resolved" => {
+                store.get_connection().execute(
+                    "UPDATE edge SET resolved_target_node_id = source_node_id WHERE id = ?1",
+                    [marker.id.0],
+                )?;
+            }
+            _ => unreachable!(),
+        }
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        let fact = store
+            .get_proof_resolution_facts()?
+            .into_iter()
+            .find(|fact| fact.callsite.raw_target == "target")
+            .expect("closed Python import fact");
+        assert_ne!(
+            fact.status,
+            ProofResolutionStatus::Exact,
+            "{mutation}: {fact:#?}"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn python_nested_relative_import_authenticates_every_package_marker_exactly() -> anyhow::Result<()>
+{
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(
+        project.path(),
+        &mut store,
+        &[
+            ("pkg/__init__.py", ""),
+            ("pkg/sub/__init__.py", ""),
+            ("pkg/sub/target.py", "def target():\n    pass\n"),
+            (
+                "pkg/main.py",
+                "from .sub.target import target\ndef caller():\n    target()\n",
+            ),
+        ],
+    )?;
+
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    store.validate_proof_resolution_publication(&publication(1))?;
+    let fact = store
+        .get_proof_resolution_facts()?
+        .into_iter()
+        .find(|fact| {
+            fact.provenance.language_adapter == "python" && fact.callsite.raw_target == "target"
+        })
+        .expect("nested relative-import fact");
+    assert_eq!(fact.status, ProofResolutionStatus::Exact, "{fact:#?}");
+
+    let files = store.get_files()?;
+    let expected = [
+        "pkg/__init__.py",
+        "pkg/sub/__init__.py",
+        "pkg/sub/target.py",
+        "pkg/main.py",
+    ]
+    .into_iter()
+    .map(|suffix| {
+        FileId(
+            files
+                .iter()
+                .find(|file| file.path.ends_with(suffix))
+                .unwrap_or_else(|| panic!("missing indexed dependency {suffix}"))
+                .id,
+        )
+    })
+    .collect::<BTreeSet<_>>();
+    let observed = fact
+        .provenance
+        .dependency_file_hashes
+        .iter()
+        .map(|dependency| dependency.file_id)
+        .collect::<BTreeSet<_>>();
+    assert_eq!(observed, expected, "{fact:#?}");
+    Ok(())
+}
+
+#[test]
+fn python_nested_relative_import_store_replay_rejects_dependency_mutations() -> anyhow::Result<()> {
+    for mutation in ["missing", "extra", "hash"] {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(
+            project.path(),
+            &mut store,
+            &[
+                ("pkg/__init__.py", ""),
+                ("pkg/sub/__init__.py", ""),
+                ("pkg/sub/target.py", "def target():\n    pass\n"),
+                ("pkg/unrelated.py", "unrelated = True\n"),
+                (
+                    "pkg/main.py",
+                    "from .sub.target import target\ndef caller():\n    target()\n",
+                ),
+            ],
+        )?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        let receipt = store
+            .get_proof_resolution_publication()?
+            .expect("Python proof publication");
+        let files = store.get_files()?;
+        let file = |suffix: &str| {
+            files
+                .iter()
+                .find(|file| file.path.ends_with(suffix))
+                .unwrap_or_else(|| panic!("missing {suffix}"))
+        };
+        let intermediate = FileId(file("pkg/sub/__init__.py").id);
+        let unrelated = FileId(file("pkg/unrelated.py").id);
+        let unrelated_hash = store
+            .get_file_content_hash(unrelated.0)?
+            .expect("unrelated source hash");
+        let mut facts = store.get_proof_resolution_facts()?;
+        let fact = facts
+            .iter_mut()
+            .find(|fact| {
+                fact.provenance.language_adapter == "python" && fact.callsite.raw_target == "target"
+            })
+            .expect("nested relative-import fact");
+        match mutation {
+            "missing" => fact
+                .provenance
+                .dependency_file_hashes
+                .retain(|dependency| dependency.file_id != intermediate),
+            "extra" => fact
+                .provenance
+                .dependency_file_hashes
+                .push(DependencyFileHash {
+                    file_id: unrelated,
+                    source_sha256: unrelated_hash,
+                }),
+            "hash" => {
+                fact.provenance
+                    .dependency_file_hashes
+                    .iter_mut()
+                    .find(|dependency| dependency.file_id == intermediate)
+                    .expect("intermediate package marker dependency")
+                    .source_sha256 = "0".repeat(64);
+            }
+            _ => unreachable!(),
+        }
+        *fact = seal_call_resolution_fact(fact.clone())?;
+        let projection = ProofResolutionProjection {
+            adapter_roster: receipt.adapter_roster,
+            funnel: build_proof_resolution_funnel(&facts),
+            facts,
+        };
+        let error = store
+            .replace_proof_resolution_projection(&publication(2), &projection)
+            .expect_err("resealed nested Python dependency mutation must fail closed");
+        assert!(
+            error.to_string().contains("depend") || error.to_string().contains("source hash"),
+            "{mutation}: {error}"
+        );
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn python_nested_relative_import_rejects_symlinked_package_marker() -> anyhow::Result<()> {
+    use std::os::unix::fs::symlink;
+
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    let root_marker = project.path().join("pkg/__init__.py");
+    let nested_marker = project.path().join("pkg/sub/__init__.py");
+    fs::create_dir_all(nested_marker.parent().unwrap())?;
+    fs::write(&root_marker, "")?;
+    symlink(&root_marker, &nested_marker)?;
+    fs::write(
+        project.path().join("pkg/sub/target.py"),
+        "def target():\n    pass\n",
+    )?;
+    fs::write(
+        project.path().join("pkg/main.py"),
+        "from .sub.target import target\ndef caller():\n    target()\n",
+    )?;
+    WorkspaceIndexer::new(project.path().to_path_buf()).run_incremental(
+        &mut store,
+        &RefreshInfo {
+            mode: BuildMode::Incremental,
+            files_to_index: vec![
+                root_marker,
+                nested_marker,
+                project.path().join("pkg/sub/target.py"),
+                project.path().join("pkg/main.py"),
+            ],
+            files_to_remove: Vec::new(),
+            existing_file_ids: HashMap::new(),
+        },
+        &EventBus::new(),
+        None,
+    )?;
+    let error = rematerialize_proof_resolution_projection(&mut store, &publication(1))
+        .expect_err("symlinked Python package marker must fail closed");
+    assert!(
+        error.to_string().contains("identity collision") || error.to_string().contains("symlink"),
+        "{error}"
+    );
     Ok(())
 }
 
@@ -3659,7 +4521,7 @@ fn complete_projection_requires_cache_coverage_but_empty_and_unsupported_reposit
     let mut empty = Store::new_in_memory()?;
     let empty_receipt = rematerialize_proof_resolution_projection(&mut empty, &publication(1))?;
     assert_eq!(empty_receipt.fact_count, 0);
-    assert_eq!(empty_receipt.adapter_roster.len(), 5);
+    assert_eq!(empty_receipt.adapter_roster.len(), 6);
 
     let project = tempfile::tempdir()?;
     let mut unsupported = Store::new_in_memory()?;
@@ -3674,7 +4536,7 @@ fn complete_projection_requires_cache_coverage_but_empty_and_unsupported_reposit
     let unsupported_receipt =
         rematerialize_proof_resolution_projection(&mut unsupported, &publication(1))?;
     assert_eq!(unsupported_receipt.fact_count, 0);
-    assert_eq!(unsupported_receipt.adapter_roster.len(), 5);
+    assert_eq!(unsupported_receipt.adapter_roster.len(), 6);
 
     let governed_project = tempfile::tempdir()?;
     let mut governed = Store::new_in_memory()?;
@@ -3902,7 +4764,7 @@ fn complete_projection_rejects_cache_schema_adapter_and_language_mismatch() -> a
             .expect_err("cache provenance mismatch must reject the complete projection");
         let message = error.to_string();
         assert!(
-            ["stale", "schema-v8", "adapter", "language"]
+            ["stale", "schema-v9", "adapter", "language"]
                 .iter()
                 .any(|needle| message.contains(needle)),
             "{mutation}: {error}"

--- a/crates/codestory-indexer/tests/proof_resolution.rs
+++ b/crates/codestory-indexer/tests/proof_resolution.rs
@@ -587,6 +587,43 @@ fn python_closed_exact_subset_authorizes_s1_through_s4() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[test]
+fn python_single_simple_base_authorizes_a_direct_same_class_method() -> anyhow::Result<()> {
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(
+        project.path(),
+        &mut store,
+        &[(
+            "main.py",
+            concat!(
+                "class Base:\n    pass\n\n",
+                "class Worker(Base):\n",
+                "    def target(self):\n        pass\n",
+                "    def caller(self):\n        self.target()\n",
+            ),
+        )],
+    )?;
+
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    let facts = store.get_proof_resolution_facts()?;
+    let fact = facts
+        .iter()
+        .find(|fact| {
+            fact.provenance.language_adapter == "python" && fact.callsite.raw_target == "target"
+        })
+        .unwrap_or_else(|| panic!("missing Python target fact: {facts:#?}"));
+    assert_eq!(fact.status, ProofResolutionStatus::Exact, "{fact:#?}");
+    assert!(matches!(
+        fact.evidence_chain.as_slice(),
+        [
+            ResolutionEvidence::ImplicitReceiver { .. },
+            ResolutionEvidence::SameFileDeclaration { .. }
+        ]
+    ));
+    Ok(())
+}
+
 fn assert_python_target_has_closed_status(
     files: &[(&str, &str)],
     raw_target: &str,
@@ -4764,7 +4801,7 @@ fn complete_projection_rejects_cache_schema_adapter_and_language_mismatch() -> a
             .expect_err("cache provenance mismatch must reject the complete projection");
         let message = error.to_string();
         assert!(
-            ["stale", "schema-v9", "adapter", "language"]
+            ["stale", "schema-v10", "adapter", "language"]
                 .iter()
                 .any(|needle| message.contains(needle)),
             "{mutation}: {error}"

--- a/crates/codestory-runtime/src/indexed_source_call_path_v1.rs
+++ b/crates/codestory-runtime/src/indexed_source_call_path_v1.rs
@@ -404,6 +404,8 @@ where
     let files = store.files().inventory().map_err(store_error)?;
     let file_rows = store.files().get_files().map_err(store_error)?;
     let mut path_identities = OperationPathIdentityResolver::native();
+    let canonical_index =
+        CanonicalSelectorIndex::prepare(project_root, &file_rows, &mut path_identities);
     let mut resolved = Vec::with_capacity(contract.spec().steps().len() + 1);
     let mut gaps = Vec::new();
     let mut unavailable = Vec::new();
@@ -414,6 +416,7 @@ where
         project_id,
         publication,
         files: &file_rows,
+        canonical_index: &canonical_index,
     };
 
     for (selector_index, selector) in std::iter::once(contract.spec().start())
@@ -962,6 +965,108 @@ struct SelectorContext<'a> {
     project_id: &'a str,
     publication: &'a IndexPublicationRecord,
     files: &'a [FileInfo],
+    canonical_index: &'a CanonicalSelectorIndex,
+}
+
+#[derive(Default)]
+struct CanonicalSelectorIndex {
+    stored_prefixes_by_relative: BTreeMap<String, Vec<String>>,
+    unavailable: bool,
+}
+
+impl CanonicalSelectorIndex {
+    fn prepare(
+        project_root: &Path,
+        files: &[FileInfo],
+        identities: &mut OperationPathIdentityResolver,
+    ) -> Self {
+        let mut index = Self::default();
+        let mut relative_by_identity = HashMap::<WorkspacePathIdentity, String>::new();
+        for file in files {
+            let Some(stored_prefix) = file.path.to_str().map(str::to_owned) else {
+                index.unavailable = true;
+                continue;
+            };
+            let Some(absolute) = stored_absolute(project_root, &file.path) else {
+                index.unavailable = true;
+                continue;
+            };
+            let Ok(native_identity) = identities.resolve(&absolute) else {
+                index.unavailable = true;
+                continue;
+            };
+            let Some(relative) = workspace_relative_path(project_root, &absolute) else {
+                index.unavailable = true;
+                continue;
+            };
+            let Some(relative) = normalized_project_relative_text(&relative) else {
+                index.unavailable = true;
+                continue;
+            };
+            if relative_by_identity
+                .insert(native_identity, relative.clone())
+                .is_some_and(|existing| existing != relative)
+            {
+                index.unavailable = true;
+                continue;
+            }
+            index
+                .stored_prefixes_by_relative
+                .entry(format!("{relative}:"))
+                .or_default()
+                .push(stored_prefix);
+        }
+        for prefixes in index.stored_prefixes_by_relative.values_mut() {
+            prefixes.sort();
+            prefixes.dedup();
+        }
+        index
+    }
+
+    fn reconstruct(&self, canonical_id: &str) -> Result<Vec<String>, ()> {
+        if self.unavailable {
+            return Err(());
+        }
+        let Some((relative_prefix, stored_prefixes)) = self
+            .stored_prefixes_by_relative
+            .range(..=canonical_id.to_owned())
+            .next_back()
+        else {
+            return Ok(Vec::new());
+        };
+        let Some(suffix) = canonical_id.strip_prefix(relative_prefix) else {
+            return Ok(Vec::new());
+        };
+        if suffix.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut reconstructed = stored_prefixes
+            .iter()
+            .map(|stored| format!("{stored}:{suffix}"))
+            .collect::<Vec<_>>();
+        reconstructed.sort();
+        reconstructed.dedup();
+        Ok(reconstructed)
+    }
+}
+
+fn normalized_project_relative_text(path: &Path) -> Option<String> {
+    let mut components = Vec::new();
+    for component in path.components() {
+        let std::path::Component::Normal(component) = component else {
+            return None;
+        };
+        let component = component.to_str()?;
+        if component.is_empty()
+            || component == "."
+            || component == ".."
+            || component.contains(['/', '\\', '\0'])
+        {
+            return None;
+        }
+        components.push(component);
+    }
+    (!components.is_empty()).then(|| components.join("/"))
 }
 
 fn resolve_scope_selector(
@@ -1031,13 +1136,103 @@ fn resolve_canonical(
     canonical_id: &str,
     identities: &mut OperationPathIdentityResolver,
 ) -> Result<SelectorResolution, ApiError> {
-    let matches = context
+    let mut matched_canonical = canonical_id.to_owned();
+    let mut matches = context
         .store
         .node_ids_by_canonical_ids(&[canonical_id.to_owned()])
         .map_err(store_error)?
         .remove(canonical_id)
         .unwrap_or_default();
-    resolve_unique_node(context, matches, identities)
+    if matches.is_empty() {
+        let reconstructed = match context.canonical_index.reconstruct(canonical_id) {
+            Ok(reconstructed) => reconstructed,
+            Err(()) => {
+                return Ok(SelectorResolution::Unavailable(
+                    UnavailableReason::SourceNotBoundToPublication,
+                ));
+            }
+        };
+        if reconstructed.len() > 1 {
+            return Ok(SelectorResolution::Ambiguous);
+        }
+        if let Some(reconstructed) = reconstructed.first() {
+            matched_canonical.clone_from(reconstructed);
+            matches = context
+                .store
+                .node_ids_by_canonical_ids(std::slice::from_ref(reconstructed))
+                .map_err(store_error)?
+                .remove(reconstructed)
+                .unwrap_or_default();
+        }
+    }
+    if !matches.is_empty()
+        && !canonical_id_authenticates_selected_files(
+            context,
+            &matched_canonical,
+            &matches,
+            identities,
+        )
+    {
+        return Ok(SelectorResolution::Unavailable(
+            UnavailableReason::SourceNotBoundToPublication,
+        ));
+    }
+    let resolved = resolve_unique_node(context, matches, identities)?;
+    Ok(match resolved {
+        SelectorResolution::Resolved(mut identity) => {
+            identity.canonical_id = canonical_id.to_owned();
+            SelectorResolution::Resolved(identity)
+        }
+        other => other,
+    })
+}
+
+fn canonical_id_authenticates_selected_files(
+    context: &SelectorContext<'_>,
+    canonical_id: &str,
+    node_ids: &[NodeId],
+    identities: &mut OperationPathIdentityResolver,
+) -> bool {
+    if !canonical_id.contains('#') {
+        return true;
+    }
+    node_ids.iter().all(|node_id| {
+        let Ok(Some(node)) = context.store.get_node(*node_id) else {
+            return false;
+        };
+        let Some(file_id) = node.file_node_id else {
+            return false;
+        };
+        let Some(file) = context.files.iter().find(|file| file.id == file_id.0) else {
+            return false;
+        };
+        let Some(stored_path) = stored_absolute(context.project_root, &file.path) else {
+            return false;
+        };
+        let Ok(stored_identity) = identities.resolve(&stored_path) else {
+            return false;
+        };
+        let mut matching_prefixes = 0usize;
+        for (index, character) in canonical_id.char_indices() {
+            if character != ':' || index == 0 {
+                continue;
+            }
+            let candidate = Path::new(&canonical_id[..index]);
+            let Some(candidate) = stored_absolute(context.project_root, candidate) else {
+                continue;
+            };
+            if workspace_relative_path(context.project_root, &candidate).is_none() {
+                continue;
+            }
+            if identities
+                .resolve(&candidate)
+                .is_ok_and(|identity| identity == stored_identity)
+            {
+                matching_prefixes += 1;
+            }
+        }
+        matching_prefixes == 1
+    })
 }
 
 fn resolve_qualified(
@@ -2531,6 +2726,79 @@ mod tests {
     }
 
     #[test]
+    fn python_exact_fact_accepts_reconstructed_project_relative_selectors() {
+        let fixture = source_built_fixture_with_extension(
+            "py",
+            "def target():\n    pass\n\ndef source():\n    target()\n",
+        );
+        let source = source_callable(&fixture.store, "source");
+        let target = source_callable(&fixture.store, "target");
+        let facts = fixture.store.get_proof_resolution_facts().unwrap();
+        let exact_fact = facts
+            .iter()
+            .find(|fact| {
+                fact.callsite.raw_target == "target"
+                    && fact.status == ProofResolutionStatus::Exact
+                    && fact.edge_id.is_some()
+            })
+            .unwrap_or_else(|| panic!("{facts:#?}"));
+        let edge = fixture
+            .store
+            .get_edges()
+            .unwrap()
+            .into_iter()
+            .find(|edge| Some(edge.id) == exact_fact.edge_id)
+            .unwrap();
+        let admitted = diagnose_raw_call_edge(&edge, source.id, target.id).unwrap();
+        assert!(resolution_fact_matches_raw_edge(
+            exact_fact, &admitted, source.id, target.id
+        ));
+        assert!(canonical_id(&source).ends_with(":source#0"));
+        assert!(canonical_id(&target).ends_with(":target#0"));
+        let (contract, hashes, rendering) =
+            validated_contract("src/lib.py:source#0", &["src/lib.py:target#0"]);
+        let observed = build_from_store_observed(
+            &fixture.store,
+            &fixture.root,
+            &fixture.project_id,
+            &fixture.publication,
+            &contract,
+            |path| fs::read(path),
+        )
+        .unwrap();
+        assert!(
+            matches!(
+                observed.trace.steps.as_slice(),
+                [StepQualificationTrace {
+                    outcome: StepQualificationOutcome::Admitted { edge_ids },
+                    ..
+                }] if edge_ids == &[edge.id]
+            ),
+            "{:#?}",
+            observed.trace
+        );
+        let result =
+            check_built_call_path_integration(&contract, &hashes, &rendering, observed.built)
+                .unwrap();
+        assert!(
+            matches!(
+                result.disposition(),
+                ProofDisposition::ContractProven { receipts, .. } if receipts.len() == 1
+            ),
+            "{:#?}",
+            result.disposition()
+        );
+        assert_eq!(
+            result.built_facts().receipts[0].source.pinned.node_id,
+            source.id.0.to_string()
+        );
+        assert_eq!(
+            result.built_facts().receipts[0].target.pinned.node_id,
+            target.id.0.to_string()
+        );
+    }
+
+    #[test]
     fn source_built_resealed_span_cannot_move_to_an_identical_same_line_token() {
         let source_text = "fn target() {}\n\
                            fn source() { target(); let _label = \"target\"; }\n";
@@ -3143,6 +3411,71 @@ mod tests {
     }
 
     #[test]
+    fn python_resealed_path_move_is_rejected_by_the_public_operation_freshness_fence() {
+        let project = tempfile::tempdir().unwrap();
+        let source_path = project.path().join("src/lib.py");
+        fs::create_dir_all(source_path.parent().unwrap()).unwrap();
+        fs::write(
+            &source_path,
+            "def target():\n    pass\n\ndef source():\n    target()\n",
+        )
+        .unwrap();
+        let storage_path = project.path().join(".codestory-test/codestory.db");
+        let controller = AppController::new_with_config(crate::test_sidecar_runtime_from_env());
+        controller
+            .open_project_summary_with_storage_path(
+                project.path().to_path_buf(),
+                storage_path.clone(),
+            )
+            .unwrap();
+        controller
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+            .unwrap();
+        let contract = contract("src/lib.py:source#0", &["src/lib.py:target#0"]);
+        let service = crate::services::PublicOperationService::new(controller.clone());
+        let builds = Cell::new(0_usize);
+        let operation = service
+            .run_with_cancel(PROOF_DOMAIN, Arc::new(AtomicBool::new(false)), || {
+                let attempt = builds.get() + 1;
+                builds.set(attempt);
+                let built = build_indexed_source_call_path_facts(&controller, &contract)?;
+                if attempt == 1 {
+                    assert_eq!(built.receipts.len(), 1, "{built:#?}");
+                    let moved = project.path().join("src/moved.py");
+                    fs::rename(&source_path, &moved).unwrap();
+                    let store = Store::open(&storage_path).unwrap();
+                    let file_id = store
+                        .get_files()
+                        .unwrap()
+                        .into_iter()
+                        .find(|file| file.language == "python")
+                        .expect("indexed Python source")
+                        .id;
+                    store
+                        .get_connection()
+                        .execute(
+                            "UPDATE file SET path = ?1 WHERE id = ?2",
+                            (moved.to_string_lossy().into_owned(), file_id),
+                        )
+                        .unwrap();
+                }
+                Ok(built)
+            })
+            .unwrap();
+        assert_eq!(operation.attempt, 2);
+        assert!(
+            operation.value.receipts.is_empty(),
+            "{:#?}",
+            operation.value
+        );
+        assert_eq!(
+            operation.value.unavailable,
+            vec![UnavailableReason::ProofSemanticProjectionUnavailable]
+        );
+        assert_eq!(builds.get(), 2);
+    }
+
+    #[test]
     fn builds_a_hash_bound_raw_edge_receipt_and_reads_source_once() {
         let fixture = fixture(b"fn source() { target(); }\r\nfn target() {}\n");
         fixture
@@ -3633,15 +3966,202 @@ mod tests {
     }
 
     #[test]
-    fn qualified_resolution_uses_exact_names_components_and_native_file_identity() {
+    fn canonical_selector_reconstructs_one_exact_project_relative_file_identity() {
         let fixture = fixture(b"fn source() { target(); }\nfn target() {}\n");
-        let files = fixture.store.files().get_files().unwrap();
+        let absolute_prefix = fixture.source_path.to_string_lossy();
+        fixture
+            .store
+            .get_connection()
+            .execute(
+                "UPDATE node SET canonical_id = ?1 WHERE id = 2",
+                [format!("{absolute_prefix}:crate::source#0")],
+            )
+            .unwrap();
+        fixture
+            .store
+            .get_connection()
+            .execute(
+                "UPDATE node SET canonical_id = ?1 WHERE id = 3",
+                [format!("{absolute_prefix}:crate::target#0")],
+            )
+            .unwrap();
+
+        let relative = contract(
+            "src/lib.rs:crate::source#0",
+            &["src/lib.rs:crate::target#0"],
+        );
+        let observed = build_from_store_observed(
+            &fixture.store,
+            &fixture.root,
+            &fixture.project_id,
+            &fixture.publication,
+            &relative,
+            |path| fs::read(path),
+        )
+        .unwrap();
+
+        assert!(
+            !observed.trace.selector_early_return,
+            "{:#?}",
+            observed.trace
+        );
+        assert!(
+            observed
+                .trace
+                .selectors
+                .iter()
+                .all(|selector| matches!(selector.outcome, SelectorGateOutcome::Resolved { .. }))
+        );
+    }
+
+    #[test]
+    fn exact_canonical_selector_rejects_resealed_file_path_move() {
+        let fixture = source_built_fixture("fn source() { target(); }\nfn target() {}\n");
+        let source = source_callable(&fixture.store, "source");
+        let old_canonical = canonical_id(&source).to_owned();
+        let moved = fixture.root.join("src/moved.rs");
+        fs::rename(&fixture.source_path, &moved).unwrap();
+        fixture
+            .store
+            .get_connection()
+            .execute(
+                "UPDATE file SET path = ?1 WHERE id = ?2",
+                (
+                    moved.to_string_lossy().into_owned(),
+                    source.file_node_id.unwrap().0,
+                ),
+            )
+            .unwrap();
+
+        let files = fixture.store.get_files().unwrap();
+        let mut identities = OperationPathIdentityResolver::native();
+        let canonical_index =
+            CanonicalSelectorIndex::prepare(&fixture.root, &files, &mut identities);
         let context = SelectorContext {
             store: &fixture.store,
             project_root: &fixture.root,
             project_id: &fixture.project_id,
             publication: &fixture.publication,
             files: &files,
+            canonical_index: &canonical_index,
+        };
+        assert!(matches!(
+            resolve_canonical(
+                &context,
+                &old_canonical,
+                &mut OperationPathIdentityResolver::native(),
+            )
+            .unwrap(),
+            SelectorResolution::Unavailable(UnavailableReason::SourceNotBoundToPublication)
+        ));
+    }
+
+    #[test]
+    fn canonical_selector_reconstruction_fails_closed_for_hostile_file_identity_cases() {
+        let fixture = fixture(b"fn source() { target(); }\nfn target() {}\n");
+        let absolute_prefix = fixture.source_path.to_string_lossy();
+        fixture
+            .store
+            .get_connection()
+            .execute(
+                "UPDATE node SET canonical_id = ?1 WHERE id = 3",
+                [format!("{absolute_prefix}:crate::target#0")],
+            )
+            .unwrap();
+        let files = fixture.store.files().get_files().unwrap();
+        let mut identities = OperationPathIdentityResolver::native();
+        let canonical_index =
+            CanonicalSelectorIndex::prepare(&fixture.root, &files, &mut identities);
+        let context = SelectorContext {
+            store: &fixture.store,
+            project_root: &fixture.root,
+            project_id: &fixture.project_id,
+            publication: &fixture.publication,
+            files: &files,
+            canonical_index: &canonical_index,
+        };
+
+        for missing in ["src/index:crate::target#0", "src/indexer:crate::target#0"] {
+            assert!(matches!(
+                resolve_canonical(
+                    &context,
+                    missing,
+                    &mut OperationPathIdentityResolver::native(),
+                )
+                .unwrap(),
+                SelectorResolution::Missing
+            ));
+        }
+
+        fixture
+            .store
+            .insert_node(&node(
+                4,
+                NodeKind::FUNCTION,
+                "target",
+                &format!("{absolute_prefix}:crate::target#0"),
+                1,
+                2,
+                2,
+            ))
+            .unwrap();
+        assert!(matches!(
+            resolve_canonical(
+                &context,
+                "src/lib.rs:crate::target#0",
+                &mut OperationPathIdentityResolver::native(),
+            )
+            .unwrap(),
+            SelectorResolution::Ambiguous
+        ));
+
+        #[cfg(unix)]
+        {
+            let alias = fixture.root.join("src/alias.rs");
+            std::fs::hard_link(&fixture.source_path, &alias).unwrap();
+            let mut colliding_files = files.clone();
+            let mut alias_file = colliding_files[0].clone();
+            alias_file.id += 100;
+            alias_file.path = PathBuf::from("src/alias.rs");
+            colliding_files.push(alias_file);
+            let collision = CanonicalSelectorIndex::prepare(
+                &fixture.root,
+                &colliding_files,
+                &mut OperationPathIdentityResolver::native(),
+            );
+            assert!(collision.reconstruct("src/lib.rs:crate::target#0").is_err());
+
+            let outside = tempfile::tempdir().unwrap();
+            fs::write(outside.path().join("outside.rs"), "fn outside() {}\n").unwrap();
+            std::os::unix::fs::symlink(outside.path(), fixture.root.join("src/escape")).unwrap();
+            let mut escaped_files = files.clone();
+            let mut escaped_file = escaped_files[0].clone();
+            escaped_file.id += 101;
+            escaped_file.path = PathBuf::from("src/escape/outside.rs");
+            escaped_files.push(escaped_file);
+            let escaped = CanonicalSelectorIndex::prepare(
+                &fixture.root,
+                &escaped_files,
+                &mut OperationPathIdentityResolver::native(),
+            );
+            assert!(escaped.reconstruct("src/lib.rs:crate::target#0").is_err());
+        }
+    }
+
+    #[test]
+    fn qualified_resolution_uses_exact_names_components_and_native_file_identity() {
+        let fixture = fixture(b"fn source() { target(); }\nfn target() {}\n");
+        let files = fixture.store.files().get_files().unwrap();
+        let mut identities = OperationPathIdentityResolver::native();
+        let canonical_index =
+            CanonicalSelectorIndex::prepare(&fixture.root, &files, &mut identities);
+        let context = SelectorContext {
+            store: &fixture.store,
+            project_root: &fixture.root,
+            project_id: &fixture.project_id,
+            publication: &fixture.publication,
+            files: &files,
+            canonical_index: &canonical_index,
         };
         let exact_path = ["src".to_owned(), "lib.rs".to_owned()];
         let exact = resolve_qualified(
@@ -3744,12 +4264,16 @@ mod tests {
             node_id: "2".to_owned(),
         };
         let files = fixture.store.files().get_files().unwrap();
+        let mut identities = OperationPathIdentityResolver::native();
+        let canonical_index =
+            CanonicalSelectorIndex::prepare(&fixture.root, &files, &mut identities);
         let context = SelectorContext {
             store: &fixture.store,
             project_root: &fixture.root,
             project_id: &fixture.project_id,
             publication: &wrong_publication,
             files: &files,
+            canonical_index: &canonical_index,
         };
         assert!(matches!(
             resolve_pinned(&context, &pin, &mut OperationPathIdentityResolver::native(),).unwrap(),

--- a/crates/codestory-store/src/storage_impl/proof_resolution.rs
+++ b/crates/codestory-store/src/storage_impl/proof_resolution.rs
@@ -983,7 +983,7 @@ mod python_replay_complexity_tests {
                 fact_schema_version: PROOF_RESOLUTION_FACT_SCHEMA_VERSION,
                 algorithm: EXACT_CALL_RESOLUTION_ALGORITHM.to_owned(),
                 language_adapter: "python".to_owned(),
-                language_adapter_version: "reference-v12".to_owned(),
+                language_adapter_version: "reference-v13".to_owned(),
                 parser_fingerprint: source_hash.clone(),
                 dependency_file_hashes: vec![DependencyFileHash {
                     file_id: FileId(source_file_id),

--- a/crates/codestory-store/src/storage_impl/proof_resolution.rs
+++ b/crates/codestory-store/src/storage_impl/proof_resolution.rs
@@ -15,25 +15,25 @@ const PUBLICATION_DIGEST_DOMAIN: &[u8] = b"codestory-proof-resolution-publicatio
 
 #[cfg(test)]
 thread_local! {
-    static GO_STORE_REPLAY_WORK: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static STORE_REPLAY_WORK: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
 
 #[inline]
-fn count_go_store_replay_work(amount: usize) {
+fn count_store_replay_work(amount: usize) {
     #[cfg(test)]
-    GO_STORE_REPLAY_WORK.with(|work| work.set(work.get().saturating_add(amount)));
+    STORE_REPLAY_WORK.with(|work| work.set(work.get().saturating_add(amount)));
     #[cfg(not(test))]
     let _ = amount;
 }
 
 #[cfg(test)]
-fn reset_go_store_replay_work() {
-    GO_STORE_REPLAY_WORK.with(|work| work.set(0));
+fn reset_store_replay_work() {
+    STORE_REPLAY_WORK.with(|work| work.set(0));
 }
 
 #[cfg(test)]
-fn go_store_replay_work() -> usize {
-    GO_STORE_REPLAY_WORK.with(std::cell::Cell::get)
+fn store_replay_work() -> usize {
+    STORE_REPLAY_WORK.with(std::cell::Cell::get)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -94,6 +94,22 @@ fn is_sha256(value: &str) -> bool {
         && value
             .bytes()
             .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn parse_canonical_json<T>(value: &str, label: &str) -> Result<T, String>
+where
+    T: serde::de::DeserializeOwned + serde::Serialize,
+{
+    let parsed: T = serde_json::from_str(value)
+        .map_err(|error| format!("stored {label} JSON is invalid: {error}"))?;
+    let canonical = serde_json::to_string(&parsed)
+        .map_err(|error| format!("stored {label} JSON cannot be serialized: {error}"))?;
+    if canonical != value {
+        return Err(format!(
+            "stored {label} JSON bytes are not canonical typed serialization"
+        ));
+    }
+    Ok(parsed)
 }
 
 fn validate_fact_shape(fact: &CallResolutionFact, require_seal: bool) -> Result<(), StorageError> {
@@ -209,6 +225,9 @@ struct ProofResolutionValidationContext {
     parsed_callsite_identity_by_edge: HashMap<EdgeId, StoredCanonicalCallsiteIdentity>,
     import_relations: HashMap<(NodeId, NodeId, NodeId), ProofRelationState>,
     member_relations: HashMap<(NodeId, NodeId), ProofRelationState>,
+    python_import_paths: HashMap<(NodeId, NodeId), Vec<Vec<NodeId>>>,
+    python_file_ids_by_path: HashMap<PathBuf, Vec<FileId>>,
+    python_attestation_error_by_file: HashMap<i64, String>,
     go_package_identity_by_file: HashMap<i64, GoPackageIdentity>,
     go_dependency_ids_by_package: HashMap<GoPackageIdentity, BTreeSet<FileId>>,
     go_attestation_error_by_file: HashMap<i64, String>,
@@ -247,7 +266,7 @@ fn prepare_call_edge_correlation_index(
     let mut indices = Vec::new();
     let mut identities = HashMap::new();
     for (index, edge) in edges.iter().enumerate() {
-        count_go_store_replay_work(1);
+        count_store_replay_work(1);
         if edge.kind != EdgeKind::CALL || !node_by_id.contains_key(&edge.target) {
             continue;
         }
@@ -292,7 +311,7 @@ fn go_package_dependency_ids(
         .get(&source_file_id.0)
         .ok_or_else(|| proof_error("Go source dependency has no authenticated package clause"))?;
     for file_id in evidence_ids {
-        count_go_store_replay_work(1);
+        count_store_replay_work(1);
         if let Some(error) = context.go_attestation_error_by_file.get(&file_id.0) {
             return Err(proof_error(format!(
                 "Go evidence dependency is not publication-authenticated: {error}"
@@ -304,7 +323,7 @@ fn go_package_dependency_ids(
             ));
         }
     }
-    count_go_store_replay_work(1);
+    count_store_replay_work(1);
     context
         .go_dependency_ids_by_package
         .get(source_identity)
@@ -318,6 +337,7 @@ fn stored_go_package_dependency_ids(
     stored_fact_ids: &BTreeSet<FileId>,
     context: &ProofResolutionValidationContext,
 ) -> Result<BTreeSet<FileId>, StorageError> {
+    count_store_replay_work(1);
     if !required_evidence_ids.is_subset(stored_fact_ids) {
         return Err(proof_error(
             "stored Go dependency receipt omits source or typed evidence files",
@@ -332,7 +352,7 @@ fn stored_go_package_dependency_ids(
         .parent()
         .ok_or_else(|| proof_error("stored Go source path has no package directory"))?;
     for file_id in stored_fact_ids {
-        count_go_store_replay_work(1);
+        count_store_replay_work(1);
         let file = context
             .file_by_id
             .get(&file_id.0)
@@ -353,6 +373,312 @@ fn stored_go_package_dependency_ids(
     Ok(stored_fact_ids.clone())
 }
 
+fn python_dependency_ids(
+    fact: &CallResolutionFact,
+    required_evidence_ids: &BTreeSet<FileId>,
+    stored_fact_ids: &BTreeSet<FileId>,
+    context: &ProofResolutionValidationContext,
+) -> Result<BTreeSet<FileId>, StorageError> {
+    if !required_evidence_ids.is_subset(stored_fact_ids) {
+        return Err(proof_error(
+            "Python dependency receipt omits source or typed evidence files",
+        ));
+    }
+    let mut expected = required_evidence_ids.clone();
+    let imported = fact
+        .evidence_chain
+        .iter()
+        .any(|evidence| matches!(evidence, ResolutionEvidence::StaticImportBinding { .. }));
+    let source = context
+        .file_by_id
+        .get(&fact.callsite.file_id.0)
+        .ok_or_else(|| proof_error("Python source dependency file is missing"))?;
+    if source.language != "python"
+        || source
+            .path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            != Some("py")
+    {
+        return Err(proof_error(
+            "Python proof source is not an indexed runtime source file",
+        ));
+    }
+    if imported {
+        let module_specifier = fact
+            .evidence_chain
+            .iter()
+            .find_map(|evidence| {
+                let ResolutionEvidence::QualifiedPath { components } = evidence else {
+                    return None;
+                };
+                components.iter().find_map(|component| {
+                    context
+                        .node_by_id
+                        .get(component)
+                        .filter(|node| node.kind == NodeKind::MODULE)
+                        .map(|node| node.serialized_name.as_str())
+                })
+            })
+            .ok_or_else(|| proof_error("Python relative import has no authenticated module"))?;
+        if !python_exact_relative_module(module_specifier) {
+            return Err(proof_error(
+                "Python relative import module is outside the exact subset",
+            ));
+        }
+        let parent = source
+            .path
+            .parent()
+            .ok_or_else(|| proof_error("Python source path has no package directory"))?;
+        let components = module_specifier[1..].split('.').collect::<Vec<_>>();
+        let mut base = parent.to_path_buf();
+        for marker_path in std::iter::once(parent.join("__init__.py")).chain(
+            components[..components.len() - 1].iter().map(|component| {
+                base.push(component);
+                base.join("__init__.py")
+            }),
+        ) {
+            let markers = context
+                .python_file_ids_by_path
+                .get(&marker_path)
+                .map(Vec::as_slice)
+                .unwrap_or_default();
+            let [marker] = markers else {
+                return Err(proof_error(
+                    "Python relative import has no unique indexed package marker",
+                ));
+            };
+            expected.insert(*marker);
+        }
+        let target = fact.target.expect("Exact Python fact has a target");
+        let target_file_id = context
+            .node_by_id
+            .get(&target)
+            .and_then(|node| node.file_node_id)
+            .ok_or_else(|| proof_error("Python imported target has no source file"))?;
+        let target_file = context
+            .file_by_id
+            .get(&target_file_id.0)
+            .ok_or_else(|| proof_error("Python imported target file is missing"))?;
+        let leaf = components.last().expect("relative module has a component");
+        let file_target = base.join(leaf).with_extension("py");
+        let package_target = base.join(leaf).join("__init__.py");
+        let target_ids = [file_target, package_target]
+            .into_iter()
+            .flat_map(|path| {
+                context
+                    .python_file_ids_by_path
+                    .get(&path)
+                    .into_iter()
+                    .flatten()
+                    .copied()
+            })
+            .collect::<Vec<_>>();
+        if target_ids.as_slice() != [FileId(target_file.id)] {
+            return Err(proof_error(
+                "Python relative import has no unique indexed native module target",
+            ));
+        }
+    }
+    if expected != *stored_fact_ids {
+        return Err(proof_error(
+            "Python dependency receipt has missing or extra package dependencies",
+        ));
+    }
+    for file_id in stored_fact_ids {
+        count_store_replay_work(1);
+        let file = context
+            .file_by_id
+            .get(&file_id.0)
+            .ok_or_else(|| proof_error("Python dependency file is missing"))?;
+        if file.language != "python"
+            || file
+                .path
+                .extension()
+                .and_then(|extension| extension.to_str())
+                != Some("py")
+        {
+            return Err(proof_error(
+                "Python dependency receipt contains a non-runtime source file",
+            ));
+        }
+        if let Some(error) = context.python_attestation_error_by_file.get(&file.id) {
+            return Err(proof_error(format!(
+                "Python dependency source is not publication-authenticated: {error}"
+            )));
+        }
+    }
+    Ok(expected)
+}
+
+fn prepare_python_file_ids_by_path(
+    file_by_id: &HashMap<i64, FileInfo>,
+) -> HashMap<PathBuf, Vec<FileId>> {
+    let mut by_path = HashMap::<PathBuf, Vec<FileId>>::new();
+    for file in file_by_id.values().filter(|file| file.language == "python") {
+        count_store_replay_work(1);
+        by_path
+            .entry(file.path.clone())
+            .or_default()
+            .push(FileId(file.id));
+    }
+    by_path
+}
+
+fn python_exact_relative_module(module: &str) -> bool {
+    module.starts_with('.')
+        && !module.starts_with("..")
+        && module.len() > 1
+        && module[1..].split('.').all(|component| {
+            let mut chars = component.chars();
+            chars
+                .next()
+                .is_some_and(|ch| ch == '_' || ch.is_ascii_alphabetic())
+                && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+        })
+}
+
+#[cfg(unix)]
+type PythonNativeFileIdentity = (u64, u64);
+#[cfg(not(unix))]
+type PythonNativeFileIdentity = PathBuf;
+
+fn python_native_file_identity(path: &Path) -> Result<PythonNativeFileIdentity, String> {
+    let metadata = fs::symlink_metadata(path)
+        .map_err(|error| format!("source cannot be inspected: {error}"))?;
+    if metadata.file_type().is_symlink() {
+        return Err("source cannot be a symlink".to_owned());
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        Ok((metadata.dev(), metadata.ino()))
+    }
+    #[cfg(not(unix))]
+    {
+        fs::canonicalize(path)
+            .map(|path| PathBuf::from(path.to_string_lossy().to_lowercase()))
+            .map_err(|error| format!("source has no native identity: {error}"))
+    }
+}
+
+fn canonical_file_node_id_for_path(path: &Path) -> i64 {
+    #[cfg(windows)]
+    let file_identity = path
+        .canonicalize()
+        .unwrap_or_else(|_| path.to_path_buf())
+        .to_string_lossy()
+        .replace('\\', "/")
+        .to_lowercase();
+    #[cfg(not(windows))]
+    let file_identity = path.to_string_lossy().into_owned();
+    let canonical_id = format!("{file_identity}:{file_identity}:1");
+    let mut hash: u64 = 0xcbf29ce484222325;
+    for byte in canonical_id.bytes() {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash as i64
+}
+
+fn prepare_python_source_attestation(
+    file_by_id: &HashMap<i64, FileInfo>,
+    file_content_hash_by_id: &HashMap<i64, String>,
+    authenticate_live_sources: bool,
+) -> HashMap<i64, String> {
+    let mut errors = HashMap::new();
+    let mut native_owners = HashMap::<PythonNativeFileIdentity, i64>::new();
+    for file in file_by_id.values().filter(|file| file.language == "python") {
+        count_store_replay_work(1);
+        if canonical_file_node_id_for_path(&file.path) != file.id {
+            errors.insert(
+                file.id,
+                "file row path does not reproduce its canonical file node id".to_owned(),
+            );
+            continue;
+        }
+        if !authenticate_live_sources {
+            continue;
+        }
+        let identity = match python_native_file_identity(&file.path) {
+            Ok(identity) => identity,
+            Err(error) => {
+                errors.insert(file.id, error);
+                continue;
+            }
+        };
+        if let Some(previous) = native_owners.insert(identity, file.id)
+            && previous != file.id
+        {
+            errors.insert(previous, "native source identity is not unique".to_owned());
+            errors.insert(file.id, "native source identity is not unique".to_owned());
+            continue;
+        }
+        let bytes = match fs::read(&file.path) {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                errors.insert(file.id, format!("source cannot be read: {error}"));
+                continue;
+            }
+        };
+        count_store_replay_work(bytes.len().saturating_add(1));
+        let observed = format!("{:x}", Sha256::digest(&bytes));
+        if file_content_hash_by_id.get(&file.id) != Some(&observed) {
+            errors.insert(
+                file.id,
+                "source bytes do not match the stored source hash".to_owned(),
+            );
+            continue;
+        }
+        if std::str::from_utf8(&bytes).is_err() {
+            errors.insert(file.id, "source bytes are not strict UTF-8".to_owned());
+        }
+    }
+    errors
+}
+
+fn validate_python_import_target(
+    context: &ProofResolutionValidationContext,
+    source_file: NodeId,
+    module: NodeId,
+    target: NodeId,
+) -> bool {
+    let Some(source) = context.file_by_id.get(&source_file.0) else {
+        return false;
+    };
+    let Some(module_node) = context.node_by_id.get(&module) else {
+        return false;
+    };
+    let Some(target_file) = context
+        .node_by_id
+        .get(&target)
+        .and_then(|node| node.file_node_id)
+        .and_then(|file| context.file_by_id.get(&file.0))
+    else {
+        return false;
+    };
+    let module_specifier = module_node.serialized_name.as_str();
+    if !module_specifier.starts_with('.')
+        || module_specifier.starts_with("..")
+        || module_specifier.len() <= 1
+        || !module_specifier[1..].split('.').all(|component| {
+            let mut chars = component.chars();
+            chars
+                .next()
+                .is_some_and(|ch| ch == '_' || ch.is_ascii_alphabetic())
+                && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+        })
+    {
+        return false;
+    }
+    let Some(parent) = source.path.parent() else {
+        return false;
+    };
+    let relative = module_specifier[1..].replace('.', std::path::MAIN_SEPARATOR_STR);
+    let base = parent.join(relative);
+    target_file.path == base.with_extension("py") || target_file.path == base.join("__init__.py")
+}
+
 type PreparedGoPackageClosure = (
     HashMap<i64, GoPackageIdentity>,
     HashMap<GoPackageIdentity, BTreeSet<FileId>>,
@@ -367,7 +693,7 @@ fn prepare_go_package_closure(
     let mut dependencies_by_package = HashMap::<GoPackageIdentity, BTreeSet<FileId>>::new();
     let mut errors = HashMap::new();
     for file in file_by_id.values().filter(|file| file.language == "go") {
-        count_go_store_replay_work(1);
+        count_store_replay_work(1);
         match attest_go_file(file, file_content_hash_by_id) {
             Ok(identity) => {
                 if !file
@@ -400,7 +726,7 @@ fn attest_go_file(
         .ok_or_else(|| "stored source hash is missing".to_owned())?;
     let bytes =
         fs::read(&file.path).map_err(|error| format!("source bytes cannot be read: {error}"))?;
-    count_go_store_replay_work(bytes.len().saturating_add(1));
+    count_store_replay_work(bytes.len().saturating_add(1));
     let observed_hash = format!("{:x}", Sha256::digest(&bytes));
     if &observed_hash != expected_hash {
         return Err("source bytes do not match the stored source hash".to_owned());
@@ -503,7 +829,7 @@ mod go_replay_complexity_tests {
             );
             file_content_hash_by_id.insert(id, source_hash.clone());
         }
-        reset_go_store_replay_work();
+        reset_store_replay_work();
         let (
             go_package_identity_by_file,
             go_dependency_ids_by_package,
@@ -519,6 +845,9 @@ mod go_replay_complexity_tests {
             parsed_callsite_identity_by_edge: HashMap::new(),
             import_relations: HashMap::new(),
             member_relations: HashMap::new(),
+            python_import_paths: HashMap::new(),
+            python_file_ids_by_path: HashMap::new(),
+            python_attestation_error_by_file: HashMap::new(),
             go_package_identity_by_file,
             go_dependency_ids_by_package,
             go_attestation_error_by_file,
@@ -528,7 +857,7 @@ mod go_replay_complexity_tests {
             go_package_dependency_ids(FileId(1), &BTreeSet::from([FileId(1)]), &context)
                 .expect("package closure");
         }
-        go_store_replay_work()
+        store_replay_work()
     }
 
     #[test]
@@ -575,11 +904,11 @@ mod go_replay_complexity_tests {
                 ..Default::default()
             })
             .collect::<Vec<_>>();
-        reset_go_store_replay_work();
+        reset_store_replay_work();
         let (indices, identities) = prepare_call_edge_correlation_index(&edges, &node_by_id);
         assert_eq!(indices.len(), count);
         assert_eq!(identities.len(), count);
-        go_store_replay_work()
+        store_replay_work()
     }
 
     #[test]
@@ -590,6 +919,131 @@ mod go_replay_complexity_tests {
         assert!(
             large <= small * 2 + 64,
             "same-line callsite identity indexing grew superlinearly: {small} -> {large}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod python_replay_complexity_tests {
+    use super::*;
+
+    fn measured_python_replay_work(file_count: usize, fact_count: usize) -> usize {
+        let temp = tempfile::tempdir().expect("Python replay tempdir");
+        let mut file_by_id = HashMap::new();
+        let mut file_content_hash_by_id = HashMap::new();
+        let source = b"def target():\n    pass\n";
+        let source_hash = format!("{:x}", Sha256::digest(source));
+        let mut source_file_id = None;
+        for index in 0..file_count {
+            let path = temp.path().join(format!("file_{index}.py"));
+            fs::write(&path, source).expect("write Python replay source");
+            let id = canonical_file_node_id_for_path(&path);
+            source_file_id.get_or_insert(id);
+            file_by_id.insert(
+                id,
+                FileInfo {
+                    id,
+                    path,
+                    language: "python".to_owned(),
+                    modification_time: 0,
+                    indexed: true,
+                    complete: true,
+                    line_count: 1,
+                    file_role: FileRole::Source,
+                },
+            );
+            file_content_hash_by_id.insert(id, source_hash.clone());
+        }
+        let source_file_id = source_file_id.expect("source file id");
+        let fact = CallResolutionFact {
+            fact_id: String::new(),
+            edge_id: Some(EdgeId(1)),
+            raw_edge_target: Some(NodeId(2)),
+            raw_callsite_identity: Some("1:1:1:2".to_owned()),
+            callsite: ExactCallsite {
+                file_id: FileId(source_file_id),
+                source_sha256: source_hash.clone(),
+                start_byte: 0,
+                end_byte_exclusive: 6,
+                line: 1,
+                column: 1,
+                callee_form: CalleeForm::Identifier,
+                raw_target: "target".to_owned(),
+            },
+            caller: NodeId(source_file_id),
+            target: Some(NodeId(2)),
+            status: ProofResolutionStatus::Exact,
+            reason: ProofResolutionReason::ExactResolution,
+            evidence_chain: vec![ResolutionEvidence::SameFileDeclaration {
+                declaration: NodeId(2),
+            }],
+            lookup_domain_complete: true,
+            provenance: ResolutionProvenance {
+                producer: INTERNAL_RESOLUTION_PRODUCER.to_owned(),
+                fact_schema_version: PROOF_RESOLUTION_FACT_SCHEMA_VERSION,
+                algorithm: EXACT_CALL_RESOLUTION_ALGORITHM.to_owned(),
+                language_adapter: "python".to_owned(),
+                language_adapter_version: "reference-v11".to_owned(),
+                parser_fingerprint: source_hash.clone(),
+                dependency_file_hashes: vec![DependencyFileHash {
+                    file_id: FileId(source_file_id),
+                    source_sha256: source_hash.clone(),
+                }],
+                evidence_sha256: String::new(),
+            },
+        };
+        reset_store_replay_work();
+        let python_file_ids_by_path = prepare_python_file_ids_by_path(&file_by_id);
+        let python_attestation_error_by_file =
+            prepare_python_source_attestation(&file_by_id, &file_content_hash_by_id, true);
+        let context = ProofResolutionValidationContext {
+            file_content_hash_by_id,
+            file_by_id,
+            node_by_id: HashMap::new(),
+            edges: Vec::new(),
+            edge_index_by_id: HashMap::new(),
+            ordinary_call_edge_indices: Vec::new(),
+            parsed_callsite_identity_by_edge: HashMap::new(),
+            import_relations: HashMap::new(),
+            member_relations: HashMap::new(),
+            python_import_paths: HashMap::new(),
+            python_file_ids_by_path,
+            python_attestation_error_by_file,
+            go_package_identity_by_file: HashMap::new(),
+            go_dependency_ids_by_package: HashMap::new(),
+            go_attestation_error_by_file: HashMap::new(),
+            live_go_sources_authenticated: true,
+        };
+        for _ in 0..fact_count {
+            python_dependency_ids(
+                &fact,
+                &BTreeSet::from([FileId(source_file_id)]),
+                &BTreeSet::from([FileId(source_file_id)]),
+                &context,
+            )
+            .expect("Python dependency replay");
+        }
+        store_replay_work()
+    }
+
+    #[test]
+    fn python_file_preparation_and_fact_replay_are_independently_linear() {
+        let baseline = measured_python_replay_work(32, 32);
+        let more_files = measured_python_replay_work(64, 32);
+        let more_facts = measured_python_replay_work(32, 64);
+        let combined = measured_python_replay_work(64, 64);
+        assert!(baseline > 0, "Python store replay work was not counted");
+        assert!(
+            more_files <= baseline * 2 + 64,
+            "Python store preparation grew superlinearly: {baseline} -> {more_files}"
+        );
+        assert!(
+            more_facts <= baseline * 2 + 64,
+            "Python fact replay grew superlinearly: {baseline} -> {more_facts}"
+        );
+        assert!(
+            combined <= baseline * 2 + 128,
+            "combined Python store replay grew superlinearly: {baseline} -> {combined}"
         );
     }
 }
@@ -606,6 +1060,34 @@ impl ProofRelationState {
     }
 }
 
+fn python_raw_import_marker_is_admissible(edge: &Edge, nodes: &HashMap<NodeId, Node>) -> bool {
+    if edge.kind != EdgeKind::IMPORT
+        || edge.effective_source() != edge.source
+        || !edge.candidate_targets.is_empty()
+    {
+        return false;
+    }
+    let Some(file_id) = edge.file_node_id else {
+        return false;
+    };
+    let raw_markers_are_local = [edge.source, edge.target].into_iter().all(|node_id| {
+        nodes.get(&node_id).is_some_and(|node| {
+            node.file_node_id == Some(file_id)
+                && matches!(node.kind, NodeKind::UNKNOWN | NodeKind::MODULE)
+        })
+    });
+    let target_relation_is_consistent = match edge.resolved_target {
+        None => edge.effective_target() == edge.target,
+        Some(resolved) => {
+            edge.effective_target() == resolved
+                && resolved != edge.source
+                && resolved != edge.target
+                && nodes.contains_key(&resolved)
+        }
+    };
+    raw_markers_are_local && target_relation_is_consistent
+}
+
 impl ProofResolutionValidationContext {
     fn prepare(
         storage: &Storage,
@@ -616,7 +1098,13 @@ impl ProofResolutionValidationContext {
             .into_iter()
             .map(|file| (file.id, file))
             .collect();
+        let python_file_ids_by_path = prepare_python_file_ids_by_path(&file_by_id);
         let file_content_hash_by_id = storage.get_file_content_hashes()?;
+        let python_attestation_error_by_file = prepare_python_source_attestation(
+            &file_by_id,
+            &file_content_hash_by_id,
+            authenticate_live_go_sources,
+        );
         let (
             go_package_identity_by_file,
             go_dependency_ids_by_package,
@@ -637,6 +1125,7 @@ impl ProofResolutionValidationContext {
         let mut edge_index_by_id = HashMap::with_capacity(edges.len());
         let mut import_relations = HashMap::<_, ProofRelationState>::new();
         let mut member_relations = HashMap::<_, ProofRelationState>::new();
+        let mut python_import_edges = HashMap::<NodeId, Vec<NodeId>>::new();
         for (index, edge) in edges.iter().enumerate() {
             edge_index_by_id.insert(edge.id, index);
             if edge.kind == EdgeKind::IMPORT
@@ -668,6 +1157,12 @@ impl ProofResolutionValidationContext {
                     state.conflicting += 1;
                 }
             }
+            if python_raw_import_marker_is_admissible(edge, &node_by_id) {
+                python_import_edges
+                    .entry(edge.source)
+                    .or_default()
+                    .push(edge.target);
+            }
             if edge.kind == EdgeKind::MEMBER {
                 let owner = node_by_id.get(&edge.source);
                 let member = node_by_id.get(&edge.target);
@@ -686,10 +1181,8 @@ impl ProofResolutionValidationContext {
                                         | NodeKind::CLASS
                                         | NodeKind::ENUM
                                 )
-                            ) | (
-                                NodeKind::STRUCT | NodeKind::CLASS | NodeKind::ENUM,
-                                Some(NodeKind::METHOD)
-                            )
+                            ) | (NodeKind::STRUCT | NodeKind::ENUM, Some(NodeKind::METHOD))
+                                | (NodeKind::CLASS, Some(NodeKind::METHOD | NodeKind::FUNCTION))
                         )
                     })
                     && member.is_some_and(|member| {
@@ -705,6 +1198,44 @@ impl ProofResolutionValidationContext {
                 }
             }
         }
+        for targets in python_import_edges.values_mut() {
+            targets.sort();
+            targets.dedup();
+        }
+        let python_import_targets = python_import_edges
+            .values()
+            .flatten()
+            .copied()
+            .collect::<BTreeSet<_>>();
+        let mut python_import_paths = HashMap::<_, Vec<Vec<NodeId>>>::new();
+        for &source in python_import_edges
+            .keys()
+            .filter(|source| !python_import_targets.contains(source))
+        {
+            let Some(file_id) = node_by_id.get(&source).and_then(|node| node.file_node_id) else {
+                continue;
+            };
+            let mut path = vec![source];
+            let mut visited = BTreeSet::from([source]);
+            let mut current = source;
+            while let Some([next]) = python_import_edges.get(&current).map(Vec::as_slice) {
+                if !visited.insert(*next) {
+                    break;
+                }
+                path.push(*next);
+                let Some(node) = node_by_id.get(next) else {
+                    break;
+                };
+                if node.kind == NodeKind::MODULE {
+                    python_import_paths
+                        .entry((file_id, source))
+                        .or_default()
+                        .push(path);
+                    break;
+                }
+                current = *next;
+            }
+        }
         Ok(Self {
             file_by_id,
             file_content_hash_by_id,
@@ -715,6 +1246,9 @@ impl ProofResolutionValidationContext {
             parsed_callsite_identity_by_edge,
             import_relations,
             member_relations,
+            python_import_paths,
+            python_file_ids_by_path,
+            python_attestation_error_by_file,
             go_package_identity_by_file,
             go_dependency_ids_by_package,
             go_attestation_error_by_file,
@@ -732,6 +1266,21 @@ impl ProofResolutionValidationContext {
         self.member_relations
             .get(&(owner, member))
             .is_some_and(ProofRelationState::is_unique)
+    }
+
+    fn has_python_import_path(&self, file: NodeId, components: &[NodeId]) -> bool {
+        let Some(import) = components.first() else {
+            return false;
+        };
+        self.python_import_paths
+            .get(&(file, *import))
+            .is_some_and(|paths| {
+                paths
+                    .iter()
+                    .filter(|path| path.as_slice() == components)
+                    .count()
+                    == 1
+            })
     }
 }
 
@@ -758,19 +1307,22 @@ impl Storage {
                 |row| {
                     let adapter_roster_json: String = row.get(3)?;
                     let funnel_json: String = row.get(7)?;
-                    let adapter_roster =
-                        serde_json::from_str(&adapter_roster_json).map_err(|error| {
-                            rusqlite::Error::FromSqlConversionFailure(
-                                adapter_roster_json.len(),
-                                rusqlite::types::Type::Text,
-                                Box::new(error),
-                            )
-                        })?;
-                    let funnel = serde_json::from_str(&funnel_json).map_err(|error| {
+                    let adapter_roster = parse_canonical_json(
+                        &adapter_roster_json,
+                        "adapter roster",
+                    )
+                    .map_err(|error| {
+                        rusqlite::Error::FromSqlConversionFailure(
+                            adapter_roster_json.len(),
+                            rusqlite::types::Type::Text,
+                            Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, error)),
+                        )
+                    })?;
+                    let funnel = parse_canonical_json(&funnel_json, "funnel").map_err(|error| {
                         rusqlite::Error::FromSqlConversionFailure(
                             funnel_json.len(),
                             rusqlite::types::Type::Text,
-                            Box::new(error),
+                            Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, error)),
                         )
                     })?;
                     Ok(ProofResolutionPublication {
@@ -841,14 +1393,10 @@ impl Storage {
                 .ok_or_else(|| proof_error("stored status is outside the closed domain"))?;
             let reason = ProofResolutionReason::from_label(&reason_text)
                 .ok_or_else(|| proof_error("stored reason is outside the closed domain"))?;
-            let evidence_chain: Vec<ResolutionEvidence> = serde_json::from_str(&evidence_json)
-                .map_err(|error| {
-                    proof_error(format!("stored evidence JSON is invalid: {error}"))
-                })?;
+            let evidence_chain: Vec<ResolutionEvidence> =
+                parse_canonical_json(&evidence_json, "evidence").map_err(proof_error)?;
             let dependency_file_hashes: Vec<DependencyFileHash> =
-                serde_json::from_str(&dependency_json).map_err(|error| {
-                    proof_error(format!("stored dependency JSON is invalid: {error}"))
-                })?;
+                parse_canonical_json(&dependency_json, "dependency").map_err(proof_error)?;
             facts.push(CallResolutionFact {
                 fact_id: row.get(0)?,
                 edge_id: row.get::<_, Option<i64>>(1)?.map(EdgeId),
@@ -982,7 +1530,8 @@ impl Storage {
                 let edge = &context.edges[*index];
                 let raw = &context.node_by_id[&edge.target];
                 let direct_member_edge = edge.target == edge.effective_target()
-                    && (raw.kind == NodeKind::METHOD || raw.file_node_id != edge.file_node_id);
+                    && (matches!(raw.kind, NodeKind::FUNCTION | NodeKind::METHOD)
+                        || raw.file_node_id != edge.file_node_id);
                 OrdinaryCallEdgeCorrelationInput {
                     file_id: edge.file_node_id.map(|file| FileId(file.0)),
                     line: edge.line,
@@ -1104,6 +1653,16 @@ impl Storage {
             };
         }
         let observed_dependency_ids = dependency_file_ids(fact);
+        if fact.status == ProofResolutionStatus::Exact
+            && fact.provenance.language_adapter == "python"
+        {
+            required_dependency_ids = python_dependency_ids(
+                fact,
+                &required_dependency_ids,
+                &observed_dependency_ids,
+                context,
+            )?;
+        }
         if observed_dependency_ids != required_dependency_ids {
             return Err(proof_error(format!(
                 "dependency hashes do not exactly cover source, import, package, and target files for {}: observed={observed_dependency_ids:?} required={required_dependency_ids:?}",
@@ -1198,7 +1757,7 @@ impl Storage {
             fact.callsite.callee_form,
             CalleeForm::ImplicitReceiver | CalleeForm::ExplicitReceiver | CalleeForm::NamedImport
         ) && raw_edge_target == target
-            && (raw_placeholder.kind == NodeKind::METHOD
+            && (matches!(raw_placeholder.kind, NodeKind::FUNCTION | NodeKind::METHOD)
                 || raw_placeholder.file_node_id != Some(NodeId(fact.callsite.file_id.0)));
         if !direct_member_target
             && (raw_placeholder.file_node_id != Some(NodeId(fact.callsite.file_id.0))
@@ -1225,8 +1784,11 @@ impl Storage {
         if matches!(
             fact.callsite.callee_form,
             CalleeForm::ImplicitReceiver | CalleeForm::ExplicitReceiver
-        ) && target_node.kind != NodeKind::METHOD
-        {
+        ) && if fact.provenance.language_adapter == "python" {
+            target_node.kind != NodeKind::FUNCTION
+        } else {
+            target_node.kind != NodeKind::METHOD
+        } {
             return Err(proof_error(
                 "receiver evidence target is not a METHOD graph node",
             ));
@@ -1293,13 +1855,39 @@ impl Storage {
                     .node_by_id
                     .get(import)
                     .ok_or_else(|| proof_error("static import binding is missing"))?;
-                if import_node.kind != NodeKind::MODULE
-                    || import_node.file_node_id != Some(source_file)
-                    || graph_leaf_name(&import_node.serialized_name) != fact.callsite.raw_target
-                    || !context.has_import(source_file, *import, target)
-                    || components
-                        .windows(2)
-                        .any(|pair| !context.has_member(pair[0], pair[1]))
+                let python_module_index = (fact.provenance.language_adapter == "python")
+                    .then(|| {
+                        components.iter().rposition(|component| {
+                            context
+                                .node_by_id
+                                .get(component)
+                                .is_some_and(|node| node.kind == NodeKind::MODULE)
+                        })
+                    })
+                    .flatten();
+                let python_relative = python_module_index.is_some_and(|module_index| {
+                    import_node.kind == NodeKind::UNKNOWN
+                        && components.first() == Some(import)
+                        && components.last() == Some(&target)
+                        && import_node.file_node_id == Some(source_file)
+                        && graph_leaf_name(&import_node.serialized_name) == fact.callsite.raw_target
+                        && context.has_python_import_path(source_file, &components[..=module_index])
+                        && validate_python_import_target(
+                            context,
+                            source_file,
+                            components[module_index],
+                            target,
+                        )
+                });
+                if !python_relative
+                    && (import_node.kind != NodeKind::MODULE
+                        || import_node.file_node_id != Some(source_file)
+                        || graph_leaf_name(&import_node.serialized_name)
+                            != fact.callsite.raw_target
+                        || !context.has_import(source_file, *import, target)
+                        || components
+                            .windows(2)
+                            .any(|pair| !context.has_member(pair[0], pair[1])))
                 {
                     return Err(proof_error(
                         "StaticImportBinding path is not one unique source IMPORT and MEMBER chain",
@@ -1538,10 +2126,7 @@ impl Storage {
                     ResolutionEvidence::ExplicitReceiverType { receiver_type },
                     ResolutionEvidence::QualifiedPath { components },
                 ],
-            ) if *owner == *constructor
-                && *owner == *receiver_type
-                && components.as_slice() == [*owner, target] =>
-            {
+            ) if *owner == *constructor && *owner == *receiver_type => {
                 Self::validate_imported_receiver_evidence(
                     fact,
                     context,
@@ -1549,6 +2134,7 @@ impl Storage {
                     *owner,
                     target,
                     target_node,
+                    Some(components),
                 )?;
             }
             (
@@ -1561,7 +2147,7 @@ impl Storage {
                     ResolutionEvidence::ExplicitReceiverType { receiver_type },
                     ResolutionEvidence::QualifiedPath { components },
                 ],
-            ) if *owner == *receiver_type && components.as_slice() == [*owner, target] => {
+            ) if *owner == *receiver_type => {
                 Self::validate_imported_receiver_evidence(
                     fact,
                     context,
@@ -1569,6 +2155,7 @@ impl Storage {
                     *owner,
                     target,
                     target_node,
+                    Some(components),
                 )?;
             }
             (
@@ -1590,6 +2177,7 @@ impl Storage {
                     *owner,
                     target,
                     target_node,
+                    None,
                 )?;
             }
             (
@@ -1610,6 +2198,7 @@ impl Storage {
                     *owner,
                     target,
                     target_node,
+                    None,
                 )?;
             }
             _ => {
@@ -1670,6 +2259,7 @@ impl Storage {
         owner: NodeId,
         target: NodeId,
         target_node: &Node,
+        components: Option<&[NodeId]>,
     ) -> Result<(), StorageError> {
         let import_node = context
             .node_by_id
@@ -1679,13 +2269,28 @@ impl Storage {
             .node_by_id
             .get(&owner)
             .ok_or_else(|| proof_error("imported receiver owner is missing"))?;
-        if import_node.file_node_id != Some(NodeId(fact.callsite.file_id.0))
+        let source_file = NodeId(fact.callsite.file_id.0);
+        let python_relative = fact.provenance.language_adapter == "python"
+            && components.is_some_and(|components| {
+                components.len() >= 4
+                    && components[components.len() - 2] == owner
+                    && components.last() == Some(&target)
+                    && context
+                        .has_python_import_path(source_file, &components[..components.len() - 2])
+                    && validate_python_import_target(
+                        context,
+                        source_file,
+                        components[components.len() - 3],
+                        owner,
+                    )
+            });
+        if import_node.file_node_id != Some(source_file)
             || !matches!(
                 owner_node.kind,
                 NodeKind::CLASS | NodeKind::STRUCT | NodeKind::ENUM
             )
             || owner_node.file_node_id != target_node.file_node_id
-            || !context.has_import(NodeId(fact.callsite.file_id.0), import, owner)
+            || !(python_relative || context.has_import(source_file, import, owner))
             || !context.has_member(owner, target)
         {
             return Err(proof_error(
@@ -2017,7 +2622,7 @@ fn graph_leaf_name(name: &str) -> &str {
 fn proof_import_node_kind_is_literal(language: &str, kind: NodeKind) -> bool {
     match language {
         "rust" => kind == NodeKind::MODULE,
-        "javascript" | "typescript" | "tsx" => {
+        "javascript" | "typescript" | "tsx" | "python" => {
             matches!(kind, NodeKind::MODULE | NodeKind::UNKNOWN)
         }
         _ => false,

--- a/crates/codestory-store/src/storage_impl/proof_resolution.rs
+++ b/crates/codestory-store/src/storage_impl/proof_resolution.rs
@@ -983,7 +983,7 @@ mod python_replay_complexity_tests {
                 fact_schema_version: PROOF_RESOLUTION_FACT_SCHEMA_VERSION,
                 algorithm: EXACT_CALL_RESOLUTION_ALGORITHM.to_owned(),
                 language_adapter: "python".to_owned(),
-                language_adapter_version: "reference-v11".to_owned(),
+                language_adapter_version: "reference-v12".to_owned(),
                 parser_fingerprint: source_hash.clone(),
                 dependency_file_hashes: vec![DependencyFileHash {
                     file_id: FileId(source_file_id),

--- a/crates/codestory-store/tests/proof_resolution.rs
+++ b/crates/codestory-store/tests/proof_resolution.rs
@@ -1664,6 +1664,108 @@ fn publication_digest_authenticates_roster_and_funnel() {
 }
 
 #[test]
+fn stored_proof_json_requires_exact_typed_canonical_bytes() {
+    fn serialize_with_object_key_order(value: &serde_json::Value, reverse: bool) -> String {
+        match value {
+            serde_json::Value::Array(values) => format!(
+                "[{}]",
+                values
+                    .iter()
+                    .map(|value| serialize_with_object_key_order(value, reverse))
+                    .collect::<Vec<_>>()
+                    .join(",")
+            ),
+            serde_json::Value::Object(fields) => {
+                let mut fields = fields.iter().collect::<Vec<_>>();
+                if reverse {
+                    fields.reverse();
+                }
+                format!(
+                    "{{{}}}",
+                    fields
+                        .into_iter()
+                        .map(|(key, value)| format!(
+                            "{}:{}",
+                            serde_json::to_string(key).unwrap(),
+                            serialize_with_object_key_order(value, reverse)
+                        ))
+                        .collect::<Vec<_>>()
+                        .join(",")
+                )
+            }
+            _ => serde_json::to_string(value).unwrap(),
+        }
+    }
+
+    for mutation in ["whitespace", "key_order"] {
+        for (table, column, reader) in [
+            ("proof_resolution_fact", "evidence_json", "facts"),
+            ("proof_resolution_fact", "dependency_json", "facts"),
+            (
+                "proof_resolution_publication",
+                "adapter_roster_json",
+                "publication",
+            ),
+            ("proof_resolution_publication", "funnel_json", "publication"),
+        ] {
+            let mut store = Store::new_in_memory().unwrap();
+            if column == "evidence_json" && mutation == "key_order" {
+                seed_imported_receiver_graph(&mut store);
+                store
+                    .replace_proof_resolution_projection(
+                        &publication(),
+                        &receiver_projection(imported_receiver_fact(false)),
+                    )
+                    .unwrap();
+            } else {
+                seed_exact_graph(&mut store);
+                store
+                    .replace_proof_resolution_projection(
+                        &publication(),
+                        &projection(vec![exact_fact(EdgeId(7))]),
+                    )
+                    .unwrap();
+            }
+            let stored = store
+                .get_connection()
+                .query_row(&format!("SELECT {column} FROM {table}"), [], |row| {
+                    row.get::<_, String>(0)
+                })
+                .unwrap();
+            let hostile = if mutation == "whitespace" {
+                format!(" {stored}")
+            } else {
+                let parsed = serde_json::from_str(&stored).expect("stored JSON");
+                let forward = serialize_with_object_key_order(&parsed, false);
+                if forward != stored {
+                    forward
+                } else {
+                    serialize_with_object_key_order(&parsed, true)
+                }
+            };
+            assert_ne!(hostile, stored, "{column} {mutation} fixture");
+            store
+                .get_connection()
+                .execute(&format!("UPDATE {table} SET {column} = ?1"), [hostile])
+                .unwrap();
+            let error = if reader == "facts" {
+                store
+                    .get_proof_resolution_facts()
+                    .expect_err("noncanonical fact JSON must reject")
+            } else {
+                store
+                    .get_proof_resolution_publication()
+                    .expect_err("noncanonical publication JSON must reject")
+            };
+            assert!(
+                error.to_string().contains("canonical"),
+                "{column} {mutation}: {error}"
+            );
+        }
+    }
+}
+
+#[test]
 fn failed_replacement_and_stale_validation_preserve_the_previous_complete_publication() {
     let mut store = Store::new_in_memory().unwrap();
     seed_exact_graph(&mut store);


### PR DESCRIPTION
## Context

The proof kernel was sound but Python CALL edges had no durable proof-authoritative resolution evidence. This PR implements the frozen Python subset on top of the schema-32 exact-resolution overlay without changing navigation graph behavior or making proof public.

Closes #2036
Refs #2023

## What changed

- produces exact Python receipts for the closed S1-S4 subset: same-module functions, direct same-class `self` calls, exact relative named imports, and straight-line concrete receivers;
- authenticates complete Python module/package domains, parser provenance, graph/fact correlation, native paths, source coordinates, repeated callsites, and canonical stored evidence;
- keeps dynamic dispatch, inheritance lookup, decorators, metaclasses, star/dynamic imports, rebinding, mutation, factories, and incomplete domains explicitly non-exact;
- rematerializes the proof overlay in linear work and bumps proof-input cache/adapter provenance when semantics change;
- fixes class-header comments such as `# type: ignore[type-arg]` so comment bytes cannot change AST semantics.

Proof facts remain one-way authority for the dark verifier. Search, retrieval, packet, context, navigation, public dispatch, CLI, and MCP do not consume them.

## Review boundary

The implementation was frozen, reviewed once across language-domain closure, parser provenance, graph/fact correlation, repeated callsites, coordinates, native ordering, storage integrity, and complexity, then corrected as one batch. The accepted head is:

- base: `55286e8533f409f0fd991371636f2a4e93fe00d9`
- head: `00b714cb8a24e9476cfa1a60f4f53773f6e2acfe`
- tree: `0591cf9fb8f4d7d31aad45e5d1e84fdb3c76df6e`

## Verification

Focused:

- indexer proof-resolution: 84 passed;
- store proof-resolution integration: 21 passed;
- cache provenance, Python hostile matrix, replay complexity, formatting, and focused clippy: passed.

Exact-tree serial gates:

- format, workspace check, all-target/all-feature clippy: passed;
- nextest: 4,016 passed, 34 skipped;
- workspace docs: passed;
- stdio protocol contracts: 63 passed;
- installer: 6 passed;
- plugin static: 140 passed, 1 Windows-only skip;
- documentation links: 85 files / 317 links;
- sealed evidence-only v3 feature build and four-revision conformance: passed;
- clean tree and `git diff --check`: passed.

Local qualification `20260824T103319Z-00b714cb8a24`:

- Python 12/30; combined 62/120;
- zero false `ContractProven` results;
- zero non-exact authoritative receipts;
- zero incomplete provenance, unclassified positive steps, disposition mismatches, invalid results, over-cap results, or transport errors.

The qualification outcome remains `keep_proof_dark`: the Python cohort floor and hard gates pass, while combined stable recall, usefulness, latency, and response-size gates remain for later roadmap work.

## Risk and non-claims

The main risk is conservative availability: unsupported Python remains `Unknown`. This PR does not add public routes, broaden adapters, change packet/context/search DTOs, add a dependency index, change versions, or touch the 0.17 release lane.
