### PR TITLE
[proof availability] Refine Rust name-local closure

### DIFF
--- a/crates/codestory-indexer/src/cache.rs
+++ b/crates/codestory-indexer/src/cache.rs
@@ -286,7 +286,7 @@ impl CachedIndexArtifact {
         resolution_file: Option<CachedResolutionFile>,
     ) -> Self {
         Self {
-            resolution_input_schema_version: 11,
+            resolution_input_schema_version: 12,
             files: index_result.files,
             nodes: index_result.nodes,
             edges: index_result.edges,

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -87,7 +87,8 @@ use cache::{
 pub use cancellation::CancellationToken;
 use intermediate_storage::IntermediateStorage;
 pub use proof_resolution::{
-    build_funnel as build_proof_resolution_funnel, rematerialize_proof_resolution_projection,
+    build_funnel as build_proof_resolution_funnel, current_proof_resolution_adapter_roster,
+    rematerialize_proof_resolution_projection,
 };
 use symbol_table::SymbolTable;
 

--- a/crates/codestory-indexer/src/proof_resolution.rs
+++ b/crates/codestory-indexer/src/proof_resolution.rs
@@ -85,7 +85,7 @@ fn python_resolution_work() -> usize {
 }
 
 const ADAPTER_VERSION: &str = "reference-v13";
-const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 11;
+const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 12;
 const INSTALLED_ADAPTERS: &[(&str, &str)] = &[
     ("go", ADAPTER_VERSION),
     ("javascript", ADAPTER_VERSION),
@@ -4457,7 +4457,7 @@ impl<'tree> RustResolutionIndex<'tree> {
                     && !rust_inner_allow_preserves_module_bindings(*item, source))
                 || (item.kind() == "attribute_item"
                     && !rust_attribute_is_bounded_item_metadata(*item, source))
-                || (!matches!(item.kind(), "function_item" | "mod_item" | "impl_item")
+                || (item.kind() == "expression_statement"
                     && contains_node_kind(*item, "macro_invocation"))
             {
                 domain_complete = false;

--- a/crates/codestory-indexer/src/proof_resolution.rs
+++ b/crates/codestory-indexer/src/proof_resolution.rs
@@ -4464,14 +4464,14 @@ impl<'tree> RustResolutionIndex<'tree> {
         let mut cursor = body.walk();
         let items = body.named_children(&mut cursor).collect::<Vec<_>>();
         let attributed_items = rust_attributed_item_ids(&items);
+        let bounded_attribute_ids = rust_bounded_outer_attribute_ids(&items, source);
         self.attributed_items
             .extend(attributed_items.iter().copied());
         for item in &items {
             let direct_domain_poison = item.kind() == "macro_invocation"
                 || (item.kind() == "inner_attribute_item"
                     && !rust_inner_allow_preserves_module_bindings(*item, source))
-                || (item.kind() == "attribute_item"
-                    && !rust_attribute_is_bounded_item_metadata(*item, source))
+                || (item.kind() == "attribute_item" && !bounded_attribute_ids.contains(&item.id()))
                 || (item.kind() == "expression_statement"
                     && contains_node_kind(*item, "macro_invocation"));
             if direct_domain_poison {
@@ -5333,20 +5333,67 @@ fn rust_attributed_item_ids(items: &[TsNode<'_>]) -> HashSet<usize> {
     result
 }
 
-fn rust_attribute_is_bounded_item_metadata(attribute: TsNode<'_>, source: &str) -> bool {
-    let Some(surface) = node_text(attribute, source) else {
-        return false;
-    };
-    let Some(body) = surface.trim().strip_prefix("#[") else {
-        return false;
-    };
-    let name = body
-        .split(|character: char| {
-            character == '(' || character == '=' || character == ']' || character.is_whitespace()
+fn rust_bounded_outer_attribute_ids(items: &[TsNode<'_>], source: &str) -> HashSet<usize> {
+    let mut result = HashSet::new();
+    let mut attributes = Vec::new();
+    for item in items {
+        if item.kind() == "attribute_item" {
+            attributes.push(*item);
+        } else {
+            if rust_attribute_group_is_bounded(&attributes, *item, source) {
+                result.extend(attributes.iter().map(|attribute| attribute.id()));
+            }
+            attributes.clear();
+        }
+    }
+    result
+}
+
+fn rust_attribute_group_is_bounded(
+    attributes: &[TsNode<'_>],
+    attributed_item: TsNode<'_>,
+    source: &str,
+) -> bool {
+    let is_helper_type = matches!(attributed_item.kind(), "struct_item" | "enum_item");
+    let has_derive = attributes.iter().any(|attribute| {
+        node_text(*attribute, source).is_some_and(|surface| {
+            surface
+                .trim()
+                .strip_prefix("#[")
+                .is_some_and(|body| body.starts_with("derive("))
         })
-        .next()
-        .unwrap_or_default();
-    matches!(name, "allow" | "cfg" | "derive" | "doc")
+    });
+    attributes.iter().all(|attribute| {
+        let Some(surface) = node_text(*attribute, source) else {
+            return false;
+        };
+        let Some(body) = surface.trim().strip_prefix("#[") else {
+            return false;
+        };
+        let name = body
+            .split(|character: char| {
+                character == '('
+                    || character == '='
+                    || character == ']'
+                    || character.is_whitespace()
+            })
+            .next()
+            .unwrap_or_default();
+        match name {
+            "allow" | "cfg" | "derive" | "doc" => true,
+            "inline" => attributed_item.kind() == "function_item",
+            "serde" | "error" => is_helper_type && has_derive,
+            "cfg_attr" if is_helper_type => body
+                .strip_prefix("cfg_attr(")
+                .and_then(|arguments| arguments.strip_suffix(")]"))
+                .and_then(|arguments| arguments.split_once(','))
+                .is_some_and(|(_, injected)| {
+                    let injected = injected.trim();
+                    injected.starts_with("derive(") && injected.ends_with(')')
+                }),
+            _ => false,
+        }
+    })
 }
 
 fn rust_inner_allow_preserves_module_bindings(attribute: TsNode<'_>, source: &str) -> bool {
@@ -5395,10 +5442,7 @@ fn rust_callable_poison_ranges(function: TsNode<'_>, source: &str) -> Vec<(usize
                 continue;
             }
             if !pending_attributes.is_empty() {
-                if pending_attributes
-                    .iter()
-                    .all(|attribute| rust_attribute_is_bounded_item_metadata(*attribute, source))
-                {
+                if rust_attribute_group_is_bounded(&pending_attributes, child, source) {
                     output.push((child.start_byte(), child.end_byte()));
                 } else {
                     output.push(scope);

--- a/crates/codestory-indexer/src/proof_resolution.rs
+++ b/crates/codestory-indexer/src/proof_resolution.rs
@@ -84,7 +84,7 @@ fn python_resolution_work() -> usize {
     PYTHON_RESOLUTION_WORK.with(std::cell::Cell::get)
 }
 
-const ADAPTER_VERSION: &str = "reference-v13";
+const ADAPTER_VERSION: &str = "reference-v14";
 const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 12;
 const INSTALLED_ADAPTERS: &[(&str, &str)] = &[
     ("go", ADAPTER_VERSION),
@@ -94,6 +94,18 @@ const INSTALLED_ADAPTERS: &[(&str, &str)] = &[
     ("tsx", ADAPTER_VERSION),
     ("typescript", ADAPTER_VERSION),
 ];
+
+pub fn current_proof_resolution_adapter_roster() -> Vec<ProofResolutionAdapter> {
+    let mut roster = INSTALLED_ADAPTERS
+        .iter()
+        .map(|(language, adapter_version)| ProofResolutionAdapter {
+            language: (*language).to_owned(),
+            adapter_version: (*adapter_version).to_owned(),
+        })
+        .collect::<Vec<_>>();
+    roster.sort();
+    roster
+}
 
 pub(crate) struct CollectedResolutionInputs {
     pub calls: Vec<CachedCallResolutionInput>,
@@ -4344,6 +4356,7 @@ struct RustResolutionIndex<'tree> {
     methods_by_owner_name: HashMap<(Vec<String>, String, String), Vec<CachedInherentMethod>>,
     uses_by_module_name: HashMap<(Vec<String>, String), Vec<CachedRustUseBinding>>,
     module_complete: HashMap<Vec<String>, bool>,
+    identifier_module_complete: HashMap<Vec<String>, bool>,
     module_value_blockers: HashMap<Vec<String>, HashSet<String>>,
     module_incomplete_value_names: HashMap<Vec<String>, HashSet<String>>,
     module_unsupported_value_names: HashMap<Vec<String>, HashSet<String>>,
@@ -4376,6 +4389,7 @@ impl<'tree> RustResolutionIndex<'tree> {
             methods_by_owner_name: HashMap::new(),
             uses_by_module_name: HashMap::new(),
             module_complete: HashMap::new(),
+            identifier_module_complete: HashMap::new(),
             module_value_blockers: HashMap::new(),
             module_incomplete_value_names: HashMap::new(),
             module_unsupported_value_names: HashMap::new(),
@@ -4442,6 +4456,7 @@ impl<'tree> RustResolutionIndex<'tree> {
         graph_nodes: &RustGraphNodeIndex,
     ) {
         let mut domain_complete = true;
+        let mut identifier_module_complete = true;
         let mut file_children = Vec::new();
         let mut value_blockers = HashSet::new();
         let mut incomplete_value_names = HashSet::new();
@@ -4452,15 +4467,38 @@ impl<'tree> RustResolutionIndex<'tree> {
         self.attributed_items
             .extend(attributed_items.iter().copied());
         for item in &items {
-            if item.kind() == "macro_invocation"
+            let direct_domain_poison = item.kind() == "macro_invocation"
                 || (item.kind() == "inner_attribute_item"
                     && !rust_inner_allow_preserves_module_bindings(*item, source))
                 || (item.kind() == "attribute_item"
                     && !rust_attribute_is_bounded_item_metadata(*item, source))
                 || (item.kind() == "expression_statement"
-                    && contains_node_kind(*item, "macro_invocation"))
-            {
+                    && contains_node_kind(*item, "macro_invocation"));
+            if direct_domain_poison {
                 domain_complete = false;
+                identifier_module_complete = false;
+            } else {
+                let conservative_macro_container =
+                    !matches!(item.kind(), "function_item" | "mod_item" | "impl_item");
+                let identifier_macro_container = !matches!(
+                    item.kind(),
+                    "function_item"
+                        | "mod_item"
+                        | "impl_item"
+                        | "const_item"
+                        | "static_item"
+                        | "enum_item"
+                );
+                if (conservative_macro_container || identifier_macro_container)
+                    && contains_node_kind(*item, "macro_invocation")
+                {
+                    if conservative_macro_container {
+                        domain_complete = false;
+                    }
+                    if identifier_macro_container {
+                        identifier_module_complete = false;
+                    }
+                }
             }
             match item.kind() {
                 "function_item" => {
@@ -4470,11 +4508,13 @@ impl<'tree> RustResolutionIndex<'tree> {
                             incomplete_value_names.insert(name);
                         } else {
                             domain_complete = false;
+                            identifier_module_complete = false;
                         }
                         continue;
                     }
                     let Some(name) = name else {
                         domain_complete = false;
+                        identifier_module_complete = false;
                         continue;
                     };
                     let Some(declaration) = graph_nodes.callable(*item, source) else {
@@ -4502,6 +4542,7 @@ impl<'tree> RustResolutionIndex<'tree> {
                             incomplete_value_names.insert(name.to_string());
                         } else {
                             domain_complete = false;
+                            identifier_module_complete = false;
                         }
                         continue;
                     }
@@ -4510,6 +4551,7 @@ impl<'tree> RustResolutionIndex<'tree> {
                         graph_nodes.rust_type(*item, source),
                     ) else {
                         domain_complete = false;
+                        identifier_module_complete = false;
                         continue;
                     };
                     self.types_by_module_name
@@ -4546,6 +4588,7 @@ impl<'tree> RustResolutionIndex<'tree> {
                         let names = rust_use_bound_names(*item, source);
                         if names.is_empty() {
                             domain_complete = false;
+                            identifier_module_complete = false;
                         } else {
                             incomplete_value_names.extend(names);
                         }
@@ -4566,6 +4609,7 @@ impl<'tree> RustResolutionIndex<'tree> {
                     } else {
                         if node_text(*item, source).is_some_and(|surface| surface.contains('*')) {
                             domain_complete = false;
+                            identifier_module_complete = false;
                         }
                         value_blockers.extend(rust_use_bound_names(*item, source));
                     }
@@ -4578,6 +4622,7 @@ impl<'tree> RustResolutionIndex<'tree> {
                 "mod_item" => {
                     let Some(name) = declaration_name(*item, source).map(str::to_string) else {
                         domain_complete = false;
+                        identifier_module_complete = false;
                         continue;
                     };
                     if attributed_items.contains(&item.id()) {
@@ -4597,6 +4642,7 @@ impl<'tree> RustResolutionIndex<'tree> {
                     } else {
                         let Some(declaration) = module_declaration else {
                             domain_complete = false;
+                            identifier_module_complete = false;
                             continue;
                         };
                         file_children.push(CachedRustFileModule { name, declaration });
@@ -4613,6 +4659,8 @@ impl<'tree> RustResolutionIndex<'tree> {
         file_children.dedup();
         self.module_complete
             .insert(module_path.clone(), domain_complete);
+        self.identifier_module_complete
+            .insert(module_path.clone(), identifier_module_complete);
         self.module_value_blockers
             .insert(module_path.clone(), value_blockers.clone());
         self.module_incomplete_value_names
@@ -4973,7 +5021,22 @@ impl<'tree> RustResolutionIndex<'tree> {
             return (Some(caller), CachedResolutionBinding::IncompleteDomain);
         };
         if self.module_complete.get(&module_path) != Some(&true) {
-            return (Some(caller), CachedResolutionBinding::IncompleteDomain);
+            let declarations = self
+                .declarations_by_module_name
+                .get(&(module_path.clone(), raw_target.to_owned()))
+                .map(Vec::as_slice)
+                .unwrap_or_default();
+            let uses = self
+                .uses_by_module_name
+                .get(&(module_path.clone(), raw_target.to_owned()))
+                .map(Vec::as_slice)
+                .unwrap_or_default();
+            if !matches!(form, CalleeForm::Identifier)
+                || self.identifier_module_complete.get(&module_path) != Some(&true)
+                || !matches!((declarations, uses), ([_], []))
+            {
+                return (Some(caller), CachedResolutionBinding::IncompleteDomain);
+            }
         }
         match form {
             CalleeForm::Identifier => {
@@ -6513,13 +6576,7 @@ pub fn rematerialize_proof_resolution_projection(
         .replace_proof_resolution_projection(
             publication,
             &ProofResolutionProjection {
-                adapter_roster: INSTALLED_ADAPTERS
-                    .iter()
-                    .map(|(language, adapter_version)| ProofResolutionAdapter {
-                        language: (*language).to_string(),
-                        adapter_version: (*adapter_version).to_string(),
-                    })
-                    .collect(),
+                adapter_roster: current_proof_resolution_adapter_roster(),
                 facts,
                 funnel,
             },

--- a/crates/codestory-indexer/tests/proof_resolution.rs
+++ b/crates/codestory-indexer/tests/proof_resolution.rs
@@ -5025,6 +5025,48 @@ fn rust_attribute_domains_are_never_exact() -> anyhow::Result<()> {
 }
 
 #[test]
+fn rust_bounded_outer_metadata_preserves_unrelated_bindings() -> anyhow::Result<()> {
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(
+        project.path(),
+        &mut store,
+        &[(
+            "src/lib.rs",
+            "#[derive(Debug)]\n#[serde(rename = \"serde_helper\")]\nstruct SerdeHelper;\n#[derive(Debug)]\n#[error(\"error_helper\")]\nstruct ErrorHelper;\n#[inline]\nfn inline_helper() {}\n#[cfg_attr(test, derive(Debug))]\nstruct Report;\nfn target() {}\nfn caller() { target(); SerdeHelper(); ErrorHelper(); inline_helper(); Report(); }\n",
+        )],
+    )?;
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    let facts = store.get_proof_resolution_facts()?;
+    let fact = |name| {
+        facts
+            .iter()
+            .find(|fact| fact.callsite.raw_target == name)
+            .expect("one direct call")
+    };
+    assert_eq!(fact("target").status, ProofResolutionStatus::Exact);
+    for name in ["SerdeHelper", "ErrorHelper", "inline_helper", "Report"] {
+        assert_eq!(
+            fact(name).status,
+            ProofResolutionStatus::IncompleteDomain,
+            "the attributed item's own name remains incomplete: {name}"
+        );
+    }
+
+    for source in [
+        "#[unresolved_attribute_macro]\nfn helper() {}\nfn target() {}\nfn caller() { target(); }\n",
+        "#[cfg_attr(test, unresolved_attribute_macro)]\nfn helper() {}\nfn target() {}\nfn caller() { target(); }\n",
+        "#[serde(rename = \"helper\")]\nfn helper() {}\nfn target() {}\nfn caller() { target(); }\n",
+        "#[error(\"helper\")]\nfn helper() {}\nfn target() {}\nfn caller() { target(); }\n",
+        "#[serde(rename = \"helper\")]\nstruct Helper;\nfn target() {}\nfn caller() { target(); }\n",
+        "#[cfg_attr(test, derive(Debug))]\nfn helper() {}\nfn target() {}\nfn caller() { target(); }\n",
+    ] {
+        assert_only_call_is_not_exact(&[("src/lib.rs", source)])?;
+    }
+    Ok(())
+}
+
+#[test]
 fn non_exact_reference_inputs_keep_closed_fail_closed_statuses() -> anyhow::Result<()> {
     let project = tempfile::tempdir()?;
     let mut store = Store::new_in_memory()?;

--- a/crates/codestory-indexer/tests/proof_resolution.rs
+++ b/crates/codestory-indexer/tests/proof_resolution.rs
@@ -4837,7 +4837,7 @@ fn complete_projection_rejects_cache_schema_adapter_and_language_mismatch() -> a
             .expect_err("cache provenance mismatch must reject the complete projection");
         let message = error.to_string();
         assert!(
-            ["stale", "schema-v11", "adapter", "language"]
+            ["stale", "schema-v12", "adapter", "language"]
                 .iter()
                 .any(|needle| message.contains(needle)),
             "{mutation}: {error}"
@@ -4902,6 +4902,31 @@ fn rust_macro_expansion_poison_is_scoped_to_relevant_domains() -> anyhow::Result
         "src/disjoint.rs",
         "macro_rules! local_only { () => { let unrelated = 1; }; }\nfn target() {}\nfn caller() { { local_only!(); } target(); }\n",
     )])?;
+    Ok(())
+}
+
+#[test]
+fn rust_module_closure_ignores_unrelated_closed_expression_macros() -> anyhow::Result<()> {
+    for source in [
+        "const LABEL: &str = concat!(\"open\", \"\");\nfn target() {}\nfn caller() { target(); }\n",
+        "static PACKAGE: &str = env!(\"CARGO_PKG_NAME\");\nfn target() {}\nfn caller() { target(); }\n",
+        "const LABEL: &str = { let _ = format_args!(\"{}\", \"note\"); \"note\" };\nfn target() {}\nfn caller() { target(); }\n",
+        "enum Marker { Value = line!() }\nfn target() {}\nfn caller() { target(); }\n",
+        "#[cfg(any())]\nconst UNRELATED: usize = 0;\nfn target() {}\nfn caller() { target(); }\n",
+    ] {
+        assert_only_call_is_exact(&[("src/lib.rs", source)])?;
+    }
+
+    for source in [
+        "include!(\"generated.rs\");\nfn target() {}\nfn caller() { target(); }\n",
+        "thread_local! { static MARKER: usize = 0; }\nfn target() {}\nfn caller() { target(); }\n",
+        "macro_rules! generated { () => { fn target() {} }; }\ngenerated!();\nfn target() {}\nfn caller() { target(); }\n",
+        "#![cfg(any())]\nfn target() {}\nfn caller() { target(); }\n",
+        "#[cfg(any())]\nfn target() {}\nfn target() {}\nfn caller() { target(); }\n",
+        "fn target() {}\n#[cfg(any())]\nfn caller() { target(); }\n",
+    ] {
+        assert_only_call_is_not_exact(&[("src/lib.rs", source)])?;
+    }
     Ok(())
 }
 

--- a/crates/codestory-indexer/tests/proof_resolution.rs
+++ b/crates/codestory-indexer/tests/proof_resolution.rs
@@ -4921,11 +4921,64 @@ fn rust_module_closure_ignores_unrelated_closed_expression_macros() -> anyhow::R
         "include!(\"generated.rs\");\nfn target() {}\nfn caller() { target(); }\n",
         "thread_local! { static MARKER: usize = 0; }\nfn target() {}\nfn caller() { target(); }\n",
         "macro_rules! generated { () => { fn target() {} }; }\ngenerated!();\nfn target() {}\nfn caller() { target(); }\n",
+        "macro_rules! foreign_target { () => { fn target(); }; }\nunsafe extern \"C\" { foreign_target!(); }\nfn target() {}\nfn caller() { target(); }\n",
         "#![cfg(any())]\nfn target() {}\nfn caller() { target(); }\n",
         "#[cfg(any())]\nfn target() {}\nfn target() {}\nfn caller() { target(); }\n",
         "fn target() {}\n#[cfg(any())]\nfn caller() { target(); }\n",
     ] {
         assert_only_call_is_not_exact(&[("src/lib.rs", source)])?;
+    }
+    Ok(())
+}
+
+#[test]
+fn rust_closed_expression_macros_only_relax_bare_same_file_calls() -> anyhow::Result<()> {
+    assert_only_call_is_exact(&[(
+        "src/lib.rs",
+        "const LABEL: &str = concat!(\"open\", \"\");\nfn target() {}\nfn caller() { target(); }\n",
+    )])?;
+
+    for source in [
+        "const LABEL: &str = concat!(\"open\", \"\");\nstruct Worker;\nimpl Worker { fn target(&self) {} fn caller(&self) { self.target(); } }\n",
+        "const LABEL: &str = concat!(\"open\", \"\");\nstruct Worker;\nimpl Worker { fn target() {} }\nfn caller() { Worker::target(); }\n",
+        "const LABEL: &str = concat!(\"open\", \"\");\nstruct Worker;\nimpl Worker { fn target(&self) {} }\nfn caller() { let value: Worker = Worker; value.target(); }\n",
+    ] {
+        assert_only_call_is_not_exact(&[("src/lib.rs", source)])?;
+    }
+    Ok(())
+}
+
+#[test]
+fn rust_identifier_local_closure_keeps_glob_import_domains_incomplete() -> anyhow::Result<()> {
+    assert_only_call_is_not_exact(&[(
+        "src/lib.rs",
+        "use crate::*;\nfn target() {}\nfn caller() { target(); }\n",
+    )])
+}
+
+#[test]
+fn proof_resolution_roster_tracks_the_current_adapter_version() -> anyhow::Result<()> {
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(
+        project.path(),
+        &mut store,
+        &[("src/lib.rs", "fn target() {}\nfn caller() { target(); }\n")],
+    )?;
+    let receipt = rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    assert_eq!(
+        receipt
+            .adapter_roster
+            .iter()
+            .find(|adapter| adapter.language == "rust")
+            .map(|adapter| adapter.adapter_version.as_str()),
+        Some("reference-v14")
+    );
+    for fact in store.get_proof_resolution_facts()? {
+        assert!(receipt.adapter_roster.iter().any(|adapter| {
+            adapter.language == fact.provenance.language_adapter
+                && adapter.adapter_version == fact.provenance.language_adapter_version
+        }));
     }
     Ok(())
 }

--- a/crates/codestory-runtime/src/indexed_source_call_path_v1.rs
+++ b/crates/codestory-runtime/src/indexed_source_call_path_v1.rs
@@ -42,6 +42,7 @@ use codestory_agent::proof_qualification_test_support::{
 use codestory_contracts::api::ApiError;
 use codestory_contracts::graph::{Node, NodeId, NodeKind};
 use codestory_contracts::proof_resolution::{CallResolutionFact, ProofResolutionStatus};
+use codestory_indexer::current_proof_resolution_adapter_roster;
 use codestory_store::{FileInfo, IndexPublicationRecord, Store};
 use codestory_workspace::{
     ProjectRelativePathResolution, WorkspacePathIdentity, project_identity_v3,
@@ -381,10 +382,11 @@ where
         generation_id: publication.generation_id.clone(),
         run_id: publication.run_id.clone(),
     };
-    if store
-        .validate_proof_resolution_publication(publication)
-        .is_err()
-    {
+    let proof_projection_available = matches!(
+        store.validate_proof_resolution_publication(publication),
+        Ok(manifest) if manifest.adapter_roster == current_proof_resolution_adapter_roster()
+    );
+    if !proof_projection_available {
         return Ok(ObservedBuiltCallPathFacts {
             built: BuiltCallPathFacts {
                 publication: proof_publication,
@@ -1628,8 +1630,7 @@ mod tests {
     use codestory_contracts::proof_resolution::{
         CallResolutionFact, CalleeForm, DependencyFileHash, EXACT_CALL_RESOLUTION_ALGORITHM,
         ExactCallsite, FileId, INTERNAL_RESOLUTION_PRODUCER, PROOF_RESOLUTION_FACT_SCHEMA_VERSION,
-        ProofResolutionAdapter, ProofResolutionProjection, ProofResolutionReason,
-        ResolutionEvidence, ResolutionProvenance,
+        ProofResolutionProjection, ProofResolutionReason, ResolutionEvidence, ResolutionProvenance,
     };
     use codestory_indexer::{
         WorkspaceIndexer, build_proof_resolution_funnel, rematerialize_proof_resolution_projection,
@@ -1914,6 +1915,13 @@ mod tests {
         publication: &IndexPublicationRecord,
         edge_ids: &[EdgeId],
     ) {
+        let adapter_roster = current_proof_resolution_adapter_roster();
+        let rust_adapter_version = adapter_roster
+            .iter()
+            .find(|adapter| adapter.language == "rust")
+            .expect("compiled roster includes Rust")
+            .adapter_version
+            .clone();
         let nodes = store
             .get_nodes()
             .unwrap()
@@ -1994,7 +2002,7 @@ mod tests {
                         fact_schema_version: PROOF_RESOLUTION_FACT_SCHEMA_VERSION,
                         algorithm: EXACT_CALL_RESOLUTION_ALGORITHM.to_owned(),
                         language_adapter: "rust".to_owned(),
-                        language_adapter_version: "test-v1".to_owned(),
+                        language_adapter_version: rust_adapter_version.clone(),
                         parser_fingerprint: "2".repeat(64),
                         dependency_file_hashes: vec![DependencyFileHash {
                             file_id: FileId(file_id.0),
@@ -2011,10 +2019,7 @@ mod tests {
             .replace_proof_resolution_projection(
                 publication,
                 &ProofResolutionProjection {
-                    adapter_roster: vec![ProofResolutionAdapter {
-                        language: "rust".to_owned(),
-                        adapter_version: "test-v1".to_owned(),
-                    }],
+                    adapter_roster,
                     facts,
                     funnel,
                 },
@@ -2884,6 +2889,70 @@ mod tests {
                     )
             })
         ));
+    }
+
+    #[test]
+    fn source_built_runtime_rejects_a_compiled_stale_adapter_roster() {
+        let mut fixture = source_built_fixture("fn target() {}\nfn source() { target(); }\n");
+        let source = source_callable(&fixture.store, "source");
+        let target = source_callable(&fixture.store, "target");
+        let (contract, _hashes, _rendering) =
+            validated_contract(canonical_id(&source), &[canonical_id(&target)]);
+        let manifest = fixture
+            .store
+            .get_proof_resolution_publication()
+            .unwrap()
+            .unwrap();
+        let mut facts = fixture.store.get_proof_resolution_facts().unwrap();
+        for fact in &mut facts {
+            fact.provenance.language_adapter_version = "wrong-v1".to_owned();
+            *fact = seal_call_resolution_fact(fact.clone()).unwrap();
+        }
+        let mut adapter_roster = manifest.adapter_roster;
+        adapter_roster
+            .iter_mut()
+            .find(|adapter| adapter.language == "rust")
+            .unwrap()
+            .adapter_version = "wrong-v1".to_owned();
+        let funnel = build_proof_resolution_funnel(&facts);
+        fixture
+            .store
+            .get_connection()
+            .execute_batch(
+                "DELETE FROM proof_resolution_fact; DELETE FROM proof_resolution_publication;",
+            )
+            .unwrap();
+        fixture
+            .store
+            .replace_proof_resolution_projection(
+                &fixture.publication,
+                &ProofResolutionProjection {
+                    adapter_roster,
+                    facts,
+                    funnel,
+                },
+            )
+            .expect("the stored roster still covers each stored fact provenance");
+        fixture
+            .store
+            .validate_proof_resolution_publication(&fixture.publication)
+            .expect("store validation accepts a self-consistent stored roster");
+
+        let observed = build_from_store_observed(
+            &fixture.store,
+            &fixture.root,
+            &fixture.project_id,
+            &fixture.publication,
+            &contract,
+            |path| fs::read(path),
+        )
+        .unwrap();
+
+        assert_eq!(
+            observed.built.unavailable,
+            vec![UnavailableReason::ProofSemanticProjectionUnavailable]
+        );
+        assert!(observed.built.receipts.is_empty());
     }
 
     #[test]

--- a/crates/codestory-store/src/storage_impl/proof_resolution.rs
+++ b/crates/codestory-store/src/storage_impl/proof_resolution.rs
@@ -196,6 +196,39 @@ fn validate_fact_shape(fact: &CallResolutionFact, require_seal: bool) -> Result<
     Ok(())
 }
 
+fn validate_adapter_roster(
+    facts: &[CallResolutionFact],
+    adapter_roster: &[ProofResolutionAdapter],
+) -> Result<(), StorageError> {
+    let mut sorted_roster = adapter_roster.to_vec();
+    sorted_roster.sort();
+    if adapter_roster.is_empty()
+        || adapter_roster.iter().any(|adapter| {
+            adapter.language.trim().is_empty() || adapter.adapter_version.trim().is_empty()
+        })
+        || sorted_roster.windows(2).any(|pair| pair[0] == pair[1])
+    {
+        return Err(proof_error(
+            "adapter roster is empty, invalid, or duplicated",
+        ));
+    }
+    if facts.iter().any(|fact| {
+        sorted_roster
+            .iter()
+            .filter(|adapter| {
+                adapter.language == fact.provenance.language_adapter
+                    && adapter.adapter_version == fact.provenance.language_adapter_version
+            })
+            .count()
+            != 1
+    }) {
+        return Err(proof_error(
+            "fact provenance adapter is not represented exactly once in the adapter roster",
+        ));
+    }
+    Ok(())
+}
+
 fn validate_fact_seal(fact: &CallResolutionFact) -> Result<(), StorageError> {
     validate_fact_shape(fact, true)?;
     let resealed = seal_call_resolution_fact(fact.clone())?;
@@ -2383,14 +2416,7 @@ impl Storage {
 
         let mut adapter_roster = projection.adapter_roster.clone();
         adapter_roster.sort();
-        adapter_roster.dedup();
-        if adapter_roster.is_empty()
-            || adapter_roster.iter().any(|adapter| {
-                adapter.language.trim().is_empty() || adapter.adapter_version.trim().is_empty()
-            })
-        {
-            return Err(proof_error("adapter roster is empty or invalid"));
-        }
+        validate_adapter_roster(&facts, &adapter_roster)?;
         let mut funnel = projection.funnel.clone();
         funnel.sort_by(|left, right| {
             (
@@ -2549,6 +2575,7 @@ impl Storage {
             ));
         }
         let facts = self.get_proof_resolution_facts()?;
+        validate_adapter_roster(&facts, &manifest.adapter_roster)?;
         let expected_funnel = recompute_funnel(&facts);
         if manifest.funnel != expected_funnel
             || manifest.fact_count != facts.len() as u64

--- a/crates/codestory-store/tests/proof_resolution.rs
+++ b/crates/codestory-store/tests/proof_resolution.rs
@@ -1664,6 +1664,46 @@ fn publication_digest_authenticates_roster_and_funnel() {
 }
 
 #[test]
+fn replacement_rejects_fact_provenance_missing_from_the_adapter_roster() {
+    let mut store = Store::new_in_memory().unwrap();
+    seed_exact_graph(&mut store);
+    let mut result = projection(vec![exact_fact(EdgeId(7))]);
+    result.adapter_roster[0].adapter_version = "wrong-v1".to_owned();
+
+    let error = store
+        .replace_proof_resolution_projection(&publication(), &result)
+        .expect_err("a fact provenance adapter must be rostered exactly once");
+    assert!(error.to_string().contains("adapter roster"), "{error}");
+}
+
+#[test]
+fn stored_validation_rejects_fact_provenance_missing_from_the_adapter_roster() {
+    let mut store = Store::new_in_memory().unwrap();
+    seed_exact_graph(&mut store);
+    let publication = publication();
+    store
+        .replace_proof_resolution_projection(&publication, &projection(vec![exact_fact(EdgeId(7))]))
+        .unwrap();
+    let wrong_roster = serde_json::to_string(&[ProofResolutionAdapter {
+        language: "rust".to_owned(),
+        adapter_version: "wrong-v1".to_owned(),
+    }])
+    .unwrap();
+    store
+        .get_connection()
+        .execute(
+            "UPDATE proof_resolution_publication SET adapter_roster_json = ?1 WHERE id = 1",
+            [wrong_roster],
+        )
+        .unwrap();
+
+    let error = store
+        .validate_proof_resolution_publication(&publication)
+        .expect_err("stored facts must remain bound to their rostered adapter");
+    assert!(error.to_string().contains("adapter roster"), "{error}");
+}
+
+#[test]
 fn stored_proof_json_requires_exact_typed_canonical_bytes() {
     fn serialize_with_object_key_order(value: &serde_json::Value, reverse: bool) -> String {
         match value {


### PR DESCRIPTION
## Context

The first combined-head Q2 run left the Rust cohort at 12/30 full proofs. The dominant generalized cause was overly broad name-domain closure: bounded metadata attached to one Rust item poisoned unrelated declarations in the same module, while proof admission also needed a prepared fact-validation index rather than repeated whole-publication work.

This PR closes that failure class without expanding the supported Rust call forms or weakening proof admission.

Closes #2040
Refs #2023

## What changed

- build and validate the publication fact index once, then use keyed graph/fact correlation during proof admission;
- keep proof witness selection native and deterministic for repeated callsites;
- scope Rust macro and attribute uncertainty to the names and attached items they can affect;
- admit only the already-supported bounded metadata forms: derive companions for `serde`/`error`, function `inline`, and item `cfg_attr(..., derive(...))`;
- keep cfg-controlled declarations, glob imports, foreign macro expansion, unknown/procedural attributes, helper attributes without a companion derive, and unknown `cfg_attr` forms non-exact;
- bump the parser artifact cache version and adapter provenance for the changed semantics;
- add hostile coverage for foreign blocks, qualified and receiver calls, attributed-item isolation, lookalike attributes, repeated callsites, graph/fact mismatch, publication roster integrity, and prepared-index validation.

## Review

Review the trust boundary rather than individual examples:

1. Rust language-domain closure remains conservative for every unsupported form.
2. Parser/cache/adapter provenance changes with the semantics.
3. Exact facts still correlate to one raw CALL edge and one publication.
4. Repeated callsites use native `(file, start byte, edge id)` ordering.
5. The prepared validation index does not bypass source coordinates, storage integrity, or evidence hashes.
6. Admission stays linear in the publication plus selected witnesses.

## Exact candidate

- base: `df9edf78af30be57a5f3f7edbec79d4b387afe81`
- head: `a936b48c7314406524255c02329bf5d3b62c6b90`
- tree: `0ef31ebf0ad82ab630bcef3a92fb4ad1b634f6a6`

## Verification

- `cargo fmt --all -- --check`
- `cargo check --locked --workspace`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `CARGO_BUILD_JOBS=1 cargo nextest run --locked --workspace --no-fail-fast` — 4030 passed, 34 skipped
- `cargo test --locked --workspace --doc`
- `cargo test --locked -p codestory-indexer --test fidelity_regression` — 8 passed
- `cargo test --locked -p codestory-indexer --test tictactoe_language_coverage` — 13 passed
- focused `codestory-indexer` proof-resolution suite — 89 passed
- local Q2 materialize/run/verify: `20260824T152146Z-a936b48c7314`

The first nextest attempt exhausted the local debug target volume while linking. I removed only rebuildable debug artifacts and reran the identical source head successfully.

Measured change from the prior combined head:

- full proofs: 62/120 -> 66/120
- Rust full proofs: 12/30 -> 16/30
- admitted positive steps: 170/312 -> 185/312
- full-or-useful partial: 77/120 -> 82/120

All hard gates remain zero.

## Risk and non-claims

The proof route remains production-unreachable. This does not activate v3, broaden adapters, alter packet/context/search contracts, change thresholds, or touch the 0.17 release lane. Q2 still says `keep_proof_dark`; response size, warm unknown latency, and remaining recall gaps are follow-up work on separately closed designs.
