### PR TITLE
[proof availability] Restrict Python class poison to binding targets

### DIFF
--- a/crates/codestory-indexer/src/cache.rs
+++ b/crates/codestory-indexer/src/cache.rs
@@ -286,7 +286,7 @@ impl CachedIndexArtifact {
         resolution_file: Option<CachedResolutionFile>,
     ) -> Self {
         Self {
-            resolution_input_schema_version: 12,
+            resolution_input_schema_version: 13,
             files: index_result.files,
             nodes: index_result.nodes,
             edges: index_result.edges,

--- a/crates/codestory-indexer/src/proof_resolution.rs
+++ b/crates/codestory-indexer/src/proof_resolution.rs
@@ -1757,12 +1757,14 @@ impl<'tree> PythonResolutionIndex<'tree> {
                 | "global_statement"
                 | "nonlocal_statement"
                 | "delete_statement"
-                | "case_pattern"
                 | "list_comprehension"
                 | "set_comprehension"
                 | "dictionary_comprehension"
                 | "generator_expression"
                 | "import_statement" => result.collect_local_binding_node(node, source),
+                "case_pattern" if python_outermost_case_pattern(node) => {
+                    result.collect_local_binding_node(node, source);
+                }
                 _ => {}
             }
         });
@@ -2094,6 +2096,14 @@ impl<'tree> PythonResolutionIndex<'tree> {
             && let Some(function) = python_enclosing_function(node)
         {
             self.dynamic_functions.insert(function.id());
+        }
+        if python_call_on_self_dict(node, source)
+            && let Some(owner) = python_enclosing_function(node)
+                .and_then(|function| self.functions.get(&function.id()))
+                .and_then(|info| info.owner.as_ref())
+                .map(|(owner, _)| *owner)
+        {
+            self.dynamic_class_owners.insert(owner);
         }
     }
 
@@ -2656,6 +2666,44 @@ fn python_direct_call_name<'a>(node: TsNode<'_>, source: &'a str) -> Option<&'a 
     (function.kind() == "identifier").then(|| node_text(function, source))?
 }
 
+fn python_unwrap_parenthesized(mut node: TsNode<'_>) -> TsNode<'_> {
+    while node.kind() == "parenthesized_expression" && node.named_child_count() == 1 {
+        let Some(inner) = node.named_child(0) else {
+            break;
+        };
+        node = inner;
+    }
+    node
+}
+
+fn python_is_plain_self(node: TsNode<'_>, source: &str) -> bool {
+    let node = python_unwrap_parenthesized(node);
+    node.kind() == "identifier" && node_text(node, source) == Some("self")
+}
+
+fn python_is_self_dict(node: TsNode<'_>, source: &str) -> bool {
+    let node = python_unwrap_parenthesized(node);
+    node.kind() == "attribute"
+        && node
+            .child_by_field_name("object")
+            .is_some_and(|object| python_is_plain_self(object, source))
+        && node
+            .child_by_field_name("attribute")
+            .and_then(|attribute| node_text(attribute, source))
+            == Some("__dict__")
+}
+
+fn python_call_on_self_dict(node: TsNode<'_>, source: &str) -> bool {
+    let Some(function) = node.child_by_field_name("function") else {
+        return false;
+    };
+    let function = python_unwrap_parenthesized(function);
+    function.kind() == "attribute"
+        && function
+            .child_by_field_name("object")
+            .is_some_and(|object| python_is_self_dict(object, source))
+}
+
 fn python_exact_relative_module(module: &str) -> bool {
     module.starts_with('.')
         && !module.starts_with("..")
@@ -2669,6 +2717,22 @@ fn python_identifier(name: &str) -> bool {
         .next()
         .is_some_and(|ch| ch == '_' || ch.is_ascii_alphabetic())
         && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+}
+
+fn python_outermost_case_pattern(node: TsNode<'_>) -> bool {
+    !node.parent().is_some_and(|parent| {
+        matches!(
+            parent.kind(),
+            "case_pattern"
+                | "as_pattern"
+                | "class_pattern"
+                | "dict_pattern"
+                | "keyword_pattern"
+                | "list_pattern"
+                | "tuple_pattern"
+                | "union_pattern"
+        )
+    })
 }
 
 fn python_for_each_binding_target<'tree>(
@@ -2751,18 +2815,95 @@ fn python_binding_names(node: TsNode<'_>, source: &str) -> Vec<String> {
         "case_pattern" => {
             python_collect_case_capture_names(node, source, &mut names);
         }
-        "parameters"
-        | "global_statement"
-        | "nonlocal_statement"
-        | "import_statement"
-        | "import_from_statement" => {
-            python_binding_target_names(node, source, &mut names);
+        "parameters" => {
+            python_collect_parameter_binding_names(node, source, &mut names);
+        }
+        "import_statement" | "import_from_statement" => {
+            python_collect_import_binding_names(node, source, &mut names);
+        }
+        "global_statement" | "nonlocal_statement" => {
+            count_python_resolution_work(1);
+            let mut cursor = node.walk();
+            for name in node
+                .named_children(&mut cursor)
+                .filter(|child| child.kind() == "identifier")
+            {
+                python_binding_target_names(name, source, &mut names);
+            }
         }
         _ => python_binding_target_names(node, source, &mut names),
     }
     names.sort();
     names.dedup();
     names
+}
+
+fn python_collect_parameter_binding_names(node: TsNode<'_>, source: &str, names: &mut Vec<String>) {
+    count_python_resolution_work(1);
+    let mut cursor = node.walk();
+    for parameter in node.named_children(&mut cursor) {
+        count_python_resolution_work(1);
+        match parameter.kind() {
+            "default_parameter" | "typed_default_parameter" => {
+                if let Some(name) = parameter.child_by_field_name("name") {
+                    python_binding_target_names(name, source, names);
+                }
+            }
+            "typed_parameter" => {
+                for index in 0..parameter.named_child_count() {
+                    let Ok(index) = u32::try_from(index) else {
+                        break;
+                    };
+                    if parameter.field_name_for_named_child(index) == Some("type") {
+                        continue;
+                    }
+                    if let Some(target) = parameter.named_child(index) {
+                        python_binding_target_names(target, source, names);
+                    }
+                }
+            }
+            "identifier"
+            | "keyword_identifier"
+            | "list_splat_pattern"
+            | "dictionary_splat_pattern"
+            | "tuple_pattern" => {
+                python_binding_target_names(parameter, source, names);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn python_collect_import_binding_names(node: TsNode<'_>, source: &str, names: &mut Vec<String>) {
+    count_python_resolution_work(1);
+    for index in 0..node.named_child_count() {
+        let Ok(index) = u32::try_from(index) else {
+            break;
+        };
+        count_python_resolution_work(1);
+        if node.field_name_for_named_child(index) != Some("name") {
+            continue;
+        }
+        let Some(imported) = node.named_child(index) else {
+            continue;
+        };
+        if imported.kind() == "aliased_import" {
+            if let Some(alias) = imported.child_by_field_name("alias") {
+                python_binding_target_names(alias, source, names);
+            }
+            continue;
+        }
+        if imported.kind() != "dotted_name" {
+            continue;
+        }
+        let mut cursor = imported.walk();
+        if let Some(binding) = imported
+            .named_children(&mut cursor)
+            .find(|child| child.kind() == "identifier")
+        {
+            python_binding_target_names(binding, source, names);
+        }
+    }
 }
 
 fn python_collect_case_capture_names(node: TsNode<'_>, source: &str, names: &mut Vec<String>) {
@@ -2852,18 +2993,30 @@ fn python_collect_case_capture_names(node: TsNode<'_>, source: &str, names: &mut
 
 fn python_binding_target_names(node: TsNode<'_>, source: &str, names: &mut Vec<String>) {
     count_python_resolution_work(1);
-    if node.kind() == "identifier" {
-        if let Some(name) = node_text(node, source).filter(|name| python_identifier(name)) {
-            names.push(name.to_string());
+    match node.kind() {
+        "identifier" | "keyword_identifier" => {
+            if let Some(name) = node_text(node, source).filter(|name| python_identifier(name)) {
+                names.push(name.to_string());
+            }
         }
-        return;
-    }
-    if node.kind() == "attribute" {
-        return;
-    }
-    let mut cursor = node.walk();
-    for child in node.named_children(&mut cursor) {
-        python_binding_target_names(child, source, names);
+        "as_pattern_target"
+        | "dictionary_splat"
+        | "dictionary_splat_pattern"
+        | "expression_list"
+        | "list"
+        | "list_pattern"
+        | "list_splat"
+        | "list_splat_pattern"
+        | "parenthesized_expression"
+        | "pattern_list"
+        | "tuple"
+        | "tuple_pattern" => {
+            let mut cursor = node.walk();
+            for child in node.named_children(&mut cursor) {
+                python_binding_target_names(child, source, names);
+            }
+        }
+        _ => {}
     }
 }
 
@@ -2883,24 +3036,44 @@ fn python_collect_self_member_binding_names(
     names: &mut Vec<String>,
 ) {
     count_python_resolution_work(1);
-    if node.kind() == "attribute"
-        && node
-            .child_by_field_name("object")
-            .and_then(|object| node_text(object, source))
-            == Some("self")
-    {
-        if let Some(name) = node
-            .child_by_field_name("attribute")
-            .and_then(|attribute| node_text(attribute, source))
-            .filter(|name| python_identifier(name))
-        {
-            names.push(name.to_string());
+    match node.kind() {
+        "attribute" => {
+            if node
+                .child_by_field_name("object")
+                .is_some_and(|object| python_is_plain_self(object, source))
+                && let Some(name) = node
+                    .child_by_field_name("attribute")
+                    .and_then(|attribute| node_text(attribute, source))
+                    .filter(|name| python_identifier(name))
+            {
+                names.push(name.to_string());
+            }
         }
-        return;
-    }
-    let mut cursor = node.walk();
-    for child in node.named_children(&mut cursor) {
-        python_collect_self_member_binding_names(child, source, names);
+        "subscript"
+            if node
+                .child_by_field_name("value")
+                .is_some_and(|value| python_is_self_dict(value, source)) =>
+        {
+            names.push("__dict__".to_owned());
+        }
+        "as_pattern_target"
+        | "dictionary_splat"
+        | "dictionary_splat_pattern"
+        | "expression_list"
+        | "list"
+        | "list_pattern"
+        | "list_splat"
+        | "list_splat_pattern"
+        | "parenthesized_expression"
+        | "pattern_list"
+        | "tuple"
+        | "tuple_pattern" => {
+            let mut cursor = node.walk();
+            for child in node.named_children(&mut cursor) {
+                python_collect_self_member_binding_names(child, source, names);
+            }
+        }
+        _ => {}
     }
 }
 
@@ -10942,6 +11115,31 @@ mod python_complexity_tests {
         python_resolution_work()
     }
 
+    fn measured_nested_match_work(depth: usize) -> usize {
+        let mut pattern = "capture".to_owned();
+        for level in 0..depth {
+            pattern = match level % 5 {
+                0 => format!("[{pattern}]"),
+                1 => format!("({pattern},)"),
+                2 => format!("Box({pattern})"),
+                3 => format!("Box(value={pattern})"),
+                _ => format!("{{'key': {pattern}}}"),
+            };
+        }
+        let source = format!(
+            "class Box:\n    pass\ndef target():\n    pass\ndef caller(value):\n    match value:\n        case {pattern}:\n            target()\n"
+        );
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_python::LANGUAGE.into())
+            .expect("Python grammar must load");
+        let tree = parser.parse(&source, None).expect("source must parse");
+        assert!(!tree.root_node().has_error(), "nested pattern must parse");
+        reset_python_resolution_work();
+        let _ = PythonResolutionIndex::build(&tree, &source, NodeId(1), &[]);
+        python_resolution_work()
+    }
+
     fn measured_projection_work(file_count: usize, lookup_count: usize) -> usize {
         let temp = tempfile::tempdir().expect("Python projection tempdir");
         let package = temp.path().join("proof");
@@ -10994,6 +11192,17 @@ mod python_complexity_tests {
         assert!(
             large <= small * 2 + 256,
             "Python source work grew superlinearly: {small} -> {large}"
+        );
+    }
+
+    #[test]
+    fn python_nested_match_binding_work_is_linear() {
+        let small = measured_nested_match_work(64);
+        let large = measured_nested_match_work(128);
+        assert!(small > 0, "nested match work was not counted");
+        assert!(
+            large <= small * 2 + 512,
+            "nested match work grew superlinearly: {small} -> {large}"
         );
     }
 

--- a/crates/codestory-indexer/src/proof_resolution.rs
+++ b/crates/codestory-indexer/src/proof_resolution.rs
@@ -86,8 +86,8 @@ fn python_resolution_work() -> usize {
     PYTHON_RESOLUTION_WORK.with(std::cell::Cell::get)
 }
 
-const ADAPTER_VERSION: &str = "reference-v14";
-const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 12;
+const ADAPTER_VERSION: &str = "reference-v15";
+const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 13;
 const INSTALLED_ADAPTERS: &[(&str, &str)] = &[
     ("go", ADAPTER_VERSION),
     ("javascript", ADAPTER_VERSION),
@@ -2099,8 +2099,8 @@ impl<'tree> PythonResolutionIndex<'tree> {
 
     fn collect_assignment(&mut self, node: TsNode<'tree>, source: &str) {
         let Some(function) = python_enclosing_function(node) else {
-            if let Some(left) = node.child_by_field_name("left") {
-                let names = python_binding_names(left, source);
+            if node.child_by_field_name("left").is_some() {
+                let names = python_binding_names(node, source);
                 if let Some(owner) = self.enclosing_class_owner(node) {
                     self.poison_class_members(owner, names);
                 } else {
@@ -2114,7 +2114,7 @@ impl<'tree> PythonResolutionIndex<'tree> {
         let Some(left) = node.child_by_field_name("left") else {
             return;
         };
-        let names = python_binding_names(left, source);
+        let names = python_binding_names(node, source);
         self.writes_by_function
             .entry(function.id())
             .or_default()
@@ -2125,7 +2125,7 @@ impl<'tree> PythonResolutionIndex<'tree> {
             .and_then(|info| info.owner.as_ref())
             .cloned()
         {
-            self.poison_class_members(owner, python_self_member_binding_names(left, source));
+            self.poison_class_members(owner, python_self_member_binding_names(node, source));
         }
         let direct_block = python_direct_statement_in_function(node, function);
         let receiver = if names.len() == 1 && left.kind() == "identifier" && direct_block {
@@ -2280,8 +2280,12 @@ impl<'tree> PythonResolutionIndex<'tree> {
     }
 
     fn poison_class_members(&mut self, owner: NodeId, names: impl IntoIterator<Item = String>) {
-        self.method_blockers_by_owner_and_name
-            .extend(names.into_iter().map(|name| (owner, name)));
+        for name in names {
+            if name == "__dict__" {
+                self.dynamic_class_owners.insert(owner);
+            }
+            self.method_blockers_by_owner_and_name.insert((owner, name));
+        }
     }
 
     fn push_binding(
@@ -2667,43 +2671,89 @@ fn python_identifier(name: &str) -> bool {
         && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
 }
 
-fn python_binding_names(node: TsNode<'_>, source: &str) -> Vec<String> {
-    let mut names = Vec::new();
+fn python_for_each_binding_target<'tree>(
+    node: TsNode<'tree>,
+    mut visit: impl FnMut(TsNode<'tree>),
+) {
+    count_python_resolution_work(1);
     match node.kind() {
-        "assignment" | "augmented_assignment" => {
+        "assignment" | "augmented_assignment" | "for_statement" => {
             if let Some(left) = node.child_by_field_name("left") {
-                python_binding_target_names(left, source, &mut names);
+                visit(left);
             }
         }
-        "for_statement"
-        | "list_comprehension"
+        "list_comprehension"
         | "set_comprehension"
         | "dictionary_comprehension"
         | "generator_expression" => {
-            if let Some(left) = node.child_by_field_name("left") {
-                python_binding_target_names(left, source, &mut names);
+            let mut cursor = node.walk();
+            for clause in node.named_children(&mut cursor) {
+                count_python_resolution_work(1);
+                if clause.kind() == "for_in_clause"
+                    && let Some(left) = clause.child_by_field_name("left")
+                {
+                    visit(left);
+                }
+            }
+        }
+        "with_item" => {
+            if let Some(alias) = node
+                .child_by_field_name("value")
+                .filter(|value| value.kind() == "as_pattern")
+                .and_then(|value| value.child_by_field_name("alias"))
+            {
+                visit(alias);
+            }
+        }
+        "except_clause" => {
+            if let Some(alias) = node.child_by_field_name("alias").or_else(|| {
+                node.child_by_field_name("value")
+                    .filter(|value| value.kind() == "as_pattern")
+                    .and_then(|value| value.child_by_field_name("alias"))
+            }) {
+                visit(alias);
             }
         }
         "named_expression" => {
             if let Some(name) = node.child_by_field_name("name") {
-                python_binding_target_names(name, source, &mut names);
+                visit(name);
             }
         }
-        "with_item" => {
-            if let Some(alias) = node.child_by_field_name("alias") {
-                python_binding_target_names(alias, source, &mut names);
+        "delete_statement" => {
+            let mut cursor = node.walk();
+            for target in node.named_children(&mut cursor) {
+                count_python_resolution_work(1);
+                visit(target);
             }
         }
-        "except_clause" => {
-            if let Some(name) = node.child_by_field_name("name") {
-                python_binding_target_names(name, source, &mut names);
-            }
+        _ => {}
+    }
+}
+
+fn python_binding_names(node: TsNode<'_>, source: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    match node.kind() {
+        "assignment"
+        | "augmented_assignment"
+        | "for_statement"
+        | "list_comprehension"
+        | "set_comprehension"
+        | "dictionary_comprehension"
+        | "generator_expression"
+        | "with_item"
+        | "except_clause"
+        | "named_expression"
+        | "delete_statement" => {
+            python_for_each_binding_target(node, |target| {
+                python_binding_target_names(target, source, &mut names);
+            });
+        }
+        "case_pattern" => {
+            python_collect_case_capture_names(node, source, &mut names);
         }
         "parameters"
         | "global_statement"
         | "nonlocal_statement"
-        | "delete_statement"
-        | "case_pattern"
         | "import_statement"
         | "import_from_statement" => {
             python_binding_target_names(node, source, &mut names);
@@ -2713,6 +2763,91 @@ fn python_binding_names(node: TsNode<'_>, source: &str) -> Vec<String> {
     names.sort();
     names.dedup();
     names
+}
+
+fn python_collect_case_capture_names(node: TsNode<'_>, source: &str, names: &mut Vec<String>) {
+    count_python_resolution_work(1);
+    match node.kind() {
+        "dotted_name" => {
+            let mut cursor = node.walk();
+            let identifiers = node
+                .named_children(&mut cursor)
+                .filter(|child| child.kind() == "identifier")
+                .collect::<Vec<_>>();
+            if let [identifier] = identifiers.as_slice()
+                && let Some(name) =
+                    node_text(*identifier, source).filter(|name| python_identifier(name))
+            {
+                names.push(name.to_string());
+            }
+        }
+        "class_pattern" => {
+            let mut cursor = node.walk();
+            for child in node.named_children(&mut cursor) {
+                if child.kind() != "dotted_name" {
+                    python_collect_case_capture_names(child, source, names);
+                }
+            }
+        }
+        "keyword_pattern" => {
+            let mut cursor = node.walk();
+            let mut skipped_keyword = false;
+            for child in node.named_children(&mut cursor) {
+                if child.kind() == "identifier" && !skipped_keyword {
+                    skipped_keyword = true;
+                } else {
+                    python_collect_case_capture_names(child, source, names);
+                }
+            }
+        }
+        "dict_pattern" => {
+            for index in 0..node.named_child_count() {
+                let Ok(index) = u32::try_from(index) else {
+                    break;
+                };
+                let Some(child) = node.named_child(index) else {
+                    continue;
+                };
+                if node.field_name_for_named_child(index) == Some("value")
+                    || child.kind() == "splat_pattern"
+                {
+                    python_collect_case_capture_names(child, source, names);
+                }
+            }
+        }
+        "as_pattern" => {
+            let mut cursor = node.walk();
+            for child in node.named_children(&mut cursor) {
+                if child.kind() == "case_pattern" {
+                    python_collect_case_capture_names(child, source, names);
+                } else if child.kind() == "identifier"
+                    && let Some(name) =
+                        node_text(child, source).filter(|name| python_identifier(name))
+                {
+                    names.push(name.to_string());
+                }
+            }
+        }
+        "splat_pattern" => {
+            let mut cursor = node.walk();
+            for child in node
+                .named_children(&mut cursor)
+                .filter(|child| child.kind() == "identifier")
+            {
+                if let Some(name) = node_text(child, source).filter(|name| python_identifier(name))
+                {
+                    names.push(name.to_string());
+                }
+            }
+        }
+        "case_pattern" | "list_pattern" | "tuple_pattern" | "union_pattern" => {
+            let mut cursor = node.walk();
+            for child in node.named_children(&mut cursor) {
+                python_collect_case_capture_names(child, source, names);
+            }
+        }
+        _ => {}
+    }
 }
 
 fn python_binding_target_names(node: TsNode<'_>, source: &str, names: &mut Vec<String>) {
@@ -2734,7 +2869,9 @@ fn python_binding_target_names(node: TsNode<'_>, source: &str, names: &mut Vec<S
 
 fn python_self_member_binding_names(node: TsNode<'_>, source: &str) -> Vec<String> {
     let mut names = Vec::new();
-    python_collect_self_member_binding_names(node, source, &mut names);
+    python_for_each_binding_target(node, |target| {
+        python_collect_self_member_binding_names(target, source, &mut names);
+    });
     names.sort();
     names.dedup();
     names

--- a/crates/codestory-indexer/tests/proof_resolution.rs
+++ b/crates/codestory-indexer/tests/proof_resolution.rs
@@ -903,6 +903,106 @@ fn python_namespace_closure_hostiles_never_become_exact() -> anyhow::Result<()> 
 }
 
 #[test]
+fn python_control_flow_member_reads_do_not_poison_direct_methods() -> anyhow::Result<()> {
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(
+        project.path(),
+        &mut store,
+        &[(
+            "main.py",
+            concat!(
+                "class Worker:\n",
+                "    marker = object()\n",
+                "    def target(self, value=None):\n        return ()\n",
+                "    def caller(self, values):\n",
+                "        self.target()\n",
+                "        self.other = values\n",
+                "        self.target()\n",
+                "        for item in self.target():\n            self.target()\n",
+                "        with self.target():\n            self.target()\n",
+                "        try:\n            raise ValueError\n",
+                "        except ValueError:\n            self.target()\n",
+                "        if (value := self.target()):\n            pass\n",
+                "        [self.target() for item in self.target() if self.target()]\n",
+                "        match value:\n",
+                "            case self.marker if self.target():\n                self.target()\n",
+                "        self.target(); self.target()\n",
+                "        return self.target(self.target())\n",
+            ),
+        )],
+    )?;
+
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    let facts = store.get_proof_resolution_facts()?;
+    let target_facts = facts
+        .iter()
+        .filter(|fact| {
+            fact.provenance.language_adapter == "python" && fact.callsite.raw_target == "target"
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(target_facts.len(), 17, "unexpected target call census");
+    assert!(
+        target_facts
+            .iter()
+            .all(|fact| fact.status == ProofResolutionStatus::Exact),
+        "read-only control-flow use poisoned target: {target_facts:#?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn python_control_flow_member_binding_targets_remain_non_exact() -> anyhow::Result<()> {
+    let cases = [
+        "for self.target in values:\n        pass",
+        "for (self.target, other) in values:\n        pass",
+        "for [self.target, *rest] in values:\n        pass",
+        "with resource as self.target:\n        pass",
+        "with resource as (self.target, other):\n        pass",
+        "[item for self.target in values]",
+        "[item for (self.target, *rest) in values]",
+        "self.target = replacement",
+        "self.target: object = replacement",
+        "self.target += replacement",
+        "self.__dict__['target'] = replacement",
+        "del self.target",
+    ];
+    for mutation in cases {
+        let source = format!(
+            "class Worker:\n    def target(self):\n        pass\n    def caller(self, values, resource, replacement):\n        {mutation}\n        self.target()\n"
+        );
+        assert_python_target_has_closed_status(
+            &[("main.py", source.as_str())],
+            "target",
+            ProofResolutionStatus::Unsupported,
+        )?;
+    }
+    for pattern in ["target", "_ as target", "[target]"] {
+        let source = format!(
+            "def target():\n    pass\ndef caller(value):\n    match value:\n        case {pattern}:\n            target()\n"
+        );
+        assert_python_target_has_closed_status(
+            &[("main.py", source.as_str())],
+            "target",
+            ProofResolutionStatus::Unsupported,
+        )?;
+    }
+    for caller in [
+        "    [target() for target in values]\n",
+        "    with resource as target:\n        target()\n",
+        "    try:\n        raise ValueError\n    except ValueError as target:\n        target()\n",
+    ] {
+        let source = format!("def target():\n    pass\ndef caller(values, resource):\n{caller}");
+        assert_python_target_has_closed_status(
+            &[("main.py", source.as_str())],
+            "target",
+            ProofResolutionStatus::Unsupported,
+        )?;
+    }
+    Ok(())
+}
+
+#[test]
 fn python_import_and_annotation_families_are_closed_non_exact() -> anyhow::Result<()> {
     for source in [
         "from external import target\ndef caller():\n    target()\n",
@@ -5315,7 +5415,7 @@ fn complete_projection_rejects_cache_schema_adapter_and_language_mismatch() -> a
             .expect_err("cache provenance mismatch must reject the complete projection");
         let message = error.to_string();
         assert!(
-            ["stale", "schema-v12", "adapter", "language"]
+            ["stale", "schema-v13", "adapter", "language"]
                 .iter()
                 .any(|needle| message.contains(needle)),
             "{mutation}: {error}"
@@ -5450,7 +5550,7 @@ fn proof_resolution_roster_tracks_the_current_adapter_version() -> anyhow::Resul
             .iter()
             .find(|adapter| adapter.language == "rust")
             .map(|adapter| adapter.adapter_version.as_str()),
-        Some("reference-v14")
+        Some("reference-v15")
     );
     for fact in store.get_proof_resolution_facts()? {
         assert!(receipt.adapter_roster.iter().any(|adapter| {

--- a/crates/codestory-indexer/tests/proof_resolution.rs
+++ b/crates/codestory-indexer/tests/proof_resolution.rs
@@ -722,7 +722,7 @@ fn assert_python_target_has_closed_status(
     );
     assert!(
         facts.iter().any(|fact| fact.status == expected),
-        "missing {expected:?} Python fact for {raw_target}: {facts:#?}"
+        "missing {expected:?} Python fact for {raw_target} in {files:?}: {facts:#?}"
     );
     assert!(
         facts.iter().all(|fact| {
@@ -731,6 +731,28 @@ fn assert_python_target_has_closed_status(
                 && fact.evidence_chain.is_empty()
         }),
         "unsupported Python family became authoritative: {facts:#?}"
+    );
+    Ok(())
+}
+
+fn assert_python_target_is_exact(files: &[(&str, &str)], raw_target: &str) -> anyhow::Result<()> {
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(project.path(), &mut store, files)?;
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    let facts = store
+        .get_proof_resolution_facts()?
+        .into_iter()
+        .filter(|fact| {
+            fact.provenance.language_adapter == "python" && fact.callsite.raw_target == raw_target
+        })
+        .collect::<Vec<_>>();
+    assert!(!facts.is_empty(), "missing Python fact for {raw_target}");
+    assert!(
+        facts
+            .iter()
+            .all(|fact| fact.status == ProofResolutionStatus::Exact),
+        "Python target was not exact: {facts:#?}"
     );
     Ok(())
 }
@@ -995,6 +1017,80 @@ fn python_control_flow_member_binding_targets_remain_non_exact() -> anyhow::Resu
         let source = format!("def target():\n    pass\ndef caller(values, resource):\n{caller}");
         assert_python_target_has_closed_status(
             &[("main.py", source.as_str())],
+            "target",
+            ProofResolutionStatus::Unsupported,
+        )?;
+    }
+    Ok(())
+}
+
+#[test]
+fn python_binding_target_wrappers_parameters_and_imports_are_closed() -> anyhow::Result<()> {
+    for source in [
+        concat!(
+            "class Worker:\n",
+            "    def target(self):\n        pass\n",
+            "    def caller(self, mapping, replacement):\n",
+            "        mapping[self.target] = replacement\n",
+            "        self.other = replacement\n",
+            "        self.target()\n",
+        ),
+        "def target():\n    pass\ndef caller(value: target = target):\n    target()\n",
+        concat!(
+            "class Worker:\n",
+            "    from pkg import target as alias\n",
+            "    def target(self):\n        pass\n",
+            "    def caller(self):\n        self.target()\n",
+        ),
+        "import target as alias\ndef target():\n    pass\ndef caller():\n    target()\n",
+        "from target.pkg import alias\ndef target():\n    pass\ndef caller():\n    target()\n",
+    ] {
+        assert_python_target_is_exact(&[("main.py", source)], "target")?;
+    }
+
+    for source in [
+        concat!(
+            "class Worker:\n",
+            "    def target(self):\n        pass\n",
+            "    def caller(self, replacement):\n",
+            "        (self).target = replacement\n",
+            "        self.target()\n",
+        ),
+        concat!(
+            "class Worker:\n",
+            "    def target(self):\n        pass\n",
+            "    def caller(self, replacement):\n",
+            "        self.target()\n",
+            "        (self).target = replacement\n",
+        ),
+        concat!(
+            "class Worker:\n",
+            "    def target(self):\n        pass\n",
+            "    def caller(self, replacement):\n",
+            "        self.__dict__.update(target=replacement)\n",
+            "        self.target()\n",
+        ),
+        concat!(
+            "class Worker:\n",
+            "    def target(self):\n        pass\n",
+            "    def caller(self):\n",
+            "        del self.__dict__['target']\n",
+            "        self.target()\n",
+        ),
+        "def target():\n    pass\ndef caller(target):\n    target()\n",
+        "def target():\n    pass\ndef caller(*target):\n    target()\n",
+        "def target():\n    pass\ndef caller(**target):\n    target()\n",
+        "import other as target\ndef target():\n    pass\ndef caller():\n    target()\n",
+        "from pkg import other as target\ndef target():\n    pass\ndef caller():\n    target()\n",
+        concat!(
+            "class Worker:\n",
+            "    from pkg import other as target\n",
+            "    def target(self):\n        pass\n",
+            "    def caller(self):\n        self.target()\n",
+        ),
+    ] {
+        assert_python_target_has_closed_status(
+            &[("main.py", source)],
             "target",
             ProofResolutionStatus::Unsupported,
         )?;


### PR DESCRIPTION
## Context

Python class mutation detection was treating value-side names as binding targets. That poisoned otherwise exact `self.method()` receipts, while several real target forms were missed. This PR closes that causal class without broadening the Python adapter or changing any public route.

Closes #2046
Refs #2023

## What changed

- Replace recursive name collection with grammar-owned Python binding-target extraction for assignments, parameters, imports, comprehensions, `with`/`except`, deletion, walrus targets, and match captures.
- Preserve read-side coordinates such as annotations, defaults, import module names, match value patterns, dictionary keys, keyword labels, and subscript indexes.
- Recognize parenthesized `self` mutation and dynamic `self.__dict__` mutation conservatively.
- Keep class mutation order-independent and class-wide.
- Traverse nested match patterns once, preserving linear counted work.
- Bump the parser resolution-input schema and Python reference adapter version so stale cached facts cannot cross the corrected boundary.
- Expand the hostile matrix across wrappers, destructuring, repeated callsites, source coordinates, imports, parameters, and 64/128-depth complexity.

## How to review

The trust boundary is concentrated in `crates/codestory-indexer/src/proof_resolution.rs`. Review target extraction first, then the Python class poison accumulator, then the positive/negative and complexity matrices in `crates/codestory-indexer/tests/proof_resolution.rs`.

The consolidated adversarial review covered language-domain closure, parser provenance, graph/fact correlation, repeated callsites, source coordinates, native ordering, storage integrity, and complexity. Its complete correction set is included here; there is no open stylistic review round.

## Verification

Accepted source: `a092810566962c5948847655643246e3b22d59a5`  
Tree: `4e262713803d2413ec99c7f3872b4ea1fa97fd77`

- `cargo fmt --package codestory-indexer -- --check`
- `cargo check --locked --workspace`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo nextest run --locked --workspace --no-fail-fast`: 4051 passed, 34 skipped
- `cargo test --locked --workspace --doc`
- `cargo test --locked -p codestory-cli --test stdio_protocol_contracts`: 63 passed
- sealed Q1 evidence-only feature check and four-revision conformance test
- owning proof-resolution suite: 97 passed
- generated skill syntax check
- CodeStoryDev installer tests: 6 passed
- plugin static tests: 140 passed, 1 skipped
- documentation link check and `git diff --check`

Fresh qualification `20260824T212230Z-a09281056696` was materialized, run, and verified from one locked release binary:

- full proofs: 80/120, up from 77/120
- exact positive steps: 206/312 (`0.660`), up from `0.641`
- full or useful partials: 88/120 (`0.733`), up from `0.725`
- Flask/Python exact facts linked to matching CALL edges: 117/117
- all proof hard gates: zero failures
- hostile mutations reaching `ContractProven`: 0/240
- maximum response: 30,663 bytes

The evaluator selected `keep_proof_dark` because stable step recall, full/useful partial rate, and unknown warm latency remain below threshold.

`cargo fmt --all -- --check` cannot inspect this nested worktree because Cargo resolves the vendored `tree-sitter-graph` manifest to the primary workspace before source inspection. The package-scoped formatter check above passed on the exact head.

## Risk and follow-up

The main risk is Python grammar drift. Cache/schema versioning prevents old parser inputs from being trusted, and the hostile matrix pins both over-poison and under-poison cases. This PR remains production-unreachable and does not register CLI, MCP, HTTP, packet, context, search, or runtime proof surfaces.

The next roadmap slice must choose the dominant generalized availability gap from this immutable qualification and write its full supported/unsupported/hostile matrix before implementation.
