### PR TITLE
[proof availability] Close TypeScript direct import domains

### DIFF
--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -16130,6 +16130,7 @@ fn index_file_with_resolution_inputs(
     let resolution_inputs = proof_resolution::collect_call_resolution_inputs(
         &tree,
         source,
+        path,
         language_config.language_name,
         &resolution_parser_fingerprint(language_config),
         file_id,

--- a/crates/codestory-indexer/src/proof_resolution.rs
+++ b/crates/codestory-indexer/src/proof_resolution.rs
@@ -88,14 +88,15 @@ fn python_resolution_work() -> usize {
 
 const ADAPTER_VERSION: &str = "reference-v15";
 const PYTHON_ADAPTER_VERSION: &str = "reference-v16";
+const TYPESCRIPT_ADAPTER_VERSION: &str = "reference-v17";
 const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 14;
 const INSTALLED_ADAPTERS: &[(&str, &str)] = &[
     ("go", ADAPTER_VERSION),
     ("javascript", ADAPTER_VERSION),
     ("python", PYTHON_ADAPTER_VERSION),
     ("rust", ADAPTER_VERSION),
-    ("tsx", ADAPTER_VERSION),
-    ("typescript", ADAPTER_VERSION),
+    ("tsx", TYPESCRIPT_ADAPTER_VERSION),
+    ("typescript", TYPESCRIPT_ADAPTER_VERSION),
 ];
 
 fn adapter_version(language: &str) -> &str {
@@ -125,6 +126,7 @@ pub(crate) struct CollectedResolutionInputs {
 pub(crate) fn collect_call_resolution_inputs(
     tree: &Tree,
     source: &str,
+    source_path: &Path,
     language: &str,
     parser_fingerprint: &str,
     file_id: NodeId,
@@ -139,8 +141,9 @@ pub(crate) fn collect_call_resolution_inputs(
     let complete = !tree.root_node().has_error();
     let lookup_input_complete = complete;
     let source_sha256 = source_content_hash(source.as_bytes());
-    let javascript_index = is_javascript_language(language)
-        .then(|| JavascriptResolutionIndex::build(tree, source, file_id, nodes));
+    let javascript_index = is_javascript_language(language).then(|| {
+        JavascriptResolutionIndex::build(tree, source, source_path, language, file_id, nodes)
+    });
     let rust_index =
         (language == "rust").then(|| RustResolutionIndex::build(tree, source, file_id, nodes));
     let go_index =
@@ -3177,10 +3180,18 @@ struct JavascriptResolutionIndex<'tree> {
     module_dynamic_breaker: bool,
     export_statements: Vec<TsNode<'tree>>,
     ecmascript_module: bool,
+    typescript_directory_imports_enabled: bool,
 }
 
 impl<'tree> JavascriptResolutionIndex<'tree> {
-    fn build(tree: &'tree Tree, source: &str, file_id: NodeId, nodes: &[Node]) -> Self {
+    fn build(
+        tree: &'tree Tree,
+        source: &str,
+        source_path: &Path,
+        language: &str,
+        file_id: NodeId,
+        nodes: &[Node],
+    ) -> Self {
         let root = tree.root_node();
         let mut callable_nodes = HashMap::<(u32, String), Vec<NodeId>>::new();
         let mut class_nodes = HashMap::<(u32, String), Vec<NodeId>>::new();
@@ -3226,6 +3237,10 @@ impl<'tree> JavascriptResolutionIndex<'tree> {
             module_dynamic_breaker: false,
             export_statements: Vec::new(),
             ecmascript_module: typescript_file_is_module(root),
+            typescript_directory_imports_enabled: typescript_directory_imports_enabled(
+                language,
+                source_path,
+            ),
         };
         walk_nodes(root, &mut |node| {
             if node.kind() == "export_statement" {
@@ -3277,7 +3292,11 @@ impl<'tree> JavascriptResolutionIndex<'tree> {
             return;
         }
         if node.kind() == "import_statement" {
-            let supported = typescript_import_bindings_for_statement(node, source);
+            let supported = typescript_import_bindings_for_statement(
+                node,
+                source,
+                self.typescript_directory_imports_enabled,
+            );
             let mut supported_by_name = supported
                 .unwrap_or_default()
                 .into_iter()
@@ -6395,13 +6414,19 @@ struct TypescriptImportBinding {
 fn typescript_import_bindings_for_statement(
     statement: TsNode<'_>,
     source: &str,
+    directory_imports_enabled: bool,
 ) -> Option<Vec<TypescriptImportBinding>> {
     let source_node = statement.child_by_field_name("source")?;
     let module_specifier = simple_typescript_string(source_node, source)?;
-    if !module_specifier.starts_with("./") && !module_specifier.starts_with("../") {
+    let directory_specifier = matches!(module_specifier, "." | "..");
+    if (directory_specifier && !directory_imports_enabled)
+        || (!directory_specifier
+            && !module_specifier.starts_with("./")
+            && !module_specifier.starts_with("../"))
+    {
         return None;
     }
-    if contains_unnamed_token(statement, "type") {
+    if has_direct_unnamed_token(statement, "type") {
         return None;
     }
     let mut statement_cursor = statement.walk();
@@ -6445,7 +6470,9 @@ fn typescript_import_bindings_for_statement(
             {
                 return None;
             }
+            let mut parsed = Vec::with_capacity(specifiers.len());
             for specifier in specifiers {
+                let type_only = has_direct_unnamed_token(specifier, "type");
                 let imported = specifier.child_by_field_name("name")?;
                 if imported.kind() != "identifier" {
                     return None;
@@ -6455,14 +6482,29 @@ fn typescript_import_bindings_for_statement(
                     return None;
                 }
                 let imported_name = node_text(imported, source)?;
-                bindings.push(typescript_import_binding(
-                    local,
-                    imported_name,
-                    module_specifier,
-                    false,
-                    source,
-                )?);
+                parsed.push((
+                    typescript_import_binding(
+                        local,
+                        imported_name,
+                        module_specifier,
+                        false,
+                        source,
+                    )?,
+                    type_only,
+                ));
             }
+            let mut local_counts = HashMap::<String, usize>::new();
+            for (binding, _) in &parsed {
+                *local_counts.entry(binding.local_name.clone()).or_default() += 1;
+            }
+            if local_counts.values().any(|count| *count != 1) {
+                return None;
+            }
+            bindings.extend(
+                parsed
+                    .into_iter()
+                    .filter_map(|(binding, type_only)| (!type_only).then_some(binding)),
+            );
         }
         _ => return None,
     }
@@ -6497,6 +6539,14 @@ fn typescript_identifier_is_supported(identifier: &str) -> bool {
             .all(|ch| ch == '_' || ch == '$' || ch.is_ascii_alphanumeric())
 }
 
+fn typescript_directory_imports_enabled(language: &str, source_path: &Path) -> bool {
+    matches!(language, "typescript" | "tsx")
+        && source_path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| matches!(extension, "ts" | "tsx"))
+}
+
 fn simple_typescript_string<'a>(node: TsNode<'_>, source: &'a str) -> Option<&'a str> {
     let literal = node_text(node, source)?;
     let quote = literal.as_bytes().first().copied()?;
@@ -6505,21 +6555,6 @@ fn simple_typescript_string<'a>(node: TsNode<'_>, source: &'a str) -> Option<&'a
     }
     let value = literal.get(1..literal.len().checked_sub(1)?)?;
     (!value.contains('\\')).then_some(value)
-}
-
-fn contains_unnamed_token(node: TsNode<'_>, token: &str) -> bool {
-    let mut found = false;
-    let mut visit = |current: TsNode<'_>| {
-        let mut cursor = current.walk();
-        for child in current.children(&mut cursor) {
-            if !child.is_named() && child.kind() == token {
-                found = true;
-                return;
-            }
-        }
-    };
-    walk_nodes(node, &mut visit);
-    found
 }
 
 fn export_statement_has_default_token(statement: TsNode<'_>) -> Option<bool> {
@@ -7411,7 +7446,11 @@ fn resolve_relative_import<'a>(
         return Ok(RelativeImportResolution::Missing);
     };
     let base = parent.join(module_specifier);
-    let candidates = if base.extension().is_some() {
+    let candidates = if matches!(source_record.file.language.as_str(), "typescript" | "tsx")
+        && matches!(module_specifier, "." | "..")
+    {
+        vec![base.join("index.ts"), base.join("index.tsx")]
+    } else if base.extension().is_some() {
         let supported = match source_record.file.language.as_str() {
             "typescript" | "tsx" => ["ts", "tsx", "mts", "cts"].as_slice(),
             "javascript" => ["js", "jsx", "mjs", "cjs"].as_slice(),
@@ -7503,8 +7542,45 @@ impl ProofRelationState {
     }
 }
 
+#[derive(Default)]
+struct TypescriptDirectoryImportState {
+    marker: Option<&'static str>,
+    marker_seen: bool,
+    admissible: usize,
+    conflicting: usize,
+}
+
+impl TypescriptDirectoryImportState {
+    fn record(&mut self, marker: Option<&'static str>, admissible: bool) {
+        self.marker_seen |= marker.is_some();
+        if admissible {
+            let marker = marker.expect("directory marker admission requires a marker");
+            self.marker.get_or_insert(marker);
+            self.admissible += 1;
+        } else {
+            self.conflicting += 1;
+        }
+    }
+
+    fn unique_marker(&self) -> Option<&'static str> {
+        (self.admissible == 1 && self.conflicting == 0)
+            .then_some(self.marker)
+            .flatten()
+    }
+}
+
+fn typescript_directory_specifier(literal: &str) -> Option<&'static str> {
+    match literal {
+        "'.'" | "\".\"" => Some("."),
+        "'..'" | "\"..\"" => Some(".."),
+        _ => None,
+    }
+}
+
 struct ExactEvidenceValidationIndex {
     import_relations: HashMap<(NodeId, NodeId, NodeId), ProofRelationState>,
+    typescript_directory_import_relations:
+        HashMap<(NodeId, NodeId), TypescriptDirectoryImportState>,
     member_relations: HashMap<(NodeId, NodeId), ProofRelationState>,
     python_import_paths: HashMap<(NodeId, NodeId, String), Vec<Vec<NodeId>>>,
     python_import_path_counts: HashMap<(NodeId, NodeId, Vec<NodeId>), usize>,
@@ -7541,6 +7617,8 @@ fn python_raw_import_marker_is_admissible(edge: &Edge, nodes: &HashMap<NodeId, &
 impl ExactEvidenceValidationIndex {
     fn prepare(edges: &[Edge], nodes: &HashMap<NodeId, &Node>) -> Self {
         let mut import_relations = HashMap::<_, ProofRelationState>::new();
+        let mut typescript_directory_import_relations =
+            HashMap::<_, TypescriptDirectoryImportState>::new();
         let mut member_relations = HashMap::<_, ProofRelationState>::new();
         let mut python_import_edges = HashMap::<NodeId, Vec<NodeId>>::new();
         for edge in edges {
@@ -7572,6 +7650,27 @@ impl ExactEvidenceValidationIndex {
                 } else {
                     state.conflicting += 1;
                 }
+            }
+            if edge.kind == EdgeKind::IMPORT
+                && let Some(import) = nodes.get(&edge.source)
+                && import.kind == NodeKind::UNKNOWN
+                && let Some(source_file) = import.file_node_id
+            {
+                let target = nodes.get(&edge.target);
+                let marker = target
+                    .filter(|target| target.kind == NodeKind::MODULE)
+                    .and_then(|target| typescript_directory_specifier(&target.serialized_name));
+                let admissible = marker.is_some()
+                    && edge.file_node_id == Some(source_file)
+                    && target.is_some_and(|target| target.file_node_id == Some(source_file))
+                    && edge.effective_source() == edge.source
+                    && edge.effective_target() == edge.target
+                    && edge.resolved_target.is_none()
+                    && edge.candidate_targets.is_empty();
+                typescript_directory_import_relations
+                    .entry((source_file, edge.source))
+                    .or_default()
+                    .record(marker, admissible);
             }
             if python_raw_import_marker_is_admissible(edge, nodes) {
                 python_import_edges
@@ -7658,6 +7757,7 @@ impl ExactEvidenceValidationIndex {
         }
         Self {
             import_relations,
+            typescript_directory_import_relations,
             member_relations,
             python_import_paths,
             python_import_path_counts,
@@ -7668,6 +7768,18 @@ impl ExactEvidenceValidationIndex {
         self.import_relations
             .get(&(file, import, target))
             .is_some_and(ProofRelationState::is_unique)
+    }
+
+    fn typescript_directory_import(&self, file: NodeId, import: NodeId) -> Option<&'static str> {
+        self.typescript_directory_import_relations
+            .get(&(file, import))
+            .and_then(TypescriptDirectoryImportState::unique_marker)
+    }
+
+    fn typescript_directory_marker_seen(&self, file: NodeId, import: NodeId) -> bool {
+        self.typescript_directory_import_relations
+            .get(&(file, import))
+            .is_some_and(|state| state.marker_seen)
     }
 
     fn has_member(&self, owner: NodeId, member: NodeId) -> bool {
@@ -7719,6 +7831,29 @@ impl ExactEvidenceValidationIndex {
             return false;
         }
         let source_file = NodeId(claim.input.callsite.file_id.0);
+        let typescript_directory_import =
+            matches!(claim.input.language.as_str(), "typescript" | "tsx")
+                && matches!(
+                    &claim.input.binding,
+                    CachedResolutionBinding::StaticImport { module_specifier, .. }
+                        if matches!(module_specifier.as_str(), "." | "..")
+                );
+        let typescript_directory_import_is_correlated = typescript_directory_import
+            && matches!(
+                &claim.input.binding,
+                CachedResolutionBinding::StaticImport {
+                    module_specifier,
+                    ..
+                } if matches!(module_specifier.as_str(), "." | "..")
+            )
+            && matches!(
+                &claim.input.binding,
+                CachedResolutionBinding::StaticImport {
+                    module_specifier,
+                    import,
+                    ..
+                } if self.typescript_directory_import(source_file, *import) == Some(module_specifier)
+            );
         match (
             claim.input.callsite.callee_form,
             claim.evidence_chain.as_slice(),
@@ -7750,7 +7885,13 @@ impl ExactEvidenceValidationIndex {
                             && graph_leaf_name(&import_node.serialized_name)
                                 == claim.input.callsite.raw_target
                     })
-                    && self.has_import(source_file, *import, target)
+                    && if typescript_directory_import {
+                        typescript_directory_import_is_correlated
+                    } else if self.typescript_directory_marker_seen(source_file, *import) {
+                        false
+                    } else {
+                        self.has_import(source_file, *import, target)
+                    }
             }
             (
                 CalleeForm::NamedImport,
@@ -10782,6 +10923,73 @@ mod exact_edge_projection_tests {
                 (EdgeId(8), NodeId(2), NodeId(4))
             ]
         );
+    }
+}
+
+#[cfg(test)]
+mod typescript_import_binding_tests {
+    use super::*;
+    use tree_sitter::Parser;
+
+    fn bindings(source: &str) -> Option<Vec<TypescriptImportBinding>> {
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into())
+            .expect("TypeScript grammar must load");
+        let tree = parser.parse(source, None).expect("source must parse");
+        let mut cursor = tree.root_node().walk();
+        let statement = tree
+            .root_node()
+            .named_children(&mut cursor)
+            .find(|node| node.kind() == "import_statement")?;
+        typescript_import_bindings_for_statement(statement, source, true)
+    }
+
+    #[test]
+    fn type_and_value_specifiers_share_one_local_binding_domain() {
+        assert!(bindings("import { type target, target } from './target';").is_none());
+        assert!(
+            bindings(
+                "import { target as local, /* duplicate */ type target as local, } from './target';"
+            )
+            .is_none()
+        );
+        assert!(bindings("import { target as local, other as local } from './target';").is_none());
+        let parsed = bindings("import { type target as TargetType, target } from './target';")
+            .expect("different locals sharing one imported spelling are supported");
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].local_name, "target");
+        assert_eq!(parsed[0].imported_name, "target");
+        assert!(bindings("import { target } from '.';").is_some());
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into())
+            .expect("TypeScript grammar must load");
+        let source = "import { target } from '.';";
+        let tree = parser.parse(source, None).expect("source must parse");
+        let mut cursor = tree.root_node().walk();
+        let statement = tree
+            .root_node()
+            .named_children(&mut cursor)
+            .find(|node| node.kind() == "import_statement")
+            .expect("import statement");
+        assert!(typescript_import_bindings_for_statement(statement, source, false).is_none());
+        assert!(typescript_directory_imports_enabled(
+            "typescript",
+            Path::new("source.tsx")
+        ));
+        assert!(!typescript_directory_imports_enabled(
+            "javascript",
+            Path::new("source.ts")
+        ));
+        assert!(!typescript_directory_imports_enabled(
+            "javascript",
+            Path::new("source.tsx")
+        ));
+        assert!(!typescript_directory_imports_enabled(
+            "typescript",
+            Path::new("source.mts")
+        ));
     }
 }
 

--- a/crates/codestory-indexer/tests/proof_resolution.rs
+++ b/crates/codestory-indexer/tests/proof_resolution.rs
@@ -2846,6 +2846,345 @@ fn javascript_and_typescript_direct_imports_are_exact() -> anyhow::Result<()> {
 }
 
 #[test]
+fn typescript_direct_imports_separate_type_specifiers_and_resolve_literal_directories()
+-> anyhow::Result<()> {
+    for (files, called_name) in [
+        (
+            vec![
+                ("src/target.ts", "export function target() {}\n"),
+                (
+                    "src/importer.ts",
+                    "import { type Target, target } from './target';\nexport function caller() { target(); }\n",
+                ),
+            ],
+            "target",
+        ),
+        (
+            vec![
+                ("src/target.ts", "export function target() {}\n"),
+                (
+                    "src/importer.ts",
+                    "import { target, /* type remains non-authoritative */ type Target, } from './target';\nexport function caller() { target(); }\n",
+                ),
+            ],
+            "target",
+        ),
+        (
+            vec![
+                ("src/index.ts", "export function target() {}\n"),
+                ("src.ts", "export function target() {}\n"),
+                (
+                    "src/importer.ts",
+                    "import { target } from '.';\nexport function caller() { target(); }\n",
+                ),
+            ],
+            "target",
+        ),
+        (
+            vec![
+                ("src/index.tsx", "export const target = () => <></>;\n"),
+                (
+                    "src/importer.ts",
+                    "import { target } from '.';\nexport function caller() { target(); }\n",
+                ),
+            ],
+            "target",
+        ),
+        (
+            vec![
+                ("src/index.ts", "export function target() {}\n"),
+                (
+                    "src/child/importer.ts",
+                    "import { target } from '..';\nexport function caller() { target(); }\n",
+                ),
+            ],
+            "target",
+        ),
+    ] {
+        assert_call_named_is_exact(&files, called_name)?;
+    }
+
+    for files in [
+        vec![
+            ("src/target.ts", "export function target() {}\n"),
+            (
+                "src/importer.ts",
+                "import type { target } from './target';\nexport function caller() { target(); }\n",
+            ),
+        ],
+        vec![
+            (
+                "src/target.ts",
+                "export default function fallback() {}\nexport function target() {}\n",
+            ),
+            (
+                "src/importer.ts",
+                "import fallback, { target } from './target';\nexport function caller() { target(); }\n",
+            ),
+        ],
+        vec![
+            ("src/index.js", "export function target() {}\n"),
+            (
+                "src/importer.js",
+                "import { target } from '.';\nexport function caller() { target(); }\n",
+            ),
+        ],
+    ] {
+        assert_no_exact_calls(&files)?;
+    }
+    assert_no_exact_calls(&[
+        ("src/target.ts", "export function target() {}\n"),
+        (
+            "src/aliased_type.ts",
+            "import { type Target as LocalTarget, target as local } from './target';\nexport function caller() { local(); }\n",
+        ),
+    ])?;
+    Ok(())
+}
+
+#[test]
+fn typescript_type_specifier_local_collisions_close_the_entire_import_binding() -> anyhow::Result<()>
+{
+    for files in [
+        vec![
+            ("src/target.ts", "export function target() {}\n"),
+            (
+                "src/importer.ts",
+                "import { type target, target } from './target';\nexport function caller() { target(); }\n",
+            ),
+        ],
+        vec![
+            ("src/target.ts", "export function target() {}\n"),
+            (
+                "src/importer.ts",
+                "import { target as local, /* duplicate local */ type target as local, } from './target';\nexport function caller() { local(); }\n",
+            ),
+        ],
+        vec![
+            (
+                "src/target.ts",
+                "export function target() {}\nexport function other() {}\n",
+            ),
+            (
+                "src/importer.ts",
+                "import { target as local, other as local } from './target';\nexport function caller() { local(); }\n",
+            ),
+        ],
+    ] {
+        assert_no_exact_calls(&files)?;
+    }
+    Ok(())
+}
+
+#[test]
+fn literal_directory_imports_are_limited_to_ts_and_tsx_sources() -> anyhow::Result<()> {
+    for index in ["src/index.ts", "src/index.tsx"] {
+        assert_call_named_is_exact(
+            &[
+                (index, "export function target() {}\n"),
+                (
+                    "src/importer.ts",
+                    "import { target } from '.';\nexport function caller() { target(); }\n",
+                ),
+            ],
+            "target",
+        )?;
+    }
+    for importer in [
+        "src/importer.js",
+        "src/importer.jsx",
+        "src/importer.mjs",
+        "src/importer.cjs",
+        "src/importer.mts",
+        "src/importer.cts",
+    ] {
+        assert_only_call_is_not_exact(&[
+            ("src/index.ts", "export function target() {}\n"),
+            (
+                importer,
+                "import { target } from '.';\nexport function caller() { target(); }\n",
+            ),
+        ])?;
+    }
+    Ok(())
+}
+
+#[test]
+fn typescript_literal_directory_import_markers_fail_closed_when_tampered() -> anyhow::Result<()> {
+    for mutation in [
+        "missing",
+        "duplicate",
+        "conflicting",
+        "resolved_marker",
+        "dotdot_marker",
+        "wrong_marker",
+        "direct_resolved_extra",
+        "wrong_effective_endpoint",
+        "wrong_edge_file",
+        "wrong_index",
+        "wrong_declaration",
+    ] {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(
+            project.path(),
+            &mut store,
+            &[
+                ("src/index.ts", "export function target() {}\n"),
+                ("src.ts", "export function sibling() {}\n"),
+                (
+                    "src/importer.ts",
+                    "import { target } from '.';\nexport function caller() { target(); }\n",
+                ),
+            ],
+        )?;
+        let nodes = store.get_nodes()?;
+        let marker = store
+            .get_edges()?
+            .into_iter()
+            .find(|edge| {
+                edge.kind == EdgeKind::IMPORT
+                    && nodes
+                        .iter()
+                        .find(|node| node.id == edge.source)
+                        .is_some_and(|node| node.serialized_name == "target")
+                    && nodes
+                        .iter()
+                        .find(|node| node.id == edge.target)
+                        .is_some_and(|node| {
+                            node.kind == NodeKind::MODULE && node.serialized_name == "'.'"
+                        })
+            })
+            .expect("literal directory import marker");
+        match mutation {
+            "missing" => {
+                store
+                    .get_connection()
+                    .execute("DELETE FROM edge WHERE id = ?1", [marker.id.0])?;
+            }
+            "duplicate" => {
+                let mut duplicate = marker.clone();
+                duplicate.id = EdgeId(
+                    8_700_000_000_000_000_000 + marker.id.0.unsigned_abs() as i64 % 1_000_000,
+                );
+                store.insert_edge(&duplicate)?;
+            }
+            "conflicting" => {
+                store.get_connection().execute(
+                    "UPDATE edge SET candidate_target_node_ids = ?1 WHERE id = ?2",
+                    (format!("[{}]", marker.target.0), marker.id.0),
+                )?;
+            }
+            "resolved_marker" => {
+                store.get_connection().execute(
+                    "UPDATE edge SET resolved_target_node_id = target_node_id WHERE id = ?1",
+                    [marker.id.0],
+                )?;
+            }
+            "dotdot_marker" => {
+                store.get_connection().execute(
+                    "UPDATE node SET serialized_name = \"'..'\" WHERE id = ?1",
+                    [marker.target.0],
+                )?;
+            }
+            "wrong_marker" => {
+                store.get_connection().execute(
+                    "UPDATE edge SET source_node_id = file_node_id, resolved_source_node_id = file_node_id WHERE id = ?1",
+                    [marker.id.0],
+                )?;
+            }
+            "direct_resolved_extra" => {
+                let target = nodes
+                    .iter()
+                    .find(|node| {
+                        node.kind == NodeKind::FUNCTION && node.serialized_name == "target"
+                    })
+                    .expect("indexed target declaration");
+                let mut extra = marker.clone();
+                extra.id = EdgeId(
+                    8_600_000_000_000_000_000 + marker.id.0.unsigned_abs() as i64 % 1_000_000,
+                );
+                extra.target = target.id;
+                extra.resolved_target = Some(target.id);
+                store.insert_edge(&extra)?;
+            }
+            "wrong_effective_endpoint" => {
+                let target = nodes
+                    .iter()
+                    .find(|node| {
+                        node.kind == NodeKind::FUNCTION && node.serialized_name == "target"
+                    })
+                    .expect("indexed target declaration");
+                store.get_connection().execute(
+                    "UPDATE edge SET resolved_source_node_id = ?1 WHERE id = ?2",
+                    (target.id.0, marker.id.0),
+                )?;
+            }
+            "wrong_edge_file" => {
+                let target = nodes
+                    .iter()
+                    .find(|node| {
+                        node.kind == NodeKind::FUNCTION && node.serialized_name == "target"
+                    })
+                    .expect("indexed target declaration");
+                let target_file = target.file_node_id.expect("target file");
+                store.get_connection().execute(
+                    "UPDATE edge SET file_node_id = ?1 WHERE id = ?2",
+                    (target_file.0, marker.id.0),
+                )?;
+            }
+            "wrong_index" => {
+                let sibling_file = store
+                    .get_files()?
+                    .into_iter()
+                    .find(|file| file.path.ends_with("src.ts"))
+                    .expect("sibling TypeScript file");
+                let target = nodes
+                    .iter()
+                    .find(|node| {
+                        node.kind == NodeKind::FUNCTION && node.serialized_name == "target"
+                    })
+                    .expect("indexed target declaration");
+                store.get_connection().execute(
+                    "UPDATE node SET file_node_id = ?1 WHERE id = ?2",
+                    (sibling_file.id, target.id.0),
+                )?;
+            }
+            "wrong_declaration" => {
+                let target = nodes
+                    .iter()
+                    .find(|node| {
+                        node.kind == NodeKind::FUNCTION && node.serialized_name == "target"
+                    })
+                    .expect("indexed target declaration");
+                store.get_connection().execute(
+                    "UPDATE node SET serialized_name = 'other' WHERE id = ?1",
+                    [target.id.0],
+                )?;
+            }
+            _ => unreachable!(),
+        }
+        let projection = rematerialize_proof_resolution_projection(&mut store, &publication(1));
+        if mutation == "wrong_declaration" {
+            assert!(
+                projection.is_err(),
+                "{mutation} tampering produced a literal-directory import fact"
+            );
+            continue;
+        }
+        projection?;
+        let facts = store.get_proof_resolution_facts()?;
+        assert!(
+            facts.iter().all(|fact| {
+                fact.callsite.raw_target != "target" || fact.status != ProofResolutionStatus::Exact
+            }),
+            "{mutation} tampering authorized a literal-directory import: {facts:#?}"
+        );
+    }
+    Ok(())
+}
+
+#[test]
 fn relative_module_resolution_uses_one_closed_language_family() -> anyhow::Result<()> {
     for files in [
         vec![

--- a/crates/codestory-store/src/storage_impl/proof_resolution.rs
+++ b/crates/codestory-store/src/storage_impl/proof_resolution.rs
@@ -257,6 +257,8 @@ struct ProofResolutionValidationContext {
     ordinary_call_edge_indices: Vec<usize>,
     parsed_callsite_identity_by_edge: HashMap<EdgeId, CanonicalCallsiteIdentity>,
     import_relations: HashMap<(NodeId, NodeId, NodeId), ProofRelationState>,
+    typescript_directory_import_relations:
+        HashMap<(NodeId, NodeId), TypescriptDirectoryImportState>,
     member_relations: HashMap<(NodeId, NodeId), ProofRelationState>,
     python_import_paths: HashMap<(NodeId, NodeId), Vec<Vec<NodeId>>>,
     python_file_ids_by_path: HashMap<PathBuf, Vec<FileId>>,
@@ -858,6 +860,7 @@ mod go_replay_complexity_tests {
             ordinary_call_edge_indices: Vec::new(),
             parsed_callsite_identity_by_edge: HashMap::new(),
             import_relations: HashMap::new(),
+            typescript_directory_import_relations: HashMap::new(),
             member_relations: HashMap::new(),
             python_import_paths: HashMap::new(),
             python_file_ids_by_path: HashMap::new(),
@@ -1019,6 +1022,7 @@ mod python_replay_complexity_tests {
             ordinary_call_edge_indices: Vec::new(),
             parsed_callsite_identity_by_edge: HashMap::new(),
             import_relations: HashMap::new(),
+            typescript_directory_import_relations: HashMap::new(),
             member_relations: HashMap::new(),
             python_import_paths: HashMap::new(),
             python_file_ids_by_path,
@@ -1071,6 +1075,41 @@ struct ProofRelationState {
 impl ProofRelationState {
     fn is_unique(&self) -> bool {
         self.admissible == 1 && self.conflicting == 0
+    }
+}
+
+#[derive(Default)]
+struct TypescriptDirectoryImportState {
+    marker: Option<&'static str>,
+    marker_seen: bool,
+    admissible: usize,
+    conflicting: usize,
+}
+
+impl TypescriptDirectoryImportState {
+    fn record(&mut self, marker: Option<&'static str>, admissible: bool) {
+        self.marker_seen |= marker.is_some();
+        if admissible {
+            let marker = marker.expect("directory marker admission requires a marker");
+            self.marker.get_or_insert(marker);
+            self.admissible += 1;
+        } else {
+            self.conflicting += 1;
+        }
+    }
+
+    fn unique_marker(&self) -> Option<&'static str> {
+        (self.admissible == 1 && self.conflicting == 0)
+            .then_some(self.marker)
+            .flatten()
+    }
+}
+
+fn typescript_directory_specifier(literal: &str) -> Option<&'static str> {
+    match literal {
+        "'.'" | "\".\"" => Some("."),
+        "'..'" | "\"..\"" => Some(".."),
+        _ => None,
     }
 }
 
@@ -1138,6 +1177,8 @@ impl ProofResolutionValidationContext {
             prepare_call_edge_correlation_index(&edges, &node_by_id);
         let mut edge_index_by_id = HashMap::with_capacity(edges.len());
         let mut import_relations = HashMap::<_, ProofRelationState>::new();
+        let mut typescript_directory_import_relations =
+            HashMap::<_, TypescriptDirectoryImportState>::new();
         let mut member_relations = HashMap::<_, ProofRelationState>::new();
         let mut python_import_edges = HashMap::<NodeId, Vec<NodeId>>::new();
         for (index, edge) in edges.iter().enumerate() {
@@ -1170,6 +1211,27 @@ impl ProofResolutionValidationContext {
                 } else {
                     state.conflicting += 1;
                 }
+            }
+            if edge.kind == EdgeKind::IMPORT
+                && let Some(import) = node_by_id.get(&edge.source)
+                && import.kind == NodeKind::UNKNOWN
+                && let Some(source_file) = import.file_node_id
+            {
+                let target = node_by_id.get(&edge.target);
+                let marker = target
+                    .filter(|target| target.kind == NodeKind::MODULE)
+                    .and_then(|target| typescript_directory_specifier(&target.serialized_name));
+                let admissible = marker.is_some()
+                    && edge.file_node_id == Some(source_file)
+                    && target.is_some_and(|target| target.file_node_id == Some(source_file))
+                    && edge.effective_source() == edge.source
+                    && edge.effective_target() == edge.target
+                    && edge.resolved_target.is_none()
+                    && edge.candidate_targets.is_empty();
+                typescript_directory_import_relations
+                    .entry((source_file, edge.source))
+                    .or_default()
+                    .record(marker, admissible);
             }
             if python_raw_import_marker_is_admissible(edge, &node_by_id) {
                 python_import_edges
@@ -1259,6 +1321,7 @@ impl ProofResolutionValidationContext {
             ordinary_call_edge_indices,
             parsed_callsite_identity_by_edge,
             import_relations,
+            typescript_directory_import_relations,
             member_relations,
             python_import_paths,
             python_file_ids_by_path,
@@ -1274,6 +1337,18 @@ impl ProofResolutionValidationContext {
         self.import_relations
             .get(&(file, import, target))
             .is_some_and(ProofRelationState::is_unique)
+    }
+
+    fn typescript_directory_import(&self, file: NodeId, import: NodeId) -> Option<&'static str> {
+        self.typescript_directory_import_relations
+            .get(&(file, import))
+            .and_then(TypescriptDirectoryImportState::unique_marker)
+    }
+
+    fn typescript_directory_marker_seen(&self, file: NodeId, import: NodeId) -> bool {
+        self.typescript_directory_import_relations
+            .get(&(file, import))
+            .is_some_and(|state| state.marker_seen)
     }
 
     fn has_member(&self, owner: NodeId, member: NodeId) -> bool {
@@ -1844,7 +1919,15 @@ impl Storage {
                     .ok_or_else(|| proof_error("static import binding is missing"))?;
                 if import_node.file_node_id != Some(NodeId(fact.callsite.file_id.0))
                     || graph_leaf_name(&import_node.serialized_name) != fact.callsite.raw_target
-                    || !context.has_import(NodeId(fact.callsite.file_id.0), *import, target)
+                    || !(if context
+                        .typescript_directory_marker_seen(NodeId(fact.callsite.file_id.0), *import)
+                    {
+                        typescript_directory_import_target_is_authenticated(
+                            context, fact, *import, target,
+                        )
+                    } else {
+                        context.has_import(NodeId(fact.callsite.file_id.0), *import, target)
+                    })
                 {
                     return Err(proof_error(
                         "StaticImportBinding is not the unique source import bound to target",
@@ -2632,6 +2715,142 @@ fn proof_import_node_kind_is_literal(language: &str, kind: NodeKind) -> bool {
         }
         _ => false,
     }
+}
+
+fn normalize_stored_path(path: &Path) -> Option<PathBuf> {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            std::path::Component::RootDir => normalized.push(component.as_os_str()),
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                if !normalized.pop() {
+                    return None;
+                }
+            }
+            std::path::Component::Normal(name) => normalized.push(name),
+        }
+    }
+    Some(normalized)
+}
+
+fn stored_paths_match(left: &Path, right: &Path) -> bool {
+    let native_match = {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            match (
+                std::fs::symlink_metadata(left),
+                std::fs::symlink_metadata(right),
+            ) {
+                (Ok(left), Ok(right)) => {
+                    Some((left.dev(), left.ino()) == (right.dev(), right.ino()))
+                }
+                (Err(left), _) if left.kind() == std::io::ErrorKind::NotFound => None,
+                (_, Err(right)) if right.kind() == std::io::ErrorKind::NotFound => None,
+                _ => Some(false),
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            match (std::fs::canonicalize(left), std::fs::canonicalize(right)) {
+                (Ok(left), Ok(right)) => Some(
+                    left.to_string_lossy()
+                        .eq_ignore_ascii_case(&right.to_string_lossy()),
+                ),
+                (Err(left), _) if left.kind() == std::io::ErrorKind::NotFound => None,
+                (_, Err(right)) if right.kind() == std::io::ErrorKind::NotFound => None,
+                _ => Some(false),
+            }
+        }
+    };
+    native_match.unwrap_or_else(|| {
+        let (Some(left), Some(right)) = (normalize_stored_path(left), normalize_stored_path(right))
+        else {
+            return false;
+        };
+        #[cfg(windows)]
+        {
+            left.to_string_lossy()
+                .eq_ignore_ascii_case(&right.to_string_lossy())
+        }
+        #[cfg(not(windows))]
+        {
+            left == right
+        }
+    })
+}
+
+fn typescript_source_extension_is_supported(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| matches!(extension, "ts" | "tsx"))
+}
+
+fn typescript_directory_import_target_is_authenticated(
+    context: &ProofResolutionValidationContext,
+    fact: &CallResolutionFact,
+    import: NodeId,
+    target: NodeId,
+) -> bool {
+    if !matches!(
+        fact.provenance.language_adapter.as_str(),
+        "typescript" | "tsx"
+    ) {
+        return false;
+    }
+    let source_file_id = NodeId(fact.callsite.file_id.0);
+    let Some(import_node) = context.node_by_id.get(&import) else {
+        return false;
+    };
+    if import_node.file_node_id != Some(source_file_id)
+        || import_node.kind != NodeKind::UNKNOWN
+        || graph_leaf_name(&import_node.serialized_name) != fact.callsite.raw_target
+    {
+        return false;
+    }
+    let Some(module_specifier) = context.typescript_directory_import(source_file_id, import) else {
+        return false;
+    };
+    let Some(source_file) = context.file_by_id.get(&fact.callsite.file_id.0) else {
+        return false;
+    };
+    if !matches!(source_file.language.as_str(), "typescript" | "tsx")
+        || !typescript_source_extension_is_supported(&source_file.path)
+    {
+        return false;
+    }
+    let Some(target_file_id) = context
+        .node_by_id
+        .get(&target)
+        .filter(|node| {
+            matches!(node.kind, NodeKind::FUNCTION | NodeKind::METHOD)
+                && graph_leaf_name(&node.serialized_name) == fact.callsite.raw_target
+        })
+        .and_then(|node| node.file_node_id)
+    else {
+        return false;
+    };
+    if !dependency_file_ids(fact).contains(&FileId(target_file_id.0)) {
+        return false;
+    }
+    let Some(target_file) = context.file_by_id.get(&target_file_id.0) else {
+        return false;
+    };
+    if !matches!(target_file.language.as_str(), "typescript" | "tsx") {
+        return false;
+    }
+    let Some(parent) = source_file.path.parent() else {
+        return false;
+    };
+    let Some(directory) = normalize_stored_path(&parent.join(module_specifier)) else {
+        return false;
+    };
+    [directory.join("index.ts"), directory.join("index.tsx")]
+        .into_iter()
+        .filter_map(|path| normalize_stored_path(&path))
+        .any(|path| stored_paths_match(&target_file.path, &path))
 }
 
 fn publication_integrity_digest(


### PR DESCRIPTION
## Context

The dark proof overlay could not authenticate four Vite qualification steps whose targets were already statically obvious: two mixed type/value named imports and two literal `.` directory imports. This PR closes that measured class without broadening JavaScript, package, barrel, wildcard, or dynamic import authority.

Closes #2050
Refs #2023

## What changed

- Preserve grammar-owned TypeScript type/value specifier roles and reject duplicate local binders before value filtering.
- Admit literal `.` and `..` only for TypeScript/TSX source files and only to a unique direct `index.ts` or `index.tsx` target.
- Require one aggregate import-domain witness: exactly one admissible raw marker and no other edge from the import placeholder.
- Replay the same language, extension, dependency, direct-index, and native path-identity checks in the store before publication.
- Bump only the TypeScript/TSX exact-resolution adapter to `reference-v17`.

No public CLI/MCP route is registered. Graph schema and navigation behavior are unchanged. Retrieval, packet, context, and search cannot consume the proof overlay.

## Review boundary

One consolidated adversarial review covered language-domain closure, parser provenance, graph/fact correlation, repeated callsites, source coordinates, native ordering/path identity, storage replay, and complexity. Its four causal findings were corrected as one batch; the scoped recheck accepted all corrections and added no style or abstraction work.

Review the closed trust boundary in:

- `crates/codestory-indexer/src/lib.rs`
- `crates/codestory-indexer/src/proof_resolution.rs`
- `crates/codestory-indexer/tests/proof_resolution.rs`
- `crates/codestory-store/src/storage_impl/proof_resolution.rs`

## Frozen candidate

- Commit: `ea7433f3eb38ec860faf21f22391774e18fc955f`
- Tree: `452e20799ca855c449bcdf3128987589c45b9a98`
- Qualification: `20260825T012008Z-ea7433f3eb38`
- Sealed binary SHA-256: `2b57c6b88edd655e9e358be95b4c404104cd6282f10730fa0be680796d1367b5`
- Results SHA-256: `aaa776a2a744988733c1cdeb3e719b30add293ba3cb1c40ba304bcaa7d33a9b4`

## Verification

- Focused indexer proof-resolution tests: 105 passed
- Focused store proof-resolution tests: 25 passed
- Changed-crate clippy with tests: passed
- Q1 evidence-separation check and exact conformance test: passed
- `cargo check --locked --workspace`: passed
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`: passed
- `cargo nextest run --locked --workspace --no-fail-fast`: 4,060 passed, 34 skipped
- `cargo test --workspace --doc --locked`: passed
- Indexer fidelity regression: 8 passed
- Language coverage regression: 13 passed
- `cargo fmt -- --check` and `git diff --check`: passed

The canonical `cargo fmt --all -- --check` spelling is not usable from this linked worktree because vendored `tree-sitter-graph` resolves the primary workspace; the equivalent workspace-local formatter check passed without changing manifests.

## Local qualification

The sealed driver materialized, ran, and verified once on the frozen candidate:

- Full proofs: 85/120, up from 81/120
- Cohorts: Rust 16, Flask 16, Go 24, Vite 29 (Vite was 25)
- Exact positive steps: 220/312
- Full or useful partial: 90/120
- Exact authoritative receipts: 220/220
- Hostile mutations reaching `ContractProven`: 0/240
- Every hard-gate count: zero
- Maximum response: 30,695 bytes

Decision: `keep_proof_dark`. Stable step-recall, useful-partial, and latency gates still fail, so this PR makes no activation or release claim.
