### PR TITLE
[codex] compact dark proof projection

### DIFF
--- a/crates/codestory-agent/src/indexed_source_call_path_v1.rs
+++ b/crates/codestory-agent/src/indexed_source_call_path_v1.rs
@@ -17,7 +17,10 @@ use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
 
 use codestory_contracts::graph::{Edge, EdgeId, EdgeKind, NodeId};
-use codestory_contracts::proof_resolution::{ResolutionEvidence, ResolutionProvenance};
+use codestory_contracts::proof_resolution::{
+    EXACT_CALL_RESOLUTION_ALGORITHM, INTERNAL_RESOLUTION_PRODUCER,
+    PROOF_RESOLUTION_FACT_SCHEMA_VERSION, ResolutionEvidence, ResolutionProvenance,
+};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 
@@ -1334,6 +1337,8 @@ pub struct ResolvedNodeIdentity {
     pub pinned: PinnedNodeIdentity,
     pub canonical_id: String,
     pub qualified_name: String,
+    /// The file node pinned by the same core publication as this callable.
+    pub file_node_id: NodeId,
     pub project_file_components: Vec<String>,
 }
 
@@ -1342,6 +1347,7 @@ impl ResolvedNodeIdentity {
         pinned: PinnedNodeIdentity,
         canonical_id: impl Into<String>,
         qualified_name: impl Into<String>,
+        file_node_id: NodeId,
         project_file_components: Vec<String>,
     ) -> Result<Self, SelectorValidationError> {
         validate_pinned_identity(&pinned)?;
@@ -1354,6 +1360,7 @@ impl ResolvedNodeIdentity {
             pinned,
             canonical_id,
             qualified_name,
+            file_node_id,
             project_file_components,
         })
     }
@@ -1931,8 +1938,6 @@ fn compare_receipt_sequences(
         .unwrap_or_else(|| left.len().cmp(&right.len()))
 }
 
-pub const INTERNAL_PROOF_CAP_BYTES: usize = 64 * 1024;
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CheckedBuiltCallPathIntegration {
     contract: ValidatedCallPathContract,
@@ -2268,10 +2273,6 @@ pub enum InternalProjection {
 pub enum InternalProjectionError {
     Serialization(String),
     InvalidCompactProjection(String),
-    FallbackExceedsCap {
-        cap_bytes: usize,
-        serialized_size: usize,
-    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2285,7 +2286,6 @@ struct CompactFileIdentity {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct CompactSymbolIdentity {
     node_id: String,
-    pinned: Option<PinnedNodeIdentity>,
     canonical_id: Option<String>,
     qualified_name: Option<String>,
     file: Option<u32>,
@@ -2297,7 +2297,7 @@ struct CompactIdentityTables {
     file_by_node_id: BTreeMap<i64, u32>,
     file_by_path: BTreeMap<Vec<String>, u32>,
     symbols: Vec<CompactSymbolIdentity>,
-    symbol_by_pinned: BTreeMap<String, u32>,
+    symbol_by_node_id: BTreeMap<String, u32>,
     evidence: Vec<Value>,
     evidence_by_fact_id: BTreeMap<String, u32>,
 }
@@ -2367,17 +2367,26 @@ impl CompactIdentityTables {
         &mut self,
         node: &ResolvedNodeIdentity,
     ) -> Result<u32, InternalProjectionError> {
-        let file =
-            self.intern_file(None, Some(node.project_file_components.clone()), None, None)?;
+        let file = self.intern_file(
+            Some(node.file_node_id.0),
+            Some(node.project_file_components.clone()),
+            None,
+            None,
+        )?;
         let identity = CompactSymbolIdentity {
             node_id: node.pinned.node_id.clone(),
-            pinned: Some(node.pinned.clone()),
             canonical_id: Some(node.canonical_id.clone()),
             qualified_name: Some(node.qualified_name.clone()),
             file: Some(file),
         };
-        if let Some(index) = self.symbol_by_pinned.get(&identity.node_id).copied() {
-            if self.symbols[usize::try_from(index).expect("u32 index fits usize")] != identity {
+        if let Some(index) = self.symbol_by_node_id.get(&identity.node_id).copied() {
+            let current = &mut self.symbols[usize::try_from(index).expect("u32 index fits usize")];
+            if current.canonical_id.is_none()
+                && current.qualified_name.is_none()
+                && current.file.is_none()
+            {
+                *current = identity;
+            } else if *current != identity {
                 return Err(InternalProjectionError::InvalidCompactProjection(
                     "conflicting_symbol_identity".to_owned(),
                 ));
@@ -2386,24 +2395,23 @@ impl CompactIdentityTables {
         }
         let index = bounded_index(self.symbols.len())?;
         self.symbols.push(identity.clone());
-        self.symbol_by_pinned.insert(identity.node_id, index);
+        self.symbol_by_node_id.insert(identity.node_id, index);
         Ok(index)
     }
 
     fn intern_evidence_symbol(&mut self, node_id: NodeId) -> Result<u32, InternalProjectionError> {
         let node_id = node_id.0.to_string();
-        if let Some(index) = self.symbol_by_pinned.get(&node_id).copied() {
+        if let Some(index) = self.symbol_by_node_id.get(&node_id).copied() {
             return Ok(index);
         }
         let index = bounded_index(self.symbols.len())?;
         self.symbols.push(CompactSymbolIdentity {
             node_id: node_id.clone(),
-            pinned: None,
             canonical_id: None,
             qualified_name: None,
             file: None,
         });
-        self.symbol_by_pinned.insert(node_id, index);
+        self.symbol_by_node_id.insert(node_id, index);
         Ok(index)
     }
 
@@ -2449,6 +2457,8 @@ impl CompactIdentityTables {
             "fact_id": receipt.resolution_fact_id,
             "caller": source,
             "target": target,
+            "edge_id": receipt.receipt.edge_id,
+            "callsite_identity": receipt.callsite_identity,
             "chain": chain,
             "provenance": {
                 "producer": provenance.producer,
@@ -2536,7 +2546,6 @@ impl CompactIdentityTables {
             })).collect::<Vec<_>>(),
             "symbols": self.symbols.iter().map(|symbol| json!({
                 "node_id": symbol.node_id,
-                "pinned": symbol.pinned.as_ref().map(pinned_identity_json),
                 "canonical_id": symbol.canonical_id,
                 "qualified_name": symbol.qualified_name,
                 "file": symbol.file,
@@ -2570,17 +2579,21 @@ fn merge_compact_field<T: PartialEq>(
 }
 
 fn valid_resolution_provenance(provenance: &ResolutionProvenance) -> bool {
-    !provenance.producer.is_empty()
-        && provenance.fact_schema_version > 0
-        && !provenance.algorithm.is_empty()
+    provenance.producer == INTERNAL_RESOLUTION_PRODUCER
+        && provenance.fact_schema_version == PROOF_RESOLUTION_FACT_SCHEMA_VERSION
+        && provenance.algorithm == EXACT_CALL_RESOLUTION_ALGORITHM
         && !provenance.language_adapter.is_empty()
         && !provenance.language_adapter_version.is_empty()
         && is_lower_hex_sha256(&provenance.parser_fingerprint)
         && is_lower_hex_sha256(&provenance.evidence_sha256)
+        && !provenance.dependency_file_hashes.is_empty()
         && provenance
             .dependency_file_hashes
-            .iter()
-            .all(|dependency| is_lower_hex_sha256(&dependency.source_sha256))
+            .windows(2)
+            .all(|pair| pair[0].file_id < pair[1].file_id)
+        && provenance.dependency_file_hashes.iter().all(|dependency| {
+            dependency.file_id.0 != 0 && is_lower_hex_sha256(&dependency.source_sha256)
+        })
 }
 
 fn is_lower_hex_sha256(value: &str) -> bool {
@@ -2593,32 +2606,119 @@ fn is_lower_hex_sha256(value: &str) -> bool {
 /// Rejects compact roots whose numeric references no longer describe one
 /// complete proof. The CLI calls this before serializing every revision.
 pub fn validate_compact_projection(root: &Value) -> Result<(), String> {
-    if root.get("kind") == Some(&json!("budget_exceeded")) {
-        for forbidden in ["identities", "spec", "clauses", "steps", "receipts"] {
-            if root.get(forbidden).is_some() {
-                return Err(format!("budget_fallback_contains_{forbidden}"));
-            }
-        }
-        return Ok(());
+    let root_object = compact_object(root, "compact_root_invalid")?;
+    let kind = compact_string(root_object, "kind", "compact_root_kind_invalid")?;
+    if kind == "budget_exceeded" {
+        return validate_budget_projection(root_object);
     }
-    if root.get("kind") != Some(&json!("complete")) {
+    if kind != "complete" {
         return Err("compact_root_kind_invalid".to_owned());
     }
-    let identities = root
-        .get("identities")
-        .and_then(Value::as_object)
-        .ok_or_else(|| "compact_identities_missing".to_owned())?;
+    compact_closed_object(
+        root_object,
+        &[
+            "kind",
+            "schema_version",
+            "domain",
+            "contract_interpretation",
+            "guard_version",
+            "source_text_sha256",
+            "contract_digest",
+            "core_publication",
+            "identities",
+            "spec",
+            "clauses",
+            "disposition",
+            "steps",
+            "receipts",
+        ],
+        "compact_complete_shape_invalid",
+    )?;
+    validate_common_projection_fields(root_object)?;
+    let identities = compact_object_field(root_object, "identities", "compact_identities_missing")?;
+    compact_closed_object(
+        identities,
+        &["files", "symbols", "evidence"],
+        "compact_identities_shape_invalid",
+    )?;
     let files = compact_array(identities.get("files"), "compact_files_missing")?;
     let symbols = compact_array(identities.get("symbols"), "compact_symbols_missing")?;
     let evidence = compact_array(identities.get("evidence"), "compact_evidence_missing")?;
-    let receipts = compact_array(root.get("receipts"), "compact_receipts_missing")?;
+    let receipts = compact_array(root_object.get("receipts"), "compact_receipts_missing")?;
+    let spec = compact_object_field(root_object, "spec", "compact_spec_missing")?;
+    let spec_steps = compact_array(spec.get("steps"), "compact_spec_steps_missing")?;
+    let steps = compact_array(root_object.get("steps"), "compact_steps_missing")?;
+    if steps.len() != spec_steps.len() {
+        return Err("compact_step_count_mismatch".to_owned());
+    }
 
+    let mut file_ids = BTreeSet::new();
+    let mut file_paths = BTreeSet::new();
+    for file in files {
+        let file = compact_object(file, "compact_file_row_invalid")?;
+        compact_closed_object(
+            file,
+            &[
+                "file_node_id",
+                "project_file_components",
+                "indexed_sha256",
+                "observed_sha256",
+            ],
+            "compact_file_shape_invalid",
+        )?;
+        let id = compact_i64(file, "file_node_id", "compact_file_id_invalid")?;
+        let indexed = compact_hash(file, "indexed_sha256", "compact_file_hash_invalid")?;
+        if !file_ids.insert(id) {
+            return Err("compact_file_id_duplicate".to_owned());
+        }
+        if let Some(path) = compact_optional_path(file, "project_file_components")?
+            && !file_paths.insert(path)
+        {
+            return Err("compact_file_path_duplicate".to_owned());
+        }
+        if let Some(observed) = file.get("observed_sha256").filter(|value| !value.is_null())
+            && (observed.as_str() != Some(indexed) || !is_lower_hex_sha256(indexed))
+        {
+            return Err("compact_file_observed_hash_invalid".to_owned());
+        }
+    }
+
+    let mut symbol_ids = BTreeSet::new();
     for symbol in symbols {
+        let symbol = compact_object(symbol, "compact_symbol_row_invalid")?;
+        compact_closed_object(
+            symbol,
+            &["node_id", "canonical_id", "qualified_name", "file"],
+            "compact_symbol_shape_invalid",
+        )?;
+        let node_id = compact_string(symbol, "node_id", "compact_symbol_id_invalid")?;
+        if node_id.is_empty() || !symbol_ids.insert(node_id) {
+            return Err("compact_symbol_id_duplicate".to_owned());
+        }
         if let Some(file) = symbol.get("file").filter(|file| !file.is_null()) {
             compact_index(file, files.len(), "compact_symbol_file_reference_invalid")?;
         }
     }
+    let mut fact_ids = BTreeSet::new();
     for evidence_row in evidence {
+        let evidence_row = compact_object(evidence_row, "compact_evidence_row_invalid")?;
+        compact_closed_object(
+            evidence_row,
+            &[
+                "fact_id",
+                "caller",
+                "target",
+                "edge_id",
+                "callsite_identity",
+                "chain",
+                "provenance",
+            ],
+            "compact_evidence_shape_invalid",
+        )?;
+        let fact_id = compact_hash(evidence_row, "fact_id", "compact_fact_id_invalid")?;
+        if !fact_ids.insert(fact_id) {
+            return Err("compact_fact_id_duplicate".to_owned());
+        }
         compact_index(
             evidence_row.get("caller").unwrap_or(&Value::Null),
             symbols.len(),
@@ -2629,11 +2729,62 @@ pub fn validate_compact_projection(root: &Value) -> Result<(), String> {
             symbols.len(),
             "compact_evidence_target_reference_invalid",
         )?;
+        compact_full_symbol(
+            symbols,
+            compact_index(
+                evidence_row.get("caller").unwrap_or(&Value::Null),
+                symbols.len(),
+                "compact_evidence_caller_reference_invalid",
+            )?,
+            files.len(),
+        )?;
+        compact_full_symbol(
+            symbols,
+            compact_index(
+                evidence_row.get("target").unwrap_or(&Value::Null),
+                symbols.len(),
+                "compact_evidence_target_reference_invalid",
+            )?,
+            files.len(),
+        )?;
+        if compact_string(evidence_row, "edge_id", "compact_evidence_edge_invalid")?.is_empty()
+            || compact_string(
+                evidence_row,
+                "callsite_identity",
+                "compact_evidence_callsite_invalid",
+            )?
+            .is_empty()
+        {
+            return Err("compact_evidence_key_invalid".to_owned());
+        }
         for chain in compact_array(evidence_row.get("chain"), "compact_evidence_chain_missing")? {
-            for symbol in compact_array(
+            let chain = compact_object(chain, "compact_evidence_chain_invalid")?;
+            compact_closed_object(
+                chain,
+                &["kind", "symbols"],
+                "compact_evidence_chain_shape_invalid",
+            )?;
+            let kind = compact_string(chain, "kind", "compact_evidence_kind_invalid")?;
+            let chain_symbols = compact_array(
                 chain.get("symbols"),
                 "compact_evidence_chain_symbols_missing",
-            )? {
+            )?;
+            let expected = match kind {
+                "same_file_declaration"
+                | "same_package_declaration"
+                | "explicit_receiver_type"
+                | "constructor_binding"
+                | "implicit_receiver" => Some(1),
+                "static_import_binding" => Some(2),
+                "qualified_path" => None,
+                _ => return Err("compact_evidence_kind_invalid".to_owned()),
+            };
+            if expected.is_some_and(|expected| chain_symbols.len() != expected)
+                || kind == "qualified_path" && chain_symbols.is_empty()
+            {
+                return Err("compact_evidence_chain_arity_invalid".to_owned());
+            }
+            for symbol in chain_symbols {
                 compact_index(
                     symbol,
                     symbols.len(),
@@ -2641,22 +2792,106 @@ pub fn validate_compact_projection(root: &Value) -> Result<(), String> {
                 )?;
             }
         }
-        let provenance = evidence_row
-            .get("provenance")
-            .and_then(Value::as_object)
-            .ok_or_else(|| "compact_evidence_provenance_missing".to_owned())?;
-        for file in compact_array(
+        let provenance = compact_object_field(
+            evidence_row,
+            "provenance",
+            "compact_evidence_provenance_missing",
+        )?;
+        compact_closed_object(
+            provenance,
+            &[
+                "producer",
+                "fact_schema_version",
+                "algorithm",
+                "language_adapter",
+                "language_adapter_version",
+                "parser_fingerprint",
+                "dependency_files",
+                "evidence_sha256",
+            ],
+            "compact_provenance_shape_invalid",
+        )?;
+        if compact_string(provenance, "producer", "compact_provenance_invalid")?
+            != INTERNAL_RESOLUTION_PRODUCER
+            || compact_u64(
+                provenance,
+                "fact_schema_version",
+                "compact_provenance_invalid",
+            )? != u64::from(PROOF_RESOLUTION_FACT_SCHEMA_VERSION)
+            || compact_string(provenance, "algorithm", "compact_provenance_invalid")?
+                != EXACT_CALL_RESOLUTION_ALGORITHM
+            || compact_string(provenance, "language_adapter", "compact_provenance_invalid")?
+                .is_empty()
+            || compact_string(
+                provenance,
+                "language_adapter_version",
+                "compact_provenance_invalid",
+            )?
+            .is_empty()
+        {
+            return Err("compact_provenance_invalid".to_owned());
+        }
+        compact_hash(
+            provenance,
+            "parser_fingerprint",
+            "compact_provenance_invalid",
+        )?;
+        compact_hash(provenance, "evidence_sha256", "compact_provenance_invalid")?;
+        let dependencies = compact_array(
             provenance.get("dependency_files"),
             "compact_dependency_files_missing",
-        )? {
-            compact_index(
+        )?;
+        if dependencies.is_empty() {
+            return Err("compact_dependency_files_missing".to_owned());
+        }
+        let mut prior_file_id = None;
+        for file in dependencies {
+            let index = compact_index(
                 file,
                 files.len(),
                 "compact_dependency_file_reference_invalid",
             )?;
+            let file_id = compact_i64(
+                compact_object(&files[index], "compact_file_row_invalid")?,
+                "file_node_id",
+                "compact_file_id_invalid",
+            )?;
+            if prior_file_id.is_some_and(|prior| prior >= file_id) {
+                return Err("compact_dependency_files_noncanonical".to_owned());
+            }
+            prior_file_id = Some(file_id);
         }
     }
+    let mut receipt_ids = BTreeSet::new();
+    let mut edge_ids = BTreeSet::new();
+    let mut evidence_indices = BTreeSet::new();
+    let mut source_files = BTreeSet::new();
     for receipt in receipts {
+        let receipt = compact_object(receipt, "compact_receipt_row_invalid")?;
+        compact_closed_object(
+            receipt,
+            &[
+                "receipt_id",
+                "edge_id",
+                "source",
+                "target",
+                "evidence",
+                "exact_callsite_start_byte",
+                "callsite_identity",
+                "column_or_ordinal",
+                "containment",
+                "line_window",
+            ],
+            "compact_receipt_shape_invalid",
+        )?;
+        let receipt_id = compact_string(receipt, "receipt_id", "compact_receipt_id_invalid")?;
+        let edge_id = compact_string(receipt, "edge_id", "compact_receipt_edge_invalid")?;
+        if receipt_id.is_empty() || !receipt_ids.insert(receipt_id) {
+            return Err("compact_receipt_id_duplicate".to_owned());
+        }
+        if edge_id.is_empty() || !edge_ids.insert(edge_id) {
+            return Err("compact_receipt_edge_duplicate".to_owned());
+        }
         let source = compact_index(
             receipt.get("source").unwrap_or(&Value::Null),
             symbols.len(),
@@ -2672,7 +2907,15 @@ pub fn validate_compact_projection(root: &Value) -> Result<(), String> {
             evidence.len(),
             "compact_receipt_evidence_reference_invalid",
         )?;
-        let evidence_row = &evidence[evidence_index];
+        if !evidence_indices.insert(evidence_index) {
+            return Err("compact_receipt_evidence_duplicate".to_owned());
+        }
+        let evidence_row = compact_object(
+            evidence
+                .get(evidence_index)
+                .expect("bounded evidence index"),
+            "compact_evidence_row_invalid",
+        )?;
         if compact_index(
             evidence_row.get("caller").unwrap_or(&Value::Null),
             symbols.len(),
@@ -2683,63 +2926,95 @@ pub fn validate_compact_projection(root: &Value) -> Result<(), String> {
                 symbols.len(),
                 "compact_evidence_target_reference_invalid",
             )? != target
+            || compact_string(evidence_row, "edge_id", "compact_evidence_edge_invalid")? != edge_id
+            || compact_string(
+                evidence_row,
+                "callsite_identity",
+                "compact_evidence_callsite_invalid",
+            )? != compact_string(
+                receipt,
+                "callsite_identity",
+                "compact_receipt_callsite_invalid",
+            )?
         {
-            return Err("compact_receipt_evidence_endpoint_mismatch".to_owned());
+            return Err("compact_receipt_evidence_correlation_invalid".to_owned());
         }
-        let containment = receipt
-            .get("containment")
-            .and_then(Value::as_object)
-            .ok_or_else(|| "compact_receipt_containment_missing".to_owned())?;
-        let line_window = receipt
-            .get("line_window")
-            .and_then(Value::as_object)
-            .ok_or_else(|| "compact_receipt_line_window_missing".to_owned())?;
+        let containment = compact_object_field(
+            receipt,
+            "containment",
+            "compact_receipt_containment_missing",
+        )?;
+        compact_closed_object(
+            containment,
+            &["file", "owner", "start_line", "end_line"],
+            "compact_containment_shape_invalid",
+        )?;
+        let line_window = compact_object_field(
+            receipt,
+            "line_window",
+            "compact_receipt_line_window_missing",
+        )?;
+        compact_closed_object(
+            line_window,
+            &[
+                "kind",
+                "file",
+                "anchor_line",
+                "byte_start",
+                "byte_end",
+                "text",
+            ],
+            "compact_line_window_shape_invalid",
+        )?;
         let containment_file = compact_index(
             containment.get("file").unwrap_or(&Value::Null),
             files.len(),
             "compact_containment_file_reference_invalid",
         )?;
-        compact_index(
+        if compact_index(
             containment.get("owner").unwrap_or(&Value::Null),
             symbols.len(),
             "compact_containment_owner_reference_invalid",
-        )?;
+        )? != source
+        {
+            return Err("compact_receipt_containment_correlation_invalid".to_owned());
+        }
         let line_file = compact_index(
             line_window.get("file").unwrap_or(&Value::Null),
             files.len(),
             "compact_line_window_file_reference_invalid",
         )?;
-        let source_file = symbols[source]
-            .get("file")
-            .ok_or_else(|| "compact_source_file_missing".to_owned())?;
-        if compact_index(
-            source_file,
-            files.len(),
-            "compact_symbol_file_reference_invalid",
-        )? != containment_file
-            || containment_file != line_file
-        {
+        let source_file = compact_full_symbol(symbols, source, files.len())?;
+        compact_full_symbol(symbols, target, files.len())?;
+        if source_file != containment_file || containment_file != line_file {
             return Err("compact_receipt_file_reference_mismatch".to_owned());
         }
+        source_files.insert(source_file);
+        validate_compact_line_window(line_window, files, containment_file, containment, receipt)?;
     }
-    for step in compact_array(root.get("steps"), "compact_steps_missing")? {
-        if let Some(receipt) = step.get("receipt").filter(|value| !value.is_null()) {
-            compact_index(
-                receipt,
-                receipts.len(),
-                "compact_step_receipt_reference_invalid",
-            )?;
-        }
-        if step.get("target").is_some() {
-            return Err("compact_step_repeats_target".to_owned());
+    if evidence_indices.len() != evidence.len() {
+        return Err("compact_evidence_unreferenced".to_owned());
+    }
+    for (index, file) in files.iter().enumerate() {
+        if compact_object(file, "compact_file_row_invalid")?
+            .get("observed_sha256")
+            .is_some_and(|value| !value.is_null())
+            && !source_files.contains(&index)
+        {
+            return Err("compact_observed_hash_not_callsite_source".to_owned());
         }
     }
-    let disposition = root
-        .get("disposition")
-        .and_then(Value::as_object)
-        .ok_or_else(|| "compact_disposition_missing".to_owned())?;
-    validate_disposition_receipts(disposition, receipts.len())?;
-    Ok(())
+    let step_rows = validate_compact_steps(steps, spec_steps.len(), receipts.len())?;
+    validate_disposition_receipts(
+        compact_object_field(root_object, "disposition", "compact_disposition_missing")?,
+        compact_string(
+            root_object,
+            "contract_digest",
+            "compact_contract_digest_invalid",
+        )?,
+        &step_rows,
+        receipts,
+    )
 }
 
 fn compact_array<'a>(value: Option<&'a Value>, code: &str) -> Result<&'a Vec<Value>, String> {
@@ -2756,81 +3031,564 @@ fn compact_index(value: &Value, length: usize, code: &str) -> Result<usize, Stri
         .ok_or_else(|| code.to_owned())
 }
 
+fn compact_object<'a>(
+    value: &'a Value,
+    code: &str,
+) -> Result<&'a serde_json::Map<String, Value>, String> {
+    value.as_object().ok_or_else(|| code.to_owned())
+}
+
+fn compact_object_field<'a>(
+    object: &'a serde_json::Map<String, Value>,
+    field: &str,
+    code: &str,
+) -> Result<&'a serde_json::Map<String, Value>, String> {
+    object
+        .get(field)
+        .and_then(Value::as_object)
+        .ok_or_else(|| code.to_owned())
+}
+
+fn compact_closed_object(
+    object: &serde_json::Map<String, Value>,
+    fields: &[&str],
+    code: &str,
+) -> Result<(), String> {
+    if object.len() != fields.len()
+        || fields.iter().any(|field| !object.contains_key(*field))
+        || object.keys().any(|field| !fields.contains(&field.as_str()))
+    {
+        return Err(code.to_owned());
+    }
+    Ok(())
+}
+
+fn compact_string<'a>(
+    object: &'a serde_json::Map<String, Value>,
+    field: &str,
+    code: &str,
+) -> Result<&'a str, String> {
+    object
+        .get(field)
+        .and_then(Value::as_str)
+        .ok_or_else(|| code.to_owned())
+}
+
+fn compact_u64(
+    object: &serde_json::Map<String, Value>,
+    field: &str,
+    code: &str,
+) -> Result<u64, String> {
+    object
+        .get(field)
+        .and_then(Value::as_u64)
+        .ok_or_else(|| code.to_owned())
+}
+
+fn compact_i64(
+    object: &serde_json::Map<String, Value>,
+    field: &str,
+    code: &str,
+) -> Result<i64, String> {
+    compact_string(object, field, code)?
+        .parse::<i64>()
+        .ok()
+        .filter(|value| *value != 0)
+        .ok_or_else(|| code.to_owned())
+}
+
+fn compact_hash<'a>(
+    object: &'a serde_json::Map<String, Value>,
+    field: &str,
+    code: &str,
+) -> Result<&'a str, String> {
+    let value = compact_string(object, field, code)?;
+    is_lower_hex_sha256(value)
+        .then_some(value)
+        .ok_or_else(|| code.to_owned())
+}
+
+fn compact_optional_path(
+    object: &serde_json::Map<String, Value>,
+    field: &str,
+) -> Result<Option<Vec<String>>, String> {
+    let Some(value) = object.get(field) else {
+        return Err("compact_file_path_invalid".to_owned());
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    let path = value
+        .as_array()
+        .filter(|path| !path.is_empty())
+        .and_then(|path| {
+            path.iter()
+                .map(Value::as_str)
+                .map(|part| part.filter(|part| !part.is_empty()).map(ToOwned::to_owned))
+                .collect::<Option<Vec<_>>>()
+        })
+        .ok_or_else(|| "compact_file_path_invalid".to_owned())?;
+    Ok(Some(path))
+}
+
+fn validate_common_projection_fields(root: &serde_json::Map<String, Value>) -> Result<(), String> {
+    if compact_u64(root, "schema_version", "compact_schema_version_invalid")? != 1
+        || compact_string(root, "domain", "compact_domain_invalid")? != PROOF_DOMAIN
+        || compact_string(
+            root,
+            "contract_interpretation",
+            "compact_interpretation_invalid",
+        )? != "host_supplied"
+        || compact_string(root, "guard_version", "compact_guard_version_invalid")?
+            != CLAUSE_GUARD_VERSION
+    {
+        return Err("compact_common_fields_invalid".to_owned());
+    }
+    compact_hash(root, "source_text_sha256", "compact_source_hash_invalid")?;
+    compact_hash(root, "contract_digest", "compact_contract_digest_invalid")?;
+    let publication =
+        compact_object_field(root, "core_publication", "compact_publication_missing")?;
+    compact_closed_object(
+        publication,
+        &["project_id", "generation_id", "run_id"],
+        "compact_publication_shape_invalid",
+    )?;
+    for field in ["project_id", "generation_id", "run_id"] {
+        if compact_string(publication, field, "compact_publication_invalid")?.is_empty() {
+            return Err("compact_publication_invalid".to_owned());
+        }
+    }
+    Ok(())
+}
+
+fn validate_budget_projection(root: &serde_json::Map<String, Value>) -> Result<(), String> {
+    compact_closed_object(
+        root,
+        &[
+            "kind",
+            "schema_version",
+            "domain",
+            "contract_interpretation",
+            "guard_version",
+            "source_text_sha256",
+            "contract_digest",
+            "core_publication",
+            "disposition",
+            "cap_bytes",
+            "required_complete_size",
+        ],
+        "compact_budget_shape_invalid",
+    )?;
+    validate_common_projection_fields(root)?;
+    if compact_u64(root, "cap_bytes", "compact_budget_cap_invalid")? == 0
+        || compact_u64(
+            root,
+            "required_complete_size",
+            "compact_budget_required_size_invalid",
+        )? == 0
+    {
+        return Err("compact_budget_size_invalid".to_owned());
+    }
+    let disposition = compact_object_field(root, "disposition", "compact_disposition_missing")?;
+    compact_closed_object(
+        disposition,
+        &["kind", "contract_digest", "gaps"],
+        "compact_budget_disposition_shape_invalid",
+    )?;
+    if compact_string(disposition, "kind", "compact_disposition_kind_invalid")? != "unknown"
+        || compact_string(
+            disposition,
+            "contract_digest",
+            "compact_disposition_digest_invalid",
+        )? != compact_string(root, "contract_digest", "compact_contract_digest_invalid")?
+        || compact_array(disposition.get("gaps"), "compact_budget_gaps_missing")?.as_slice()
+            != [json!({"kind":"output_budget_exceeded"})]
+    {
+        return Err("compact_budget_disposition_invalid".to_owned());
+    }
+    Ok(())
+}
+
+fn compact_full_symbol(
+    symbols: &[Value],
+    index: usize,
+    file_count: usize,
+) -> Result<usize, String> {
+    let symbol = compact_object(
+        symbols
+            .get(index)
+            .ok_or_else(|| "compact_symbol_reference_invalid".to_owned())?,
+        "compact_symbol_row_invalid",
+    )?;
+    if compact_string(symbol, "canonical_id", "compact_symbol_not_full")?.is_empty()
+        || compact_string(symbol, "qualified_name", "compact_symbol_not_full")?.is_empty()
+    {
+        return Err("compact_symbol_not_full".to_owned());
+    }
+    compact_index(
+        symbol.get("file").unwrap_or(&Value::Null),
+        file_count,
+        "compact_symbol_not_full",
+    )
+}
+
+fn validate_compact_line_window(
+    line: &serde_json::Map<String, Value>,
+    files: &[Value],
+    file: usize,
+    containment: &serde_json::Map<String, Value>,
+    receipt: &serde_json::Map<String, Value>,
+) -> Result<(), String> {
+    if compact_string(line, "kind", "compact_line_window_invalid")? != "indexed_line_v1" {
+        return Err("compact_line_window_invalid".to_owned());
+    }
+    if compact_index(
+        line.get("file").unwrap_or(&Value::Null),
+        files.len(),
+        "compact_line_window_file_reference_invalid",
+    )? != file
+    {
+        return Err("compact_line_window_file_mismatch".to_owned());
+    }
+    let anchor_line = compact_u64(line, "anchor_line", "compact_line_window_invalid")?;
+    let byte_start = compact_u64(line, "byte_start", "compact_line_window_invalid")?;
+    let byte_end = compact_u64(line, "byte_end", "compact_line_window_invalid")?;
+    let text = compact_string(line, "text", "compact_line_window_invalid")?;
+    if byte_end < byte_start
+        || byte_end - byte_start != u64::try_from(text.len()).unwrap_or(u64::MAX)
+        || anchor_line < compact_u64(containment, "start_line", "compact_containment_invalid")?
+        || anchor_line > compact_u64(containment, "end_line", "compact_containment_invalid")?
+    {
+        return Err("compact_line_window_invalid".to_owned());
+    }
+    let callsite = compact_string(
+        receipt,
+        "callsite_identity",
+        "compact_receipt_callsite_invalid",
+    )?;
+    let parts = callsite
+        .split('|')
+        .next()
+        .map(|prefix| prefix.split(':').collect::<Vec<_>>())
+        .filter(|parts| parts.len() == 4)
+        .ok_or_else(|| "compact_receipt_callsite_invalid".to_owned())?;
+    let expected_file = compact_i64(
+        compact_object(&files[file], "compact_file_row_invalid")?,
+        "file_node_id",
+        "compact_file_id_invalid",
+    )?;
+    let callsite_file = parts[0]
+        .parse::<i64>()
+        .ok()
+        .ok_or_else(|| "compact_receipt_callsite_invalid".to_owned())?;
+    let callsite_line = parts[1]
+        .parse::<u64>()
+        .ok()
+        .ok_or_else(|| "compact_receipt_callsite_invalid".to_owned())?;
+    parts[2]
+        .parse::<u64>()
+        .ok()
+        .ok_or_else(|| "compact_receipt_callsite_invalid".to_owned())?;
+    let exact_start = compact_u64(
+        receipt,
+        "exact_callsite_start_byte",
+        "compact_receipt_start_invalid",
+    )?;
+    if callsite_file != expected_file
+        || callsite_line != anchor_line
+        || parts[3].is_empty()
+        || exact_start < byte_start
+        || exact_start >= byte_end
+    {
+        return Err("compact_receipt_callsite_correlation_invalid".to_owned());
+    }
+    Ok(())
+}
+
+fn validate_compact_steps(
+    steps: &[Value],
+    expected_count: usize,
+    receipt_count: usize,
+) -> Result<Vec<(String, Option<usize>)>, String> {
+    if steps.is_empty() || steps.len() != expected_count || steps.len() > MAX_STEPS {
+        return Err("compact_step_count_mismatch".to_owned());
+    }
+    steps
+        .iter()
+        .enumerate()
+        .map(|(index, step)| {
+            let step = compact_object(step, "compact_step_row_invalid")?;
+            compact_closed_object(
+                step,
+                &["step_index", "status", "receipt"],
+                "compact_step_shape_invalid",
+            )?;
+            if compact_u64(step, "step_index", "compact_step_index_invalid")?
+                != u64::try_from(index).unwrap()
+            {
+                return Err("compact_step_index_invalid".to_owned());
+            }
+            let status = compact_string(step, "status", "compact_step_status_invalid")?;
+            if !matches!(
+                status,
+                "proven"
+                    | "positive_contradiction"
+                    | "certified_absence"
+                    | "unavailable"
+                    | "unknown"
+            ) {
+                return Err("compact_step_status_invalid".to_owned());
+            }
+            let receipt = step
+                .get("receipt")
+                .filter(|value| !value.is_null())
+                .map(|receipt| {
+                    compact_index(
+                        receipt,
+                        receipt_count,
+                        "compact_step_receipt_reference_invalid",
+                    )
+                })
+                .transpose()?;
+            Ok((status.to_owned(), receipt))
+        })
+        .collect()
+}
+
 fn validate_disposition_receipts(
     disposition: &serde_json::Map<String, Value>,
-    receipt_count: usize,
+    contract_digest: &str,
+    steps: &[(String, Option<usize>)],
+    receipts: &[Value],
 ) -> Result<(), String> {
-    let validate = |value: Option<&Value>| -> Result<(), String> {
-        for receipt in compact_array(value, "compact_disposition_receipts_missing")? {
-            compact_index(
-                receipt,
-                receipt_count,
-                "compact_disposition_receipt_reference_invalid",
+    if compact_string(
+        disposition,
+        "contract_digest",
+        "compact_disposition_digest_invalid",
+    )? != contract_digest
+    {
+        return Err("compact_disposition_digest_invalid".to_owned());
+    }
+    match compact_string(disposition, "kind", "compact_disposition_kind_invalid")? {
+        "contract_proven" => {
+            compact_closed_object(
+                disposition,
+                &["kind", "contract_digest", "receipts"],
+                "compact_disposition_shape_invalid",
             )?;
+            let sequence = compact_receipt_sequence(disposition.get("receipts"), receipts)?;
+            if sequence.len() != steps.len()
+                || !steps
+                    .iter()
+                    .zip(&sequence)
+                    .all(|((status, receipt), index)| {
+                        status == "proven" && *receipt == Some(*index)
+                    })
+            {
+                return Err("compact_proven_step_sequence_invalid".to_owned());
+            }
+            validate_receipt_sequence(&sequence, receipts)
         }
-        Ok(())
-    };
-    match disposition.get("kind").and_then(Value::as_str) {
-        Some("contract_proven") => validate(disposition.get("receipts")),
-        Some("unknown") => validate(disposition.get("connected_receipts")),
-        Some("contract_refuted") => validate(
-            disposition
-                .get("refutation")
-                .and_then(Value::as_object)
-                .and_then(|refutation| refutation.get("connected_receipts")),
-        ),
-        Some("unavailable") => Ok(()),
+        "unknown" => {
+            compact_closed_object(
+                disposition,
+                &["kind", "contract_digest", "gaps", "connected_receipts"],
+                "compact_disposition_shape_invalid",
+            )?;
+            compact_array(disposition.get("gaps"), "compact_disposition_gaps_missing")?;
+            let sequence =
+                compact_receipt_sequence(disposition.get("connected_receipts"), receipts)?;
+            validate_prefix_steps(steps, &sequence, "unknown", None)?;
+            validate_receipt_sequence(&sequence, receipts)
+        }
+        "contract_refuted" => {
+            compact_closed_object(
+                disposition,
+                &["kind", "contract_digest", "refutation"],
+                "compact_disposition_shape_invalid",
+            )?;
+            let refutation =
+                compact_object_field(disposition, "refutation", "compact_refutation_missing")?;
+            let step_index = usize::try_from(compact_u64(
+                refutation,
+                "step_index",
+                "compact_refutation_step_invalid",
+            )?)
+            .ok()
+            .filter(|index| *index < steps.len())
+            .ok_or_else(|| "compact_refutation_step_invalid".to_owned())?;
+            match compact_string(refutation, "kind", "compact_refutation_kind_invalid")? {
+                "prohibited_scope_traversal" => {
+                    compact_closed_object(
+                        refutation,
+                        &[
+                            "kind",
+                            "step_index",
+                            "prohibition_index",
+                            "connected_receipts",
+                        ],
+                        "compact_refutation_shape_invalid",
+                    )?;
+                    compact_u64(
+                        refutation,
+                        "prohibition_index",
+                        "compact_refutation_invalid",
+                    )?;
+                    let sequence =
+                        compact_receipt_sequence(refutation.get("connected_receipts"), receipts)?;
+                    if sequence.len() != step_index + 1 {
+                        return Err("compact_refutation_sequence_invalid".to_owned());
+                    }
+                    validate_prefix_steps(
+                        steps,
+                        &sequence,
+                        "unknown",
+                        Some((step_index, "positive_contradiction")),
+                    )?;
+                    validate_receipt_sequence(&sequence, receipts)
+                }
+                "certified_absence" => {
+                    compact_closed_object(
+                        refutation,
+                        &[
+                            "kind",
+                            "step_index",
+                            "extractor_capability_receipt_id",
+                            "untruncated_enumeration_receipt_id",
+                            "connected_receipts",
+                        ],
+                        "compact_refutation_shape_invalid",
+                    )?;
+                    for field in [
+                        "extractor_capability_receipt_id",
+                        "untruncated_enumeration_receipt_id",
+                    ] {
+                        if compact_string(refutation, field, "compact_refutation_invalid")?
+                            .is_empty()
+                        {
+                            return Err("compact_refutation_invalid".to_owned());
+                        }
+                    }
+                    let sequence =
+                        compact_receipt_sequence(refutation.get("connected_receipts"), receipts)?;
+                    if sequence.len() != step_index {
+                        return Err("compact_refutation_sequence_invalid".to_owned());
+                    }
+                    validate_prefix_steps(
+                        steps,
+                        &sequence,
+                        "unknown",
+                        Some((step_index, "certified_absence")),
+                    )?;
+                    validate_receipt_sequence(&sequence, receipts)
+                }
+                _ => Err("compact_refutation_kind_invalid".to_owned()),
+            }
+        }
+        "unavailable" => {
+            compact_closed_object(
+                disposition,
+                &["kind", "contract_digest", "reasons"],
+                "compact_disposition_shape_invalid",
+            )?;
+            let reasons = compact_array(
+                disposition.get("reasons"),
+                "compact_unavailable_reasons_missing",
+            )?;
+            if reasons.is_empty() || reasons.iter().any(|reason| !reason.is_string()) {
+                return Err("compact_unavailable_reasons_invalid".to_owned());
+            }
+            if steps
+                .iter()
+                .any(|(status, receipt)| status != "unavailable" || receipt.is_some())
+            {
+                return Err("compact_unavailable_step_sequence_invalid".to_owned());
+            }
+            Ok(())
+        }
         _ => Err("compact_disposition_kind_invalid".to_owned()),
     }
+}
+
+fn compact_receipt_sequence(
+    value: Option<&Value>,
+    receipts: &[Value],
+) -> Result<Vec<usize>, String> {
+    let sequence = compact_array(value, "compact_disposition_receipts_missing")?
+        .iter()
+        .map(|receipt| {
+            compact_index(
+                receipt,
+                receipts.len(),
+                "compact_disposition_receipt_reference_invalid",
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    if sequence.iter().collect::<BTreeSet<_>>().len() != sequence.len() {
+        return Err("compact_disposition_receipts_duplicate".to_owned());
+    }
+    Ok(sequence)
+}
+
+fn validate_prefix_steps(
+    steps: &[(String, Option<usize>)],
+    sequence: &[usize],
+    trailing: &str,
+    terminal: Option<(usize, &str)>,
+) -> Result<(), String> {
+    let terminal_index = terminal.map(|(index, _)| index).unwrap_or(sequence.len());
+    if sequence.len() > steps.len()
+        || terminal_index >= steps.len()
+        || !steps
+            .iter()
+            .take(terminal_index)
+            .zip(sequence.iter().take(terminal_index))
+            .all(|((status, receipt), index)| status == "proven" && *receipt == Some(*index))
+    {
+        return Err("compact_prefix_step_sequence_invalid".to_owned());
+    }
+    if let Some((index, status)) = terminal
+        && (steps[index].0 != status
+            || steps[index].1
+                != if status == "certified_absence" {
+                    None
+                } else {
+                    sequence.last().copied()
+                })
+    {
+        return Err("compact_refutation_step_sequence_invalid".to_owned());
+    }
+    let suffix = terminal
+        .map(|(index, _)| index + 1)
+        .unwrap_or(sequence.len());
+    if steps
+        .iter()
+        .skip(suffix)
+        .any(|(status, receipt)| status != trailing || receipt.is_some())
+    {
+        return Err("compact_prefix_step_sequence_invalid".to_owned());
+    }
+    Ok(())
+}
+
+fn validate_receipt_sequence(sequence: &[usize], receipts: &[Value]) -> Result<(), String> {
+    for pair in sequence.windows(2) {
+        let left = compact_object(&receipts[pair[0]], "compact_receipt_row_invalid")?;
+        let right = compact_object(&receipts[pair[1]], "compact_receipt_row_invalid")?;
+        if left.get("target") != right.get("source") {
+            return Err("compact_receipt_sequence_disconnected".to_owned());
+        }
+    }
+    Ok(())
 }
 
 pub fn project_internal_call_path_result(
     integration: &CheckedBuiltCallPathIntegration,
 ) -> Result<InternalProjection, InternalProjectionError> {
-    project_internal_call_path_result_with_cap(integration, INTERNAL_PROOF_CAP_BYTES)
-}
-
-fn project_internal_call_path_result_with_cap(
-    integration: &CheckedBuiltCallPathIntegration,
-    cap_bytes: usize,
-) -> Result<InternalProjection, InternalProjectionError> {
     let complete = complete_projection_json(integration)?;
-    let required_complete_size = serialized_json_size(&complete)?;
-    if required_complete_size <= cap_bytes {
-        return Ok(InternalProjection::Complete {
-            root: complete,
-            serialized_size: required_complete_size,
-        });
-    }
-
-    let fallback = json!({
-        "kind": "budget_exceeded",
-        "schema_version": PROOF_CONTRACT_SCHEMA_VERSION,
-        "domain": PROOF_DOMAIN,
-        "contract_interpretation": "host_supplied",
-        "guard_version": CLAUSE_GUARD_VERSION,
-        "source_text_sha256": integration.hashes.source_text_sha256,
-        "contract_digest": integration.hashes.contract_digest,
-        "core_publication": publication_json(&integration.built.publication),
-        "disposition": {
-            "kind": "unknown",
-            "contract_digest": integration.hashes.contract_digest,
-            "gaps": [{ "kind": "output_budget_exceeded" }],
-        },
-        "cap_bytes": cap_bytes,
-        "required_complete_size": required_complete_size,
-    });
-    let fallback_size = serialized_json_size(&fallback)?;
-    if fallback_size > cap_bytes {
-        return Err(InternalProjectionError::FallbackExceedsCap {
-            cap_bytes,
-            serialized_size: fallback_size,
-        });
-    }
-    Ok(InternalProjection::BudgetExceeded {
-        root: fallback,
-        required_complete_size,
-        serialized_size: fallback_size,
+    Ok(InternalProjection::Complete {
+        serialized_size: serialized_json_size(&complete)?,
+        root: complete,
     })
 }
 
@@ -3130,8 +3888,6 @@ mod tests {
     use codestory_contracts::graph::{Edge, EdgeId, EdgeKind, NodeId};
     use codestory_contracts::proof_resolution::{FileId, ResolutionEvidence, ResolutionProvenance};
 
-    const MAX_SOURCE_RECEIPT_LINE_BYTES: usize = 8_192;
-
     fn canonical_selector(name: &str) -> UnvalidatedExactSymbolSelector {
         UnvalidatedExactSymbolSelector::CanonicalId(name.to_owned())
     }
@@ -3216,15 +3972,24 @@ mod tests {
     }
 
     fn node(name: &str) -> ResolvedNodeIdentity {
+        let file_node_id = i64::from(
+            name.bytes()
+                .next()
+                .expect("fixture names are nonempty")
+                .saturating_sub(b'A')
+                + 1,
+        );
+        let node_id = (file_node_id * 10).to_string();
         ResolvedNodeIdentity::new(
             PinnedNodeIdentity {
                 project_id: "project".to_owned(),
                 core_generation_id: "generation".to_owned(),
                 core_run_id: "run".to_owned(),
-                node_id: format!("node-{name}"),
+                node_id: node_id.clone(),
             },
             name,
             format!("crate::{name}"),
+            NodeId(file_node_id),
             vec!["src".to_owned(), format!("{name}.rs")],
         )
         .expect("valid node")
@@ -3257,7 +4022,7 @@ mod tests {
             resolution_fact_id: format!("{:064x}", index + 1),
             resolution_evidence_sha256: format!("{:064x}", index + 2),
             resolution_evidence_chain: vec![ResolutionEvidence::SameFileDeclaration {
-                declaration: NodeId(i64::try_from(index + 2).unwrap()),
+                declaration: NodeId(node(target).pinned.node_id.parse().unwrap()),
             }],
             resolution_provenance: ResolutionProvenance {
                 producer: "codestory-internal".to_owned(),
@@ -3268,18 +4033,27 @@ mod tests {
                 parser_fingerprint: "f".repeat(64),
                 dependency_file_hashes: vec![
                     codestory_contracts::proof_resolution::DependencyFileHash {
-                        file_id: FileId(i64::try_from(index + 1).unwrap()),
+                        file_id: FileId(node(source).file_node_id.0),
                         source_sha256: format!("{:064x}", index + 3),
+                    },
+                    codestory_contracts::proof_resolution::DependencyFileHash {
+                        file_id: FileId(node(target).file_node_id.0),
+                        source_sha256: format!("{:064x}", index + 4),
                     },
                 ],
                 evidence_sha256: format!("{:064x}", index + 2),
             },
             exact_callsite_start_byte: (index * 10) as u64,
-            callsite_identity: format!("{index}:{}:0:{}|rust", index + 1, index + 2),
-            column_or_ordinal: 0,
+            callsite_identity: format!(
+                "{}:{}:1:{}|rust",
+                node(source).file_node_id.0,
+                index + 1,
+                node(target).pinned.node_id
+            ),
+            column_or_ordinal: 1,
             containment: CallableContainmentEvidence {
-                file_node_id: NodeId(i64::try_from(index + 1).unwrap()),
-                owner_node_id: NodeId(i64::try_from(index + 10).unwrap()),
+                file_node_id: node(source).file_node_id,
+                owner_node_id: NodeId(node(source).pinned.node_id.parse().unwrap()),
                 start_line: u32::try_from(index + 1).unwrap(),
                 end_line: u32::try_from(index + 1).unwrap(),
             },
@@ -3798,15 +4572,11 @@ mod tests {
         assert_eq!(texts.len(), 6);
         let names = ["A", "B", "C", "D", "E", "F", "G"];
         let (contract, hashes, rendering) = validate_for_projection(&names[1..]);
-        let mut receipts = texts
+        let receipts = texts
             .into_iter()
             .enumerate()
             .map(|(index, text)| indexed_receipt(index, names[index], names[index + 1], text))
             .collect::<Vec<_>>();
-        for receipt in &mut receipts {
-            receipt.line_window.byte_start = 0;
-            receipt.line_window.byte_end = MAX_SOURCE_RECEIPT_LINE_BYTES;
-        }
         (contract, hashes, rendering, receipts)
     }
 
@@ -3835,7 +4605,7 @@ mod tests {
         assert_eq!(root["contract_interpretation"], "host_supplied");
         assert_eq!(root["guard_version"], "clause_guard_v1");
         assert_eq!(root["identities"]["files"].as_array().unwrap().len(), 2);
-        assert_eq!(root["identities"]["symbols"].as_array().unwrap().len(), 4);
+        assert_eq!(root["identities"]["symbols"].as_array().unwrap().len(), 2);
         assert_eq!(root["identities"]["evidence"].as_array().unwrap().len(), 1);
         assert_eq!(root["receipts"].as_array().unwrap().len(), 1);
         assert_eq!(root["receipts"][0]["source"], 0);
@@ -3864,7 +4634,7 @@ mod tests {
         else {
             panic!("compact projection should fit");
         };
-        assert_eq!(root["identities"]["symbols"].as_array().unwrap().len(), 7);
+        assert_eq!(root["identities"]["symbols"].as_array().unwrap().len(), 3);
         assert_eq!(root["identities"]["evidence"].as_array().unwrap().len(), 2);
         assert_eq!(root["receipts"][0]["source"], 0);
         assert_eq!(root["receipts"][0]["target"], 1);
@@ -3903,7 +4673,7 @@ mod tests {
         swapped["receipts"][0]["target"] = json!(0);
         assert_eq!(
             validate_compact_projection(&swapped),
-            Err("compact_receipt_evidence_endpoint_mismatch".to_owned())
+            Err("compact_receipt_evidence_correlation_invalid".to_owned())
         );
 
         let mut missing_provenance = root;
@@ -3913,7 +4683,7 @@ mod tests {
             .remove("provenance");
         assert_eq!(
             validate_compact_projection(&missing_provenance),
-            Err("compact_evidence_provenance_missing".to_owned())
+            Err("compact_evidence_shape_invalid".to_owned())
         );
 
         let mut invalid_receipt = indexed_receipt(1, "A", "B", "call\n".to_owned());
@@ -3930,140 +4700,149 @@ mod tests {
     }
 
     #[test]
-    fn internal_projection_accepts_exactly_64_kib_and_replaces_64_kib_plus_one_whole() {
-        let (contract, hashes, rendering, mut receipts) =
-            six_step_projection_fixture(vec![String::new(); 6]);
-        let baseline_integration = checked_integration(
+    fn compact_projection_rejects_relational_identity_provenance_and_disposition_mutations() {
+        let (contract, hashes, rendering) = validate_for_projection(&["B", "C"]);
+        let integration = checked_integration(
             &contract,
             &hashes,
             &rendering,
-            built_from_receipts(receipts.clone(), Vec::new(), Vec::new()),
+            built_from_receipts(
+                vec![
+                    indexed_receipt(0, "A", "B", "A calls B();\n".to_owned()),
+                    indexed_receipt(1, "B", "C", "B calls C();\n".to_owned()),
+                ],
+                Vec::new(),
+                Vec::new(),
+            ),
         );
-        let baseline =
-            project_internal_call_path_result_with_cap(&baseline_integration, usize::MAX).unwrap();
-        let InternalProjection::Complete {
-            serialized_size: baseline_size,
-            ..
-        } = baseline
+        let InternalProjection::Complete { root, .. } =
+            project_internal_call_path_result(&integration).unwrap()
         else {
-            panic!("unbounded baseline must be complete")
+            panic!("small checked integration fits")
         };
-        let mut remaining = INTERNAL_PROOF_CAP_BYTES - baseline_size;
-        for receipt in &mut receipts {
-            let quote_count = (remaining / 2).min(MAX_SOURCE_RECEIPT_LINE_BYTES);
-            receipt.line_window.text.push_str(&"\"".repeat(quote_count));
-            remaining -= quote_count * 2;
-            if remaining == 1 && receipt.line_window.text.len() < MAX_SOURCE_RECEIPT_LINE_BYTES {
-                receipt.line_window.text.push('x');
-                remaining = 0;
-            }
-        }
-        assert_eq!(remaining, 0, "six bounded lines can reach the exact cap");
 
-        let exact_integration = checked_integration(
-            &contract,
-            &hashes,
-            &rendering,
-            built_from_receipts(receipts.clone(), Vec::new(), Vec::new()),
-        );
-        let exact = project_internal_call_path_result(&exact_integration).unwrap();
-        assert!(matches!(
-            exact,
-            InternalProjection::Complete {
-                serialized_size: INTERNAL_PROOF_CAP_BYTES,
-                ..
-            }
-        ));
+        let mut mutations = Vec::new();
 
-        receipts
-            .iter_mut()
-            .find(|receipt| receipt.line_window.text.len() < MAX_SOURCE_RECEIPT_LINE_BYTES)
-            .expect("one line retains room for the cap+1 byte")
-            .line_window
-            .text
-            .push('x');
-        let plus_one_integration = checked_integration(
-            &contract,
-            &hashes,
-            &rendering,
-            built_from_receipts(receipts, Vec::new(), Vec::new()),
-        );
-        let plus_one = project_internal_call_path_result(&plus_one_integration).unwrap();
-        let InternalProjection::BudgetExceeded {
-            root,
-            required_complete_size,
-            serialized_size,
-        } = plus_one
-        else {
-            panic!("cap+1 must replace the complete result")
-        };
-        assert_eq!(required_complete_size, INTERNAL_PROOF_CAP_BYTES + 1);
-        assert!(serialized_size < INTERNAL_PROOF_CAP_BYTES);
-        assert_eq!(root["kind"], "budget_exceeded");
-        assert_eq!(root["disposition"]["kind"], "unknown");
-        assert_eq!(
-            root["disposition"]["gaps"],
-            json!([{ "kind": "output_budget_exceeded" }])
-        );
-        for forbidden in ["identities", "spec", "clauses", "steps", "receipts"] {
+        let mut swapped_steps = root.clone();
+        swapped_steps["steps"][0]["receipt"] = json!(1);
+        swapped_steps["steps"][1]["receipt"] = json!(0);
+        mutations.push(swapped_steps);
+
+        let mut wrong_owner = root.clone();
+        wrong_owner["receipts"][0]["containment"]["owner"] = json!(1);
+        mutations.push(wrong_owner);
+
+        let mut duplicate_receipt = root.clone();
+        duplicate_receipt["receipts"][1]["receipt_id"] =
+            duplicate_receipt["receipts"][0]["receipt_id"].clone();
+        mutations.push(duplicate_receipt);
+
+        let mut duplicate_symbol = root.clone();
+        duplicate_symbol["identities"]["symbols"][1]["node_id"] =
+            duplicate_symbol["identities"]["symbols"][0]["node_id"].clone();
+        mutations.push(duplicate_symbol);
+
+        let mut empty_dependencies = root.clone();
+        empty_dependencies["identities"]["evidence"][0]["provenance"]["dependency_files"] =
+            json!([]);
+        mutations.push(empty_dependencies);
+
+        let mut invalid_chain_arity = root.clone();
+        invalid_chain_arity["identities"]["evidence"][0]["chain"][0]["symbols"] = json!([]);
+        mutations.push(invalid_chain_arity);
+
+        let mut swapped_callsite_evidence = root.clone();
+        swapped_callsite_evidence["identities"]["evidence"][0]["callsite_identity"] =
+            json!("different-callsite");
+        mutations.push(swapped_callsite_evidence);
+
+        let mut unknown_prefix = root.clone();
+        unknown_prefix["disposition"] = json!({
+            "kind":"unknown",
+            "contract_digest": hashes.contract_digest(),
+            "gaps": [{"kind":"direct_call_missing","step_index":1}],
+            "connected_receipts":[0]
+        });
+        unknown_prefix["steps"] = json!([
+            {"step_index":0,"status":"proven","receipt":0},
+            {"step_index":1,"status":"unknown","receipt":1}
+        ]);
+        mutations.push(unknown_prefix);
+
+        let mut positive_contradiction = root.clone();
+        positive_contradiction["disposition"] = json!({
+            "kind":"contract_refuted",
+            "contract_digest": hashes.contract_digest(),
+            "refutation": {
+                "kind":"prohibited_scope_traversal",
+                "step_index":1,
+                "prohibition_index":0,
+                "connected_receipts":[0, 1]
+            }
+        });
+        positive_contradiction["steps"] = json!([
+            {"step_index":0,"status":"proven","receipt":0},
+            {"step_index":1,"status":"positive_contradiction","receipt":0}
+        ]);
+        mutations.push(positive_contradiction);
+
+        let mut certified_absence = root.clone();
+        certified_absence["disposition"] = json!({
+            "kind":"contract_refuted",
+            "contract_digest": hashes.contract_digest(),
+            "refutation": {
+                "kind":"certified_absence",
+                "step_index":1,
+                "extractor_capability_receipt_id":"extractor:1",
+                "untruncated_enumeration_receipt_id":"enumeration:1",
+                "connected_receipts":[0]
+            }
+        });
+        certified_absence["steps"] = json!([
+            {"step_index":0,"status":"proven","receipt":0},
+            {"step_index":1,"status":"certified_absence","receipt":1}
+        ]);
+        mutations.push(certified_absence);
+
+        let mut unavailable = root;
+        unavailable["disposition"] = json!({
+            "kind":"unavailable",
+            "contract_digest": hashes.contract_digest(),
+            "reasons":["source_not_bound_to_publication"]
+        });
+        unavailable["steps"] = json!([
+            {"step_index":0,"status":"unavailable","receipt":0},
+            {"step_index":1,"status":"unavailable","receipt":null}
+        ]);
+        mutations.push(unavailable);
+
+        for mutation in mutations {
             assert!(
-                root.get(forbidden).is_none(),
-                "fallback carried {forbidden}"
+                validate_compact_projection(&mutation).is_err(),
+                "validator accepted relational mutation: {mutation}"
             );
         }
     }
 
     #[test]
-    fn internal_projection_measures_escaping_and_never_transports_partial_receipts() {
-        let escape_unit = "\"\\\u{0000}é";
-        let escape_heavy = escape_unit.repeat(MAX_SOURCE_RECEIPT_LINE_BYTES / escape_unit.len());
-        assert!(escape_heavy.len() <= MAX_SOURCE_RECEIPT_LINE_BYTES);
-        assert!(escape_heavy.contains('é'));
-        let (contract, hashes, rendering, receipts) =
-            six_step_projection_fixture(vec![escape_heavy; 6]);
+    fn compact_projection_merges_cross_file_dependencies_before_receipt_indices_freeze() {
+        let (contract, hashes, rendering) = validate_for_projection(&["B", "C"]);
+        let first = indexed_receipt(0, "A", "B", "A calls B();\n".to_owned());
+        let second = indexed_receipt(1, "B", "C", "B calls C();\n".to_owned());
         let integration = checked_integration(
             &contract,
             &hashes,
             &rendering,
-            built_from_receipts(receipts, Vec::new(), Vec::new()),
+            built_from_receipts(vec![first, second], Vec::new(), Vec::new()),
         );
-        let projected = project_internal_call_path_result(&integration).unwrap();
-        let InternalProjection::BudgetExceeded { root, .. } = projected else {
-            panic!("escaped receipt JSON must be measured after escaping")
+
+        let InternalProjection::Complete { root, .. } =
+            project_internal_call_path_result(&integration).expect("cross-file projection")
+        else {
+            panic!("cross-file projection must remain complete")
         };
-        assert!(root.get("receipts").is_none());
-        assert!(root.get("steps").is_none());
-    }
-
-    #[test]
-    fn six_maximum_lines_are_kept_complete_or_replaced_as_one_and_tiny_fallbacks_error() {
-        let maximum = "x".repeat(MAX_SOURCE_RECEIPT_LINE_BYTES);
-        let (contract, hashes, rendering, receipts) = six_step_projection_fixture(vec![maximum; 6]);
-        let integration = checked_integration(
-            &contract,
-            &hashes,
-            &rendering,
-            built_from_receipts(receipts, Vec::new(), Vec::new()),
-        );
-        let projected = project_internal_call_path_result(&integration).unwrap();
-        match projected {
-            InternalProjection::Complete {
-                root,
-                serialized_size,
-            } => {
-                assert!(serialized_size <= INTERNAL_PROOF_CAP_BYTES);
-                assert_eq!(root["receipts"].as_array().unwrap().len(), 6);
-            }
-            InternalProjection::BudgetExceeded { root, .. } => {
-                assert!(root.get("receipts").is_none());
-                assert!(root.get("steps").is_none());
-            }
-        }
-
-        assert!(matches!(
-            project_internal_call_path_result_with_cap(&integration, 1),
-            Err(InternalProjectionError::FallbackExceedsCap { cap_bytes: 1, .. })
-        ));
+        assert_eq!(root["identities"]["files"].as_array().unwrap().len(), 3);
+        assert_eq!(root["receipts"][0]["target"], root["receipts"][1]["source"]);
     }
 
     #[test]
@@ -4421,6 +5200,7 @@ mod tests {
             node("A").pinned,
             "A",
             "crate::A",
+            NodeId(1),
             vec!["src".to_owned(), "indexer".to_owned(), "lib.rs".to_owned()],
         )
         .unwrap();

--- a/crates/codestory-agent/src/indexed_source_call_path_v1.rs
+++ b/crates/codestory-agent/src/indexed_source_call_path_v1.rs
@@ -17,6 +17,7 @@ use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
 
 use codestory_contracts::graph::{Edge, EdgeId, EdgeKind, NodeId};
+use codestory_contracts::proof_resolution::{ResolutionEvidence, ResolutionProvenance};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 
@@ -86,6 +87,8 @@ pub struct IndexedCallEdgeReceipt {
     pub target: ResolvedNodeIdentity,
     pub resolution_fact_id: String,
     pub resolution_evidence_sha256: String,
+    pub resolution_evidence_chain: Vec<ResolutionEvidence>,
+    pub resolution_provenance: ResolutionProvenance,
     pub exact_callsite_start_byte: u64,
     pub callsite_identity: String,
     pub column_or_ordinal: u32,
@@ -2056,6 +2059,9 @@ fn validate_built_publication_and_receipts(
     for receipt in &built.receipts {
         if receipt.resolution_fact_id.len() != 64
             || receipt.resolution_evidence_sha256.len() != 64
+            || receipt.resolution_evidence_chain.is_empty()
+            || !valid_resolution_provenance(&receipt.resolution_provenance)
+            || receipt.resolution_evidence_sha256 != receipt.resolution_provenance.evidence_sha256
             || !node_matches_publication(&receipt.source, publication)
             || !node_matches_publication(&receipt.target, publication)
         {
@@ -2261,10 +2267,521 @@ pub enum InternalProjection {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum InternalProjectionError {
     Serialization(String),
+    InvalidCompactProjection(String),
     FallbackExceedsCap {
         cap_bytes: usize,
         serialized_size: usize,
     },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CompactFileIdentity {
+    file_node_id: Option<i64>,
+    project_file_components: Option<Vec<String>>,
+    indexed_sha256: Option<String>,
+    observed_sha256: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CompactSymbolIdentity {
+    node_id: String,
+    pinned: Option<PinnedNodeIdentity>,
+    canonical_id: Option<String>,
+    qualified_name: Option<String>,
+    file: Option<u32>,
+}
+
+#[derive(Default)]
+struct CompactIdentityTables {
+    files: Vec<CompactFileIdentity>,
+    file_by_node_id: BTreeMap<i64, u32>,
+    file_by_path: BTreeMap<Vec<String>, u32>,
+    symbols: Vec<CompactSymbolIdentity>,
+    symbol_by_pinned: BTreeMap<String, u32>,
+    evidence: Vec<Value>,
+    evidence_by_fact_id: BTreeMap<String, u32>,
+}
+
+impl CompactIdentityTables {
+    fn intern_file(
+        &mut self,
+        file_node_id: Option<i64>,
+        project_file_components: Option<Vec<String>>,
+        indexed_sha256: Option<String>,
+        observed_sha256: Option<String>,
+    ) -> Result<u32, InternalProjectionError> {
+        let by_id = file_node_id.and_then(|id| self.file_by_node_id.get(&id).copied());
+        let by_path = project_file_components
+            .as_ref()
+            .and_then(|path| self.file_by_path.get(path).copied());
+        if by_id
+            .zip(by_path)
+            .is_some_and(|(left, right)| left != right)
+        {
+            return Err(InternalProjectionError::InvalidCompactProjection(
+                "conflicting_file_identity".to_owned(),
+            ));
+        }
+        let index = by_id
+            .or(by_path)
+            .unwrap_or(bounded_index(self.files.len())?);
+        if usize::try_from(index).expect("u32 index fits usize") == self.files.len() {
+            self.files.push(CompactFileIdentity {
+                file_node_id: None,
+                project_file_components: None,
+                indexed_sha256: None,
+                observed_sha256: None,
+            });
+        }
+        let file = &mut self.files[usize::try_from(index).expect("u32 index fits usize")];
+        merge_compact_field(
+            &mut file.file_node_id,
+            file_node_id,
+            "conflicting_file_identity",
+        )?;
+        merge_compact_field(
+            &mut file.project_file_components,
+            project_file_components,
+            "conflicting_file_identity",
+        )?;
+        merge_compact_field(
+            &mut file.indexed_sha256,
+            indexed_sha256,
+            "conflicting_file_identity",
+        )?;
+        merge_compact_field(
+            &mut file.observed_sha256,
+            observed_sha256,
+            "conflicting_file_identity",
+        )?;
+        if let Some(id) = file.file_node_id {
+            self.file_by_node_id.insert(id, index);
+        }
+        if let Some(path) = &file.project_file_components {
+            self.file_by_path.insert(path.clone(), index);
+        }
+        Ok(index)
+    }
+
+    fn intern_resolved_symbol(
+        &mut self,
+        node: &ResolvedNodeIdentity,
+    ) -> Result<u32, InternalProjectionError> {
+        let file =
+            self.intern_file(None, Some(node.project_file_components.clone()), None, None)?;
+        let identity = CompactSymbolIdentity {
+            node_id: node.pinned.node_id.clone(),
+            pinned: Some(node.pinned.clone()),
+            canonical_id: Some(node.canonical_id.clone()),
+            qualified_name: Some(node.qualified_name.clone()),
+            file: Some(file),
+        };
+        if let Some(index) = self.symbol_by_pinned.get(&identity.node_id).copied() {
+            if self.symbols[usize::try_from(index).expect("u32 index fits usize")] != identity {
+                return Err(InternalProjectionError::InvalidCompactProjection(
+                    "conflicting_symbol_identity".to_owned(),
+                ));
+            }
+            return Ok(index);
+        }
+        let index = bounded_index(self.symbols.len())?;
+        self.symbols.push(identity.clone());
+        self.symbol_by_pinned.insert(identity.node_id, index);
+        Ok(index)
+    }
+
+    fn intern_evidence_symbol(&mut self, node_id: NodeId) -> Result<u32, InternalProjectionError> {
+        let node_id = node_id.0.to_string();
+        if let Some(index) = self.symbol_by_pinned.get(&node_id).copied() {
+            return Ok(index);
+        }
+        let index = bounded_index(self.symbols.len())?;
+        self.symbols.push(CompactSymbolIdentity {
+            node_id: node_id.clone(),
+            pinned: None,
+            canonical_id: None,
+            qualified_name: None,
+            file: None,
+        });
+        self.symbol_by_pinned.insert(node_id, index);
+        Ok(index)
+    }
+
+    fn intern_evidence(
+        &mut self,
+        receipt: &IndexedCallEdgeReceipt,
+        source: u32,
+        target: u32,
+    ) -> Result<u32, InternalProjectionError> {
+        if receipt.resolution_evidence_chain.is_empty()
+            || !valid_resolution_provenance(&receipt.resolution_provenance)
+        {
+            return Err(InternalProjectionError::InvalidCompactProjection(
+                "resolution_provenance_invalid".to_owned(),
+            ));
+        }
+        let chain = receipt
+            .resolution_evidence_chain
+            .iter()
+            .map(|evidence| {
+                Ok(json!({
+                    "kind": evidence.kind().as_str(),
+                    "symbols": evidence.node_ids().into_iter().map(|node| self.intern_evidence_symbol(node).map(Value::from)).collect::<Result<Vec<_>, _>>()?,
+                }))
+            })
+            .collect::<Result<Vec<_>, InternalProjectionError>>()?;
+        let dependency_files = receipt
+            .resolution_provenance
+            .dependency_file_hashes
+            .iter()
+            .map(|dependency| {
+                self.intern_file(
+                    Some(dependency.file_id.0),
+                    None,
+                    Some(dependency.source_sha256.clone()),
+                    None,
+                )
+                .map(Value::from)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let provenance = &receipt.resolution_provenance;
+        let row = json!({
+            "fact_id": receipt.resolution_fact_id,
+            "caller": source,
+            "target": target,
+            "chain": chain,
+            "provenance": {
+                "producer": provenance.producer,
+                "fact_schema_version": provenance.fact_schema_version,
+                "algorithm": provenance.algorithm,
+                "language_adapter": provenance.language_adapter,
+                "language_adapter_version": provenance.language_adapter_version,
+                "parser_fingerprint": provenance.parser_fingerprint,
+                "dependency_files": dependency_files,
+                "evidence_sha256": provenance.evidence_sha256,
+            },
+        });
+        if let Some(index) = self
+            .evidence_by_fact_id
+            .get(&receipt.resolution_fact_id)
+            .copied()
+        {
+            if self.evidence[usize::try_from(index).expect("u32 index fits usize")] != row {
+                return Err(InternalProjectionError::InvalidCompactProjection(
+                    "conflicting_resolution_fact".to_owned(),
+                ));
+            }
+            return Ok(index);
+        }
+        let index = bounded_index(self.evidence.len())?;
+        self.evidence.push(row);
+        self.evidence_by_fact_id
+            .insert(receipt.resolution_fact_id.clone(), index);
+        Ok(index)
+    }
+
+    fn receipt_json(
+        &mut self,
+        receipt: &IndexedCallEdgeReceipt,
+    ) -> Result<Value, InternalProjectionError> {
+        let file = self.intern_file(
+            Some(receipt.containment.file_node_id.0),
+            Some(receipt.line_window.project_file_components.clone()),
+            Some(receipt.line_window.indexed_sha256.clone()),
+            Some(receipt.line_window.observed_sha256.clone()),
+        )?;
+        let source = self.intern_resolved_symbol(&receipt.source)?;
+        let target = self.intern_resolved_symbol(&receipt.target)?;
+        let source_file = self.symbols[usize::try_from(source).expect("u32 index fits usize")].file;
+        if source_file != Some(file) {
+            return Err(InternalProjectionError::InvalidCompactProjection(
+                "callsite_source_file_mismatch".to_owned(),
+            ));
+        }
+        let owner = self.intern_evidence_symbol(receipt.containment.owner_node_id)?;
+        let evidence = self.intern_evidence(receipt, source, target)?;
+        Ok(json!({
+            "receipt_id": receipt.receipt.receipt_id,
+            "edge_id": receipt.receipt.edge_id,
+            "source": source,
+            "target": target,
+            "evidence": evidence,
+            "exact_callsite_start_byte": receipt.exact_callsite_start_byte,
+            "callsite_identity": receipt.callsite_identity,
+            "column_or_ordinal": receipt.column_or_ordinal,
+            "containment": {
+                "file": file,
+                "owner": owner,
+                "start_line": receipt.containment.start_line,
+                "end_line": receipt.containment.end_line,
+            },
+            "line_window": {
+                "kind": receipt.line_window.kind,
+                "file": file,
+                "anchor_line": receipt.line_window.anchor_line,
+                "byte_start": receipt.line_window.byte_start,
+                "byte_end": receipt.line_window.byte_end,
+                "text": receipt.line_window.text,
+            },
+        }))
+    }
+
+    fn json(&self) -> Value {
+        json!({
+            "files": self.files.iter().map(|file| json!({
+                "file_node_id": file.file_node_id.map(|id| id.to_string()),
+                "project_file_components": file.project_file_components,
+                "indexed_sha256": file.indexed_sha256,
+                "observed_sha256": file.observed_sha256,
+            })).collect::<Vec<_>>(),
+            "symbols": self.symbols.iter().map(|symbol| json!({
+                "node_id": symbol.node_id,
+                "pinned": symbol.pinned.as_ref().map(pinned_identity_json),
+                "canonical_id": symbol.canonical_id,
+                "qualified_name": symbol.qualified_name,
+                "file": symbol.file,
+            })).collect::<Vec<_>>(),
+            "evidence": self.evidence,
+        })
+    }
+}
+
+fn bounded_index(length: usize) -> Result<u32, InternalProjectionError> {
+    u32::try_from(length).map_err(|_| {
+        InternalProjectionError::InvalidCompactProjection("compact_table_index_overflow".to_owned())
+    })
+}
+
+fn merge_compact_field<T: PartialEq>(
+    current: &mut Option<T>,
+    incoming: Option<T>,
+    code: &str,
+) -> Result<(), InternalProjectionError> {
+    match (current.as_ref(), incoming) {
+        (Some(existing), Some(incoming)) if existing != &incoming => Err(
+            InternalProjectionError::InvalidCompactProjection(code.to_owned()),
+        ),
+        (None, Some(incoming)) => {
+            *current = Some(incoming);
+            Ok(())
+        }
+        _ => Ok(()),
+    }
+}
+
+fn valid_resolution_provenance(provenance: &ResolutionProvenance) -> bool {
+    !provenance.producer.is_empty()
+        && provenance.fact_schema_version > 0
+        && !provenance.algorithm.is_empty()
+        && !provenance.language_adapter.is_empty()
+        && !provenance.language_adapter_version.is_empty()
+        && is_lower_hex_sha256(&provenance.parser_fingerprint)
+        && is_lower_hex_sha256(&provenance.evidence_sha256)
+        && provenance
+            .dependency_file_hashes
+            .iter()
+            .all(|dependency| is_lower_hex_sha256(&dependency.source_sha256))
+}
+
+fn is_lower_hex_sha256(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+/// Rejects compact roots whose numeric references no longer describe one
+/// complete proof. The CLI calls this before serializing every revision.
+pub fn validate_compact_projection(root: &Value) -> Result<(), String> {
+    if root.get("kind") == Some(&json!("budget_exceeded")) {
+        for forbidden in ["identities", "spec", "clauses", "steps", "receipts"] {
+            if root.get(forbidden).is_some() {
+                return Err(format!("budget_fallback_contains_{forbidden}"));
+            }
+        }
+        return Ok(());
+    }
+    if root.get("kind") != Some(&json!("complete")) {
+        return Err("compact_root_kind_invalid".to_owned());
+    }
+    let identities = root
+        .get("identities")
+        .and_then(Value::as_object)
+        .ok_or_else(|| "compact_identities_missing".to_owned())?;
+    let files = compact_array(identities.get("files"), "compact_files_missing")?;
+    let symbols = compact_array(identities.get("symbols"), "compact_symbols_missing")?;
+    let evidence = compact_array(identities.get("evidence"), "compact_evidence_missing")?;
+    let receipts = compact_array(root.get("receipts"), "compact_receipts_missing")?;
+
+    for symbol in symbols {
+        if let Some(file) = symbol.get("file").filter(|file| !file.is_null()) {
+            compact_index(file, files.len(), "compact_symbol_file_reference_invalid")?;
+        }
+    }
+    for evidence_row in evidence {
+        compact_index(
+            evidence_row.get("caller").unwrap_or(&Value::Null),
+            symbols.len(),
+            "compact_evidence_caller_reference_invalid",
+        )?;
+        compact_index(
+            evidence_row.get("target").unwrap_or(&Value::Null),
+            symbols.len(),
+            "compact_evidence_target_reference_invalid",
+        )?;
+        for chain in compact_array(evidence_row.get("chain"), "compact_evidence_chain_missing")? {
+            for symbol in compact_array(
+                chain.get("symbols"),
+                "compact_evidence_chain_symbols_missing",
+            )? {
+                compact_index(
+                    symbol,
+                    symbols.len(),
+                    "compact_evidence_symbol_reference_invalid",
+                )?;
+            }
+        }
+        let provenance = evidence_row
+            .get("provenance")
+            .and_then(Value::as_object)
+            .ok_or_else(|| "compact_evidence_provenance_missing".to_owned())?;
+        for file in compact_array(
+            provenance.get("dependency_files"),
+            "compact_dependency_files_missing",
+        )? {
+            compact_index(
+                file,
+                files.len(),
+                "compact_dependency_file_reference_invalid",
+            )?;
+        }
+    }
+    for receipt in receipts {
+        let source = compact_index(
+            receipt.get("source").unwrap_or(&Value::Null),
+            symbols.len(),
+            "compact_receipt_source_reference_invalid",
+        )?;
+        let target = compact_index(
+            receipt.get("target").unwrap_or(&Value::Null),
+            symbols.len(),
+            "compact_receipt_target_reference_invalid",
+        )?;
+        let evidence_index = compact_index(
+            receipt.get("evidence").unwrap_or(&Value::Null),
+            evidence.len(),
+            "compact_receipt_evidence_reference_invalid",
+        )?;
+        let evidence_row = &evidence[evidence_index];
+        if compact_index(
+            evidence_row.get("caller").unwrap_or(&Value::Null),
+            symbols.len(),
+            "compact_evidence_caller_reference_invalid",
+        )? != source
+            || compact_index(
+                evidence_row.get("target").unwrap_or(&Value::Null),
+                symbols.len(),
+                "compact_evidence_target_reference_invalid",
+            )? != target
+        {
+            return Err("compact_receipt_evidence_endpoint_mismatch".to_owned());
+        }
+        let containment = receipt
+            .get("containment")
+            .and_then(Value::as_object)
+            .ok_or_else(|| "compact_receipt_containment_missing".to_owned())?;
+        let line_window = receipt
+            .get("line_window")
+            .and_then(Value::as_object)
+            .ok_or_else(|| "compact_receipt_line_window_missing".to_owned())?;
+        let containment_file = compact_index(
+            containment.get("file").unwrap_or(&Value::Null),
+            files.len(),
+            "compact_containment_file_reference_invalid",
+        )?;
+        compact_index(
+            containment.get("owner").unwrap_or(&Value::Null),
+            symbols.len(),
+            "compact_containment_owner_reference_invalid",
+        )?;
+        let line_file = compact_index(
+            line_window.get("file").unwrap_or(&Value::Null),
+            files.len(),
+            "compact_line_window_file_reference_invalid",
+        )?;
+        let source_file = symbols[source]
+            .get("file")
+            .ok_or_else(|| "compact_source_file_missing".to_owned())?;
+        if compact_index(
+            source_file,
+            files.len(),
+            "compact_symbol_file_reference_invalid",
+        )? != containment_file
+            || containment_file != line_file
+        {
+            return Err("compact_receipt_file_reference_mismatch".to_owned());
+        }
+    }
+    for step in compact_array(root.get("steps"), "compact_steps_missing")? {
+        if let Some(receipt) = step.get("receipt").filter(|value| !value.is_null()) {
+            compact_index(
+                receipt,
+                receipts.len(),
+                "compact_step_receipt_reference_invalid",
+            )?;
+        }
+        if step.get("target").is_some() {
+            return Err("compact_step_repeats_target".to_owned());
+        }
+    }
+    let disposition = root
+        .get("disposition")
+        .and_then(Value::as_object)
+        .ok_or_else(|| "compact_disposition_missing".to_owned())?;
+    validate_disposition_receipts(disposition, receipts.len())?;
+    Ok(())
+}
+
+fn compact_array<'a>(value: Option<&'a Value>, code: &str) -> Result<&'a Vec<Value>, String> {
+    value
+        .and_then(Value::as_array)
+        .ok_or_else(|| code.to_owned())
+}
+
+fn compact_index(value: &Value, length: usize, code: &str) -> Result<usize, String> {
+    value
+        .as_u64()
+        .and_then(|index| usize::try_from(index).ok())
+        .filter(|index| *index < length)
+        .ok_or_else(|| code.to_owned())
+}
+
+fn validate_disposition_receipts(
+    disposition: &serde_json::Map<String, Value>,
+    receipt_count: usize,
+) -> Result<(), String> {
+    let validate = |value: Option<&Value>| -> Result<(), String> {
+        for receipt in compact_array(value, "compact_disposition_receipts_missing")? {
+            compact_index(
+                receipt,
+                receipt_count,
+                "compact_disposition_receipt_reference_invalid",
+            )?;
+        }
+        Ok(())
+    };
+    match disposition.get("kind").and_then(Value::as_str) {
+        Some("contract_proven") => validate(disposition.get("receipts")),
+        Some("unknown") => validate(disposition.get("connected_receipts")),
+        Some("contract_refuted") => validate(
+            disposition
+                .get("refutation")
+                .and_then(Value::as_object)
+                .and_then(|refutation| refutation.get("connected_receipts")),
+        ),
+        Some("unavailable") => Ok(()),
+        _ => Err("compact_disposition_kind_invalid".to_owned()),
+    }
 }
 
 pub fn project_internal_call_path_result(
@@ -2277,7 +2794,7 @@ fn project_internal_call_path_result_with_cap(
     integration: &CheckedBuiltCallPathIntegration,
     cap_bytes: usize,
 ) -> Result<InternalProjection, InternalProjectionError> {
-    let complete = complete_projection_json(integration);
+    let complete = complete_projection_json(integration)?;
     let required_complete_size = serialized_json_size(&complete)?;
     if required_complete_size <= cap_bytes {
         return Ok(InternalProjection::Complete {
@@ -2317,8 +2834,25 @@ fn project_internal_call_path_result_with_cap(
     })
 }
 
-fn complete_projection_json(integration: &CheckedBuiltCallPathIntegration) -> Value {
-    json!({
+fn complete_projection_json(
+    integration: &CheckedBuiltCallPathIntegration,
+) -> Result<Value, InternalProjectionError> {
+    let mut tables = CompactIdentityTables::default();
+    let mut receipts = Vec::with_capacity(integration.authoritative_receipts.len());
+    let mut receipt_refs = BTreeMap::new();
+    for receipt in &integration.authoritative_receipts {
+        let receipt_index = bounded_index(receipts.len())?;
+        if receipt_refs
+            .insert(receipt.receipt.clone(), receipt_index)
+            .is_some()
+        {
+            return Err(InternalProjectionError::InvalidCompactProjection(
+                "duplicate_receipt_reference".to_owned(),
+            ));
+        }
+        receipts.push(tables.receipt_json(receipt)?);
+    }
+    let complete = json!({
         "kind": "complete",
         "schema_version": PROOF_CONTRACT_SCHEMA_VERSION,
         "domain": PROOF_DOMAIN,
@@ -2327,6 +2861,7 @@ fn complete_projection_json(integration: &CheckedBuiltCallPathIntegration) -> Va
         "source_text_sha256": integration.hashes.source_text_sha256,
         "contract_digest": integration.hashes.contract_digest,
         "core_publication": publication_json(&integration.built.publication),
+        "identities": tables.json(),
         "spec": spec_json(&integration.contract.spec),
         "clauses": integration
             .rendering
@@ -2334,14 +2869,13 @@ fn complete_projection_json(integration: &CheckedBuiltCallPathIntegration) -> Va
             .iter()
             .map(normalized_clause_json)
             .collect::<Vec<_>>(),
-        "disposition": disposition_json(&integration.disposition),
-        "steps": step_results_json(&integration.contract, &integration.disposition),
-        "receipts": integration
-            .authoritative_receipts
-            .iter()
-            .map(indexed_receipt_json)
-            .collect::<Vec<_>>(),
-    })
+        "disposition": disposition_json(&integration.disposition, &receipt_refs)?,
+        "steps": step_results_json(&integration.contract, &integration.disposition, &receipt_refs)?,
+        "receipts": receipts,
+    });
+    validate_compact_projection(&complete)
+        .map_err(InternalProjectionError::InvalidCompactProjection)?;
+    Ok(complete)
 }
 
 fn publication_json(publication: &InternalCorePublicationIdentity) -> Value {
@@ -2352,79 +2886,76 @@ fn publication_json(publication: &InternalCorePublicationIdentity) -> Value {
     })
 }
 
-fn disposition_json(disposition: &ProofDisposition) -> Value {
+fn disposition_json(
+    disposition: &ProofDisposition,
+    receipt_refs: &BTreeMap<ReceiptRef, u32>,
+) -> Result<Value, InternalProjectionError> {
     match disposition {
         ProofDisposition::ContractProven {
             contract_digest,
             receipts,
-        } => json!({
+        } => Ok(json!({
             "kind": "contract_proven",
             "contract_digest": contract_digest,
-            "receipts": receipts.iter().map(receipt_ref_json).collect::<Vec<_>>(),
-        }),
+            "receipts": receipt_indices_json(receipts, receipt_refs)?,
+        })),
         ProofDisposition::ContractRefuted {
             contract_digest,
             refutation,
-        } => json!({
+        } => Ok(json!({
             "kind": "contract_refuted",
             "contract_digest": contract_digest,
-            "refutation": refutation_json(refutation),
-        }),
+            "refutation": refutation_json(refutation, receipt_refs)?,
+        })),
         ProofDisposition::Unknown {
             contract_digest,
             gaps,
             connected_receipts,
-        } => json!({
+        } => Ok(json!({
             "kind": "unknown",
             "contract_digest": contract_digest,
             "gaps": gaps.iter().map(proof_gap_json).collect::<Vec<_>>(),
-            "connected_receipts": connected_receipts
-                .iter()
-                .map(receipt_ref_json)
-                .collect::<Vec<_>>(),
-        }),
+            "connected_receipts": receipt_indices_json(connected_receipts, receipt_refs)?,
+        })),
         ProofDisposition::Unavailable {
             contract_digest,
             reasons,
-        } => json!({
+        } => Ok(json!({
             "kind": "unavailable",
             "contract_digest": contract_digest,
             "reasons": reasons.iter().map(unavailable_reason_name).collect::<Vec<_>>(),
-        }),
+        })),
     }
 }
 
-fn refutation_json(refutation: &Refutation) -> Value {
+fn refutation_json(
+    refutation: &Refutation,
+    receipt_refs: &BTreeMap<ReceiptRef, u32>,
+) -> Result<Value, InternalProjectionError> {
     match refutation {
         Refutation::ProhibitedScopeTraversal {
             step_index,
             prohibition_index,
             connected_receipts,
-        } => json!({
+        } => Ok(json!({
             "kind": "prohibited_scope_traversal",
             "step_index": step_index,
             "prohibition_index": prohibition_index,
-            "connected_receipts": connected_receipts
-                .iter()
-                .map(receipt_ref_json)
-                .collect::<Vec<_>>(),
-        }),
+            "connected_receipts": receipt_indices_json(connected_receipts, receipt_refs)?,
+        })),
         #[cfg(any(test, feature = "test-support"))]
         Refutation::CertifiedAbsence {
             step_index,
             extractor_capability_receipt_id,
             untruncated_enumeration_receipt_id,
             connected_receipts,
-        } => json!({
+        } => Ok(json!({
             "kind": "certified_absence",
             "step_index": step_index,
             "extractor_capability_receipt_id": extractor_capability_receipt_id,
             "untruncated_enumeration_receipt_id": untruncated_enumeration_receipt_id,
-            "connected_receipts": connected_receipts
-                .iter()
-                .map(receipt_ref_json)
-                .collect::<Vec<_>>(),
-        }),
+            "connected_receipts": receipt_indices_json(connected_receipts, receipt_refs)?,
+        })),
     }
 }
 
@@ -2492,13 +3023,14 @@ fn unavailable_reason_name(reason: &UnavailableReason) -> &'static str {
 fn step_results_json(
     contract: &ValidatedCallPathContract,
     disposition: &ProofDisposition,
-) -> Vec<Value> {
+    receipt_refs: &BTreeMap<ReceiptRef, u32>,
+) -> Result<Vec<Value>, InternalProjectionError> {
     contract
         .spec
         .steps
         .iter()
         .enumerate()
-        .map(|(step_index, step)| {
+        .map(|(step_index, _step)| {
             let (status, receipt) = match disposition {
                 ProofDisposition::ContractProven { receipts, .. } => {
                     ("proven", receipts.get(step_index))
@@ -2552,58 +3084,38 @@ fn step_results_json(
                 ProofDisposition::Unavailable { .. } => ("unavailable", None),
                 _ => ("unknown", None),
             };
-            json!({
+            Ok(json!({
                 "step_index": step_index,
-                "target": symbol_selector_json(&step.target),
                 "status": status,
-                "receipt": receipt.map(receipt_ref_json),
-            })
+                "receipt": receipt.map(|receipt| receipt_index_json(receipt, receipt_refs)).transpose()?,
+            }))
         })
+        .collect::<Result<Vec<_>, _>>()
+}
+
+fn receipt_indices_json(
+    receipts: &[ReceiptRef],
+    receipt_refs: &BTreeMap<ReceiptRef, u32>,
+) -> Result<Vec<Value>, InternalProjectionError> {
+    receipts
+        .iter()
+        .map(|receipt| receipt_index_json(receipt, receipt_refs))
         .collect()
 }
 
-fn receipt_ref_json(receipt: &ReceiptRef) -> Value {
-    json!({
-        "receipt_id": receipt.receipt_id,
-        "edge_id": receipt.edge_id,
-    })
-}
-
-fn indexed_receipt_json(receipt: &IndexedCallEdgeReceipt) -> Value {
-    json!({
-        "receipt": receipt_ref_json(&receipt.receipt),
-        "source": resolved_node_json(&receipt.source),
-        "target": resolved_node_json(&receipt.target),
-        "resolution_fact_id": receipt.resolution_fact_id,
-        "resolution_evidence_sha256": receipt.resolution_evidence_sha256,
-        "exact_callsite_start_byte": receipt.exact_callsite_start_byte,
-        "callsite_identity": receipt.callsite_identity,
-        "containment": {
-            "file_node_id": receipt.containment.file_node_id.0.to_string(),
-            "owner_node_id": receipt.containment.owner_node_id.0.to_string(),
-            "start_line": receipt.containment.start_line,
-            "end_line": receipt.containment.end_line,
-        },
-        "line_window": {
-            "kind": receipt.line_window.kind,
-            "project_file_components": receipt.line_window.project_file_components,
-            "indexed_sha256": receipt.line_window.indexed_sha256,
-            "observed_sha256": receipt.line_window.observed_sha256,
-            "anchor_line": receipt.line_window.anchor_line,
-            "byte_start": receipt.line_window.byte_start,
-            "byte_end": receipt.line_window.byte_end,
-            "text": receipt.line_window.text,
-        },
-    })
-}
-
-fn resolved_node_json(node: &ResolvedNodeIdentity) -> Value {
-    json!({
-        "pinned": pinned_identity_json(&node.pinned),
-        "canonical_id": node.canonical_id,
-        "qualified_name": node.qualified_name,
-        "project_file_components": node.project_file_components,
-    })
+fn receipt_index_json(
+    receipt: &ReceiptRef,
+    receipt_refs: &BTreeMap<ReceiptRef, u32>,
+) -> Result<Value, InternalProjectionError> {
+    receipt_refs
+        .get(receipt)
+        .copied()
+        .map(Value::from)
+        .ok_or_else(|| {
+            InternalProjectionError::InvalidCompactProjection(
+                "dangling_receipt_reference".to_owned(),
+            )
+        })
 }
 
 fn serialized_json_size(value: &Value) -> Result<usize, InternalProjectionError> {
@@ -2616,6 +3128,7 @@ fn serialized_json_size(value: &Value) -> Result<usize, InternalProjectionError>
 mod tests {
     use super::*;
     use codestory_contracts::graph::{Edge, EdgeId, EdgeKind, NodeId};
+    use codestory_contracts::proof_resolution::{FileId, ResolutionEvidence, ResolutionProvenance};
 
     const MAX_SOURCE_RECEIPT_LINE_BYTES: usize = 8_192;
 
@@ -2743,6 +3256,24 @@ mod tests {
             target: node(target),
             resolution_fact_id: format!("{:064x}", index + 1),
             resolution_evidence_sha256: format!("{:064x}", index + 2),
+            resolution_evidence_chain: vec![ResolutionEvidence::SameFileDeclaration {
+                declaration: NodeId(i64::try_from(index + 2).unwrap()),
+            }],
+            resolution_provenance: ResolutionProvenance {
+                producer: "codestory-internal".to_owned(),
+                fact_schema_version: 1,
+                algorithm: "exact-call-resolution-v1".to_owned(),
+                language_adapter: "rust".to_owned(),
+                language_adapter_version: "test-v1".to_owned(),
+                parser_fingerprint: "f".repeat(64),
+                dependency_file_hashes: vec![
+                    codestory_contracts::proof_resolution::DependencyFileHash {
+                        file_id: FileId(i64::try_from(index + 1).unwrap()),
+                        source_sha256: format!("{:064x}", index + 3),
+                    },
+                ],
+                evidence_sha256: format!("{:064x}", index + 2),
+            },
             exact_callsite_start_byte: (index * 10) as u64,
             callsite_identity: format!("{index}:{}:0:{}|rust", index + 1, index + 2),
             column_or_ordinal: 0,
@@ -2754,9 +3285,9 @@ mod tests {
             },
             line_window: IndexedLineWindow {
                 kind: "indexed_line_v1",
-                project_file_components: vec!["src".to_owned(), format!("step{index}.rs")],
-                indexed_sha256: format!("indexed-{index}"),
-                observed_sha256: format!("indexed-{index}"),
+                project_file_components: vec!["src".to_owned(), format!("{source}.rs")],
+                indexed_sha256: format!("{:064x}", index + 3),
+                observed_sha256: format!("{:064x}", index + 3),
                 anchor_line: u32::try_from(index + 1).unwrap(),
                 byte_start: index * 10,
                 byte_end: index * 10 + text.len(),
@@ -2972,7 +3503,7 @@ mod tests {
                 .as_array()
                 .unwrap()
                 .iter()
-                .map(|receipt| receipt["receipt"]["receipt_id"].as_str().unwrap())
+                .map(|receipt| receipt["receipt_id"].as_str().unwrap())
                 .collect::<Vec<_>>(),
             ["receipt-0", "receipt-1"]
         );
@@ -3123,7 +3654,7 @@ mod tests {
                 .as_array()
                 .unwrap()
                 .iter()
-                .map(|receipt| receipt["receipt"]["receipt_id"].as_str().unwrap())
+                .map(|receipt| receipt["receipt_id"].as_str().unwrap())
                 .collect::<Vec<_>>(),
             ["receipt-0", "receipt-1"]
         );
@@ -3175,7 +3706,7 @@ mod tests {
                 .as_array()
                 .unwrap()
                 .iter()
-                .map(|receipt| receipt["receipt"]["receipt_id"].as_str().unwrap())
+                .map(|receipt| receipt["receipt_id"].as_str().unwrap())
                 .collect::<Vec<_>>(),
             ["receipt-0", "receipt-1"]
         );
@@ -3303,9 +3834,99 @@ mod tests {
         assert_eq!(root["domain"], "indexed_source_call_path_v1");
         assert_eq!(root["contract_interpretation"], "host_supplied");
         assert_eq!(root["guard_version"], "clause_guard_v1");
+        assert_eq!(root["identities"]["files"].as_array().unwrap().len(), 2);
+        assert_eq!(root["identities"]["symbols"].as_array().unwrap().len(), 4);
+        assert_eq!(root["identities"]["evidence"].as_array().unwrap().len(), 1);
         assert_eq!(root["receipts"].as_array().unwrap().len(), 1);
+        assert_eq!(root["receipts"][0]["source"], 0);
+        assert_eq!(root["receipts"][0]["target"], 1);
+        assert_eq!(root["receipts"][0]["evidence"], 0);
+        assert_eq!(root["steps"][0]["receipt"], 0);
+        assert_eq!(root["disposition"]["receipts"], json!([0]));
         assert_eq!(root["steps"].as_array().unwrap().len(), 1);
         assert_eq!(serialized_size, serde_json::to_vec(&root).unwrap().len());
+    }
+
+    #[test]
+    fn internal_projection_interns_shared_identities_in_authoritative_receipt_order() {
+        let (contract, hashes, rendering) = validate_for_projection(&["B", "C"]);
+        let first = indexed_receipt(0, "A", "B", "first\n".to_owned());
+        let second = indexed_receipt(1, "B", "C", "second\n".to_owned());
+        let integration = checked_integration(
+            &contract,
+            &hashes,
+            &rendering,
+            built_from_receipts(vec![first, second], Vec::new(), Vec::new()),
+        );
+
+        let InternalProjection::Complete { root, .. } =
+            project_internal_call_path_result(&integration).unwrap()
+        else {
+            panic!("compact projection should fit");
+        };
+        assert_eq!(root["identities"]["symbols"].as_array().unwrap().len(), 7);
+        assert_eq!(root["identities"]["evidence"].as_array().unwrap().len(), 2);
+        assert_eq!(root["receipts"][0]["source"], 0);
+        assert_eq!(root["receipts"][0]["target"], 1);
+        assert_eq!(root["receipts"][1]["source"], 1);
+        assert_ne!(root["receipts"][1]["target"], root["receipts"][1]["source"]);
+        assert_eq!(root["disposition"]["receipts"], json!([0, 1]));
+        assert_eq!(root["steps"][0]["receipt"], 0);
+        assert_eq!(root["steps"][1]["receipt"], 1);
+    }
+
+    #[test]
+    fn compact_projection_rejects_dangling_swapped_and_incomplete_evidence_references() {
+        let (contract, hashes, rendering) = validate_for_projection(&["B"]);
+        let receipt = indexed_receipt(0, "A", "B", "call\n".to_owned());
+        let integration = checked_integration(
+            &contract,
+            &hashes,
+            &rendering,
+            built_from_receipts(vec![receipt], Vec::new(), Vec::new()),
+        );
+        let InternalProjection::Complete { root, .. } =
+            project_internal_call_path_result(&integration).unwrap()
+        else {
+            panic!("compact projection should fit");
+        };
+
+        let mut dangling = root.clone();
+        dangling["receipts"][0]["evidence"] = json!(99);
+        assert_eq!(
+            validate_compact_projection(&dangling),
+            Err("compact_receipt_evidence_reference_invalid".to_owned())
+        );
+
+        let mut swapped = root.clone();
+        swapped["receipts"][0]["source"] = json!(1);
+        swapped["receipts"][0]["target"] = json!(0);
+        assert_eq!(
+            validate_compact_projection(&swapped),
+            Err("compact_receipt_evidence_endpoint_mismatch".to_owned())
+        );
+
+        let mut missing_provenance = root;
+        missing_provenance["identities"]["evidence"][0]
+            .as_object_mut()
+            .unwrap()
+            .remove("provenance");
+        assert_eq!(
+            validate_compact_projection(&missing_provenance),
+            Err("compact_evidence_provenance_missing".to_owned())
+        );
+
+        let mut invalid_receipt = indexed_receipt(1, "A", "B", "call\n".to_owned());
+        invalid_receipt.resolution_provenance.producer.clear();
+        assert_eq!(
+            check_built_call_path_integration(
+                &contract,
+                &hashes,
+                &rendering,
+                built_from_receipts(vec![invalid_receipt], Vec::new(), Vec::new()),
+            ),
+            Err(CheckedIntegrationError::PublicationBindingMismatch)
+        );
     }
 
     #[test]
@@ -3384,7 +4005,7 @@ mod tests {
             root["disposition"]["gaps"],
             json!([{ "kind": "output_budget_exceeded" }])
         );
-        for forbidden in ["spec", "clauses", "steps", "receipts"] {
+        for forbidden in ["identities", "spec", "clauses", "steps", "receipts"] {
             assert!(
                 root.get(forbidden).is_none(),
                 "fallback carried {forbidden}"

--- a/crates/codestory-agent/src/lib.rs
+++ b/crates/codestory-agent/src/lib.rs
@@ -40,7 +40,7 @@ pub mod proof_qualification_support {
         ValidatedCallPathContract, ValidatedContractRendering, ValidationOutcome,
         VerifiedDirectCallFact, VerifiedProofFact, admit_raw_call_edge,
         check_built_call_path_integration, diagnose_raw_call_edge,
-        project_internal_call_path_result, validate_contract,
+        project_internal_call_path_result, validate_compact_projection, validate_contract,
     };
 
     /// Identifies the sealed request domain observed by benchmark qualification.

--- a/crates/codestory-bench/src/bin/codestory_proof_availability/contracts.rs
+++ b/crates/codestory-bench/src/bin/codestory_proof_availability/contracts.rs
@@ -1939,7 +1939,7 @@ pub(crate) fn product_disposition_from_projection(root: &Value) -> Result<Produc
     let actual = match kind {
         "contract_proven" => ActualProductResultV1::ContractProven {
             contract_digest,
-            receipts: projected_receipts(disposition.get("receipts"))?,
+            receipts: projected_receipts(root, disposition.get("receipts"))?,
         },
         "contract_refuted" => {
             let refutation = disposition
@@ -1947,7 +1947,8 @@ pub(crate) fn product_disposition_from_projection(root: &Value) -> Result<Produc
                 .and_then(Value::as_object)
                 .ok_or_else(|| anyhow::anyhow!("proof_availability_refutation_missing"))?;
             let step_index = projected_u8(refutation, "step_index")?;
-            let connected_receipts = projected_receipts(refutation.get("connected_receipts"))?;
+            let connected_receipts =
+                projected_receipts(root, refutation.get("connected_receipts"))?;
             let basis = match refutation.get("kind").and_then(Value::as_str) {
                 Some("prohibited_scope_traversal") => {
                     ProductRefutationBasisV1::PositiveContradiction {
@@ -1983,7 +1984,7 @@ pub(crate) fn product_disposition_from_projection(root: &Value) -> Result<Produc
                 .map(serde_json::from_value)
                 .transpose()?
                 .unwrap_or_default(),
-            connected_receipts: projected_receipts(disposition.get("connected_receipts"))?,
+            connected_receipts: projected_receipts(root, disposition.get("connected_receipts"))?,
         },
         "unavailable" => ActualProductResultV1::Unavailable {
             contract_digest,
@@ -2057,13 +2058,40 @@ pub(crate) fn product_disposition_from_projection(root: &Value) -> Result<Produc
     })
 }
 
-fn projected_receipts(value: Option<&Value>) -> Result<Vec<ProjectedReceiptReferenceV1>> {
-    value
-        .cloned()
-        .map(serde_json::from_value)
-        .transpose()
-        .map(|value| value.unwrap_or_default())
-        .map_err(Into::into)
+fn projected_receipts(
+    root: &Value,
+    value: Option<&Value>,
+) -> Result<Vec<ProjectedReceiptReferenceV1>> {
+    let Some(value) = value else {
+        return Ok(Vec::new());
+    };
+    let references = value
+        .as_array()
+        .ok_or_else(|| anyhow::anyhow!("proof_availability_compact_receipt_references_invalid"))?;
+    let receipts = root
+        .get("receipts")
+        .and_then(Value::as_array)
+        .ok_or_else(|| anyhow::anyhow!("proof_availability_compact_receipt_table_missing"))?;
+    references
+        .iter()
+        .map(|reference| {
+            let index = reference
+                .as_u64()
+                .and_then(|index| usize::try_from(index).ok())
+                .filter(|index| *index < receipts.len())
+                .ok_or_else(|| {
+                    anyhow::anyhow!("proof_availability_compact_receipt_reference_dangling")
+                })?;
+            let receipt = receipts
+                .get(index)
+                .and_then(Value::as_object)
+                .ok_or_else(|| anyhow::anyhow!("proof_availability_compact_receipt_row_invalid"))?;
+            Ok(ProjectedReceiptReferenceV1 {
+                receipt_id: projected_string(receipt, "receipt_id")?,
+                edge_id: projected_string(receipt, "edge_id")?,
+            })
+        })
+        .collect()
 }
 
 fn projected_u8(object: &serde_json::Map<String, Value>, field: &str) -> Result<u8> {

--- a/crates/codestory-bench/src/bin/codestory_proof_availability/report.rs
+++ b/crates/codestory-bench/src/bin/codestory_proof_availability/report.rs
@@ -3262,6 +3262,21 @@ mod tests {
             target: resolved(&prior.target, TARGET_CANONICAL_ID),
             resolution_fact_id: "a".repeat(64),
             resolution_evidence_sha256: "b".repeat(64),
+            resolution_evidence_chain: vec![
+                codestory_contracts::proof_resolution::ResolutionEvidence::SameFileDeclaration {
+                    declaration: NodeId(prior.target.pinned.node_id.parse().unwrap()),
+                },
+            ],
+            resolution_provenance: codestory_contracts::proof_resolution::ResolutionProvenance {
+                producer: "codestory-internal".into(),
+                fact_schema_version: 1,
+                algorithm: "exact-call-resolution-v1".into(),
+                language_adapter: "rust".into(),
+                language_adapter_version: "test-v1".into(),
+                parser_fingerprint: "c".repeat(64),
+                dependency_file_hashes: Vec::new(),
+                evidence_sha256: "b".repeat(64),
+            },
             exact_callsite_start_byte: 0,
             callsite_identity: prior.callsite_identity.clone(),
             column_or_ordinal: 0,

--- a/crates/codestory-bench/src/bin/codestory_proof_availability/report.rs
+++ b/crates/codestory-bench/src/bin/codestory_proof_availability/report.rs
@@ -3250,6 +3250,7 @@ mod tests {
                 },
                 canonical_id: canonical_id.to_owned(),
                 qualified_name: identity.qualified_name.clone(),
+                file_node_id: NodeId(prior.containment.file_node_id),
                 project_file_components: identity.project_file_components.clone(),
             }
         };

--- a/crates/codestory-bench/tests/proof_availability_contracts.rs
+++ b/crates/codestory-bench/tests/proof_availability_contracts.rs
@@ -109,6 +109,27 @@ fn exact_graph_ids_serialize_as_canonical_signed_decimal_strings() {
 }
 
 #[test]
+fn qualification_reader_resolves_compact_receipt_indices_and_rejects_dangling_rows() {
+    let root = json!({
+        "kind":"complete",
+        "receipts":[{"receipt_id":"indexed-call-edge:compact","edge_id":"-42"}],
+        "disposition":{"kind":"contract_proven","contract_digest":SHA,"receipts":[0]}
+    });
+    let disposition = contracts::product_disposition_from_projection(&root).unwrap();
+    assert_eq!(
+        disposition.authoritative_receipts,
+        vec![ReceiptReferenceV1 {
+            receipt_id: "indexed-call-edge:compact".into(),
+            edge_id: -42
+        }]
+    );
+
+    let mut dangling = root;
+    dangling["disposition"]["receipts"] = json!([1]);
+    assert!(contracts::product_disposition_from_projection(&dangling).is_err());
+}
+
+#[test]
 fn exact_graph_id_codecs_reject_noncanonical_or_lossy_json() {
     for invalid in [
         json!(0),
@@ -433,12 +454,12 @@ fn task11a_product_result_contract_preserves_every_disposition_and_failure_basis
 
     for (projected, expected_kind, expected_summary_kind) in [
         (
-            json!({"kind":"contract_proven","contract_digest":SHA,"receipts":[{"receipt_id":"indexed-call-edge:1","edge_id":"1"}]}),
+            json!({"kind":"contract_proven","contract_digest":SHA,"receipts":[0]}),
             "contract_proven",
             "contract_proven",
         ),
         (
-            json!({"kind":"contract_refuted","contract_digest":SHA,"refutation":{"kind":"prohibited_scope_traversal","step_index":0,"prohibition_index":0,"connected_receipts":[{"receipt_id":"indexed-call-edge:1","edge_id":"1"}]}}),
+            json!({"kind":"contract_refuted","contract_digest":SHA,"refutation":{"kind":"prohibited_scope_traversal","step_index":0,"prohibition_index":0,"connected_receipts":[0]}}),
             "contract_refuted",
             "unknown",
         ),
@@ -458,9 +479,12 @@ fn task11a_product_result_contract_preserves_every_disposition_and_failure_basis
             "unknown",
         ),
     ] {
-        let report =
-            contracts::product_disposition_from_projection(&json!({"disposition":projected}))
-                .expect("actual product projection conversion");
+        let report = contracts::product_disposition_from_projection(&json!({
+            "kind":"complete",
+            "receipts":[{"receipt_id":"indexed-call-edge:1","edge_id":"1"}],
+            "disposition":projected
+        }))
+        .expect("actual product projection conversion");
         assert_eq!(
             serde_json::to_value(&report.actual).unwrap()["kind"],
             expected_kind
@@ -1314,6 +1338,21 @@ fn runtime_receipt_comparison_uses_the_oracle_file_hash_not_hash_self_agreement(
         target: identity("2", &oracle.target),
         resolution_fact_id: "a".repeat(64),
         resolution_evidence_sha256: "b".repeat(64),
+        resolution_evidence_chain: vec![
+            codestory_contracts::proof_resolution::ResolutionEvidence::SameFileDeclaration {
+                declaration: codestory_contracts::graph::NodeId(2),
+            },
+        ],
+        resolution_provenance: codestory_contracts::proof_resolution::ResolutionProvenance {
+            producer: "codestory-internal".into(),
+            fact_schema_version: 1,
+            algorithm: "exact-call-resolution-v1".into(),
+            language_adapter: "rust".into(),
+            language_adapter_version: "test-v1".into(),
+            parser_fingerprint: "c".repeat(64),
+            dependency_file_hashes: Vec::new(),
+            evidence_sha256: "b".repeat(64),
+        },
         exact_callsite_start_byte: 0,
         callsite_identity: "1:1:0:2|fixture".into(),
         column_or_ordinal: 0,
@@ -1458,6 +1497,21 @@ fn canonical_selector_oracles_recompute_the_contextual_receipt_binding() {
         target: identity("-2", target_raw, &oracle.target.symbol),
         resolution_fact_id: "a".repeat(64),
         resolution_evidence_sha256: "b".repeat(64),
+        resolution_evidence_chain: vec![
+            codestory_contracts::proof_resolution::ResolutionEvidence::SameFileDeclaration {
+                declaration: NodeId(-2),
+            },
+        ],
+        resolution_provenance: codestory_contracts::proof_resolution::ResolutionProvenance {
+            producer: "codestory-internal".into(),
+            fact_schema_version: 1,
+            algorithm: "exact-call-resolution-v1".into(),
+            language_adapter: "rust".into(),
+            language_adapter_version: "test-v1".into(),
+            parser_fingerprint: "c".repeat(64),
+            dependency_file_hashes: Vec::new(),
+            evidence_sha256: "b".repeat(64),
+        },
         exact_callsite_start_byte: 0,
         callsite_identity: format!("-3:{}:0:-2|fixture", oracle.callsite_line),
         column_or_ordinal: 0,
@@ -2640,6 +2694,21 @@ fn producer_facade_conversions_preserve_task4_and_task6_semantics() {
         target: identity("-2", "codestory-rust-l1-0::target_0"),
         resolution_fact_id: "a".repeat(64),
         resolution_evidence_sha256: "b".repeat(64),
+        resolution_evidence_chain: vec![
+            codestory_contracts::proof_resolution::ResolutionEvidence::SameFileDeclaration {
+                declaration: NodeId(-2),
+            },
+        ],
+        resolution_provenance: codestory_contracts::proof_resolution::ResolutionProvenance {
+            producer: "codestory-internal".into(),
+            fact_schema_version: 1,
+            algorithm: "exact-call-resolution-v1".into(),
+            language_adapter: "rust".into(),
+            language_adapter_version: "test-v1".into(),
+            parser_fingerprint: "c".repeat(64),
+            dependency_file_hashes: Vec::new(),
+            evidence_sha256: "b".repeat(64),
+        },
         exact_callsite_start_byte: 0,
         callsite_identity: "-3:1:0:-2|fixture".into(),
         column_or_ordinal: 0,
@@ -2838,6 +2907,21 @@ fn admitted_callsite_identity_is_opaque_after_task6() {
         target: identity(RESOLVED_TARGET, &oracle.target),
         resolution_fact_id: "a".repeat(64),
         resolution_evidence_sha256: "b".repeat(64),
+        resolution_evidence_chain: vec![
+            codestory_contracts::proof_resolution::ResolutionEvidence::SameFileDeclaration {
+                declaration: NodeId(RESOLVED_TARGET),
+            },
+        ],
+        resolution_provenance: codestory_contracts::proof_resolution::ResolutionProvenance {
+            producer: "codestory-internal".into(),
+            fact_schema_version: 1,
+            algorithm: "exact-call-resolution-v1".into(),
+            language_adapter: "rust".into(),
+            language_adapter_version: "test-v1".into(),
+            parser_fingerprint: "c".repeat(64),
+            dependency_file_hashes: Vec::new(),
+            evidence_sha256: "b".repeat(64),
+        },
         exact_callsite_start_byte: 0,
         callsite_identity: callsite_identity.clone(),
         column_or_ordinal: 0,

--- a/crates/codestory-bench/tests/proof_availability_contracts.rs
+++ b/crates/codestory-bench/tests/proof_availability_contracts.rs
@@ -1325,6 +1325,7 @@ fn runtime_receipt_comparison_uses_the_oracle_file_hash_not_hash_self_agreement(
             pinned: pinned(node_id),
             canonical_id: format!("canonical-{node_id}"),
             qualified_name: declaration.symbol.clone(),
+            file_node_id: codestory_contracts::graph::NodeId(10),
             project_file_components: project_file_components.clone(),
         }
     };
@@ -1385,6 +1386,7 @@ fn runtime_receipt_comparison_uses_the_oracle_file_hash_not_hash_self_agreement(
 #[test]
 fn resolved_canonical_id_bindings_cover_host_paths_relative_ids_and_context() {
     use codestory_agent::proof_qualification_support::{PinnedNodeIdentity, ResolvedNodeIdentity};
+    use codestory_contracts::graph::NodeId;
 
     let raws = [
         "/Users/private/worktree/src/caller.rs::caller",
@@ -1410,6 +1412,7 @@ fn resolved_canonical_id_bindings_cover_host_paths_relative_ids_and_context() {
                 },
                 canonical_id: raw.into(),
                 qualified_name: "module::callable".into(),
+                file_node_id: NodeId(node_id.parse().unwrap()),
                 project_file_components: vec!["src".into(), "caller.rs".into()],
             };
             let public = contracts::ResolvedNodeIdentityV1::try_from(&product).unwrap();
@@ -1447,6 +1450,7 @@ fn resolved_canonical_id_bindings_cover_host_paths_relative_ids_and_context() {
         },
         canonical_id: String::new(),
         qualified_name: "module::callable".into(),
+        file_node_id: NodeId(-1),
         project_file_components: vec!["src".into(), "caller.rs".into()],
     };
     contracts::ResolvedNodeIdentityV1::try_from(&empty)
@@ -1481,6 +1485,7 @@ fn canonical_selector_oracles_recompute_the_contextual_receipt_binding() {
         },
         canonical_id: canonical_id.into(),
         qualified_name: qualified_name.into(),
+        file_node_id: NodeId(-3),
         project_file_components: oracle
             .receipt_line_window
             .path
@@ -2683,6 +2688,7 @@ fn producer_facade_conversions_preserve_task4_and_task6_semantics() {
         },
         canonical_id: format!("canonical-{node_id}"),
         qualified_name: qualified_name.into(),
+        file_node_id: NodeId(-3),
         project_file_components: vec!["src".into(), "area0".into(), "file0.rs".into()],
     };
     let task6_receipt = IndexedCallEdgeReceipt {
@@ -2895,6 +2901,7 @@ fn admitted_callsite_identity_is_opaque_after_task6() {
             },
             canonical_id: format!("canonical-{node_id}"),
             qualified_name: declaration.symbol.clone(),
+            file_node_id: NodeId(-3),
             project_file_components: project_file_components.clone(),
         };
     let callsite_identity = format!("-3:{}:0:{RAW_TARGET}|fixture", oracle.callsite_line);

--- a/crates/codestory-cli/src/stdio_v3/catalog.rs
+++ b/crates/codestory-cli/src/stdio_v3/catalog.rs
@@ -116,15 +116,6 @@ fn proof_file_schema_v3() -> Value {
 fn proof_symbol_schema_v3() -> Value {
     closed_object_schema_v3(vec![
         ("node_id", string_schema_v3()),
-        (
-            "pinned",
-            nullable_schema_v3(closed_object_schema_v3(vec![
-                ("project_id", string_schema_v3()),
-                ("core_generation_id", string_schema_v3()),
-                ("core_run_id", string_schema_v3()),
-                ("node_id", string_schema_v3()),
-            ])),
-        ),
         ("canonical_id", nullable_schema_v3(string_schema_v3())),
         ("qualified_name", nullable_schema_v3(string_schema_v3())),
         ("file", nullable_schema_v3(unsigned_integer_schema_v3())),
@@ -136,6 +127,8 @@ fn proof_evidence_schema_v3() -> Value {
         ("fact_id", sha256_schema_v3()),
         ("caller", unsigned_integer_schema_v3()),
         ("target", unsigned_integer_schema_v3()),
+        ("edge_id", string_schema_v3()),
+        ("callsite_identity", string_schema_v3()),
         (
             "chain",
             json!({"type":"array","items":closed_object_schema_v3(vec![

--- a/crates/codestory-cli/src/stdio_v3/catalog.rs
+++ b/crates/codestory-cli/src/stdio_v3/catalog.rs
@@ -22,79 +22,193 @@ pub(crate) fn tools_for_surface_v3(revision: McpRevisionV3, surface: V3SurfaceSe
 }
 
 pub(crate) fn proof_output_schema_v3() -> Value {
-    let common = Map::from_iter([
-        ("kind".to_string(), json!({"type":"string"})),
-        ("schema_version".to_string(), json!({"type":"integer"})),
-        ("domain".to_string(), json!({"type":"string"})),
-        (
-            "contract_interpretation".to_string(),
-            json!({"type":"string","enum":["host_supplied"]}),
-        ),
-        ("guard_version".to_string(), json!({"type":"string"})),
-        (
-            "source_text_sha256".to_string(),
-            json!({"type":"string","minLength":64,"maxLength":64}),
-        ),
-        (
-            "contract_digest".to_string(),
-            json!({"type":"string","minLength":64,"maxLength":64}),
-        ),
-        ("core_publication".to_string(), json!({"type":"object"})),
-        ("disposition".to_string(), json!({"type":"object"})),
-    ]);
-    let variant = |kind: &str, additional: &[(&str, Value)], required: &[&str]| {
-        let mut properties = common.clone();
-        properties.insert("kind".to_string(), json!({"type":"string","enum":[kind]}));
-        properties.extend(
-            additional
-                .iter()
-                .map(|(name, schema)| ((*name).to_string(), schema.clone())),
-        );
-        let mut required_fields = vec![
-            "kind",
-            "schema_version",
-            "domain",
-            "contract_interpretation",
-            "guard_version",
-            "source_text_sha256",
-            "contract_digest",
-            "core_publication",
-            "disposition",
-        ];
-        required_fields.extend_from_slice(required);
-        json!({
-            "type": "object",
-            "properties": properties,
-            "required": required_fields,
-            "additionalProperties": false
-        })
-    };
     json!({
         "type": "object",
         "oneOf": [
-            variant(
-                "complete",
-                &[
-                    ("spec", json!({"type":"object"})),
-                    ("clauses", json!({"type":"array"})),
-                    ("steps", json!({"type":"array"})),
-                    ("receipts", json!({"type":"array"})),
-                ],
-                &["spec", "clauses", "steps", "receipts"],
-            ),
-            variant(
-                "budget_exceeded",
-                &[
-                    ("cap_bytes", json!({"type":"integer","minimum":1})),
-                    (
-                        "required_complete_size",
-                        json!({"type":"integer","minimum":1}),
-                    ),
-                ],
-                &["cap_bytes", "required_complete_size"],
-            )
+            proof_complete_schema_v3(),
+            proof_budget_exceeded_schema_v3()
         ]
     })
+}
+
+fn proof_common_fields_v3(kind: &str) -> Vec<(&str, Value)> {
+    vec![
+        ("kind", enum_schema_v3(&[kind])),
+        ("schema_version", json!({"type":"integer","enum":[1]})),
+        ("domain", enum_schema_v3(&["indexed_source_call_path_v1"])),
+        (
+            "contract_interpretation",
+            enum_schema_v3(&["host_supplied"]),
+        ),
+        ("guard_version", enum_schema_v3(&["clause_guard_v1"])),
+        ("source_text_sha256", sha256_schema_v3()),
+        ("contract_digest", sha256_schema_v3()),
+        (
+            "core_publication",
+            closed_object_schema_v3(vec![
+                ("project_id", string_schema_v3()),
+                ("generation_id", string_schema_v3()),
+                ("run_id", string_schema_v3()),
+            ]),
+        ),
+        ("disposition", json!({"type":"object"})),
+    ]
+}
+
+fn proof_complete_schema_v3() -> Value {
+    let mut fields = proof_common_fields_v3("complete");
+    fields.extend([
+        (
+            "identities",
+            closed_object_schema_v3(vec![
+                (
+                    "files",
+                    json!({"type":"array","items":proof_file_schema_v3(),"maxItems":65536}),
+                ),
+                (
+                    "symbols",
+                    json!({"type":"array","items":proof_symbol_schema_v3(),"maxItems":65536}),
+                ),
+                (
+                    "evidence",
+                    json!({"type":"array","items":proof_evidence_schema_v3(),"maxItems":65536}),
+                ),
+            ]),
+        ),
+        ("spec", json!({"type":"object"})),
+        ("clauses", json!({"type":"array"})),
+        (
+            "steps",
+            json!({"type":"array","items":proof_step_schema_v3(),"maxItems":6}),
+        ),
+        (
+            "receipts",
+            json!({"type":"array","items":proof_receipt_schema_v3(),"maxItems":6}),
+        ),
+    ]);
+    closed_object_schema_v3(fields)
+}
+
+fn proof_budget_exceeded_schema_v3() -> Value {
+    let mut fields = proof_common_fields_v3("budget_exceeded");
+    fields.extend([
+        ("cap_bytes", json!({"type":"integer","minimum":1})),
+        (
+            "required_complete_size",
+            json!({"type":"integer","minimum":1}),
+        ),
+    ]);
+    closed_object_schema_v3(fields)
+}
+
+fn proof_file_schema_v3() -> Value {
+    closed_object_schema_v3(vec![
+        ("file_node_id", nullable_schema_v3(string_schema_v3())),
+        (
+            "project_file_components",
+            nullable_schema_v3(json!({"type":"array","items":string_schema_v3()})),
+        ),
+        ("indexed_sha256", nullable_schema_v3(sha256_schema_v3())),
+        ("observed_sha256", nullable_schema_v3(sha256_schema_v3())),
+    ])
+}
+
+fn proof_symbol_schema_v3() -> Value {
+    closed_object_schema_v3(vec![
+        ("node_id", string_schema_v3()),
+        (
+            "pinned",
+            nullable_schema_v3(closed_object_schema_v3(vec![
+                ("project_id", string_schema_v3()),
+                ("core_generation_id", string_schema_v3()),
+                ("core_run_id", string_schema_v3()),
+                ("node_id", string_schema_v3()),
+            ])),
+        ),
+        ("canonical_id", nullable_schema_v3(string_schema_v3())),
+        ("qualified_name", nullable_schema_v3(string_schema_v3())),
+        ("file", nullable_schema_v3(unsigned_integer_schema_v3())),
+    ])
+}
+
+fn proof_evidence_schema_v3() -> Value {
+    closed_object_schema_v3(vec![
+        ("fact_id", sha256_schema_v3()),
+        ("caller", unsigned_integer_schema_v3()),
+        ("target", unsigned_integer_schema_v3()),
+        (
+            "chain",
+            json!({"type":"array","items":closed_object_schema_v3(vec![
+                ("kind", string_schema_v3()), ("symbols", json!({"type":"array","items":unsigned_integer_schema_v3()})),
+            ])}),
+        ),
+        (
+            "provenance",
+            closed_object_schema_v3(vec![
+                ("producer", string_schema_v3()),
+                ("fact_schema_version", json!({"type":"integer","minimum":1})),
+                ("algorithm", string_schema_v3()),
+                ("language_adapter", string_schema_v3()),
+                ("language_adapter_version", string_schema_v3()),
+                ("parser_fingerprint", sha256_schema_v3()),
+                (
+                    "dependency_files",
+                    json!({"type":"array","items":unsigned_integer_schema_v3()}),
+                ),
+                ("evidence_sha256", sha256_schema_v3()),
+            ]),
+        ),
+    ])
+}
+
+fn proof_receipt_schema_v3() -> Value {
+    closed_object_schema_v3(vec![
+        ("receipt_id", string_schema_v3()),
+        ("edge_id", string_schema_v3()),
+        ("source", unsigned_integer_schema_v3()),
+        ("target", unsigned_integer_schema_v3()),
+        ("evidence", unsigned_integer_schema_v3()),
+        ("exact_callsite_start_byte", unsigned_integer_schema_v3()),
+        ("callsite_identity", string_schema_v3()),
+        ("column_or_ordinal", unsigned_integer_schema_v3()),
+        (
+            "containment",
+            closed_object_schema_v3(vec![
+                ("file", unsigned_integer_schema_v3()),
+                ("owner", unsigned_integer_schema_v3()),
+                ("start_line", unsigned_integer_schema_v3()),
+                ("end_line", unsigned_integer_schema_v3()),
+            ]),
+        ),
+        (
+            "line_window",
+            closed_object_schema_v3(vec![
+                ("kind", enum_schema_v3(&["indexed_line_v1"])),
+                ("file", unsigned_integer_schema_v3()),
+                ("anchor_line", unsigned_integer_schema_v3()),
+                ("byte_start", unsigned_integer_schema_v3()),
+                ("byte_end", unsigned_integer_schema_v3()),
+                ("text", string_schema_v3()),
+            ]),
+        ),
+    ])
+}
+
+fn proof_step_schema_v3() -> Value {
+    closed_object_schema_v3(vec![
+        ("step_index", unsigned_integer_schema_v3()),
+        (
+            "status",
+            enum_schema_v3(&[
+                "proven",
+                "positive_contradiction",
+                "certified_absence",
+                "unavailable",
+                "unknown",
+            ]),
+        ),
+        ("receipt", nullable_schema_v3(unsigned_integer_schema_v3())),
+    ])
 }
 
 fn project_tool_v3(revision: McpRevisionV3, source: &Value) -> Value {
@@ -780,6 +894,7 @@ mod tests {
             "source_text_sha256": "a".repeat(64),
             "contract_digest": "b".repeat(64),
             "core_publication": {"project_id":"p","generation_id":"g","run_id":"r"},
+            "identities": {"files":[],"symbols":[],"evidence":[]},
             "spec": {"start":{"kind":"canonical_id","canonical_id":"A"},"steps":[],"prohibit_traversal_through":[],"exclude_from_projection":[]},
             "clauses": [],
             "disposition": {"kind":"unknown","contract_digest":"b".repeat(64),"gaps":[],"connected_receipts":[]},

--- a/crates/codestory-cli/src/stdio_v3/mod.rs
+++ b/crates/codestory-cli/src/stdio_v3/mod.rs
@@ -51,6 +51,7 @@ pub(crate) enum StdioV3InternalError {
     },
 }
 
+#[cfg(feature = "proof-qualification-support")]
 pub(crate) fn measure_revision_native_proof_result_v3(
     root: &serde_json::Value,
 ) -> Result<Vec<RevisionNativeToolResultMeasurementV3>, StdioV3InternalError> {

--- a/crates/codestory-cli/src/stdio_v3/transport.rs
+++ b/crates/codestory-cli/src/stdio_v3/transport.rs
@@ -87,6 +87,8 @@ pub(crate) fn build_proof_tool_result_v3(
     revision: McpRevisionV3,
     root: &Value,
 ) -> Result<Value, StdioV3InternalError> {
+    codestory_runtime::proof_qualification_support::validate_compact_projection(root)
+        .map_err(|_| StdioV3InternalError::InvalidProjection("prove_call_path".to_owned()))?;
     let result = build_tool_result_for_surface_v3(
         revision,
         "prove_call_path",
@@ -100,6 +102,8 @@ pub(crate) fn build_proof_tool_result_v3(
     }
 
     let fallback = proof_budget_fallback_v3(root, bytes.len())?;
+    codestory_runtime::proof_qualification_support::validate_compact_projection(&fallback)
+        .map_err(|_| StdioV3InternalError::InvalidProjection("prove_call_path".to_owned()))?;
     let fallback_result = build_tool_result_for_surface_v3(
         revision,
         "prove_call_path",
@@ -252,11 +256,19 @@ mod tests {
             "source_text_sha256": "a".repeat(64),
             "contract_digest": "b".repeat(64),
             "core_publication": {"project_id":"p","generation_id":"g","run_id":"r"},
+            "identities": {
+                "files":[{"file_node_id":"1","project_file_components":["src","lib.rs"],"indexed_sha256":"c".repeat(64),"observed_sha256":"c".repeat(64)}],
+                "symbols":[
+                    {"node_id":"1","pinned":{"project_id":"p","core_generation_id":"g","core_run_id":"r","node_id":"1"},"canonical_id":"A","qualified_name":"crate::A","file":0},
+                    {"node_id":"2","pinned":{"project_id":"p","core_generation_id":"g","core_run_id":"r","node_id":"2"},"canonical_id":"B","qualified_name":"crate::B","file":0}
+                ],
+                "evidence":[{"fact_id":"d".repeat(64),"caller":0,"target":1,"chain":[{"kind":"same_file_declaration","symbols":[1]}],"provenance":{"producer":"codestory-internal","fact_schema_version":1,"algorithm":"exact-call-resolution-v1","language_adapter":"rust","language_adapter_version":"test-v1","parser_fingerprint":"e".repeat(64),"dependency_files":[0],"evidence_sha256":"f".repeat(64)}}]
+            },
             "spec": {"start":{"kind":"canonical_id","canonical_id":"A"},"steps":[],"prohibit_traversal_through":[],"exclude_from_projection":[]},
             "clauses": [],
             "disposition": disposition,
             "steps": [],
-            "receipts": []
+            "receipts": [{"receipt_id":"receipt-1","edge_id":"1","source":0,"target":1,"evidence":0,"exact_callsite_start_byte":0,"callsite_identity":"1:1:1:2","column_or_ordinal":1,"containment":{"file":0,"owner":0,"start_line":1,"end_line":1},"line_window":{"kind":"indexed_line_v1","file":0,"anchor_line":1,"byte_start":0,"byte_end":1,"text":"x"}}]
         })
     }
 
@@ -389,7 +401,7 @@ mod tests {
         assert!(response.pointer("/error/data/structuredContent").is_none());
 
         let mut oversized = proof_root("unknown");
-        oversized["receipts"] = json!([{"line_window":{"text":"\\\"é".repeat(24_000)}}]);
+        oversized["receipts"][0]["line_window"]["text"] = json!("\\\"é".repeat(24_000));
         let result = build_proof_tool_result_v3(McpRevisionV3::June2025, &oversized)
             .expect("fallback result");
         assert_eq!(
@@ -609,6 +621,92 @@ mod tests {
                 .expect("exact tool result bytes");
             assert_eq!(measurement.call_tool_result_bytes, direct_bytes);
             assert_eq!(measurement.byte_length, direct_bytes.len());
+        }
+    }
+
+    fn proof_root_at_revision_bytes(revision: McpRevisionV3, target: usize) -> Value {
+        let root = proof_root("unknown");
+        let size = |root: &Value| {
+            let result = build_tool_result_for_surface_v3(
+                revision,
+                "prove_call_path",
+                root,
+                V3SurfaceSet::WithProof,
+            )
+            .expect("unbounded revision-native result");
+            crate::stdio_transport::v3_serialize_call_tool_result(&result)
+                .expect("unbounded revision-native bytes")
+                .len()
+        };
+        for column_or_ordinal in [1, 10] {
+            let mut root = root.clone();
+            root["receipts"][0]["column_or_ordinal"] = json!(column_or_ordinal);
+            let baseline = size(&root);
+            assert!(baseline < target);
+            for quote_count in 0..=16 {
+                let mut seed = root.clone();
+                seed["receipts"][0]["line_window"]["text"] = json!("\"".repeat(quote_count));
+                let seed_size = size(&seed);
+                let mut one_more = seed.clone();
+                one_more["receipts"][0]["line_window"]["text"] =
+                    json!(format!("{}x", "\"".repeat(quote_count)));
+                let byte_step = size(&one_more) - seed_size;
+                let remaining = target.saturating_sub(seed_size);
+                if byte_step > 0 && remaining % byte_step == 0 {
+                    seed["receipts"][0]["line_window"]["text"] = json!(format!(
+                        "{}{}",
+                        "\"".repeat(quote_count),
+                        "x".repeat(remaining / byte_step)
+                    ));
+                    if size(&seed) == target {
+                        return seed;
+                    }
+                }
+            }
+        }
+        panic!("revision {revision:?} cannot reach target {target}");
+    }
+
+    #[test]
+    fn every_revision_measures_the_whole_proof_result_at_the_cap_and_cap_plus_one() {
+        for revision in McpRevisionV3::all() {
+            // Modern results mirror the root in both text and structured content, so every
+            // admissible byte delta is even while this fixture's envelope is odd. Its last
+            // fitting result is therefore cap-minus-one; legacy revisions reach the cap.
+            let fitting_size = if revision.profile().structured_content {
+                PROOF_TOOL_RESULT_MAX_BYTES_V3 - 1
+            } else {
+                PROOF_TOOL_RESULT_MAX_BYTES_V3
+            };
+            let exact = proof_root_at_revision_bytes(*revision, fitting_size);
+            let exact_result = build_proof_tool_result_v3(*revision, &exact).unwrap();
+            assert_eq!(
+                crate::stdio_transport::v3_serialize_call_tool_result(&exact_result)
+                    .unwrap()
+                    .len(),
+                fitting_size
+            );
+
+            let plus_one = proof_root_at_revision_bytes(*revision, fitting_size + 2);
+            let fallback = build_proof_tool_result_v3(*revision, &plus_one).unwrap();
+            assert!(
+                crate::stdio_transport::v3_serialize_call_tool_result(&fallback)
+                    .unwrap()
+                    .len()
+                    <= PROOF_TOOL_RESULT_MAX_BYTES_V3
+            );
+            let fallback_root = serde_json::from_str::<Value>(
+                fallback
+                    .pointer("/content/0/text")
+                    .and_then(Value::as_str)
+                    .unwrap(),
+            )
+            .unwrap();
+            assert_eq!(fallback_root["kind"], "budget_exceeded");
+            assert_eq!(fallback_root["required_complete_size"], fitting_size + 2);
+            for forbidden in ["identities", "spec", "clauses", "steps", "receipts"] {
+                assert!(fallback_root.get(forbidden).is_none());
+            }
         }
     }
 }

--- a/crates/codestory-cli/src/stdio_v3/transport.rs
+++ b/crates/codestory-cli/src/stdio_v3/transport.rs
@@ -87,6 +87,15 @@ pub(crate) fn build_proof_tool_result_v3(
     revision: McpRevisionV3,
     root: &Value,
 ) -> Result<Value, StdioV3InternalError> {
+    if crate::stdio_arguments::validate_structured_content(
+        &super::catalog::proof_output_schema_v3(),
+        root,
+    )
+    .is_err()
+    {
+        return Err(StdioV3InternalError::OutputSchemaViolation);
+    }
+    #[cfg(feature = "proof-qualification-support")]
     codestory_runtime::proof_qualification_support::validate_compact_projection(root)
         .map_err(|_| StdioV3InternalError::InvalidProjection("prove_call_path".to_owned()))?;
     let result = build_tool_result_for_surface_v3(
@@ -102,6 +111,15 @@ pub(crate) fn build_proof_tool_result_v3(
     }
 
     let fallback = proof_budget_fallback_v3(root, bytes.len())?;
+    if crate::stdio_arguments::validate_structured_content(
+        &super::catalog::proof_output_schema_v3(),
+        &fallback,
+    )
+    .is_err()
+    {
+        return Err(StdioV3InternalError::OutputSchemaViolation);
+    }
+    #[cfg(feature = "proof-qualification-support")]
     codestory_runtime::proof_qualification_support::validate_compact_projection(&fallback)
         .map_err(|_| StdioV3InternalError::InvalidProjection("prove_call_path".to_owned()))?;
     let fallback_result = build_tool_result_for_surface_v3(
@@ -232,9 +250,325 @@ pub(crate) fn jsonrpc_internal_error_v3(id: Value, _error: &StdioV3InternalError
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "proof-qualification-support")]
+    use codestory_contracts::graph::NodeId;
+    #[cfg(feature = "proof-qualification-support")]
+    use codestory_contracts::proof_resolution::{
+        DependencyFileHash, ResolutionEvidence, ResolutionProvenance,
+    };
+    #[cfg(feature = "proof-qualification-support")]
+    use codestory_runtime::proof_qualification_support::{
+        BuiltCallPathFacts, CallableContainmentEvidence, ClauseAnchor, ClauseClassification,
+        IndexedCallEdgeReceipt, IndexedLineWindow, InternalCorePublicationIdentity,
+        InternalProjection, PinnedNodeIdentity, ProofContractField, ReceiptRef,
+        ResolvedNodeIdentity, UnvalidatedCallPathContract, UnvalidatedCallPathSpec,
+        UnvalidatedDirectCallStep, UnvalidatedExactSymbolSelector, ValidationOutcome,
+        VerifiedDirectCallFact, VerifiedProofFact, check_built_call_path_integration,
+        project_internal_call_path_result, validate_contract,
+    };
+
+    #[cfg(feature = "proof-qualification-support")]
+    fn actual_projected_root(text: String) -> Value {
+        let source = "exact direct ordered call path";
+        let ValidationOutcome::Validated {
+            contract,
+            hashes,
+            rendering,
+        } = validate_contract(UnvalidatedCallPathContract::new(
+            source,
+            vec![ClauseAnchor {
+                clause_id: "contract".to_owned(),
+                start: 0,
+                end: source.len(),
+                quote: source.to_owned(),
+                classification: ClauseClassification::ResolvedMaterial {
+                    fields: vec![
+                        ProofContractField::Start,
+                        ProofContractField::StepTarget { step: 0 },
+                        ProofContractField::Directness { step: 0 },
+                        ProofContractField::Ordering { step: 0 },
+                        ProofContractField::Relation { step: 0 },
+                    ],
+                },
+            }],
+            UnvalidatedCallPathSpec {
+                start: UnvalidatedExactSymbolSelector::CanonicalId("A".to_owned()),
+                steps: vec![UnvalidatedDirectCallStep {
+                    target: UnvalidatedExactSymbolSelector::CanonicalId("B".to_owned()),
+                }],
+                prohibit_traversal_through: Vec::new(),
+                exclude_from_projection: Vec::new(),
+            },
+        ))
+        .expect("valid contract")
+        else {
+            panic!("fixture contract validates")
+        };
+        let node = |node_id: &str, canonical_id: &str, qualified_name: &str, path: &[&str]| {
+            ResolvedNodeIdentity::new(
+                PinnedNodeIdentity {
+                    project_id: "project".to_owned(),
+                    core_generation_id: "generation".to_owned(),
+                    core_run_id: "run".to_owned(),
+                    node_id: node_id.to_owned(),
+                },
+                canonical_id,
+                qualified_name,
+                NodeId(if node_id == "10" { 1 } else { 2 }),
+                path.iter().map(|part| (*part).to_owned()).collect(),
+            )
+            .expect("valid node")
+        };
+        let source = node("10", "A", "crate::A", &["src", "a.rs"]);
+        let target = node("20", "B", "crate::B", &["src", "b.rs"]);
+        let receipt = IndexedCallEdgeReceipt {
+            receipt: ReceiptRef {
+                receipt_id: "receipt-0".to_owned(),
+                edge_id: "1".to_owned(),
+            },
+            source: source.clone(),
+            target: target.clone(),
+            resolution_fact_id: "a".repeat(64),
+            resolution_evidence_sha256: "b".repeat(64),
+            resolution_evidence_chain: vec![ResolutionEvidence::SameFileDeclaration {
+                declaration: NodeId(20),
+            }],
+            resolution_provenance: ResolutionProvenance {
+                producer: "codestory-internal".to_owned(),
+                fact_schema_version: 1,
+                algorithm: "exact-call-resolution-v1".to_owned(),
+                language_adapter: "rust".to_owned(),
+                language_adapter_version: "test-v1".to_owned(),
+                parser_fingerprint: "c".repeat(64),
+                dependency_file_hashes: vec![
+                    DependencyFileHash {
+                        file_id: codestory_contracts::proof_resolution::FileId(1),
+                        source_sha256: "d".repeat(64),
+                    },
+                    DependencyFileHash {
+                        file_id: codestory_contracts::proof_resolution::FileId(2),
+                        source_sha256: "e".repeat(64),
+                    },
+                ],
+                evidence_sha256: "b".repeat(64),
+            },
+            exact_callsite_start_byte: 0,
+            callsite_identity: "1:1:1:20|rust".to_owned(),
+            column_or_ordinal: 1,
+            containment: CallableContainmentEvidence {
+                file_node_id: NodeId(1),
+                owner_node_id: NodeId(10),
+                start_line: 1,
+                end_line: 1,
+            },
+            line_window: IndexedLineWindow {
+                kind: "indexed_line_v1",
+                project_file_components: vec!["src".to_owned(), "a.rs".to_owned()],
+                indexed_sha256: "d".repeat(64),
+                observed_sha256: "d".repeat(64),
+                anchor_line: 1,
+                byte_start: 0,
+                byte_end: text.len(),
+                text,
+            },
+        };
+        let integration = check_built_call_path_integration(
+            &contract,
+            &hashes,
+            &rendering,
+            BuiltCallPathFacts {
+                publication: InternalCorePublicationIdentity {
+                    project_id: "project".to_owned(),
+                    generation_id: "generation".to_owned(),
+                    run_id: "run".to_owned(),
+                },
+                facts: vec![VerifiedProofFact::DirectCall(VerifiedDirectCallFact {
+                    receipt: receipt.receipt.clone(),
+                    source,
+                    target,
+                })],
+                receipts: vec![receipt],
+                gaps: Vec::new(),
+                unavailable: Vec::new(),
+            },
+        )
+        .expect("checked integration");
+        let InternalProjection::Complete { root, .. } =
+            project_internal_call_path_result(&integration).expect("actual projected root")
+        else {
+            panic!("fixture must preserve its complete root for transport")
+        };
+        root
+    }
+
+    #[cfg(feature = "proof-qualification-support")]
+    fn set_receipt_line_text(root: &mut Value, text: String) {
+        let byte_start = root["receipts"][0]["line_window"]["byte_start"]
+            .as_u64()
+            .expect("line byte start");
+        root["receipts"][0]["line_window"]["text"] = json!(text);
+        root["receipts"][0]["line_window"]["byte_end"] = json!(
+            byte_start
+                + u64::try_from(
+                    root["receipts"][0]["line_window"]["text"]
+                        .as_str()
+                        .expect("line text")
+                        .len()
+                )
+                .expect("line text length")
+        );
+    }
+
+    #[cfg(feature = "proof-qualification-support")]
+    #[test]
+    fn actual_projected_root_round_trips_through_all_revision_profiles() {
+        let root = actual_projected_root("A calls B();\n".to_owned());
+        for revision in McpRevisionV3::all() {
+            let result = build_proof_tool_result_v3(*revision, &root)
+                .unwrap_or_else(|error| panic!("{revision:?}: {error:?}"));
+            assert_eq!(
+                serde_json::from_str::<Value>(result["content"][0]["text"].as_str().unwrap())
+                    .unwrap(),
+                root
+            );
+            if revision.profile().structured_content {
+                assert_eq!(result["structuredContent"], root);
+            }
+        }
+    }
+
+    #[cfg(feature = "proof-qualification-support")]
+    #[test]
+    fn actual_projector_leaves_an_oversized_complete_root_for_revision_transport() {
+        let root = actual_projected_root("\\\"é".repeat(24_000));
+        assert_eq!(root["kind"], "complete");
+    }
+
+    #[cfg(feature = "proof-qualification-support")]
+    fn actual_projected_root_at_revision_bytes(revision: McpRevisionV3, target: usize) -> Value {
+        let root = actual_projected_root("A calls B();\n".to_owned());
+        let size = |root: &Value| {
+            let result = build_tool_result_for_surface_v3(
+                revision,
+                "prove_call_path",
+                root,
+                V3SurfaceSet::WithProof,
+            )
+            .expect("unbounded revision-native result");
+            crate::stdio_transport::v3_serialize_call_tool_result(&result)
+                .expect("unbounded revision-native bytes")
+                .len()
+        };
+        let baseline = size(&root);
+        assert!(baseline < target);
+        for quote_count in 0..=16 {
+            let mut candidate = root.clone();
+            set_receipt_line_text(&mut candidate, "\"".repeat(quote_count));
+            let candidate_size = size(&candidate);
+            let mut one_more = candidate.clone();
+            set_receipt_line_text(&mut one_more, format!("{}x", "\"".repeat(quote_count)));
+            let byte_step = size(&one_more) - candidate_size;
+            let remaining = target.saturating_sub(candidate_size);
+            if byte_step > 0 && remaining % byte_step == 0 {
+                let mut count = remaining / byte_step;
+                for _ in 0..4 {
+                    set_receipt_line_text(
+                        &mut candidate,
+                        format!("{}{}", "\"".repeat(quote_count), "x".repeat(count)),
+                    );
+                    let actual = size(&candidate);
+                    if actual == target {
+                        return candidate;
+                    }
+                    let delta = isize::try_from(target).unwrap() - isize::try_from(actual).unwrap();
+                    let adjustment = delta / isize::try_from(byte_step).unwrap();
+                    let Some(next) = count.checked_add_signed(adjustment) else {
+                        break;
+                    };
+                    if next == count {
+                        break;
+                    }
+                    count = next;
+                }
+            }
+        }
+        panic!("revision {revision:?} cannot reach target {target}");
+    }
+
+    #[cfg(feature = "proof-qualification-support")]
+    #[test]
+    fn revision_transport_owns_actual_projected_root_budgeting_and_internal_errors() {
+        for revision in McpRevisionV3::all() {
+            let fitting_size = if revision.profile().structured_content {
+                PROOF_TOOL_RESULT_MAX_BYTES_V3 - 1
+            } else {
+                PROOF_TOOL_RESULT_MAX_BYTES_V3
+            };
+            let complete = actual_projected_root_at_revision_bytes(*revision, fitting_size);
+            let complete_result = build_proof_tool_result_v3(*revision, &complete).unwrap();
+            assert_eq!(
+                crate::stdio_transport::v3_serialize_call_tool_result(&complete_result)
+                    .unwrap()
+                    .len(),
+                fitting_size
+            );
+
+            let oversized = actual_projected_root_at_revision_bytes(
+                *revision,
+                PROOF_TOOL_RESULT_MAX_BYTES_V3 + 1,
+            );
+            let expected_size = crate::stdio_transport::v3_serialize_call_tool_result(
+                &build_tool_result_for_surface_v3(
+                    *revision,
+                    "prove_call_path",
+                    &oversized,
+                    V3SurfaceSet::WithProof,
+                )
+                .unwrap(),
+            )
+            .unwrap()
+            .len();
+            let fallback = build_proof_tool_result_v3(*revision, &oversized).unwrap();
+            let fallback_bytes =
+                crate::stdio_transport::v3_serialize_call_tool_result(&fallback).unwrap();
+            assert!(fallback_bytes.len() <= PROOF_TOOL_RESULT_MAX_BYTES_V3);
+            let fallback_root =
+                serde_json::from_str::<Value>(fallback["content"][0]["text"].as_str().unwrap())
+                    .unwrap();
+            assert_eq!(fallback_root["kind"], "budget_exceeded");
+            assert_eq!(fallback_root["required_complete_size"], expected_size);
+            assert!(
+                codestory_runtime::proof_qualification_support::validate_compact_projection(
+                    &fallback_root
+                )
+                .is_ok()
+            );
+            if revision.profile().structured_content {
+                assert_eq!(fallback["structuredContent"], fallback_root);
+            }
+        }
+
+        let mut fallback_too_large = actual_projected_root("A calls B();\n".to_owned());
+        fallback_too_large["core_publication"]["project_id"] = json!("p".repeat(70_000));
+        let error = build_proof_tool_result_v3(McpRevisionV3::November2024, &fallback_too_large)
+            .expect_err("oversized fallback must fail internally");
+        assert!(matches!(
+            error,
+            StdioV3InternalError::ResultExceedsBudget { .. }
+        ));
+        assert_eq!(
+            jsonrpc_internal_error_v3(json!(99), &error).pointer("/error/code"),
+            Some(&json!(-32603))
+        );
+    }
 
     fn proof_root(disposition_kind: &str) -> Value {
         let disposition = match disposition_kind {
+            "proven" => json!({
+                "kind": "contract_proven",
+                "contract_digest": "b".repeat(64),
+                "receipts": [0]
+            }),
             "unavailable" => json!({
                 "kind": "unavailable",
                 "contract_digest": "b".repeat(64),
@@ -247,6 +581,31 @@ mod tests {
                 "connected_receipts": []
             }),
         };
+        let (identities, steps, receipts) = if disposition_kind == "proven" {
+            (
+                json!({
+                    "files":[{"file_node_id":"1","project_file_components":["src","lib.rs"],"indexed_sha256":"c".repeat(64),"observed_sha256":"c".repeat(64)}],
+                    "symbols":[
+                        {"node_id":"1","canonical_id":"A","qualified_name":"crate::A","file":0},
+                        {"node_id":"2","canonical_id":"B","qualified_name":"crate::B","file":0}
+                    ],
+                    "evidence":[{"fact_id":"d".repeat(64),"caller":0,"target":1,"edge_id":"1","callsite_identity":"1:1:1:2|rust","chain":[{"kind":"same_file_declaration","symbols":[1]}],"provenance":{"producer":"codestory-internal","fact_schema_version":1,"algorithm":"exact-call-resolution-v1","language_adapter":"rust","language_adapter_version":"test-v1","parser_fingerprint":"e".repeat(64),"dependency_files":[0],"evidence_sha256":"f".repeat(64)}}]
+                }),
+                json!([{"step_index":0,"status":"proven","receipt":0}]),
+                json!([{"receipt_id":"receipt-1","edge_id":"1","source":0,"target":1,"evidence":0,"exact_callsite_start_byte":0,"callsite_identity":"1:1:1:2|rust","column_or_ordinal":1,"containment":{"file":0,"owner":0,"start_line":1,"end_line":1},"line_window":{"kind":"indexed_line_v1","file":0,"anchor_line":1,"byte_start":0,"byte_end":1,"text":"x"}}]),
+            )
+        } else {
+            let step_status = if disposition_kind == "unavailable" {
+                "unavailable"
+            } else {
+                "unknown"
+            };
+            (
+                json!({"files":[],"symbols":[],"evidence":[]}),
+                json!([{"step_index":0,"status":step_status,"receipt":null}]),
+                json!([]),
+            )
+        };
         json!({
             "kind": "complete",
             "schema_version": 1,
@@ -256,19 +615,12 @@ mod tests {
             "source_text_sha256": "a".repeat(64),
             "contract_digest": "b".repeat(64),
             "core_publication": {"project_id":"p","generation_id":"g","run_id":"r"},
-            "identities": {
-                "files":[{"file_node_id":"1","project_file_components":["src","lib.rs"],"indexed_sha256":"c".repeat(64),"observed_sha256":"c".repeat(64)}],
-                "symbols":[
-                    {"node_id":"1","pinned":{"project_id":"p","core_generation_id":"g","core_run_id":"r","node_id":"1"},"canonical_id":"A","qualified_name":"crate::A","file":0},
-                    {"node_id":"2","pinned":{"project_id":"p","core_generation_id":"g","core_run_id":"r","node_id":"2"},"canonical_id":"B","qualified_name":"crate::B","file":0}
-                ],
-                "evidence":[{"fact_id":"d".repeat(64),"caller":0,"target":1,"chain":[{"kind":"same_file_declaration","symbols":[1]}],"provenance":{"producer":"codestory-internal","fact_schema_version":1,"algorithm":"exact-call-resolution-v1","language_adapter":"rust","language_adapter_version":"test-v1","parser_fingerprint":"e".repeat(64),"dependency_files":[0],"evidence_sha256":"f".repeat(64)}}]
-            },
-            "spec": {"start":{"kind":"canonical_id","canonical_id":"A"},"steps":[],"prohibit_traversal_through":[],"exclude_from_projection":[]},
+            "identities": identities,
+            "spec": {"start":{"kind":"canonical_id","canonical_id":"A"},"steps":[{"target":{"kind":"canonical_id","canonical_id":"B"},"relation":"direct_outgoing_call"}],"prohibit_traversal_through":[],"exclude_from_projection":[]},
             "clauses": [],
             "disposition": disposition,
-            "steps": [],
-            "receipts": [{"receipt_id":"receipt-1","edge_id":"1","source":0,"target":1,"evidence":0,"exact_callsite_start_byte":0,"callsite_identity":"1:1:1:2","column_or_ordinal":1,"containment":{"file":0,"owner":0,"start_line":1,"end_line":1},"line_window":{"kind":"indexed_line_v1","file":0,"anchor_line":1,"byte_start":0,"byte_end":1,"text":"x"}}]
+            "steps": steps,
+            "receipts": receipts,
         })
     }
 
@@ -389,6 +741,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "proof-qualification-support")]
     #[test]
     fn post_budget_validation_suppresses_invalid_payload_and_whole_result_falls_back() {
         let mut invalid = proof_root("unknown");
@@ -400,8 +753,8 @@ mod tests {
         assert_eq!(response.pointer("/error/code"), Some(&json!(-32603)));
         assert!(response.pointer("/error/data/structuredContent").is_none());
 
-        let mut oversized = proof_root("unknown");
-        oversized["receipts"][0]["line_window"]["text"] = json!("\\\"é".repeat(24_000));
+        let mut oversized = proof_root("proven");
+        set_receipt_line_text(&mut oversized, "\\\"é".repeat(24_000));
         let result = build_proof_tool_result_v3(McpRevisionV3::June2025, &oversized)
             .expect("fallback result");
         assert_eq!(
@@ -609,9 +962,10 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "proof-qualification-support")]
     #[test]
     fn measurement_seam_owns_exact_builder_bytes_for_every_revision() {
-        let root = proof_root("unknown");
+        let root = proof_root("proven");
         let measured = super::super::measure_revision_native_proof_result_v3(&root)
             .expect("revision-native measurements");
         assert_eq!(measured.len(), 4);
@@ -621,92 +975,6 @@ mod tests {
                 .expect("exact tool result bytes");
             assert_eq!(measurement.call_tool_result_bytes, direct_bytes);
             assert_eq!(measurement.byte_length, direct_bytes.len());
-        }
-    }
-
-    fn proof_root_at_revision_bytes(revision: McpRevisionV3, target: usize) -> Value {
-        let root = proof_root("unknown");
-        let size = |root: &Value| {
-            let result = build_tool_result_for_surface_v3(
-                revision,
-                "prove_call_path",
-                root,
-                V3SurfaceSet::WithProof,
-            )
-            .expect("unbounded revision-native result");
-            crate::stdio_transport::v3_serialize_call_tool_result(&result)
-                .expect("unbounded revision-native bytes")
-                .len()
-        };
-        for column_or_ordinal in [1, 10] {
-            let mut root = root.clone();
-            root["receipts"][0]["column_or_ordinal"] = json!(column_or_ordinal);
-            let baseline = size(&root);
-            assert!(baseline < target);
-            for quote_count in 0..=16 {
-                let mut seed = root.clone();
-                seed["receipts"][0]["line_window"]["text"] = json!("\"".repeat(quote_count));
-                let seed_size = size(&seed);
-                let mut one_more = seed.clone();
-                one_more["receipts"][0]["line_window"]["text"] =
-                    json!(format!("{}x", "\"".repeat(quote_count)));
-                let byte_step = size(&one_more) - seed_size;
-                let remaining = target.saturating_sub(seed_size);
-                if byte_step > 0 && remaining % byte_step == 0 {
-                    seed["receipts"][0]["line_window"]["text"] = json!(format!(
-                        "{}{}",
-                        "\"".repeat(quote_count),
-                        "x".repeat(remaining / byte_step)
-                    ));
-                    if size(&seed) == target {
-                        return seed;
-                    }
-                }
-            }
-        }
-        panic!("revision {revision:?} cannot reach target {target}");
-    }
-
-    #[test]
-    fn every_revision_measures_the_whole_proof_result_at_the_cap_and_cap_plus_one() {
-        for revision in McpRevisionV3::all() {
-            // Modern results mirror the root in both text and structured content, so every
-            // admissible byte delta is even while this fixture's envelope is odd. Its last
-            // fitting result is therefore cap-minus-one; legacy revisions reach the cap.
-            let fitting_size = if revision.profile().structured_content {
-                PROOF_TOOL_RESULT_MAX_BYTES_V3 - 1
-            } else {
-                PROOF_TOOL_RESULT_MAX_BYTES_V3
-            };
-            let exact = proof_root_at_revision_bytes(*revision, fitting_size);
-            let exact_result = build_proof_tool_result_v3(*revision, &exact).unwrap();
-            assert_eq!(
-                crate::stdio_transport::v3_serialize_call_tool_result(&exact_result)
-                    .unwrap()
-                    .len(),
-                fitting_size
-            );
-
-            let plus_one = proof_root_at_revision_bytes(*revision, fitting_size + 2);
-            let fallback = build_proof_tool_result_v3(*revision, &plus_one).unwrap();
-            assert!(
-                crate::stdio_transport::v3_serialize_call_tool_result(&fallback)
-                    .unwrap()
-                    .len()
-                    <= PROOF_TOOL_RESULT_MAX_BYTES_V3
-            );
-            let fallback_root = serde_json::from_str::<Value>(
-                fallback
-                    .pointer("/content/0/text")
-                    .and_then(Value::as_str)
-                    .unwrap(),
-            )
-            .unwrap();
-            assert_eq!(fallback_root["kind"], "budget_exceeded");
-            assert_eq!(fallback_root["required_complete_size"], fitting_size + 2);
-            for forbidden in ["identities", "spec", "clauses", "steps", "receipts"] {
-                assert!(fallback_root.get(forbidden).is_none());
-            }
         }
     }
 }

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -1336,7 +1336,12 @@ fn exact_resolution_facts_are_a_one_way_proof_overlay() {
         ),
         (
             "CLI navigation adapters",
-            read_source_tree("crates/codestory-cli/src"),
+            read_source_tree_excluding_many("crates/codestory-cli/src", &["stdio_v3/transport.rs"]),
+        ),
+        (
+            "production proof transport",
+            production_source_prefix(&read("crates/codestory-cli/src/stdio_v3/transport.rs"))
+                .to_owned(),
         ),
     ] {
         for forbidden in [

--- a/crates/codestory-runtime/src/indexed_source_call_path_v1.rs
+++ b/crates/codestory-runtime/src/indexed_source_call_path_v1.rs
@@ -780,7 +780,9 @@ where
                 source: source.clone(),
                 target: target.clone(),
                 resolution_fact_id: resolution_fact.fact_id,
-                resolution_evidence_sha256: resolution_fact.provenance.evidence_sha256,
+                resolution_evidence_sha256: resolution_fact.provenance.evidence_sha256.clone(),
+                resolution_evidence_chain: resolution_fact.evidence_chain,
+                resolution_provenance: resolution_fact.provenance,
                 exact_callsite_start_byte: resolution_fact.callsite.start_byte,
                 callsite_identity: admitted.callsite_identity,
                 column_or_ordinal: admitted.column_or_ordinal,
@@ -3205,15 +3207,7 @@ mod tests {
         };
         assert_eq!(
             root["disposition"]["refutation"]["connected_receipts"],
-            json!(
-                expected_chain
-                    .iter()
-                    .map(|receipt| json!({
-                        "receipt_id": receipt.receipt_id,
-                        "edge_id": receipt.edge_id,
-                    }))
-                    .collect::<Vec<_>>()
-            )
+            json!([0, 1])
         );
 
         let (excluded, excluded_hashes, excluded_rendering) = validated_contract_with_policies(

--- a/crates/codestory-runtime/src/indexed_source_call_path_v1.rs
+++ b/crates/codestory-runtime/src/indexed_source_call_path_v1.rs
@@ -1366,6 +1366,7 @@ fn resolved_node(
             .canonical_id
             .unwrap_or_else(|| format!("node:{}", node.id.0)),
         qualified_name: node.qualified_name.unwrap_or(node.serialized_name),
+        file_node_id: NodeId(file.id),
         project_file_components: components,
     }))
 }
@@ -2515,7 +2516,7 @@ mod tests {
     }
 
     #[test]
-    fn observed_runtime_trace_reports_receipt_and_projection_finalization_failures() {
+    fn observed_runtime_trace_keeps_oversized_complete_roots_for_transport() {
         let fixture = fixture(b"fn source() { target(); }\nfn target() {}\n");
         let (contract, hashes, rendering) = validated_contract("source-id", &["target-id"]);
         let observed = build_from_store_observed(
@@ -2548,20 +2549,23 @@ mod tests {
         );
 
         let mut receipt_budget = observed.clone();
-        receipt_budget.built.receipts[0].callsite_identity = "x".repeat(70_000);
+        receipt_budget.built.receipts[0].callsite_identity =
+            format!("1:1:1:{}", "x".repeat(70_000));
         let receipt_budget =
             finalize_observed_call_path(&contract, &hashes, &rendering, receipt_budget);
         assert!(matches!(
             receipt_budget.result,
             Ok(IntegratedProjectedCallPathResult {
-                projection: InternalProjection::BudgetExceeded { .. },
+                projection: InternalProjection::Complete { .. },
                 ..
             })
         ));
-        assert_eq!(
+        assert!(matches!(
             receipt_budget.trace.finalization,
-            FinalizationTrace::Failed(FinalizationFailure::ReceiptBudget)
-        );
+            FinalizationTrace::Complete {
+                projection_bytes
+            } if projection_bytes > 70_000
+        ));
 
         let (missing_contract, missing_hashes, missing_rendering) =
             validated_contract("missing-id", &["target-id"]);
@@ -2581,11 +2585,19 @@ mod tests {
             &missing_rendering,
             projection_budget,
         );
-        assert!(projection_budget.result.is_err());
-        assert_eq!(
+        assert!(matches!(
+            projection_budget.result,
+            Ok(IntegratedProjectedCallPathResult {
+                projection: InternalProjection::Complete { .. },
+                ..
+            })
+        ));
+        assert!(matches!(
             projection_budget.trace.finalization,
-            FinalizationTrace::Failed(FinalizationFailure::ProjectionBudget)
-        );
+            FinalizationTrace::Complete {
+                projection_bytes
+            } if projection_bytes > 70_000
+        ));
     }
 
     #[test]

--- a/crates/codestory-runtime/src/proof_qualification_support.rs
+++ b/crates/codestory-runtime/src/proof_qualification_support.rs
@@ -49,6 +49,12 @@ pub fn proof_domain() -> &'static str {
     codestory_agent::proof_qualification_support::proof_domain()
 }
 
+/// The sealed CLI seam validates every compact numeric reference before a
+/// revision-native transport serializes it.
+pub fn validate_compact_projection(root: &serde_json::Value) -> Result<(), String> {
+    codestory_agent::proof_qualification_support::validate_compact_projection(root)
+}
+
 #[cfg(test)]
 mod tests {
     use super::{

--- a/crates/codestory-runtime/src/proof_qualification_support.rs
+++ b/crates/codestory-runtime/src/proof_qualification_support.rs
@@ -17,6 +17,14 @@ pub use crate::indexed_source_call_path_v1::{
     ResolutionFactFailure, SelectorFailure, SelectorGateOutcome, SelectorQualificationTrace,
     SourceBindingFailure, StepQualificationOutcome, StepQualificationTrace,
 };
+pub use codestory_agent::proof_qualification_support::{
+    BuiltCallPathFacts, CallableContainmentEvidence, ClauseAnchor, ClauseClassification,
+    IndexedCallEdgeReceipt, IndexedLineWindow, InternalCorePublicationIdentity, InternalProjection,
+    PinnedNodeIdentity, ProofContractField, ReceiptRef, ResolvedNodeIdentity,
+    UnvalidatedCallPathContract, UnvalidatedCallPathSpec, UnvalidatedDirectCallStep,
+    UnvalidatedExactSymbolSelector, ValidationOutcome, VerifiedDirectCallFact, VerifiedProofFact,
+    check_built_call_path_integration, project_internal_call_path_result, validate_contract,
+};
 
 /// Executes one observed proof through the runtime's existing core-only public
 /// operation. The benchmark cannot obtain the controller or add a second


### PR DESCRIPTION
## Context

The dark exact-call-path response repeated publication, symbol, file, and resolution-provenance data per receipt. Real qualified paths remained sound but exceeded the stable response-size budget. This slice compacts the proof projection without registering a public proof route or changing proof authority.

## What changed

- Intern one publication plus deterministic file, symbol, and evidence identity tables.
- Preserve the full authenticated resolution evidence chain and provenance behind compact receipt references.
- Validate graph/fact correlation, source ownership, callsite identity, evidence arity, disposition order, duplicate identities, hashes, and cross-file dependencies before transport.
- Measure the complete revision-native `CallToolResult`, emit a partial-free budget fallback at 64 KiB, and keep modern text/structured mirrors identical.
- Teach the qualification reader to resolve compact receipt identities without changing contract digests, clauses, normalized specs, proof counts, packet/context/search, or storage.
- Keep all proof projection and measurement paths production-unreachable behind the existing qualification feature.

## Review

One consolidated adversarial review covered language-domain closure, parser provenance, graph/fact correlation, repeated callsites, source coordinates, native ordering, storage integrity, and complexity. Its four soundness findings were corrected together. The broad gate then exposed and fixed two feature-boundary contract defects: test-only proof fixtures were misclassified as navigation consumers, and all-feature unification masked a default CLI dependency on qualification-only runtime code.

The final implementation is linear in the emitted identity, evidence, receipt, and step rows. It adds no semantic abstraction, adapter coverage, public route, CLI command, graph migration, or release surface.

## Verification

Exact source: `9e008d0685f1bac449e0c3627bba8205e3d65d42`  
Exact tree: `d343a4e47e53a6bb25c2e80d630d337cf8689af7`

- `cargo fmt --all -- --check`
- `cargo check --locked --workspace`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo nextest run --locked --workspace --no-fail-fast` — 4,022 passed, 34 skipped
- `cargo test --locked --workspace --doc`
- `cargo test --locked -p codestory-cli --test stdio_protocol_contracts` — 63 passed
- Q1 evidence-only feature build and four-revision conformance — passed
- CodeStoryDev installer tests — 6 passed
- plugin static tests — 140 passed, 1 Windows-only skipped
- generated syntax check, documentation links, and `git diff --check` — passed

Local materialize/run/verify: `20260824T130003Z-9e008d0685f1`

- 62/120 full proofs; cohort counts 12/12/18/20 (unchanged authority)
- 170/312 exact positive steps
- hard gates: all zero
- maximum response: 46,619 bytes; no over-cap results
- complete p95: 39,232 bytes; unknown p95: 28,158 bytes
- frozen decision: `keep_proof_dark`

The stable activation gates still fail on positive-step recall, full-or-useful partials, unknown warm latency, and response p95. This PR makes no public-availability or release claim.

Closes #2038
Refs #2023
