### PR TITLE
[codex] close Python relative import paths

### DIFF
--- a/crates/codestory-indexer/src/proof_resolution.rs
+++ b/crates/codestory-indexer/src/proof_resolution.rs
@@ -87,7 +87,7 @@ fn python_resolution_work() -> usize {
 }
 
 const ADAPTER_VERSION: &str = "reference-v15";
-const PYTHON_ADAPTER_VERSION: &str = "reference-v16";
+const PYTHON_ADAPTER_VERSION: &str = "reference-v17";
 const TYPESCRIPT_ADAPTER_VERSION: &str = "reference-v17";
 const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 14;
 const INSTALLED_ADAPTERS: &[(&str, &str)] = &[
@@ -2037,6 +2037,13 @@ impl<'tree> PythonResolutionIndex<'tree> {
         else {
             return;
         };
+        if !python_exact_single_name_import(node, module, imported_name, local_name, source) {
+            *self
+                .module_blockers
+                .entry(local_name.to_string())
+                .or_default() += 1;
+            return;
+        }
         let key = (
             local_node.start_position().row as u32 + 1,
             local_node.start_position().column as u32 + 1,
@@ -2736,10 +2743,36 @@ fn python_call_on_self_dict(node: TsNode<'_>, source: &str) -> bool {
 }
 
 fn python_exact_relative_module(module: &str) -> bool {
-    module.starts_with('.')
-        && !module.starts_with("..")
-        && module[1..].split('.').all(python_identifier)
-        && module.len() > 1
+    python_relative_module_components(module).is_some()
+}
+
+fn python_exact_single_name_import(
+    node: TsNode<'_>,
+    module: &str,
+    imported_name: &str,
+    local_name: &str,
+    source: &str,
+) -> bool {
+    let Some(surface) = node_text(node, source).map(str::trim) else {
+        return false;
+    };
+    let expected = if imported_name == local_name {
+        format!("from {module} import {imported_name}")
+    } else {
+        format!("from {module} import {imported_name} as {local_name}")
+    };
+    surface == expected
+}
+
+fn python_relative_module_components(module: &str) -> Option<(usize, Vec<&str>)> {
+    let depth = module.bytes().take_while(|byte| *byte == b'.').count();
+    let components = module.get(depth..)?.split('.').collect::<Vec<_>>();
+    (depth > 0
+        && !components.is_empty()
+        && components
+            .iter()
+            .all(|component| python_identifier(component)))
+    .then_some((depth, components))
 }
 
 fn python_identifier(name: &str) -> bool {
@@ -7170,9 +7203,27 @@ struct PythonRelativeImportResolution<'a> {
     dependencies: Vec<FileId>,
 }
 
+#[derive(Clone)]
+struct PythonPackageMarker {
+    file_id: FileId,
+}
+
+#[derive(Default)]
+struct PythonModuleCandidates {
+    indexed: Vec<FileId>,
+    uncovered: bool,
+}
+
 #[derive(Default)]
 struct PythonProjectionIndex {
     complete_directories: HashSet<WorkspacePathIdentity>,
+    aliased_directories: HashSet<WorkspacePathIdentity>,
+    package_markers: HashMap<WorkspacePathIdentity, PythonPackageMarker>,
+    package_ancestry_by_file: HashMap<i64, Vec<WorkspacePathIdentity>>,
+    module_candidates: HashMap<(WorkspacePathIdentity, String), PythonModuleCandidates>,
+    package_directories_by_marker: HashMap<i64, WorkspacePathIdentity>,
+    file_directories: HashMap<i64, WorkspacePathIdentity>,
+    record_identities_by_file: HashMap<i64, WorkspacePathIdentity>,
     declarations_by_file_and_name: HashMap<(i64, String), Vec<NodeId>>,
     classes_by_file_and_name: HashMap<(i64, String), Vec<NodeId>>,
     methods_by_file_owner_and_name: HashMap<(i64, NodeId, String), Vec<NodeId>>,
@@ -7202,9 +7253,23 @@ impl PythonProjectionIndex {
                     directory.display()
                 )
             })?;
-            directories
-                .entry(identity)
-                .or_insert_with(|| directory.to_path_buf());
+            if let Some(existing) = directories.insert(identity.clone(), directory.to_path_buf())
+                && existing != directory
+            {
+                index.aliased_directories.insert(identity.clone());
+            }
+            index
+                .file_directories
+                .insert(record.file.file_id.0, identity);
+            index.record_identities_by_file.insert(
+                record.file.file_id.0,
+                workspace_path_identity(&record.path).map_err(|error| {
+                    anyhow!(
+                        "Python proof resolution source has no native identity ({}): {error}",
+                        record.path.display()
+                    )
+                })?,
+            );
             for declaration in &record.file.top_level_declarations {
                 count_python_resolution_work(1);
                 index
@@ -7234,8 +7299,104 @@ impl PythonProjectionIndex {
                 }
             }
         }
+        for record in records
+            .iter()
+            .filter(|record| record.file.language == "python")
+        {
+            count_python_resolution_work(1);
+            if record
+                .path
+                .extension()
+                .and_then(|extension| extension.to_str())
+                != Some("py")
+            {
+                continue;
+            }
+            let Some(directory) = record.path.parent() else {
+                continue;
+            };
+            let Ok(directory_identity) = workspace_path_identity(directory) else {
+                continue;
+            };
+            let Some(file_name) = record.path.file_name().and_then(|name| name.to_str()) else {
+                continue;
+            };
+            if file_name == "__init__.py" {
+                if std::fs::symlink_metadata(&record.path)
+                    .map_or(true, |metadata| metadata.file_type().is_symlink())
+                {
+                    continue;
+                }
+                let Some(parent) = directory.parent() else {
+                    continue;
+                };
+                let Ok(parent_identity) = workspace_path_identity(parent) else {
+                    continue;
+                };
+                if index.aliased_directories.contains(&directory_identity)
+                    || std::fs::symlink_metadata(directory)
+                        .map_or(true, |metadata| metadata.file_type().is_symlink())
+                {
+                    continue;
+                }
+                index.package_markers.insert(
+                    directory_identity.clone(),
+                    PythonPackageMarker {
+                        file_id: FileId(record.file.file_id.0),
+                    },
+                );
+                index
+                    .package_directories_by_marker
+                    .insert(record.file.file_id.0, directory_identity);
+                let Some(package_name) = directory.file_name().and_then(|name| name.to_str())
+                else {
+                    continue;
+                };
+                if python_identifier(package_name) {
+                    index
+                        .module_candidates
+                        .entry((parent_identity, package_name.to_owned()))
+                        .or_default()
+                        .indexed
+                        .push(FileId(record.file.file_id.0));
+                }
+            } else if let Some(stem) = record.path.file_stem().and_then(|stem| stem.to_str())
+                && python_identifier(stem)
+            {
+                index
+                    .module_candidates
+                    .entry((directory_identity, stem.to_owned()))
+                    .or_default()
+                    .indexed
+                    .push(FileId(record.file.file_id.0));
+            }
+        }
+        for candidates in index.module_candidates.values_mut() {
+            candidates.indexed.sort();
+            candidates.indexed.dedup();
+        }
+        for record in records
+            .iter()
+            .filter(|record| record.file.language == "python")
+        {
+            if let Some(ancestry) = python_prepared_package_ancestry(
+                &record.path,
+                &index.package_markers,
+                &index.aliased_directories,
+            ) {
+                index
+                    .package_ancestry_by_file
+                    .insert(record.file.file_id.0, ancestry);
+            }
+        }
         for (identity, directory) in directories {
             let mut complete = true;
+            if index.aliased_directories.contains(&identity)
+                || std::fs::symlink_metadata(&directory)
+                    .map_or(true, |metadata| metadata.file_type().is_symlink())
+            {
+                continue;
+            }
             let entries = match std::fs::read_dir(&directory) {
                 Ok(entries) => entries,
                 Err(_) => {
@@ -7266,17 +7427,75 @@ impl PythonProjectionIndex {
                 }
             }
             if complete {
+                let entries = match std::fs::read_dir(&directory) {
+                    Ok(entries) => entries,
+                    Err(_) => continue,
+                };
+                for entry in entries {
+                    count_python_resolution_work(1);
+                    let Ok(entry) = entry else {
+                        complete = false;
+                        break;
+                    };
+                    let path = entry.path();
+                    let Ok(kind) = entry.file_type() else {
+                        complete = false;
+                        break;
+                    };
+                    if !kind.is_dir() && !kind.is_symlink() {
+                        continue;
+                    }
+                    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+                        continue;
+                    };
+                    if !python_identifier(name) {
+                        continue;
+                    }
+                    let domain = index
+                        .module_candidates
+                        .entry((identity.clone(), name.to_owned()))
+                        .or_default();
+                    if kind.is_symlink() {
+                        domain.uncovered = true;
+                        continue;
+                    }
+                    let marker = path.join("__init__.py");
+                    match std::fs::symlink_metadata(&marker) {
+                        Ok(metadata) if metadata.file_type().is_symlink() || kind.is_symlink() => {
+                            domain.uncovered = true;
+                        }
+                        Ok(_) => match workspace_path_identity(&marker) {
+                            Ok(marker_identity)
+                                if records_by_path.contains_key(&marker_identity) => {}
+                            _ => domain.uncovered = true,
+                        },
+                        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                        Err(_) => domain.uncovered = true,
+                    }
+                }
+            }
+            if complete {
                 index.complete_directories.insert(identity);
             }
         }
         Ok(index)
     }
 
-    fn directory_is_complete(&self, directory: &Path) -> bool {
+    fn directory_identity_is_complete(&self, directory: &WorkspacePathIdentity) -> bool {
         count_python_resolution_work(1);
-        workspace_path_identity(directory)
-            .ok()
-            .is_some_and(|identity| self.complete_directories.contains(&identity))
+        self.complete_directories.contains(directory)
+    }
+
+    fn module_candidates(
+        &self,
+        directory: &WorkspacePathIdentity,
+        name: &str,
+    ) -> (&[FileId], bool) {
+        count_python_resolution_work(1);
+        self.module_candidates
+            .get(&(directory.clone(), name.to_owned()))
+            .map(|domain| (domain.indexed.as_slice(), domain.uncovered))
+            .unwrap_or_default()
     }
 
     fn classes(&self, file_id: FileId, name: &str) -> &[NodeId] {
@@ -7304,131 +7523,158 @@ impl PythonProjectionIndex {
     }
 }
 
+fn python_prepared_package_ancestry(
+    source: &Path,
+    package_markers: &HashMap<WorkspacePathIdentity, PythonPackageMarker>,
+    aliased_directories: &HashSet<WorkspacePathIdentity>,
+) -> Option<Vec<WorkspacePathIdentity>> {
+    let mut directory = source.parent()?.to_path_buf();
+    let mut ancestry = Vec::new();
+    let mut visited = HashSet::new();
+    loop {
+        count_python_resolution_work(1);
+        if !visited.insert(directory.clone()) {
+            return None;
+        }
+        let marker = directory.join("__init__.py");
+        match std::fs::symlink_metadata(&marker) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Some(ancestry),
+            Err(_) => return None,
+            Ok(marker_metadata)
+                if marker_metadata.file_type().is_symlink() || !marker_metadata.is_file() =>
+            {
+                return None;
+            }
+            Ok(_) => {}
+        }
+        let directory_metadata = std::fs::symlink_metadata(&directory).ok()?;
+        if directory_metadata.file_type().is_symlink() || !directory_metadata.is_dir() {
+            return None;
+        }
+        let identity = workspace_path_identity(&directory).ok()?;
+        if aliased_directories.contains(&identity) || !package_markers.contains_key(&identity) {
+            return None;
+        }
+        ancestry.push(identity);
+        directory = directory.parent()?.to_path_buf();
+    }
+}
+
 fn resolve_python_relative_import<'a>(
     source_record: &ResolutionCacheRecord,
     module_specifier: &str,
     records: &'a HashMap<WorkspacePathIdentity, &ResolutionCacheRecord>,
     python_index: &PythonProjectionIndex,
 ) -> Result<PythonRelativeImportResolution<'a>> {
-    if !python_exact_relative_module(module_specifier) {
-        return Ok(PythonRelativeImportResolution {
-            target: RelativeImportResolution::Missing,
-            dependencies: Vec::new(),
-        });
-    }
-    let Some(source_directory) = source_record.path.parent() else {
+    let Some((depth, components)) = python_relative_module_components(module_specifier) else {
         return Ok(PythonRelativeImportResolution {
             target: RelativeImportResolution::Missing,
             dependencies: Vec::new(),
         });
     };
-    let mut dependency_records = Vec::new();
-    let source_marker = source_directory.join("__init__.py");
-    let source_marker_identity = match workspace_path_identity(&source_marker) {
-        Ok(identity) => identity,
-        Err(_) => {
-            return Ok(PythonRelativeImportResolution {
-                target: RelativeImportResolution::Incomplete,
-                dependencies: Vec::new(),
-            });
-        }
-    };
-    let Some(source_marker_record) = records.get(&source_marker_identity).copied() else {
+    let Some(ancestry) = python_index
+        .package_ancestry_by_file
+        .get(&source_record.file.file_id.0)
+    else {
         return Ok(PythonRelativeImportResolution {
             target: RelativeImportResolution::Incomplete,
             dependencies: Vec::new(),
         });
     };
-    dependency_records.push(source_marker_record);
-
-    let components = module_specifier[1..].split('.').collect::<Vec<_>>();
-    let mut base = source_directory.to_path_buf();
-    for component in &components[..components.len().saturating_sub(1)] {
-        base.push(component);
-        let marker = base.join("__init__.py");
-        let identity = match workspace_path_identity(&marker) {
-            Ok(identity) => identity,
-            Err(_) => {
-                return Ok(PythonRelativeImportResolution {
-                    target: RelativeImportResolution::Incomplete,
-                    dependencies: Vec::new(),
-                });
-            }
-        };
-        let Some(record) = records.get(&identity).copied() else {
+    let Some(base) = ancestry.get(depth - 1).cloned() else {
+        return Ok(PythonRelativeImportResolution {
+            target: RelativeImportResolution::Missing,
+            dependencies: Vec::new(),
+        });
+    };
+    let mut package_directories = ancestry[..depth].to_vec();
+    let mut dependency_ids = package_directories
+        .iter()
+        .filter_map(|directory| python_index.package_markers.get(directory))
+        .map(|marker| marker.file_id)
+        .collect::<Vec<_>>();
+    let mut current = base;
+    for component in &components[..components.len() - 1] {
+        let (candidates, uncovered) = python_index.module_candidates(&current, component);
+        if uncovered {
             return Ok(PythonRelativeImportResolution {
                 target: RelativeImportResolution::Incomplete,
                 dependencies: Vec::new(),
             });
-        };
-        dependency_records.push(record);
-    }
-    let leaf = components
-        .last()
-        .expect("exact relative module has a component");
-    let file_candidate = base.join(leaf).with_extension("py");
-    let package_candidate = base.join(leaf).join("__init__.py");
-    let mut matches: Vec<&ResolutionCacheRecord> = Vec::new();
-    let mut uncovered = false;
-    for candidate in [&file_candidate, &package_candidate] {
-        match std::fs::symlink_metadata(candidate) {
-            Ok(metadata) if metadata.file_type().is_symlink() => {
-                uncovered = true;
-                continue;
-            }
-            Ok(_) => {}
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
-            Err(_) => {
-                uncovered = true;
-                continue;
-            }
         }
-        let identity = match workspace_path_identity(candidate) {
-            Ok(identity) => identity,
-            Err(_) => {
-                uncovered = true;
-                continue;
-            }
+        let Some(marker_file) = (match candidates {
+            [file_id] => python_index.package_directories_by_marker.get(&file_id.0),
+            _ => None,
+        })
+        .cloned() else {
+            return Ok(PythonRelativeImportResolution {
+                target: if candidates.is_empty() && !uncovered {
+                    RelativeImportResolution::Missing
+                } else {
+                    RelativeImportResolution::Incomplete
+                },
+                dependencies: Vec::new(),
+            });
         };
-        if let Some(record) = records.get(&identity) {
-            matches.push(*record);
-        } else {
-            uncovered = true;
-        }
+        let marker = python_index
+            .package_markers
+            .get(&marker_file)
+            .expect("package marker directory maps to a marker");
+        dependency_ids.push(marker.file_id);
+        package_directories.push(marker_file.clone());
+        current = marker_file;
     }
-    matches.sort_by_key(|record| record.file.file_id);
-    matches.dedup_by_key(|record| record.file.file_id);
-    if uncovered || matches.len() != 1 {
+    let (candidates, uncovered) =
+        python_index.module_candidates(&current, components.last().expect("relative module leaf"));
+    if uncovered {
         return Ok(PythonRelativeImportResolution {
-            target: if matches.is_empty() && !uncovered {
+            target: RelativeImportResolution::Incomplete,
+            dependencies: Vec::new(),
+        });
+    }
+    let [target_file_id] = candidates else {
+        return Ok(PythonRelativeImportResolution {
+            target: if candidates.is_empty() && !uncovered {
                 RelativeImportResolution::Missing
             } else {
                 RelativeImportResolution::Incomplete
             },
             dependencies: Vec::new(),
         });
-    }
-    let target = matches[0];
-    if package_candidate == target.path {
-        dependency_records.push(target);
-    }
-    if [
-        source_directory,
-        target.path.parent().unwrap_or(source_directory),
-    ]
-    .into_iter()
-    .any(|directory| !python_index.directory_is_complete(directory))
+    };
+    let Some(target_identity) = python_index
+        .record_identities_by_file
+        .get(&target_file_id.0)
+    else {
+        return Ok(PythonRelativeImportResolution {
+            target: RelativeImportResolution::Incomplete,
+            dependencies: Vec::new(),
+        });
+    };
+    let Some(target) = records.get(target_identity).copied() else {
+        return Ok(PythonRelativeImportResolution {
+            target: RelativeImportResolution::Incomplete,
+            dependencies: Vec::new(),
+        });
+    };
+    let Some(target_directory) = python_index.file_directories.get(&target_file_id.0) else {
+        return Ok(PythonRelativeImportResolution {
+            target: RelativeImportResolution::Incomplete,
+            dependencies: Vec::new(),
+        });
+    };
+    package_directories.push(target_directory.clone());
+    if package_directories
+        .iter()
+        .any(|directory| !python_index.directory_identity_is_complete(directory))
     {
         return Ok(PythonRelativeImportResolution {
             target: RelativeImportResolution::Incomplete,
             dependencies: Vec::new(),
         });
     }
-    let mut dependencies = dependency_records
-        .into_iter()
-        .map(|record| FileId(record.file.file_id.0))
-        .chain(std::iter::once(FileId(target.file.file_id.0)))
-        .collect::<Vec<_>>();
+    dependency_ids.push(*target_file_id);
+    let mut dependencies = dependency_ids;
     dependencies.sort();
     dependencies.dedup();
     Ok(PythonRelativeImportResolution {
@@ -7712,10 +7958,6 @@ impl ExactEvidenceValidationIndex {
                     state.conflicting += 1;
                 }
             }
-        }
-        for targets in python_import_edges.values_mut() {
-            targets.sort();
-            targets.dedup();
         }
         let python_import_targets = python_import_edges
             .values()

--- a/crates/codestory-indexer/tests/proof_resolution.rs
+++ b/crates/codestory-indexer/tests/proof_resolution.rs
@@ -628,6 +628,313 @@ fn python_closed_exact_subset_authorizes_s1_through_s4() -> anyhow::Result<()> {
 }
 
 #[test]
+fn python_classic_relative_imports_resolve_direct_and_multi_dot_paths() -> anyhow::Result<()> {
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(
+        project.path(),
+        &mut store,
+        &[
+            ("pkg/__init__.py", ""),
+            ("pkg/scaffold.py", "def find_package():\n    pass\n"),
+            ("pkg/helpers.py", "def root_value():\n    pass\n"),
+            (
+                "pkg/main.py",
+                "from .scaffold import find_package\ndef direct():\n    find_package()\n",
+            ),
+            ("pkg/sub/__init__.py", ""),
+            ("pkg/sub/near.py", "def near_value():\n    pass\n"),
+            ("pkg/sub/deep/__init__.py", ""),
+            (
+                "pkg/sub/deep/main.py",
+                concat!(
+                    "from ...helpers import root_value\n",
+                    "from ..near import near_value\n\n",
+                    "from ..near import near_value as aliased_near\n\n",
+                    "def caller():\n",
+                    "    root_value()\n",
+                    "    near_value()\n",
+                    "    aliased_near()\n",
+                ),
+            ),
+        ],
+    )?;
+
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    store.validate_proof_resolution_publication(&publication(1))?;
+    let facts = store
+        .get_proof_resolution_facts()?
+        .into_iter()
+        .filter(|fact| fact.provenance.language_adapter == "python")
+        .collect::<Vec<_>>();
+    for target in ["find_package", "root_value", "near_value", "aliased_near"] {
+        let fact = facts
+            .iter()
+            .find(|fact| fact.callsite.raw_target == target)
+            .unwrap_or_else(|| panic!("missing Python fact for {target}: {facts:#?}"));
+        assert_eq!(fact.status, ProofResolutionStatus::Exact, "{fact:#?}");
+        assert!(fact.edge_id.is_some(), "{fact:#?}");
+    }
+    Ok(())
+}
+
+#[test]
+fn python_multi_dot_relative_imports_fail_closed_outside_classic_package_paths()
+-> anyhow::Result<()> {
+    for files in [
+        vec![
+            ("pkg/__init__.py", ""),
+            ("pkg/helper.py", "def target():\n    pass\n"),
+            ("pkg/sub/__init__.py", ""),
+            (
+                "pkg/sub/main.py",
+                "from ...helper import target\ndef caller():\n    target()\n",
+            ),
+        ],
+        vec![
+            ("pkg/__init__.py", ""),
+            ("pkg/helper.py", "def target():\n    pass\n"),
+            (
+                "pkg/sub/main.py",
+                "from ..helper import target\ndef caller():\n    target()\n",
+            ),
+        ],
+        vec![
+            ("pkg/__init__.py", ""),
+            ("pkg/helper.py", "def target():\n    pass\n"),
+            ("pkg/helper/__init__.py", "def target():\n    pass\n"),
+            ("pkg/sub/__init__.py", ""),
+            (
+                "pkg/sub/main.py",
+                "from ..helper import target\ndef caller():\n    target()\n",
+            ),
+        ],
+    ] {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(project.path(), &mut store, &files)?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        let fact = store
+            .get_proof_resolution_facts()?
+            .into_iter()
+            .find(|fact| {
+                fact.provenance.language_adapter == "python" && fact.callsite.raw_target == "target"
+            })
+            .expect("closed multi-dot Python fact");
+        assert_ne!(fact.status, ProofResolutionStatus::Exact, "{fact:#?}");
+    }
+    Ok(())
+}
+
+#[test]
+fn python_relative_imports_reject_live_unindexed_package_collisions_and_replay_them()
+-> anyhow::Result<()> {
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(
+        project.path(),
+        &mut store,
+        &[
+            ("pkg/__init__.py", ""),
+            ("pkg/target.py", "def target():\n    pass\n"),
+            ("pkg/sub/__init__.py", ""),
+            (
+                "pkg/sub/main.py",
+                "from ..target import target\ndef caller():\n    target()\n",
+            ),
+        ],
+    )?;
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    store.validate_proof_resolution_publication(&publication(1))?;
+
+    let unindexed_marker = project.path().join("pkg/target/__init__.py");
+    fs::create_dir_all(unindexed_marker.parent().expect("package parent"))?;
+    fs::write(&unindexed_marker, "def target():\n    pass\n")?;
+    let error = store
+        .validate_proof_resolution_publication(&publication(1))
+        .expect_err("live package collision must reject the sealed fact");
+    assert!(error.to_string().contains("candidate"), "{error}");
+
+    rematerialize_proof_resolution_projection(&mut store, &publication(2))?;
+    let fact = store
+        .get_proof_resolution_facts()?
+        .into_iter()
+        .find(|fact| fact.callsite.raw_target == "target")
+        .expect("relative-import fact");
+    assert_ne!(fact.status, ProofResolutionStatus::Exact, "{fact:#?}");
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn python_relative_imports_reject_symlinked_source_package_ancestry() -> anyhow::Result<()> {
+    use std::os::unix::fs::symlink;
+
+    let project = tempfile::tempdir()?;
+    let outside = tempfile::tempdir()?;
+    symlink(outside.path(), project.path().join("pkg"))?;
+    let mut store = Store::new_in_memory()?;
+    index_files(
+        project.path(),
+        &mut store,
+        &[
+            ("pkg/__init__.py", ""),
+            ("pkg/target.py", "def target():\n    pass\n"),
+            (
+                "pkg/main.py",
+                "from .target import target\ndef caller():\n    target()\n",
+            ),
+            ("pkg/sub/__init__.py", ""),
+            ("pkg/sub/target.py", "def target():\n    pass\n"),
+            (
+                "pkg/sub/main.py",
+                "from .target import target\ndef caller():\n    target()\n",
+            ),
+        ],
+    )?;
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    let facts = store
+        .get_proof_resolution_facts()?
+        .into_iter()
+        .filter(|fact| fact.callsite.raw_target == "target")
+        .collect::<Vec<_>>();
+    assert_eq!(facts.len(), 2, "{facts:#?}");
+    assert!(
+        facts
+            .iter()
+            .all(|fact| fact.status != ProofResolutionStatus::Exact),
+        "{facts:#?}"
+    );
+
+    let replay_project = tempfile::tempdir()?;
+    let replay_outside = tempfile::tempdir()?;
+    let mut replay_store = Store::new_in_memory()?;
+    index_files(
+        replay_project.path(),
+        &mut replay_store,
+        &[
+            ("pkg/__init__.py", ""),
+            ("pkg/sub/__init__.py", ""),
+            ("pkg/sub/target.py", "def target():\n    pass\n"),
+            (
+                "pkg/sub/main.py",
+                "from .target import target\ndef caller():\n    target()\n",
+            ),
+        ],
+    )?;
+    rematerialize_proof_resolution_projection(&mut replay_store, &publication(1))?;
+    replay_store.validate_proof_resolution_publication(&publication(1))?;
+    fs::rename(
+        replay_project.path().join("pkg"),
+        replay_outside.path().join("pkg"),
+    )?;
+    symlink(
+        replay_outside.path().join("pkg"),
+        replay_project.path().join("pkg"),
+    )?;
+    replay_store
+        .validate_proof_resolution_publication(&publication(1))
+        .expect_err("symlinked source package ancestry must reject replay");
+    Ok(())
+}
+
+#[test]
+fn python_relative_imports_reject_parenthesized_one_name_forms() -> anyhow::Result<()> {
+    for statement in [
+        "from ..target import (target)",
+        "from ..target import (\n    target\n)",
+        "from ..target import (target,)",
+    ] {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        let source = format!("{statement}\ndef caller():\n    target()\n");
+        index_files(
+            project.path(),
+            &mut store,
+            &[
+                ("pkg/__init__.py", ""),
+                ("pkg/target.py", "def target():\n    pass\n"),
+                ("pkg/sub/__init__.py", ""),
+                ("pkg/sub/main.py", source.as_str()),
+            ],
+        )?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        let fact = store
+            .get_proof_resolution_facts()?
+            .into_iter()
+            .find(|fact| fact.callsite.raw_target == "target")
+            .expect("parenthesized import fact");
+        assert_ne!(
+            fact.status,
+            ProofResolutionStatus::Exact,
+            "{statement}: {fact:#?}"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn python_relative_imports_reject_duplicate_raw_import_hops_before_and_after_replay()
+-> anyhow::Result<()> {
+    for replay in [false, true] {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(
+            project.path(),
+            &mut store,
+            &[
+                ("pkg/__init__.py", ""),
+                ("pkg/target.py", "def target():\n    pass\n"),
+                ("pkg/sub/__init__.py", ""),
+                (
+                    "pkg/sub/main.py",
+                    "from ..target import target\ndef caller():\n    target()\n",
+                ),
+            ],
+        )?;
+        if replay {
+            rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+            store.validate_proof_resolution_publication(&publication(1))?;
+        }
+        let mut hops = store
+            .get_edges()?
+            .into_iter()
+            .filter(|edge| edge.kind == EdgeKind::IMPORT)
+            .filter(|edge| {
+                store
+                    .get_node(edge.target)
+                    .ok()
+                    .flatten()
+                    .is_some_and(|node| node.kind == NodeKind::MODULE)
+            })
+            .collect::<Vec<_>>();
+        hops.sort_by_key(|edge| edge.id);
+        for (offset, hop) in hops.into_iter().enumerate() {
+            let mut duplicate = hop.clone();
+            duplicate.id = EdgeId(8_700_000_000_000_000_000 + offset as i64);
+            store.insert_edge(&duplicate)?;
+            if replay {
+                store
+                    .validate_proof_resolution_publication(&publication(1))
+                    .expect_err("duplicate raw import hop must reject replay");
+            } else {
+                rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+                let fact = store
+                    .get_proof_resolution_facts()?
+                    .into_iter()
+                    .find(|fact| fact.callsite.raw_target == "target")
+                    .expect("relative-import fact");
+                assert_ne!(fact.status, ProofResolutionStatus::Exact, "{fact:#?}");
+            }
+            store
+                .get_connection()
+                .execute("DELETE FROM edge WHERE id = ?1", [duplicate.id.0])?;
+        }
+    }
+    Ok(())
+}
+
+#[test]
 fn python_read_only_getattr_does_not_poison_closed_static_neighbors() -> anyhow::Result<()> {
     let project = tempfile::tempdir()?;
     let mut store = Store::new_in_memory()?;
@@ -686,7 +993,7 @@ fn python_read_only_getattr_does_not_poison_closed_static_neighbors() -> anyhow:
             static_facts.iter().all(|fact| {
                 fact.status == ProofResolutionStatus::Exact
                     && fact.edge_id.is_some()
-                    && fact.provenance.language_adapter_version == "reference-v16"
+                    && fact.provenance.language_adapter_version == "reference-v17"
             }),
             "read-only getter poisoned {target}: {static_facts:#?}"
         );
@@ -6218,7 +6525,7 @@ fn proof_resolution_roster_tracks_the_current_adapter_version() -> anyhow::Resul
             .iter()
             .find(|adapter| adapter.language == "python")
             .map(|adapter| adapter.adapter_version.as_str()),
-        Some("reference-v16")
+        Some("reference-v17")
     );
     for fact in store.get_proof_resolution_facts()? {
         assert!(receipt.adapter_roster.iter().any(|adapter| {

--- a/crates/codestory-store/src/storage_impl/proof_resolution.rs
+++ b/crates/codestory-store/src/storage_impl/proof_resolution.rs
@@ -437,34 +437,35 @@ fn python_dependency_ids(
                 })
             })
             .ok_or_else(|| proof_error("Python relative import has no authenticated module"))?;
-        if !python_exact_relative_module(module_specifier) {
+        let Some((depth, components)) = python_relative_module_components(module_specifier) else {
             return Err(proof_error(
                 "Python relative import module is outside the exact subset",
             ));
-        }
-        let parent = source
+        };
+        let mut base = source
             .path
             .parent()
-            .ok_or_else(|| proof_error("Python source path has no package directory"))?;
-        let components = module_specifier[1..].split('.').collect::<Vec<_>>();
-        let mut base = parent.to_path_buf();
-        for marker_path in std::iter::once(parent.join("__init__.py")).chain(
-            components[..components.len() - 1].iter().map(|component| {
-                base.push(component);
-                base.join("__init__.py")
-            }),
-        ) {
-            let markers = context
-                .python_file_ids_by_path
-                .get(&marker_path)
-                .map(Vec::as_slice)
-                .unwrap_or_default();
-            let [marker] = markers else {
-                return Err(proof_error(
-                    "Python relative import has no unique indexed package marker",
-                ));
-            };
-            expected.insert(*marker);
+            .ok_or_else(|| proof_error("Python source path has no package directory"))?
+            .to_path_buf();
+        for _ in 0..depth {
+            expected.insert(python_live_package_marker(context, &base)?);
+            base = base.parent().map(Path::to_path_buf).ok_or_else(|| {
+                proof_error("Python relative import escapes the classic package root")
+            })?;
+        }
+        base = source
+            .path
+            .parent()
+            .expect("checked Python source package directory")
+            .to_path_buf();
+        for _ in 1..depth {
+            base = base.parent().map(Path::to_path_buf).ok_or_else(|| {
+                proof_error("Python relative import escapes the classic package root")
+            })?;
+        }
+        for component in &components[..components.len() - 1] {
+            base.push(component);
+            expected.insert(python_live_package_marker(context, &base)?);
         }
         let target = fact.target.expect("Exact Python fact has a target");
         let target_file_id = context
@@ -477,19 +478,7 @@ fn python_dependency_ids(
             .get(&target_file_id.0)
             .ok_or_else(|| proof_error("Python imported target file is missing"))?;
         let leaf = components.last().expect("relative module has a component");
-        let file_target = base.join(leaf).with_extension("py");
-        let package_target = base.join(leaf).join("__init__.py");
-        let target_ids = [file_target, package_target]
-            .into_iter()
-            .flat_map(|path| {
-                context
-                    .python_file_ids_by_path
-                    .get(&path)
-                    .into_iter()
-                    .flatten()
-                    .copied()
-            })
-            .collect::<Vec<_>>();
+        let target_ids = python_live_module_candidates(context, &base, leaf)?;
         if target_ids.as_slice() != [FileId(target_file.id)] {
             return Err(proof_error(
                 "Python relative import has no unique indexed native module target",
@@ -541,17 +530,102 @@ fn prepare_python_file_ids_by_path(
     by_path
 }
 
-fn python_exact_relative_module(module: &str) -> bool {
-    module.starts_with('.')
-        && !module.starts_with("..")
-        && module.len() > 1
-        && module[1..].split('.').all(|component| {
+fn python_live_package_marker(
+    context: &ProofResolutionValidationContext,
+    directory: &Path,
+) -> Result<FileId, StorageError> {
+    let directory_metadata = fs::symlink_metadata(directory)
+        .map_err(|_| proof_error("Python package directory cannot be inspected"))?;
+    if directory_metadata.file_type().is_symlink() || !directory_metadata.is_dir() {
+        return Err(proof_error(
+            "Python package directory is not a native in-project directory",
+        ));
+    }
+    let marker = directory.join("__init__.py");
+    let marker_metadata = fs::symlink_metadata(&marker)
+        .map_err(|_| proof_error("Python relative import has no unique indexed package marker"))?;
+    if marker_metadata.file_type().is_symlink() || !marker_metadata.is_file() {
+        return Err(proof_error(
+            "Python relative import package marker is not a regular source file",
+        ));
+    }
+    let markers = context
+        .python_file_ids_by_path
+        .get(&marker)
+        .map(Vec::as_slice)
+        .unwrap_or_default();
+    let [marker] = markers else {
+        return Err(proof_error(
+            "Python relative import has no unique indexed package marker",
+        ));
+    };
+    Ok(*marker)
+}
+
+fn python_live_module_candidates(
+    context: &ProofResolutionValidationContext,
+    base: &Path,
+    leaf: &str,
+) -> Result<Vec<FileId>, StorageError> {
+    let file = base.join(leaf).with_extension("py");
+    let package = base.join(leaf);
+    let mut candidates = Vec::new();
+    for path in [&file, &package.join("__init__.py")] {
+        match fs::symlink_metadata(path) {
+            Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => {
+                return Err(proof_error(
+                    "Python relative import candidate is not a regular source file",
+                ));
+            }
+            Ok(_) => {
+                if path != &file {
+                    let package_metadata = fs::symlink_metadata(&package).map_err(|_| {
+                        proof_error("Python relative import package candidate cannot be inspected")
+                    })?;
+                    if package_metadata.file_type().is_symlink() || !package_metadata.is_dir() {
+                        return Err(proof_error(
+                            "Python relative import package candidate is not a native directory",
+                        ));
+                    }
+                }
+                let indexed = context
+                    .python_file_ids_by_path
+                    .get(path)
+                    .map(Vec::as_slice)
+                    .unwrap_or_default();
+                let [file_id] = indexed else {
+                    return Err(proof_error(
+                        "Python relative import candidate is present but not uniquely indexed",
+                    ));
+                };
+                candidates.push(*file_id);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(_) => {
+                return Err(proof_error(
+                    "Python relative import candidate cannot be inspected",
+                ));
+            }
+        }
+    }
+    candidates.sort();
+    candidates.dedup();
+    Ok(candidates)
+}
+
+fn python_relative_module_components(module: &str) -> Option<(usize, Vec<&str>)> {
+    let depth = module.bytes().take_while(|byte| *byte == b'.').count();
+    let components = module.get(depth..)?.split('.').collect::<Vec<_>>();
+    (depth > 0
+        && !components.is_empty()
+        && components.iter().all(|component| {
             let mut chars = component.chars();
             chars
                 .next()
                 .is_some_and(|ch| ch == '_' || ch.is_ascii_alphabetic())
                 && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
-        })
+        }))
+    .then_some((depth, components))
 }
 
 #[cfg(unix)]
@@ -604,6 +678,8 @@ fn prepare_python_source_attestation(
 ) -> HashMap<i64, String> {
     let mut errors = HashMap::new();
     let mut native_owners = HashMap::<PythonNativeFileIdentity, i64>::new();
+    let python_file_ids_by_path = prepare_python_file_ids_by_path(file_by_id);
+    let mut package_ancestry_cache = HashMap::<PathBuf, Result<(), String>>::new();
     for file in file_by_id.values().filter(|file| file.language == "python") {
         count_store_replay_work(1);
         if canonical_file_node_id_for_path(&file.path) != file.id {
@@ -614,6 +690,18 @@ fn prepare_python_source_attestation(
             continue;
         }
         if !authenticate_live_sources {
+            continue;
+        }
+        let Some(directory) = file.path.parent() else {
+            errors.insert(file.id, "source has no package directory".to_owned());
+            continue;
+        };
+        if let Err(error) = attest_python_classic_package_ancestry(
+            directory,
+            &python_file_ids_by_path,
+            &mut package_ancestry_cache,
+        ) {
+            errors.insert(file.id, error);
             continue;
         }
         let identity = match python_native_file_identity(&file.path) {
@@ -653,6 +741,69 @@ fn prepare_python_source_attestation(
     errors
 }
 
+fn attest_python_classic_package_ancestry(
+    source_directory: &Path,
+    indexed_files: &HashMap<PathBuf, Vec<FileId>>,
+    cache: &mut HashMap<PathBuf, Result<(), String>>,
+) -> Result<(), String> {
+    let mut directory = source_directory.to_path_buf();
+    let mut traversed = Vec::new();
+    let mut visited = HashSet::new();
+    loop {
+        count_store_replay_work(1);
+        if !visited.insert(directory.clone()) {
+            return Err("package ancestry is cyclic".to_owned());
+        }
+        if let Some(result) = cache.get(&directory) {
+            let result = result.clone();
+            for visited in traversed {
+                cache.insert(visited, result.clone());
+            }
+            return result;
+        }
+        let marker = directory.join("__init__.py");
+        let result = match fs::symlink_metadata(&marker) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(format!("package marker cannot be inspected: {error}")),
+            Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => {
+                Err("package marker is not a regular source file".to_owned())
+            }
+            Ok(_) => {
+                let directory_metadata = fs::symlink_metadata(&directory)
+                    .map_err(|error| format!("package directory cannot be inspected: {error}"));
+                match directory_metadata {
+                    Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
+                        Err("package directory is not a native directory".to_owned())
+                    }
+                    Err(error) => Err(error),
+                    Ok(_) => match indexed_files
+                        .get(&marker)
+                        .map(Vec::as_slice)
+                        .unwrap_or_default()
+                    {
+                        [_] => {
+                            traversed.push(directory.clone());
+                            match directory.parent() {
+                                Some(parent) => {
+                                    directory = parent.to_path_buf();
+                                    continue;
+                                }
+                                None => Err("package ancestry has no parent".to_owned()),
+                            }
+                        }
+                        _ => Err("package marker is not uniquely indexed".to_owned()),
+                    },
+                }
+            }
+        };
+        for visited in traversed {
+            cache.insert(visited, result.clone());
+        }
+        cache.insert(directory, result.clone());
+        return result;
+    }
+}
+
 fn validate_python_import_target(
     context: &ProofResolutionValidationContext,
     source_file: NodeId,
@@ -674,24 +825,22 @@ fn validate_python_import_target(
         return false;
     };
     let module_specifier = module_node.serialized_name.as_str();
-    if !module_specifier.starts_with('.')
-        || module_specifier.starts_with("..")
-        || module_specifier.len() <= 1
-        || !module_specifier[1..].split('.').all(|component| {
-            let mut chars = component.chars();
-            chars
-                .next()
-                .is_some_and(|ch| ch == '_' || ch.is_ascii_alphabetic())
-                && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
-        })
-    {
-        return false;
-    }
-    let Some(parent) = source.path.parent() else {
+    let Some((depth, components)) = python_relative_module_components(module_specifier) else {
         return false;
     };
-    let relative = module_specifier[1..].replace('.', std::path::MAIN_SEPARATOR_STR);
-    let base = parent.join(relative);
+    let Some(mut base) = source.path.parent().map(Path::to_path_buf) else {
+        return false;
+    };
+    for _ in 1..depth {
+        let Some(parent) = base.parent() else {
+            return false;
+        };
+        base = parent.to_path_buf();
+    }
+    for component in &components[..components.len() - 1] {
+        base.push(component);
+    }
+    let base = base.join(components.last().expect("relative module leaf"));
     target_file.path == base.with_extension("py") || target_file.path == base.join("__init__.py")
 }
 
@@ -1273,10 +1422,6 @@ impl ProofResolutionValidationContext {
                     state.conflicting += 1;
                 }
             }
-        }
-        for targets in python_import_edges.values_mut() {
-            targets.sort();
-            targets.dedup();
         }
         let python_import_targets = python_import_edges
             .values()


### PR DESCRIPTION
## Context

Python relative imports remained outside the exact-resolution overlay even when a classic-package path was fully closed by local source, package markers, native file identity, and the published graph. This PR closes that bounded class without widening proof semantics or changing navigation edges.

Closes #2052
Refs #2023

## What changed

- admits only unparenthesized, one-name, module-level relative imports with one or more leading dots and optional aliases;
- authenticates the complete classic-package ancestry, module candidate domain, source hashes, and native path identity before emitting an exact fact;
- preserves raw import-edge multiplicity so any duplicate hop fails closed;
- independently reconstructs and verifies the same evidence during store replay;
- bumps the Python exact-resolution adapter provenance to `reference-v17`;
- adds hostile fixtures for root escape, missing or unindexed package markers, file/package collisions, direct and ancestor symlink escapes, duplicate hops, excessive dots, and parenthesized imports.

The graph remains the navigation graph. Proof still requires the separate exact-resolution publication and rejects inconsistent graph/fact data. No public CLI, MCP route, packet, context, search, retrieval, or graph wire contract changed.

## Review

One consolidated adversarial review covered language-domain closure, parser provenance, graph/fact correlation, repeated callsites and import hops, source coordinates, native ordering and identity, storage integrity, and complexity. Its findings were corrected as one causal batch. A remaining ancestor-symlink case changed the fix from immediate-directory checking to complete classic-package ancestry attestation; focused source audit and permanent tests accepted that candidate. No stylistic review round followed.

## Verification

Frozen source:
- commit `f8808359a5747c5dc58e381b71cc888fa3de89e0`
- tree `e4e6c6c2bf514d88531c22708cb02d7acf7ad2e8`

Passed:
- `cargo fmt -- --check`
- `cargo check --locked --workspace`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo nextest run --locked --workspace --no-fail-fast` — 4066 passed, 34 skipped
- `cargo test --workspace --doc --locked`
- indexer proof-resolution suite — 111 passed
- fidelity regression — 8 passed
- language coverage — 13 passed
- Q1 evidence-separation feature build and sealed four-revision conformance test
- production-unreachability architecture tests
- `git diff --check`

Local Q2 materialize/run/verify used one locked release binary:
- qualification `20260825T032152Z-f8808359a574`
- binary SHA-256 `d03360ea00ab313a7c7905ac602425f2c0b7893d8ba3fbdcb01dd946a05c638c`
- results SHA-256 `62345feff7c9efc29f71ee86e286d452497d57e4779aa807d8f8006b03456ee3`
- 220/220 exact authoritative receipts
- 0 false proofs
- 0/240 hostile mutations reaching `ContractProven`
- 0 unclassified positive steps
- 0 disposition mismatches
- 85/120 full proofs; Flask 16/30; 220/312 exact steps

The corpus score is unchanged, so the signed outcome remains `keep_proof_dark`.

## Risk and nonclaims

The main risk is false exactness at Python package boundaries; the closed syntax subset, complete ancestry attestation, duplicate preservation, native identity checks, and independent store replay constrain it. The projection remains production-unreachable. This PR makes no public-proof, release, 0.17, runtime-execution, dynamic-import, namespace-package, re-export, or complete-Python-semantics claim.