### PR TITLE
[codex] isolate read-only Python getattr resolution

### DIFF
--- a/crates/codestory-indexer/src/cache.rs
+++ b/crates/codestory-indexer/src/cache.rs
@@ -286,7 +286,7 @@ impl CachedIndexArtifact {
         resolution_file: Option<CachedResolutionFile>,
     ) -> Self {
         Self {
-            resolution_input_schema_version: 13,
+            resolution_input_schema_version: 14,
             files: index_result.files,
             nodes: index_result.nodes,
             edges: index_result.edges,

--- a/crates/codestory-indexer/src/proof_resolution.rs
+++ b/crates/codestory-indexer/src/proof_resolution.rs
@@ -87,15 +87,23 @@ fn python_resolution_work() -> usize {
 }
 
 const ADAPTER_VERSION: &str = "reference-v15";
-const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 13;
+const PYTHON_ADAPTER_VERSION: &str = "reference-v16";
+const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 14;
 const INSTALLED_ADAPTERS: &[(&str, &str)] = &[
     ("go", ADAPTER_VERSION),
     ("javascript", ADAPTER_VERSION),
-    ("python", ADAPTER_VERSION),
+    ("python", PYTHON_ADAPTER_VERSION),
     ("rust", ADAPTER_VERSION),
     ("tsx", ADAPTER_VERSION),
     ("typescript", ADAPTER_VERSION),
 ];
+
+fn adapter_version(language: &str) -> &str {
+    INSTALLED_ADAPTERS
+        .iter()
+        .find_map(|(installed, version)| (*installed == language).then_some(*version))
+        .unwrap_or(ADAPTER_VERSION)
+}
 
 pub fn current_proof_resolution_adapter_roster() -> Vec<ProofResolutionAdapter> {
     let mut roster = INSTALLED_ADAPTERS
@@ -216,7 +224,7 @@ pub(crate) fn collect_call_resolution_inputs(
                 caller,
                 binding,
                 language: language.to_string(),
-                adapter_version: ADAPTER_VERSION.to_string(),
+                adapter_version: adapter_version(language).to_string(),
                 parser_fingerprint: parser_fingerprint.to_string(),
             });
         };
@@ -258,7 +266,7 @@ pub(crate) fn collect_call_resolution_inputs(
             file_id,
             source_sha256,
             language: language.to_string(),
-            adapter_version: ADAPTER_VERSION.to_string(),
+            adapter_version: adapter_version(language).to_string(),
             parser_fingerprint: parser_fingerprint.to_string(),
             complete,
             lookup_input_complete,
@@ -315,11 +323,11 @@ pub(crate) fn cached_resolution_inputs_are_current(
         || (artifact.resolution_input_schema_version == RESOLUTION_INPUT_SCHEMA_VERSION
             && artifact.resolution_file.as_ref().is_some_and(|file| {
                 file.language == language
-                    && file.adapter_version == ADAPTER_VERSION
+                    && file.adapter_version == adapter_version(language)
                     && file.parser_fingerprint == expected_parser_fingerprint
                     && artifact.call_resolution_inputs.iter().all(|call| {
                         call.language == language
-                            && call.adapter_version == ADAPTER_VERSION
+                            && call.adapter_version == adapter_version(language)
                             && call.parser_fingerprint == expected_parser_fingerprint
                     })
             }))
@@ -2091,8 +2099,9 @@ impl<'tree> PythonResolutionIndex<'tree> {
             form,
             raw_target,
         });
-        if python_direct_call_name(node, source)
-            .is_some_and(|name| matches!(name, "getattr" | "setattr" | "delattr"))
+        if (python_direct_call_name(node, source)
+            .is_some_and(|name| matches!(name, "setattr" | "delattr"))
+            || python_getattr_exposes_namespace(node, source))
             && let Some(function) = python_enclosing_function(node)
         {
             self.dynamic_functions.insert(function.id());
@@ -2140,9 +2149,9 @@ impl<'tree> PythonResolutionIndex<'tree> {
         let direct_block = python_direct_statement_in_function(node, function);
         let receiver = if names.len() == 1 && left.kind() == "identifier" && direct_block {
             let class_name = match node.child_by_field_name("right") {
-                Some(right) => {
-                    python_direct_constructor_name(right, source).map(|name| (name, true))
-                }
+                Some(right) => python_direct_constructor_name(right, source)
+                    .filter(|name| name != "getattr")
+                    .map(|name| (name, true)),
                 None => node
                     .child_by_field_name("type")
                     .and_then(|annotation| python_exact_annotation(annotation, source))
@@ -2371,6 +2380,9 @@ impl<'tree> PythonResolutionIndex<'tree> {
             return (Some(caller), CachedResolutionBinding::Unsupported);
         }
         if python_has_enclosing_lambda(call, function) {
+            return (Some(caller), CachedResolutionBinding::Unsupported);
+        }
+        if python_direct_call_name(call, source).is_some_and(|name| name == "getattr") {
             return (Some(caller), CachedResolutionBinding::Unsupported);
         }
         if self.dynamic_functions.contains(&function.id()) {
@@ -2664,6 +2676,22 @@ fn python_exact_annotation(node: TsNode<'_>, source: &str) -> Option<String> {
 fn python_direct_call_name<'a>(node: TsNode<'_>, source: &'a str) -> Option<&'a str> {
     let function = node.child_by_field_name("function")?;
     (function.kind() == "identifier").then(|| node_text(function, source))?
+}
+
+fn python_getattr_exposes_namespace(node: TsNode<'_>, source: &str) -> bool {
+    if python_direct_call_name(node, source) != Some("getattr") {
+        return false;
+    }
+    let Some(arguments) = node.child_by_field_name("arguments") else {
+        return false;
+    };
+    let mut cursor = arguments.walk();
+    let mut values = arguments.named_children(&mut cursor);
+    let _receiver = values.next();
+    matches!(
+        values.next().and_then(|value| node_text(value, source)),
+        Some("\"__dict__\"" | "'__dict__'")
+    )
 }
 
 fn python_unwrap_parenthesized(mut node: TsNode<'_>) -> TsNode<'_> {
@@ -6825,7 +6853,7 @@ pub fn rematerialize_proof_resolution_projection(
             || record.file.source_sha256 != *stored_hash
             || record.file.language != indexed_file.language
             || record.file.complete != indexed_file.complete
-            || record.file.adapter_version != ADAPTER_VERSION
+            || record.file.adapter_version != adapter_version(&indexed_file.language)
             || record.calls.iter().any(|call| {
                 call.callsite.file_id != FileId(indexed_file.id)
                     || call.callsite.source_sha256 != *stored_hash
@@ -11098,11 +11126,11 @@ mod python_complexity_tests {
 
     fn measured_source_work(call_count: usize) -> usize {
         let mut source = String::from(
-            "class Worker:\n    def run(self):\n        pass\n\ndef target():\n    pass\n\ndef caller():\n",
+            "class Worker:\n    def run(self):\n        pass\n\ndef target():\n    pass\n\ndef caller(obj):\n",
         );
         for index in 0..call_count {
             source.push_str(&format!(
-                "    worker_{index} = Worker()\n    worker_{index}.run()\n    target()\n"
+                "    getattr(obj, 'marker')\n    worker_{index} = Worker()\n    worker_{index}.run()\n    target()\n"
             ));
         }
         let mut parser = Parser::new();

--- a/crates/codestory-indexer/tests/proof_resolution.rs
+++ b/crates/codestory-indexer/tests/proof_resolution.rs
@@ -628,6 +628,225 @@ fn python_closed_exact_subset_authorizes_s1_through_s4() -> anyhow::Result<()> {
 }
 
 #[test]
+fn python_read_only_getattr_does_not_poison_closed_static_neighbors() -> anyhow::Result<()> {
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(
+        project.path(),
+        &mut store,
+        &[
+            ("pkg/__init__.py", ""),
+            ("pkg/target.py", "def imported_target():\n    pass\n"),
+            (
+                "pkg/main.py",
+                concat!(
+                    "from .target import imported_target\n\n",
+                    "def local_target():\n    pass\n\n",
+                    "class Worker:\n",
+                    "    def run(self):\n        pass\n",
+                    "    def self_caller(self, obj):\n",
+                    "        self.run()\n",
+                    "        getattr(obj, 'value')\n",
+                    "        self.run()\n\n",
+                    "def local_caller(obj):\n",
+                    "    local_target()\n",
+                    "    getattr(obj, 'value')\n",
+                    "    local_target()\n\n",
+                    "def import_caller(obj):\n",
+                    "    imported_target()\n",
+                    "    getattr(obj, 'value')\n",
+                    "    imported_target()\n\n",
+                    "def receiver_caller(obj):\n",
+                    "    worker: Worker\n",
+                    "    worker.run()\n",
+                    "    getattr(obj, 'value')\n",
+                    "    worker.run()\n",
+                ),
+            ),
+        ],
+    )?;
+
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    let facts = store
+        .get_proof_resolution_facts()?
+        .into_iter()
+        .filter(|fact| fact.provenance.language_adapter == "python")
+        .collect::<Vec<_>>();
+    for (target, expected_count) in [("local_target", 2), ("imported_target", 2), ("run", 4)] {
+        let static_facts = facts
+            .iter()
+            .filter(|fact| fact.callsite.raw_target == target)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            static_facts.len(),
+            expected_count,
+            "missing before/after {target} facts: {facts:#?}"
+        );
+        assert!(
+            static_facts.iter().all(|fact| {
+                fact.status == ProofResolutionStatus::Exact
+                    && fact.edge_id.is_some()
+                    && fact.provenance.language_adapter_version == "reference-v16"
+            }),
+            "read-only getter poisoned {target}: {static_facts:#?}"
+        );
+    }
+    let getter_facts = facts
+        .iter()
+        .filter(|fact| fact.callsite.raw_target == "getattr")
+        .collect::<Vec<_>>();
+    assert_eq!(getter_facts.len(), 4, "missing getter facts: {facts:#?}");
+    assert!(
+        getter_facts.iter().all(|fact| {
+            fact.status == ProofResolutionStatus::Unsupported
+                && fact.reason.matches_status(fact.status)
+                && fact.evidence_chain.is_empty()
+        }),
+        "getter became authoritative: {getter_facts:#?}"
+    );
+    Ok(())
+}
+
+fn assert_python_facts_are_non_authoritative(files: &[(&str, &str)]) -> anyhow::Result<()> {
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(project.path(), &mut store, files)?;
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    let facts = store
+        .get_proof_resolution_facts()?
+        .into_iter()
+        .filter(|fact| fact.provenance.language_adapter == "python")
+        .collect::<Vec<_>>();
+    assert!(!facts.is_empty(), "missing Python facts for {files:?}");
+    assert!(
+        facts.iter().all(|fact| {
+            fact.status != ProofResolutionStatus::Exact && fact.evidence_chain.is_empty()
+        }),
+        "dynamic Python fact became authoritative: {facts:#?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn python_getattr_and_derived_values_remain_non_authoritative() -> anyhow::Result<()> {
+    for source in [
+        "def caller(obj):\n    getattr(obj, 'target')()\n",
+        "def caller(obj):\n    callback = getattr(obj, 'target')\n    callback()\n",
+        "def caller(obj):\n    getattr(obj, 'target').method()\n",
+        "def caller(obj, getattr):\n    getattr(obj, 'target')()\n",
+        "def caller(obj):\n    getattr = obj\n    getattr(obj, 'target')()\n",
+        "from foreign import getattr\ndef caller(obj):\n    getattr(obj, 'target')()\n",
+        "def target():\n    pass\ndef caller(obj):\n    getattr(obj, 'value')\n    def inner():\n        target()\n    inner()\n",
+        "def caller(obj):\n    callback = lambda: getattr(obj, 'target')()\n    callback()\n",
+        "def caller(obj):\n    receiver = getattr(obj, 'receiver')\n    receiver.target()\n",
+        "def caller(obj):\n    constructor = getattr(obj, 'Worker')\n    constructor()\n",
+    ] {
+        assert_python_facts_are_non_authoritative(&[("main.py", source)])?;
+    }
+    Ok(())
+}
+
+#[test]
+fn python_getattr_does_not_relax_existing_dynamic_guards() -> anyhow::Result<()> {
+    for guard in [
+        "setattr(obj, 'target', replacement)",
+        "delattr(obj, 'target')",
+        "exec('target = replacement')",
+        "eval('target = replacement')",
+        "globals()",
+    ] {
+        let source = format!(
+            "def target():\n    pass\ndef caller(obj, replacement):\n    target()\n    getattr(obj, 'value')\n    {guard}\n    target()\n"
+        );
+        assert_python_target_has_closed_status(
+            &[("main.py", source.as_str())],
+            "target",
+            ProofResolutionStatus::Unsupported,
+        )?;
+    }
+    for hook in [
+        "__getattribute__",
+        "__getattr__",
+        "__setattr__",
+        "__delattr__",
+    ] {
+        let source = format!(
+            "class Worker:\n    def target(self):\n        pass\n    def {hook}(self, *args):\n        pass\n    def caller(self, obj):\n        self.target()\n        getattr(obj, 'value')\n        self.target()\n"
+        );
+        assert_python_target_has_closed_status(
+            &[("main.py", source.as_str())],
+            "target",
+            ProofResolutionStatus::Unsupported,
+        )?;
+    }
+    let source = concat!(
+        "class Worker:\n",
+        "    def target(self):\n        pass\n",
+        "    def caller(self, obj):\n",
+        "        self.target()\n",
+        "        getattr(obj, 'value')\n",
+        "        self.__dict__['target'] = None\n",
+        "        self.target()\n",
+    );
+    assert_python_target_has_closed_status(
+        &[("main.py", source)],
+        "target",
+        ProofResolutionStatus::Unsupported,
+    )?;
+    Ok(())
+}
+
+#[test]
+fn python_namespace_getattr_and_getattr_named_constructor_stay_closed() -> anyhow::Result<()> {
+    for source in [
+        concat!(
+            "class Worker:\n    def target(self):\n        pass\n",
+            "def caller(worker: Worker):\n",
+            "    worker.target()\n",
+            "    namespace = getattr(worker, '__dict__')\n",
+            "    alias = namespace\n",
+            "    alias.update(target=None)\n",
+            "    worker.target()\n",
+        ),
+        concat!(
+            "class Worker:\n",
+            "    def target(self):\n        pass\n",
+            "    def caller(self):\n",
+            "        self.target()\n",
+            "        getattr(self, '__dict__').__setitem__('target', None)\n",
+            "        self.target()\n",
+        ),
+        concat!(
+            "def target():\n    pass\n",
+            "def caller():\n",
+            "    target()\n",
+            "    getattr(sys.modules[__name__], '__dict__').__setitem__('target', None)\n",
+            "    target()\n",
+        ),
+    ] {
+        assert_python_target_has_closed_status(
+            &[("main.py", source)],
+            "target",
+            ProofResolutionStatus::Unsupported,
+        )?;
+    }
+
+    let class_named_getattr = concat!(
+        "class getattr:\n",
+        "    def run(self):\n        pass\n",
+        "def caller():\n",
+        "    receiver = getattr()\n",
+        "    receiver.run()\n",
+    );
+    assert_python_target_has_closed_status(
+        &[("main.py", class_named_getattr)],
+        "run",
+        ProofResolutionStatus::Unsupported,
+    )?;
+    Ok(())
+}
+
+#[test]
 fn python_single_simple_base_authorizes_a_direct_same_class_method() -> anyhow::Result<()> {
     let project = tempfile::tempdir()?;
     let mut store = Store::new_in_memory()?;
@@ -5486,8 +5705,8 @@ fn complete_projection_rejects_cache_schema_adapter_and_language_mismatch() -> a
             project.path(),
             &mut store,
             &[(
-                "src/main.ts",
-                "export function target() {}\nexport function caller() { target(); }\n",
+                "src/main.py",
+                "def target():\n    pass\ndef caller():\n    target()\n",
             )],
         )?;
         let artifact_blob = store.get_connection().query_row(
@@ -5511,7 +5730,7 @@ fn complete_projection_rejects_cache_schema_adapter_and_language_mismatch() -> a
             .expect_err("cache provenance mismatch must reject the complete projection");
         let message = error.to_string();
         assert!(
-            ["stale", "schema-v13", "adapter", "language"]
+            ["stale", "schema-v14", "adapter", "language"]
                 .iter()
                 .any(|needle| message.contains(needle)),
             "{mutation}: {error}"
@@ -5637,7 +5856,13 @@ fn proof_resolution_roster_tracks_the_current_adapter_version() -> anyhow::Resul
     index_files(
         project.path(),
         &mut store,
-        &[("src/lib.rs", "fn target() {}\nfn caller() { target(); }\n")],
+        &[
+            ("src/lib.rs", "fn target() {}\nfn caller() { target(); }\n"),
+            (
+                "src/main.py",
+                "def target():\n    pass\ndef caller():\n    target()\n",
+            ),
+        ],
     )?;
     let receipt = rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
     assert_eq!(
@@ -5647,6 +5872,14 @@ fn proof_resolution_roster_tracks_the_current_adapter_version() -> anyhow::Resul
             .find(|adapter| adapter.language == "rust")
             .map(|adapter| adapter.adapter_version.as_str()),
         Some("reference-v15")
+    );
+    assert_eq!(
+        receipt
+            .adapter_roster
+            .iter()
+            .find(|adapter| adapter.language == "python")
+            .map(|adapter| adapter.adapter_version.as_str()),
+        Some("reference-v16")
     );
     for fact in store.get_proof_resolution_facts()? {
         assert!(receipt.adapter_roster.iter().any(|adapter| {


### PR DESCRIPTION
## Context

The Python proof adapter previously treated every direct `getattr(...)` call as a whole-callable dynamic mutation. That discarded unrelated exact local, import, constructor, and receiver evidence in the same function. The change is deliberately narrow: it isolates ordinary read-only `getattr` while retaining fail-closed behavior for namespace exposure and every mutation-capable form.

Closes #2048
Refs #2023

## What changed

- classify ordinary direct `getattr(...)` as a locally unsupported call instead of poisoning neighboring static calls;
- retain whole-callable invalidation for `getattr(..., "__dict__")`, `setattr`, `delattr`, `exec`, `eval`, `globals`, dynamic owner hooks, `self.__dict__`, and lexical shadows;
- prevent `getattr(...)` from establishing constructor/receiver evidence, including when a class is named `getattr`;
- bump the parser-call-input cache schema and the Python adapter version only;
- cover the frozen G1-G3 and H1-H5 matrix, plus a linear-work regression test.

Only these files change:

- `crates/codestory-indexer/src/cache.rs`
- `crates/codestory-indexer/src/proof_resolution.rs`
- `crates/codestory-indexer/tests/proof_resolution.rs`

The proof surface remains production-unreachable. No CLI, MCP, packet, context, search, navigation, release, version, or marketplace surface changes.

## Review

One consolidated adversarial review covered language-domain closure, parser provenance, graph/fact correlation, repeated callsites, source coordinates, native ordering, storage integrity, and complexity. Its two findings were one soundness class: getter-derived values must not create mutation or receiver authority. Both were corrected in one batch before the broad gates and qualification.

Accepted source: `76c8817f8f9bbe74a8fd44f6e523a17b8fe5a424`  
Accepted tree: `84795fda5b9dd527fbd0c1f0e2c3cdee0c7d618d`

## Verification

Focused:

- indexer proof-resolution suite: 101 passed
- getter-inclusive linear-work test: passed
- focused clippy with warnings denied: passed
- diff check: passed

Broad serial source gate on the accepted head:

- workspace check: passed
- workspace all-target/all-feature clippy with warnings denied: passed
- nextest: 4055 passed, 34 skipped, 2 slow
- workspace docs: passed
- stdio protocol contracts: 63 passed
- sealed Q1 evidence-only feature and four-revision conformance: passed
- generated skill syntax, CodeStoryDev installer, plugin static, doc links, and diff check: passed
- `cargo fmt --all -- --check` could not traverse the linked worktree because the vendored `tree-sitter-graph` path points at the primary checkout; the owning-package formatter check passed and the exact worktree remained clean

Fresh local qualification `20260824T230400Z-76c8817f8f9b` used one locked release binary for materialize, run, and read-only verify:

- binary SHA-256: `7e149974677635afc15996f7ac15095666c064fd744f19772205da1a748e8a66`
- results SHA-256: `efc30923a0f9698bdf7f9e0736b0e260e79c0b29d76b9d7fe2ace021b98c43b4`
- 81/120 full proofs; Flask 16/30
- 207/312 exact positive steps
- all hard gates zero
- 0/240 hostile mutations reached `ContractProven`
- `flask-python-l2-07` is fully proven
- `flask-python-l4-01` admits the targeted final edge but remains unknown because two earlier steps still fail

The unchanged evaluator returns `keep_proof_dark`. This PR makes no public proof or release claim.

## Risk

The risk is conservative availability loss around namespace exposure. That is intentional: `__dict__` and mutation-capable builtins continue to invalidate the callable rather than minting proof authority. Retrieval and navigation keep their existing graph behavior.
