### PR TITLE
resolve package calls in returned go closures

### DIFF
--- a/crates/codestory-indexer/src/proof_resolution.rs
+++ b/crates/codestory-indexer/src/proof_resolution.rs
@@ -87,11 +87,12 @@ fn python_resolution_work() -> usize {
 }
 
 const ADAPTER_VERSION: &str = "reference-v15";
+const GO_ADAPTER_VERSION: &str = "reference-v16";
 const PYTHON_ADAPTER_VERSION: &str = "reference-v17";
 const TYPESCRIPT_ADAPTER_VERSION: &str = "reference-v17";
 const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 14;
 const INSTALLED_ADAPTERS: &[(&str, &str)] = &[
-    ("go", ADAPTER_VERSION),
+    ("go", GO_ADAPTER_VERSION),
     ("javascript", ADAPTER_VERSION),
     ("python", PYTHON_ADAPTER_VERSION),
     ("rust", ADAPTER_VERSION),
@@ -429,6 +430,8 @@ struct GoResolutionIndex<'tree> {
     import_names: HashSet<String>,
     import_domain_complete: bool,
     callable_nodes: HashMap<usize, NodeId>,
+    returned_closure_calls: HashSet<usize>,
+    returned_closure_outer_blockers: HashSet<(usize, String)>,
     binding_decisions: HashMap<(usize, usize, String), GoBindingDecision>,
     build_constrained: bool,
     generated: bool,
@@ -456,6 +459,7 @@ impl<'tree> GoResolutionIndex<'tree> {
         let package_name = go_package_name(root, source);
         let graph_nodes = GoGraphNodeIndex::prepare(file_id, nodes);
         let import_domain = go_import_domain(root, source);
+        let returned_closures = GoReturnedClosureIndex::prepare(root);
         let mut result = Self {
             calls: Vec::new(),
             package_name,
@@ -466,6 +470,8 @@ impl<'tree> GoResolutionIndex<'tree> {
             import_names: import_domain.names,
             import_domain_complete: import_domain.complete,
             callable_nodes: HashMap::new(),
+            returned_closure_calls: HashSet::new(),
+            returned_closure_outer_blockers: HashSet::new(),
             binding_decisions: HashMap::new(),
             build_constrained: go_source_has_build_constraint(source),
             generated: go_source_is_generated(root, source),
@@ -565,10 +571,15 @@ impl<'tree> GoResolutionIndex<'tree> {
                     let Some(function) = node.child_by_field_name("function") else {
                         return;
                     };
-                    let callable_id = go_enclosing_callable(node).map(|callable| callable.id());
+                    let returned_closure = returned_closures.contains(node);
+                    let callable_id = go_enclosing_callable(node, &returned_closures)
+                        .map(|callable| callable.id());
                     match function.kind() {
                         "identifier" => {
                             if let Some(raw_target) = node_text(function, source) {
+                                if returned_closure {
+                                    result.returned_closure_calls.insert(function.start_byte());
+                                }
                                 result.calls.push(IndexedGoCall {
                                     callee: function,
                                     form: CalleeForm::Identifier,
@@ -584,6 +595,9 @@ impl<'tree> GoResolutionIndex<'tree> {
                             let Some(raw_target) = node_text(field, source) else {
                                 return;
                             };
+                            if returned_closure {
+                                result.returned_closure_calls.insert(field.start_byte());
+                            }
                             result.calls.push(IndexedGoCall {
                                 callee: field,
                                 form: CalleeForm::ExplicitReceiver,
@@ -597,6 +611,9 @@ impl<'tree> GoResolutionIndex<'tree> {
                                 .named_children(&mut cursor)
                                 .last()
                                 .unwrap_or(function);
+                            if returned_closure {
+                                result.returned_closure_calls.insert(leaf.start_byte());
+                            }
                             result.calls.push(IndexedGoCall {
                                 callee: leaf,
                                 form: CalleeForm::DynamicAccess,
@@ -633,8 +650,16 @@ impl<'tree> GoResolutionIndex<'tree> {
         result
             .calls
             .sort_by_key(|call| (call.callee.start_byte(), call.callee.end_byte()));
-        result.binding_decisions =
-            go_prepare_binding_decisions(root, source, &result.calls, &result.import_names);
+        (
+            result.binding_decisions,
+            result.returned_closure_outer_blockers,
+        ) = go_prepare_binding_decisions(
+            root,
+            source,
+            &result.calls,
+            &result.import_names,
+            &returned_closures,
+        );
         result
     }
 
@@ -675,9 +700,18 @@ impl<'tree> GoResolutionIndex<'tree> {
         if !self.import_domain_complete {
             return (Some(caller), CachedResolutionBinding::IncompleteDomain);
         }
+        if form != CalleeForm::Identifier
+            && self.returned_closure_calls.contains(&callee.start_byte())
+        {
+            return (Some(caller), CachedResolutionBinding::Unsupported);
+        }
         match form {
             CalleeForm::Identifier => {
-                if self.import_names.contains(raw_target)
+                if (self.returned_closure_calls.contains(&callee.start_byte())
+                    && self
+                        .returned_closure_outer_blockers
+                        .contains(&(callable_id, raw_target.to_string())))
+                    || self.import_names.contains(raw_target)
                     || self.binding_decisions.contains_key(&(
                         callable_id,
                         callee.start_byte(),
@@ -807,7 +841,77 @@ fn go_spec_is_package_level(node: TsNode<'_>, root: TsNode<'_>) -> bool {
         .is_some_and(|parent| parent.id() == root.id())
 }
 
-fn go_enclosing_callable(mut node: TsNode<'_>) -> Option<TsNode<'_>> {
+struct GoReturnedClosureIndex<'tree> {
+    member_owners: HashMap<usize, TsNode<'tree>>,
+    outer_body_owners: HashMap<usize, TsNode<'tree>>,
+}
+
+impl<'tree> GoReturnedClosureIndex<'tree> {
+    fn prepare(root: TsNode<'tree>) -> Self {
+        let mut literals = Vec::new();
+        let mut outer_body_owners = HashMap::new();
+        walk_nodes(root, &mut |node| {
+            count_go_resolution_work(1);
+            if node.kind() == "func_literal"
+                && let Some(owner) = go_direct_returned_closure_owner(node)
+            {
+                let body = owner
+                    .child_by_field_name("body")
+                    .expect("direct returned closure owner has a body");
+                outer_body_owners.insert(body.id(), owner);
+                literals.push((node, owner));
+            }
+        });
+        let mut member_owners = HashMap::new();
+        for (literal, owner) in literals {
+            go_record_returned_closure_members(literal, literal.id(), owner, &mut member_owners);
+        }
+        Self {
+            member_owners,
+            outer_body_owners,
+        }
+    }
+
+    fn contains(&self, node: TsNode<'_>) -> bool {
+        count_go_resolution_work(1);
+        self.member_owners.contains_key(&node.id())
+    }
+
+    fn member_owner(&self, node: TsNode<'tree>) -> Option<TsNode<'tree>> {
+        count_go_resolution_work(1);
+        self.member_owners.get(&node.id()).copied()
+    }
+
+    fn outer_body_owner(&self, scope_id: usize) -> Option<TsNode<'tree>> {
+        count_go_resolution_work(1);
+        self.outer_body_owners.get(&scope_id).copied()
+    }
+}
+
+fn go_record_returned_closure_members<'tree>(
+    node: TsNode<'tree>,
+    literal_id: usize,
+    owner: TsNode<'tree>,
+    members: &mut HashMap<usize, TsNode<'tree>>,
+) {
+    count_go_resolution_work(1);
+    if node.id() != literal_id && node.kind() == "func_literal" {
+        return;
+    }
+    members.insert(node.id(), owner);
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        go_record_returned_closure_members(child, literal_id, owner, members);
+    }
+}
+
+fn go_enclosing_callable<'tree>(
+    mut node: TsNode<'tree>,
+    returned_closures: &GoReturnedClosureIndex<'tree>,
+) -> Option<TsNode<'tree>> {
+    if let Some(owner) = returned_closures.member_owner(node) {
+        return Some(owner);
+    }
     loop {
         if matches!(node.kind(), "function_declaration" | "method_declaration") {
             return Some(node);
@@ -817,6 +921,53 @@ fn go_enclosing_callable(mut node: TsNode<'_>) -> Option<TsNode<'_>> {
         }
         node = node.parent()?;
     }
+}
+
+fn go_direct_returned_closure_owner<'tree>(literal: TsNode<'tree>) -> Option<TsNode<'tree>> {
+    if literal.kind() != "func_literal" {
+        return None;
+    }
+    let returned = literal.parent()?;
+    if returned.kind() != "expression_list" {
+        return None;
+    }
+    let mut cursor = returned.walk();
+    let expressions = returned.named_children(&mut cursor).collect::<Vec<_>>();
+    let [expression] = expressions.as_slice() else {
+        return None;
+    };
+    if expression.id() != literal.id() {
+        return None;
+    }
+    let returned = returned.parent()?;
+    if returned.kind() != "return_statement" {
+        return None;
+    }
+    let mut cursor = returned.walk();
+    let return_values = returned.named_children(&mut cursor).collect::<Vec<_>>();
+    let [return_value] = return_values.as_slice() else {
+        return None;
+    };
+    if return_value.kind() != "expression_list" || return_value.id() != literal.parent()?.id() {
+        return None;
+    }
+    let statements = returned.parent()?;
+    if statements.kind() != "statement_list" {
+        return None;
+    }
+    let body = statements.parent()?;
+    if body.kind() != "block" {
+        return None;
+    }
+    let owner = body.parent()?;
+    if !matches!(owner.kind(), "function_declaration" | "method_declaration")
+        || owner
+            .child_by_field_name("body")
+            .is_none_or(|owner_body| owner_body.id() != body.id())
+    {
+        return None;
+    }
+    Some(owner)
 }
 
 fn go_receiver_declaration(receiver: TsNode<'_>, source: &str) -> Option<(String, bool, String)> {
@@ -1004,12 +1155,17 @@ fn go_prepare_binding_decisions(
     source: &str,
     calls: &[IndexedGoCall<'_>],
     import_names: &HashSet<String>,
-) -> HashMap<(usize, usize, String), GoBindingDecision> {
-    let shadowed_new = go_callables_declaring_name(root, source, "new");
+    returned_closures: &GoReturnedClosureIndex<'_>,
+) -> (
+    HashMap<(usize, usize, String), GoBindingDecision>,
+    HashSet<(usize, String)>,
+) {
+    let shadowed_new = go_callables_declaring_name(root, source, "new", returned_closures);
     let mut intervals = Vec::<GoBindingInterval>::new();
+    let mut outer_blockers = HashSet::new();
     walk_nodes(root, &mut |node| {
         count_go_resolution_work(1);
-        let Some(callable) = go_enclosing_callable(node) else {
+        let Some(callable) = go_enclosing_callable(node, returned_closures) else {
             return;
         };
         if node.id() == callable.id() {
@@ -1037,9 +1193,36 @@ fn go_prepare_binding_decisions(
             }
             return;
         }
-        let Some((scope_start, scope_end, depth)) = go_binding_scope(node, callable) else {
+        let Some((scope_id, scope_start, scope_end, depth)) = go_binding_scope(node, callable)
+        else {
             return;
         };
+        let returned_closure_binding = returned_closures.contains(node);
+        let complete_outer_scope = returned_closures
+            .outer_body_owner(scope_id)
+            .is_some_and(|owner| owner.id() == callable.id());
+        if complete_outer_scope {
+            let names = match node.kind() {
+                "short_var_declaration" | "assignment_statement" => node
+                    .child_by_field_name("left")
+                    .map(|left| go_expression_names(left, source))
+                    .unwrap_or_default(),
+                "var_spec" | "const_spec" | "type_spec" => {
+                    let mut names = Vec::new();
+                    go_declared_names(node, source, &mut names);
+                    if node.kind() == "type_spec"
+                        && let Some(name) = node
+                            .child_by_field_name("name")
+                            .and_then(|name| node_text(name, source))
+                    {
+                        names.push(name.to_string());
+                    }
+                    names
+                }
+                _ => Vec::new(),
+            };
+            outer_blockers.extend(names.into_iter().map(|name| (callable.id(), name)));
+        }
         match node.kind() {
             "parameter_declaration" | "variadic_parameter_declaration" => {
                 if callable.kind() == "method_declaration"
@@ -1100,7 +1283,11 @@ fn go_prepare_binding_decisions(
                     intervals.push(GoBindingInterval {
                         name,
                         callable_id: callable.id(),
-                        start_byte: node.end_byte().max(scope_start),
+                        start_byte: if returned_closure_binding {
+                            scope_start
+                        } else {
+                            node.end_byte().max(scope_start)
+                        },
                         end_byte: if assignment {
                             callable.end_byte()
                         } else {
@@ -1112,19 +1299,22 @@ fn go_prepare_binding_decisions(
                 }
             }
             "var_spec" => {
-                let Some(type_node) = node.child_by_field_name("type") else {
-                    return;
-                };
-                let receiver = (!go_binding_uses_control_flow(node, callable))
-                    .then(|| go_typed_receiver_binding(type_node, source, import_names))
-                    .flatten();
+                let receiver = node.child_by_field_name("type").and_then(|type_node| {
+                    (!go_binding_uses_control_flow(node, callable))
+                        .then(|| go_typed_receiver_binding(type_node, source, import_names))
+                        .flatten()
+                });
                 let mut names = Vec::new();
                 go_declared_names(node, source, &mut names);
                 for name in names {
                     intervals.push(GoBindingInterval {
                         name,
                         callable_id: callable.id(),
-                        start_byte: node.end_byte().max(scope_start),
+                        start_byte: if returned_closure_binding {
+                            scope_start
+                        } else {
+                            node.end_byte().max(scope_start)
+                        },
                         end_byte: scope_end,
                         scope_depth: depth,
                         receiver: receiver.clone(),
@@ -1145,7 +1335,11 @@ fn go_prepare_binding_decisions(
                     intervals.push(GoBindingInterval {
                         name,
                         callable_id: callable.id(),
-                        start_byte: node.end_byte().max(scope_start),
+                        start_byte: if returned_closure_binding {
+                            scope_start
+                        } else {
+                            node.end_byte().max(scope_start)
+                        },
                         end_byte: scope_end,
                         scope_depth: depth,
                         receiver: None,
@@ -1207,7 +1401,7 @@ fn go_prepare_binding_decisions(
         if node.kind() != "identifier" {
             return;
         }
-        let Some(callable) = go_outer_callable_for_captured_node(node) else {
+        let Some(callable) = go_outer_callable_for_captured_node(node, returned_closures) else {
             return;
         };
         let Some(name) = node_text(node, source).filter(|name| go_identifier(name)) else {
@@ -1305,13 +1499,18 @@ fn go_prepare_binding_decisions(
             }
         }
     }
-    decisions
+    (decisions, outer_blockers)
 }
 
-fn go_callables_declaring_name(root: TsNode<'_>, source: &str, wanted: &str) -> HashSet<usize> {
+fn go_callables_declaring_name(
+    root: TsNode<'_>,
+    source: &str,
+    wanted: &str,
+    returned_closures: &GoReturnedClosureIndex<'_>,
+) -> HashSet<usize> {
     let mut result = HashSet::new();
     walk_nodes(root, &mut |node| {
-        let Some(callable) = go_enclosing_callable(node) else {
+        let Some(callable) = go_enclosing_callable(node, returned_closures) else {
             return;
         };
         let declared = match node.kind() {
@@ -1455,16 +1654,24 @@ fn go_scope_depth(mut node: TsNode<'_>, callable: TsNode<'_>) -> usize {
     depth
 }
 
-fn go_binding_scope(node: TsNode<'_>, callable: TsNode<'_>) -> Option<(usize, usize, usize)> {
+fn go_binding_scope(
+    node: TsNode<'_>,
+    callable: TsNode<'_>,
+) -> Option<(usize, usize, usize, usize)> {
     let mut current = node;
     let mut depth = 0;
     loop {
         if current.kind() == "block" {
             depth += 1;
-            return Some((current.start_byte(), current.end_byte(), depth));
+            return Some((
+                current.id(),
+                current.start_byte(),
+                current.end_byte(),
+                depth,
+            ));
         }
         if current.id() == callable.id() {
-            return Some((callable.start_byte(), callable.end_byte(), 0));
+            return Some((callable.id(), callable.start_byte(), callable.end_byte(), 0));
         }
         current = current.parent()?;
     }
@@ -1490,10 +1697,18 @@ fn go_binding_uses_control_flow(mut node: TsNode<'_>, callable: TsNode<'_>) -> b
     false
 }
 
-fn go_outer_callable_for_captured_node(mut node: TsNode<'_>) -> Option<TsNode<'_>> {
+fn go_outer_callable_for_captured_node<'tree>(
+    mut node: TsNode<'tree>,
+    returned_closures: &GoReturnedClosureIndex<'tree>,
+) -> Option<TsNode<'tree>> {
+    if returned_closures.contains(node) {
+        return None;
+    }
     let mut crossed_closure = false;
     loop {
-        crossed_closure |= node.kind() == "func_literal";
+        if node.kind() == "func_literal" {
+            crossed_closure = true;
+        }
         if crossed_closure && matches!(node.kind(), "function_declaration" | "method_declaration") {
             return Some(node);
         }
@@ -6996,6 +7211,7 @@ pub fn rematerialize_proof_resolution_projection(
             )
         })
         .collect::<Result<Vec<_>>>()?;
+    enforce_go_exact_callable_ownership(&mut claims, &nodes);
     enforce_exact_dependency_eligibility(
         &mut claims,
         &file_by_id,
@@ -7774,6 +7990,96 @@ struct ResolvedSyntaxClaim {
     evidence_chain: Vec<ResolutionEvidence>,
     exact_node_file_expectations: Vec<(NodeId, FileId)>,
     exact_dependency_files: Vec<FileId>,
+}
+
+enum GoCallableContainmentSubject {
+    Callable(NodeId),
+    Claim(usize),
+}
+
+struct GoCallableContainmentEvent {
+    file_id: NodeId,
+    line: u32,
+    column: u32,
+    order: u8,
+    subject: GoCallableContainmentSubject,
+}
+
+fn enforce_go_exact_callable_ownership(claims: &mut [ResolvedSyntaxClaim], nodes: &[Node]) {
+    let mut events = Vec::new();
+    for node in nodes
+        .iter()
+        .filter(|node| matches!(node.kind, NodeKind::FUNCTION | NodeKind::METHOD))
+    {
+        let (Some(file_id), Some(start_line), Some(end_line)) =
+            (node.file_node_id, node.start_line, node.end_line)
+        else {
+            continue;
+        };
+        let start_column = node.start_col.unwrap_or(0);
+        let end_column = node.end_col.unwrap_or(u32::MAX);
+        if (end_line, end_column) < (start_line, start_column) {
+            continue;
+        }
+        events.push(GoCallableContainmentEvent {
+            file_id,
+            line: start_line,
+            column: start_column,
+            order: 0,
+            subject: GoCallableContainmentSubject::Callable(node.id),
+        });
+        events.push(GoCallableContainmentEvent {
+            file_id,
+            line: end_line,
+            column: end_column,
+            order: 2,
+            subject: GoCallableContainmentSubject::Callable(node.id),
+        });
+    }
+    for (index, claim) in claims.iter().enumerate().filter(|(_, claim)| {
+        claim.status == ProofResolutionStatus::Exact && claim.input.language == "go"
+    }) {
+        events.push(GoCallableContainmentEvent {
+            file_id: NodeId(claim.input.callsite.file_id.0),
+            line: claim.input.callsite.line,
+            column: claim.input.callsite.column,
+            order: 1,
+            subject: GoCallableContainmentSubject::Claim(index),
+        });
+    }
+    events.sort_by(|left, right| {
+        (left.file_id, left.line, left.column, left.order).cmp(&(
+            right.file_id,
+            right.line,
+            right.column,
+            right.order,
+        ))
+    });
+    let mut active_file = None;
+    let mut active = HashSet::new();
+    for event in events {
+        if active_file != Some(event.file_id) {
+            active.clear();
+            active_file = Some(event.file_id);
+        }
+        match event.subject {
+            GoCallableContainmentSubject::Callable(callable) if event.order == 0 => {
+                active.insert(callable);
+            }
+            GoCallableContainmentSubject::Callable(callable) => {
+                active.remove(&callable);
+            }
+            GoCallableContainmentSubject::Claim(index) => {
+                let claim = &mut claims[index];
+                if active.len() != 1 || !active.contains(&claim.caller) {
+                    claim.status = ProofResolutionStatus::Ambiguous;
+                    claim.reason = ProofResolutionReason::MultipleBindings;
+                    claim.target = None;
+                    claim.evidence_chain.clear();
+                }
+            }
+        }
+    }
 }
 
 #[derive(Default)]
@@ -11422,13 +11728,51 @@ mod go_complexity_tests {
 
     fn measured_source_work(count: usize) -> usize {
         let source = go_source(count);
+        measured_source(&source)
+    }
+
+    fn returned_closure_source(count: usize) -> String {
+        let mut source = String::from(
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc caller() Handler { return func() {\n",
+        );
+        for _ in 0..count {
+            source.push_str("  target()\n");
+        }
+        source.push_str("} }\n");
+        source
+    }
+
+    fn measured_returned_closure_work(count: usize) -> usize {
+        measured_source(&returned_closure_source(count))
+    }
+
+    fn nested_returned_closure_source(depth: usize) -> String {
+        let mut source = String::from(
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc caller() Handler { return func() {\n",
+        );
+        for _ in 0..depth {
+            source.push_str("{\n");
+        }
+        source.push_str("target()\n");
+        for _ in 0..depth {
+            source.push_str("}\n");
+        }
+        source.push_str("} }\n");
+        source
+    }
+
+    fn measured_nested_returned_closure_work(depth: usize) -> usize {
+        measured_source(&nested_returned_closure_source(depth))
+    }
+
+    fn measured_source(source: &str) -> usize {
         let mut parser = Parser::new();
         parser
             .set_language(&tree_sitter_go::LANGUAGE.into())
             .expect("Go grammar must load");
-        let tree = parser.parse(&source, None).expect("source must parse");
+        let tree = parser.parse(source, None).expect("source must parse");
         reset_go_resolution_work();
-        let _ = GoResolutionIndex::build(&tree, &source, NodeId(1), &[]);
+        let _ = GoResolutionIndex::build(&tree, source, NodeId(1), &[]);
         go_resolution_work()
     }
 
@@ -11444,7 +11788,7 @@ mod go_complexity_tests {
                     file_id: NodeId(index as i64 + 1),
                     source_sha256: "0".repeat(64),
                     language: "go".to_string(),
-                    adapter_version: ADAPTER_VERSION.to_string(),
+                    adapter_version: GO_ADAPTER_VERSION.to_string(),
                     parser_fingerprint: "parser".to_string(),
                     complete: true,
                     lookup_input_complete: true,
@@ -11491,6 +11835,28 @@ mod go_complexity_tests {
         assert!(
             large <= small * 2 + 128,
             "Go source work grew superlinearly: {small} -> {large}"
+        );
+
+        let small_closure = measured_returned_closure_work(64);
+        let large_closure = measured_returned_closure_work(128);
+        assert!(
+            small_closure > 0,
+            "Go returned-closure work was not instrumented"
+        );
+        assert!(
+            large_closure <= small_closure * 2 + 128,
+            "Go returned-closure work grew superlinearly: {small_closure} -> {large_closure}"
+        );
+
+        let shallow_nested = measured_nested_returned_closure_work(32);
+        let deep_nested = measured_nested_returned_closure_work(64);
+        assert!(
+            shallow_nested > 32,
+            "Go returned-closure membership work was not counted: {shallow_nested}"
+        );
+        assert!(
+            deep_nested <= shallow_nested * 2 + 128,
+            "Go nested returned-closure membership work grew superlinearly: {shallow_nested} -> {deep_nested}"
         );
     }
 

--- a/crates/codestory-indexer/src/proof_resolution.rs
+++ b/crates/codestory-indexer/src/proof_resolution.rs
@@ -650,15 +650,13 @@ impl<'tree> GoResolutionIndex<'tree> {
         result
             .calls
             .sort_by_key(|call| (call.callee.start_byte(), call.callee.end_byte()));
-        (
-            result.binding_decisions,
-            result.returned_closure_outer_blockers,
-        ) = go_prepare_binding_decisions(
+        result.binding_decisions = go_prepare_binding_decisions(
             root,
             source,
             &result.calls,
             &result.import_names,
             &returned_closures,
+            &mut result.returned_closure_outer_blockers,
         );
         result
     }
@@ -1156,13 +1154,10 @@ fn go_prepare_binding_decisions(
     calls: &[IndexedGoCall<'_>],
     import_names: &HashSet<String>,
     returned_closures: &GoReturnedClosureIndex<'_>,
-) -> (
-    HashMap<(usize, usize, String), GoBindingDecision>,
-    HashSet<(usize, String)>,
-) {
+    outer_blockers: &mut HashSet<(usize, String)>,
+) -> HashMap<(usize, usize, String), GoBindingDecision> {
     let shadowed_new = go_callables_declaring_name(root, source, "new", returned_closures);
     let mut intervals = Vec::<GoBindingInterval>::new();
-    let mut outer_blockers = HashSet::new();
     walk_nodes(root, &mut |node| {
         count_go_resolution_work(1);
         let Some(callable) = go_enclosing_callable(node, returned_closures) else {
@@ -1499,7 +1494,7 @@ fn go_prepare_binding_decisions(
             }
         }
     }
-    (decisions, outer_blockers)
+    decisions
 }
 
 fn go_callables_declaring_name(

--- a/crates/codestory-indexer/src/proof_resolution.rs
+++ b/crates/codestory-indexer/src/proof_resolution.rs
@@ -87,7 +87,7 @@ fn python_resolution_work() -> usize {
 }
 
 const ADAPTER_VERSION: &str = "reference-v15";
-const GO_ADAPTER_VERSION: &str = "reference-v16";
+const GO_ADAPTER_VERSION: &str = "reference-v17";
 const PYTHON_ADAPTER_VERSION: &str = "reference-v17";
 const TYPESCRIPT_ADAPTER_VERSION: &str = "reference-v17";
 const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 14;
@@ -862,7 +862,13 @@ impl<'tree> GoReturnedClosureIndex<'tree> {
         });
         let mut member_owners = HashMap::new();
         for (literal, owner) in literals {
-            go_record_returned_closure_members(literal, literal.id(), owner, &mut member_owners);
+            go_record_returned_closure_members(
+                literal,
+                literal.id(),
+                owner,
+                true,
+                &mut member_owners,
+            );
         }
         Self {
             member_owners,
@@ -890,17 +896,35 @@ fn go_record_returned_closure_members<'tree>(
     node: TsNode<'tree>,
     literal_id: usize,
     owner: TsNode<'tree>,
+    allow_deferred_child: bool,
     members: &mut HashMap<usize, TsNode<'tree>>,
 ) {
     count_go_resolution_work(1);
     if node.id() != literal_id && node.kind() == "func_literal" {
+        if allow_deferred_child && go_is_immediate_deferred_literal(node) {
+            go_record_returned_closure_members(node, node.id(), owner, false, members);
+        }
         return;
     }
     members.insert(node.id(), owner);
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        go_record_returned_closure_members(child, literal_id, owner, members);
+        go_record_returned_closure_members(child, literal_id, owner, allow_deferred_child, members);
     }
+}
+
+fn go_is_immediate_deferred_literal(literal: TsNode<'_>) -> bool {
+    let Some(call) = literal
+        .parent()
+        .filter(|parent| parent.kind() == "call_expression")
+    else {
+        return false;
+    };
+    call.child_by_field_name("function")
+        .is_some_and(|function| function.id() == literal.id())
+        && call
+            .parent()
+            .is_some_and(|parent| parent.kind() == "defer_statement")
 }
 
 fn go_enclosing_callable<'tree>(
@@ -11760,6 +11784,21 @@ mod go_complexity_tests {
         measured_source(&nested_returned_closure_source(depth))
     }
 
+    fn many_deferred_children_source(count: usize) -> String {
+        let mut source = String::from(
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc caller() Handler { return func() {\n",
+        );
+        for _ in 0..count {
+            source.push_str("defer func() { target() }()\n");
+        }
+        source.push_str("} }\n");
+        source
+    }
+
+    fn measured_many_deferred_children_work(count: usize) -> usize {
+        measured_source(&many_deferred_children_source(count))
+    }
+
     fn measured_source(source: &str) -> usize {
         let mut parser = Parser::new();
         parser
@@ -11852,6 +11891,17 @@ mod go_complexity_tests {
         assert!(
             deep_nested <= shallow_nested * 2 + 128,
             "Go nested returned-closure membership work grew superlinearly: {shallow_nested} -> {deep_nested}"
+        );
+
+        let small_deferred = measured_many_deferred_children_work(64);
+        let large_deferred = measured_many_deferred_children_work(128);
+        assert!(
+            small_deferred >= 64 * 8,
+            "Go deferred-child membership work was not fully counted: {small_deferred}"
+        );
+        assert!(
+            large_deferred <= small_deferred * 2 + 128,
+            "Go deferred-child membership work grew superlinearly: {small_deferred} -> {large_deferred}"
         );
     }
 

--- a/crates/codestory-indexer/tests/proof_resolution.rs
+++ b/crates/codestory-indexer/tests/proof_resolution.rs
@@ -2999,6 +2999,747 @@ fn go_repeated_callsites_and_utf8_crlf_coordinates_are_source_bound_and_distinct
 }
 
 #[test]
+fn go_returned_closure_h1_authorizes_only_direct_non_nested_return_ownership() -> anyhow::Result<()>
+{
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(
+        project.path(),
+        &mut store,
+        &[
+            (
+                "main.go",
+                concat!(
+                    "package proof\n",
+                    "type Handler func()\n",
+                    "type Factory struct{}\n",
+                    "func shouldRecord() {}\n",
+                    "func captureFrames() {}\n",
+                    "func buildLocal() Handler { return func() { shouldRecord(); captureFrames() } }\n",
+                    "func (Factory) buildRemote() Handler { return func() { remoteLeaf() } }\n",
+                ),
+            ),
+            ("remote.go", "package proof\nfunc remoteLeaf() {}\n"),
+        ],
+    )?;
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    store.validate_proof_resolution_publication(&publication(1))?;
+    let facts = store.get_proof_resolution_facts()?;
+    let should_record = facts
+        .iter()
+        .find(|fact| fact.callsite.raw_target == "shouldRecord")
+        .expect("first same-file returned-closure call");
+    let capture_frames = facts
+        .iter()
+        .find(|fact| fact.callsite.raw_target == "captureFrames")
+        .expect("second same-file returned-closure call");
+    let remote = facts
+        .iter()
+        .find(|fact| fact.callsite.raw_target == "remoteLeaf")
+        .expect("same-package returned-closure call");
+    assert_eq!(
+        should_record.status,
+        ProofResolutionStatus::Exact,
+        "{should_record:#?}"
+    );
+    assert_eq!(
+        capture_frames.status,
+        ProofResolutionStatus::Exact,
+        "{capture_frames:#?}"
+    );
+    assert_eq!(remote.status, ProofResolutionStatus::Exact, "{remote:#?}");
+    assert!(matches!(
+        should_record.evidence_chain.as_slice(),
+        [ResolutionEvidence::SameFileDeclaration { .. }]
+    ));
+    assert!(matches!(
+        capture_frames.evidence_chain.as_slice(),
+        [ResolutionEvidence::SameFileDeclaration { .. }]
+    ));
+    assert!(matches!(
+        remote.evidence_chain.as_slice(),
+        [ResolutionEvidence::SamePackageDeclaration { .. }]
+    ));
+    let nodes = store.get_nodes()?;
+    let build_local = nodes
+        .iter()
+        .find(|node| node.kind == NodeKind::FUNCTION && node.serialized_name == "buildLocal")
+        .expect("named outer function");
+    let build_remote = nodes
+        .iter()
+        .find(|node| node.kind == NodeKind::METHOD && node.serialized_name.ends_with("buildRemote"))
+        .expect("named outer method");
+    assert_eq!(should_record.caller, build_local.id);
+    assert_eq!(capture_frames.caller, build_local.id);
+    assert_eq!(remote.caller, build_remote.id);
+
+    let unsupported = [
+        (
+            "assigned.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { closure := func() { target() }; return closure }\n",
+        ),
+        (
+            "passed.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc consume(Handler) {}\nfunc outer() { consume(func() { target() }) }\n",
+        ),
+        (
+            "immediate.go",
+            "package proof\nfunc target() {}\nfunc outer() { func() { target() }() }\n",
+        ),
+        (
+            "go.go",
+            "package proof\nfunc target() {}\nfunc outer() { go func() { target() }() }\n",
+        ),
+        (
+            "defer.go",
+            "package proof\nfunc target() {}\nfunc outer() { defer func() { target() }() }\n",
+        ),
+        (
+            "wrapped.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return Handler(func() { target() }) }\n",
+        ),
+        (
+            "conditional.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer(enabled bool) Handler { if enabled { return func() { target() } }; return nil }\n",
+        ),
+        (
+            "nested.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { func() { target() }() } }\n",
+        ),
+        (
+            "initializer.go",
+            "package proof\nfunc target() {}\nvar handler = func() { target() }\n",
+        ),
+    ];
+    for (path, source) in unsupported {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(project.path(), &mut store, &[(path, source)])?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        let matching = store
+            .get_proof_resolution_facts()?
+            .into_iter()
+            .filter(|fact| fact.callsite.raw_target == "target")
+            .collect::<Vec<_>>();
+        assert!(!matching.is_empty(), "missing unsupported fact for {path}");
+        assert!(
+            matching
+                .iter()
+                .all(|fact| fact.status != ProofResolutionStatus::Exact),
+            "unsupported returned-closure owner became Exact for {path}: {matching:#?}"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn go_returned_closure_h2_closes_closure_and_outer_lexical_capture_domains() -> anyhow::Result<()> {
+    let blocked = [
+        (
+            "closure_parameter.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func(target func()) { target() } }\n",
+        ),
+        (
+            "closure_named_result.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() (target func()) { target(); return } }\n",
+        ),
+        (
+            "closure_local.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { var target func(); target() } }\n",
+        ),
+        (
+            "closure_const.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { const target = 1; target() } }\n",
+        ),
+        (
+            "closure_type.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { type target int; target() } }\n",
+        ),
+        (
+            "closure_short.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { target := func() {}; target() } }\n",
+        ),
+        (
+            "closure_assignment.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { target = func() {}; target() } }\n",
+        ),
+        (
+            "closure_range.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { for target := range []int{} { target() } } }\n",
+        ),
+        (
+            "closure_type_switch.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { switch target := any(1).(type) { case int: target() } } }\n",
+        ),
+        (
+            "closure_binding_after_call.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { target(); target := func() {}; _ = target } }\n",
+        ),
+        (
+            "closure_const_after_call.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { target(); const target = 1; _ = target } }\n",
+        ),
+        (
+            "closure_type_after_call.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { target(); type target int; var _ target } }\n",
+        ),
+        (
+            "outer_parameter.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer(target func()) Handler { return func() { target() } }\n",
+        ),
+        (
+            "outer_receiver.go",
+            "package proof\ntype Handler func()\ntype Factory struct{}\nfunc target() {}\nfunc (target Factory) outer() Handler { return func() { target() } }\n",
+        ),
+        (
+            "outer_named_result.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() (target Handler) { return func() { target() } }\n",
+        ),
+        (
+            "outer_local.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { target := func() {}; return func() { target() } }\n",
+        ),
+        (
+            "outer_const.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { const target = 1; return func() { target() } }\n",
+        ),
+        (
+            "outer_type.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { type target int; return func() { target() } }\n",
+        ),
+        (
+            "outer_assignment.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer(target func()) Handler { target = func() {}; return func() { target() } }\n",
+        ),
+        (
+            "outer_var_after_return.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { target() }; var target func(); _ = target }\n",
+        ),
+        (
+            "outer_const_after_return.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { target() }; const target = 1; _ = target }\n",
+        ),
+        (
+            "outer_type_after_return.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { target() }; type target int; var _ target }\n",
+        ),
+        (
+            "outer_short_after_return.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { target() }; target := func() {}; _ = target }\n",
+        ),
+        (
+            "outer_assignment_after_return.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { target() }; target = func() {} }\n",
+        ),
+    ];
+    for (path, source) in blocked {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(project.path(), &mut store, &[(path, source)])?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        let matching = store
+            .get_proof_resolution_facts()?
+            .into_iter()
+            .filter(|fact| fact.callsite.raw_target == "target")
+            .collect::<Vec<_>>();
+        assert!(!matching.is_empty(), "missing blocker fact for {path}");
+        assert!(
+            matching
+                .iter()
+                .all(|fact| fact.status != ProofResolutionStatus::Exact),
+            "closed lexical/capture domain became Exact for {path}: {matching:#?}"
+        );
+    }
+
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(
+        project.path(),
+        &mut store,
+        &[(
+            "visible.go",
+            concat!(
+                "package proof\n",
+                "type Handler func()\n",
+                "func target() {}\n",
+                "func disjoint() Handler {\n",
+                "  { target := func() {}; target() }\n",
+                "  return func() { target() }\n",
+                "}\n",
+                "func unrelated(other func()) Handler { return func() { other(); target() } }\n",
+                "func lateUnrelated() Handler { return func() { target() }; var other func(); _ = other }\n",
+                "func lateDisjoint() Handler { return func() { target() }; { var target func(); _ = target } }\n",
+            ),
+        )],
+    )?;
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    let target_facts = store
+        .get_proof_resolution_facts()?
+        .into_iter()
+        .filter(|fact| fact.callsite.raw_target == "target")
+        .collect::<Vec<_>>();
+    assert_eq!(
+        target_facts
+            .iter()
+            .filter(|fact| fact.status == ProofResolutionStatus::Exact)
+            .count(),
+        4,
+        "a disjoint binding and an unrelated capture must preserve both package calls: {target_facts:#?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn go_returned_closure_requires_the_outer_to_be_the_sole_containing_graph_callable()
+-> anyhow::Result<()> {
+    for mutate_after_seal in [false, true] {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(
+            project.path(),
+            &mut store,
+            &[(
+                "main.go",
+                "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { target() } }\n",
+            )],
+        )?;
+        if mutate_after_seal {
+            rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+            store.validate_proof_resolution_publication(&publication(1))?;
+        }
+        let nodes = store.get_nodes()?;
+        let outer = nodes
+            .iter()
+            .find(|node| node.kind == NodeKind::FUNCTION && node.serialized_name == "outer")
+            .expect("named outer graph callable");
+        let call = store
+            .get_edges()?
+            .into_iter()
+            .find(|edge| edge.kind == EdgeKind::CALL)
+            .expect("returned-closure raw CALL");
+        assert_eq!(
+            call.source, outer.id,
+            "raw CALL must continue to name outer"
+        );
+        let call_line = call.line.expect("raw CALL line");
+        let mut overlapping = outer.clone();
+        overlapping.id = NodeId(if mutate_after_seal {
+            8_205_400_000_000_002
+        } else {
+            8_205_400_000_000_001
+        });
+        overlapping.serialized_name = "overlappingCallable".to_string();
+        overlapping.qualified_name = Some("overlappingCallable".to_string());
+        overlapping.canonical_id = None;
+        overlapping.start_line = Some(call_line);
+        overlapping.start_col = Some(1);
+        overlapping.end_line = Some(call_line);
+        overlapping.end_col = Some(u32::MAX);
+        store.insert_node(&overlapping)?;
+
+        let generation = if mutate_after_seal { 2 } else { 1 };
+        rematerialize_proof_resolution_projection(&mut store, &publication(generation))?;
+        let fact = store
+            .get_proof_resolution_facts()?
+            .into_iter()
+            .find(|fact| fact.callsite.raw_target == "target")
+            .expect("returned-closure fact");
+        assert_ne!(
+            fact.status,
+            ProofResolutionStatus::Exact,
+            "a distinct overlapping graph callable retained Exact after_seal={mutate_after_seal}: {fact:#?}"
+        );
+        let stored_call = store
+            .get_edges()?
+            .into_iter()
+            .find(|edge| edge.id == call.id)
+            .expect("stored raw CALL");
+        assert_eq!(stored_call.source, outer.id, "graph repair is forbidden");
+    }
+    Ok(())
+}
+
+#[test]
+fn go_returned_closure_h3_reuses_the_closed_native_package_domain() -> anyhow::Result<()> {
+    let blocked = [
+        (
+            "duplicate_same_file",
+            vec![(
+                "main.go",
+                "package proof\ntype Handler func()\nfunc target() {}\nfunc target() {}\nfunc outer() Handler { return func() { target() } }\n",
+            )],
+        ),
+        (
+            "duplicate_same_package",
+            vec![
+                (
+                    "main.go",
+                    "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { target() } }\n",
+                ),
+                ("duplicate.go", "package proof\nfunc target() {}\n"),
+            ],
+        ),
+        (
+            "package_var_blocker",
+            vec![(
+                "main.go",
+                "package proof\ntype Handler func()\nvar target func()\nfunc target() {}\nfunc outer() Handler { return func() { target() } }\n",
+            )],
+        ),
+        (
+            "conditional_competitor",
+            vec![
+                (
+                    "main.go",
+                    "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { target() } }\n",
+                ),
+                (
+                    "conditional.go",
+                    "//go:build linux\n\npackage proof\nfunc target() {}\n",
+                ),
+            ],
+        ),
+        (
+            "generated_target",
+            vec![
+                (
+                    "main.go",
+                    "package proof\ntype Handler func()\nfunc outer() Handler { return func() { target() } }\n",
+                ),
+                (
+                    "generated.go",
+                    "// Code generated by fixture. DO NOT EDIT.\npackage proof\nfunc target() {}\n",
+                ),
+            ],
+        ),
+        (
+            "parser_error_sibling",
+            vec![
+                (
+                    "main.go",
+                    "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { target() } }\n",
+                ),
+                ("broken.go", "package proof\nfunc broken( {\n"),
+            ],
+        ),
+        (
+            "package_mismatch",
+            vec![
+                (
+                    "main.go",
+                    "package proof\ntype Handler func()\nfunc outer() Handler { return func() { target() } }\n",
+                ),
+                ("target.go", "package other\nfunc target() {}\n"),
+            ],
+        ),
+    ];
+    for (label, files) in blocked {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(project.path(), &mut store, &files)?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        let matching = store
+            .get_proof_resolution_facts()?
+            .into_iter()
+            .filter(|fact| fact.callsite.raw_target == "target")
+            .collect::<Vec<_>>();
+        assert!(
+            !matching.is_empty(),
+            "missing package-domain fact for {label}"
+        );
+        assert!(
+            matching
+                .iter()
+                .all(|fact| fact.status != ProofResolutionStatus::Exact),
+            "open or competing package domain became Exact for {label}: {matching:#?}"
+        );
+    }
+
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(
+        project.path(),
+        &mut store,
+        &[
+            (
+                "main.go",
+                "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { target() } }\n",
+            ),
+            ("other/other.go", "package proof\nfunc target() {}\n"),
+        ],
+    )?;
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    let target = store
+        .get_proof_resolution_facts()?
+        .into_iter()
+        .find(|fact| fact.callsite.raw_target == "target")
+        .expect("same-directory target fact");
+    assert_eq!(target.status, ProofResolutionStatus::Exact, "{target:#?}");
+    Ok(())
+}
+
+#[test]
+fn go_returned_closure_h4_requires_one_matching_raw_call_edge_and_one_syntax_fact()
+-> anyhow::Result<()> {
+    for mutation in 0..6 {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(
+            project.path(),
+            &mut store,
+            &[(
+                "main.go",
+                concat!(
+                    "package proof\n",
+                    "type Handler func()\n",
+                    "func target() {}\n",
+                    "func sibling() {}\n",
+                    "func outer() Handler { return func() { target() } }\n",
+                ),
+            )],
+        )?;
+        let nodes = store.get_nodes()?;
+        let outer = nodes
+            .iter()
+            .find(|node| node.kind == NodeKind::FUNCTION && node.serialized_name == "outer")
+            .expect("outer function")
+            .id;
+        let sibling = nodes
+            .iter()
+            .find(|node| node.kind == NodeKind::FUNCTION && node.serialized_name == "sibling")
+            .expect("sibling function")
+            .id;
+        let edge = store
+            .get_edges()?
+            .into_iter()
+            .find(|edge| edge.kind == EdgeKind::CALL)
+            .expect("returned-closure raw CALL edge");
+        assert_eq!(edge.source, outer, "raw graph must claim the named outer");
+        match mutation {
+            0 => {
+                store
+                    .get_connection()
+                    .execute("DELETE FROM edge WHERE id = ?1", [edge.id.0])?;
+            }
+            1 => {
+                store.get_connection().execute(
+                    "UPDATE edge SET source_node_id = ?1, resolved_source_node_id = NULL WHERE id = ?2",
+                    [sibling.0, edge.id.0],
+                )?;
+            }
+            2 => {
+                store.get_connection().execute(
+                    "UPDATE edge SET target_node_id = ?1, resolved_target_node_id = NULL WHERE id = ?2",
+                    [sibling.0, edge.id.0],
+                )?;
+            }
+            3 => {
+                store
+                    .get_connection()
+                    .execute("UPDATE edge SET line = line + 1 WHERE id = ?1", [edge.id.0])?;
+            }
+            4 => {
+                store.get_connection().execute(
+                    "UPDATE edge SET callsite_identity = 'opaque' WHERE id = ?1",
+                    [edge.id.0],
+                )?;
+            }
+            5 => {
+                let mut duplicate = edge.clone();
+                duplicate.id = EdgeId(8_205_400_000_000_000_000);
+                store.insert_edge(&duplicate)?;
+            }
+            _ => unreachable!(),
+        }
+        match rematerialize_proof_resolution_projection(&mut store, &publication(1)) {
+            Ok(_) => {
+                let matching = store
+                    .get_proof_resolution_facts()?
+                    .into_iter()
+                    .filter(|fact| fact.callsite.raw_target == "target")
+                    .collect::<Vec<_>>();
+                assert!(
+                    matching
+                        .iter()
+                        .all(|fact| fact.status != ProofResolutionStatus::Exact),
+                    "graph/fact mutation {mutation} retained Exact: {matching:#?}"
+                );
+            }
+            Err(_) => {}
+        }
+    }
+
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(
+        project.path(),
+        &mut store,
+        &[(
+            "main.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { target() } }\n",
+        )],
+    )?;
+    store.get_connection().execute(
+        "UPDATE edge SET confidence = 0.01, certainty = 'uncertain' WHERE kind = ?1",
+        [EdgeKind::CALL as i32],
+    )?;
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    let exact = store
+        .get_proof_resolution_facts()?
+        .into_iter()
+        .find(|fact| fact.callsite.raw_target == "target")
+        .expect("confidence-independent fact");
+    assert_eq!(exact.status, ProofResolutionStatus::Exact, "{exact:#?}");
+
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(
+        project.path(),
+        &mut store,
+        &[(
+            "main.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { target() } }\n",
+        )],
+    )?;
+    let artifact_blob = store.get_connection().query_row(
+        "SELECT artifact_blob FROM index_artifact_cache",
+        [],
+        |row| row.get::<_, Vec<u8>>(0),
+    )?;
+    let mut artifact: serde_json::Value = serde_json::from_slice(&artifact_blob)?;
+    artifact["call_resolution_inputs"] = serde_json::Value::Array(Vec::new());
+    store.get_connection().execute(
+        "UPDATE index_artifact_cache SET artifact_blob = ?1",
+        [serde_json::to_vec(&artifact)?],
+    )?;
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    assert!(
+        store
+            .get_proof_resolution_facts()?
+            .iter()
+            .all(|fact| fact.callsite.raw_target != "target"),
+        "an ordinary edge without its cached syntax fact must not become authoritative"
+    );
+    Ok(())
+}
+
+#[test]
+fn go_returned_closure_h5_preserves_repeated_native_source_coordinates() -> anyhow::Result<()> {
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    let source = concat!(
+        "package proof\r\n",
+        "type Handler func()\r\n",
+        "func target() {}\r\n",
+        "func outer() Handler { return func() {\r\n",
+        "\t// λλ\r\n",
+        "\ttarget(); target(); target()\r\n",
+        "\ttarget()\r\n",
+        "} }\r\n",
+    );
+    index_files(project.path(), &mut store, &[("main.go", source)])?;
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    let mut facts = store
+        .get_proof_resolution_facts()?
+        .into_iter()
+        .filter(|fact| fact.callsite.raw_target == "target")
+        .collect::<Vec<_>>();
+    facts.sort_by_key(|fact| fact.callsite.start_byte);
+    assert_eq!(facts.len(), 4, "{facts:#?}");
+    assert!(
+        facts
+            .iter()
+            .all(|fact| fact.status == ProofResolutionStatus::Exact),
+        "{facts:#?}"
+    );
+    assert_eq!(
+        facts
+            .iter()
+            .filter_map(|fact| fact.edge_id)
+            .collect::<BTreeSet<_>>()
+            .len(),
+        4
+    );
+    assert_eq!(
+        facts
+            .iter()
+            .filter_map(|fact| fact.raw_callsite_identity.as_ref())
+            .collect::<BTreeSet<_>>()
+            .len(),
+        4
+    );
+    assert_eq!(
+        facts
+            .iter()
+            .map(|fact| fact.callsite.line)
+            .collect::<Vec<_>>(),
+        [6, 6, 6, 7]
+    );
+    for fact in &facts {
+        assert_eq!(
+            &source.as_bytes()
+                [fact.callsite.start_byte as usize..fact.callsite.end_byte_exclusive as usize],
+            b"target"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn go_returned_closure_h6_seals_current_go_cache_and_fact_provenance() -> anyhow::Result<()> {
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(
+        project.path(),
+        &mut store,
+        &[
+            (
+                "main.go",
+                "package proof\ntype Handler func()\nfunc outer() Handler { return func() { target() } }\n",
+            ),
+            ("target.go", "package proof\nfunc target() {}\n"),
+        ],
+    )?;
+    let receipt = rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    store.validate_proof_resolution_publication(&publication(1))?;
+    let fact = store
+        .get_proof_resolution_facts()?
+        .into_iter()
+        .find(|fact| fact.callsite.raw_target == "target")
+        .expect("sealed returned-closure fact");
+    assert_eq!(fact.status, ProofResolutionStatus::Exact, "{fact:#?}");
+    assert_eq!(fact.provenance.language_adapter, "go");
+    assert_eq!(fact.provenance.language_adapter_version, "reference-v16");
+    assert_eq!(fact.provenance.parser_fingerprint.len(), 64);
+    assert_eq!(fact.provenance.dependency_file_hashes.len(), 2);
+    assert_eq!(fact.provenance.evidence_sha256.len(), 64);
+    assert_eq!(fact.fact_id.len(), 64);
+    assert_eq!(receipt.fact_digest.len(), 64);
+
+    let artifact_blob = store.get_connection().query_row(
+        "SELECT artifact_blob FROM index_artifact_cache WHERE file_path LIKE '%main.go'",
+        [],
+        |row| row.get::<_, Vec<u8>>(0),
+    )?;
+    let mut artifact: serde_json::Value = serde_json::from_slice(&artifact_blob)?;
+    artifact["resolution_file"]["adapter_version"] = "stale-go-adapter".into();
+    for call in artifact["call_resolution_inputs"]
+        .as_array_mut()
+        .expect("Go call inputs")
+    {
+        call["adapter_version"] = "stale-go-adapter".into();
+    }
+    store.get_connection().execute(
+        "UPDATE index_artifact_cache SET artifact_blob = ?1 WHERE file_path LIKE '%main.go'",
+        [serde_json::to_vec(&artifact)?],
+    )?;
+    let error = rematerialize_proof_resolution_projection(&mut store, &publication(2))
+        .expect_err("stale Go adapter cache must fail closed");
+    assert!(error.to_string().contains("stale"), "{error}");
+    Ok(())
+}
+
+#[test]
 fn go_authenticated_receiver_replaces_wrong_certain_navigation_target() -> anyhow::Result<()> {
     let project = tempfile::tempdir()?;
     let mut store = Store::new_in_memory()?;

--- a/crates/codestory-indexer/tests/proof_resolution.rs
+++ b/crates/codestory-indexer/tests/proof_resolution.rs
@@ -2999,8 +2999,8 @@ fn go_repeated_callsites_and_utf8_crlf_coordinates_are_source_bound_and_distinct
 }
 
 #[test]
-fn go_returned_closure_h1_authorizes_only_direct_non_nested_return_ownership() -> anyhow::Result<()>
-{
+fn go_returned_closure_h1_authorizes_only_returned_and_immediate_deferred_child_ownership()
+-> anyhow::Result<()> {
     let project = tempfile::tempdir()?;
     let mut store = Store::new_in_memory()?;
     index_files(
@@ -3015,11 +3015,14 @@ fn go_returned_closure_h1_authorizes_only_direct_non_nested_return_ownership() -
                     "type Factory struct{}\n",
                     "func shouldRecord() {}\n",
                     "func captureFrames() {}\n",
-                    "func buildLocal() Handler { return func() { shouldRecord(); captureFrames() } }\n",
-                    "func (Factory) buildRemote() Handler { return func() { remoteLeaf() } }\n",
+                    "func buildLocal() Handler { return func() { shouldRecord(); defer func() { captureFrames() }() } }\n",
+                    "func (Factory) buildRemote() Handler { return func() { remoteLeaf(); defer func() { remoteDeferred() }() } }\n",
                 ),
             ),
-            ("remote.go", "package proof\nfunc remoteLeaf() {}\n"),
+            (
+                "remote.go",
+                "package proof\nfunc remoteLeaf() {}\nfunc remoteDeferred() {}\n",
+            ),
         ],
     )?;
     rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
@@ -3037,6 +3040,10 @@ fn go_returned_closure_h1_authorizes_only_direct_non_nested_return_ownership() -
         .iter()
         .find(|fact| fact.callsite.raw_target == "remoteLeaf")
         .expect("same-package returned-closure call");
+    let remote_deferred = facts
+        .iter()
+        .find(|fact| fact.callsite.raw_target == "remoteDeferred")
+        .expect("same-package immediately deferred child call");
     assert_eq!(
         should_record.status,
         ProofResolutionStatus::Exact,
@@ -3048,6 +3055,11 @@ fn go_returned_closure_h1_authorizes_only_direct_non_nested_return_ownership() -
         "{capture_frames:#?}"
     );
     assert_eq!(remote.status, ProofResolutionStatus::Exact, "{remote:#?}");
+    assert_eq!(
+        remote_deferred.status,
+        ProofResolutionStatus::Exact,
+        "{remote_deferred:#?}"
+    );
     assert!(matches!(
         should_record.evidence_chain.as_slice(),
         [ResolutionEvidence::SameFileDeclaration { .. }]
@@ -3058,6 +3070,10 @@ fn go_returned_closure_h1_authorizes_only_direct_non_nested_return_ownership() -
     ));
     assert!(matches!(
         remote.evidence_chain.as_slice(),
+        [ResolutionEvidence::SamePackageDeclaration { .. }]
+    ));
+    assert!(matches!(
+        remote_deferred.evidence_chain.as_slice(),
         [ResolutionEvidence::SamePackageDeclaration { .. }]
     ));
     let nodes = store.get_nodes()?;
@@ -3072,6 +3088,7 @@ fn go_returned_closure_h1_authorizes_only_direct_non_nested_return_ownership() -
     assert_eq!(should_record.caller, build_local.id);
     assert_eq!(capture_frames.caller, build_local.id);
     assert_eq!(remote.caller, build_remote.id);
+    assert_eq!(remote_deferred.caller, build_remote.id);
 
     let unsupported = [
         (
@@ -3105,6 +3122,34 @@ fn go_returned_closure_h1_authorizes_only_direct_non_nested_return_ownership() -
         (
             "nested.go",
             "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { func() { target() }() } }\n",
+        ),
+        (
+            "child_go.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { go func() { target() }() } }\n",
+        ),
+        (
+            "child_assigned.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { child := func() { target() }; child() } }\n",
+        ),
+        (
+            "child_passed.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc consume(Handler) {}\nfunc outer() Handler { return func() { consume(func() { target() }) } }\n",
+        ),
+        (
+            "child_stored.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { children := []Handler{func() { target() }}; _ = children } }\n",
+        ),
+        (
+            "child_non_immediate_defer.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { child := func() { target() }; defer child() } }\n",
+        ),
+        (
+            "child_defer_argument.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc consume(Handler) {}\nfunc outer() Handler { return func() { defer consume(func() { target() }) } }\n",
+        ),
+        (
+            "child_deferred_nested.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { defer func() { func() { target() }() }() } }\n",
         ),
         (
             "initializer.go",
@@ -3176,12 +3221,64 @@ fn go_returned_closure_h2_closes_closure_and_outer_lexical_capture_domains() -> 
             "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { target(); target := func() {}; _ = target } }\n",
         ),
         (
+            "closure_var_after_call.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { target(); var target func(); _ = target } }\n",
+        ),
+        (
             "closure_const_after_call.go",
             "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { target(); const target = 1; _ = target } }\n",
         ),
         (
             "closure_type_after_call.go",
             "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { target(); type target int; var _ target } }\n",
+        ),
+        (
+            "closure_assignment_after_call.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { target(); target = func() {} } }\n",
+        ),
+        (
+            "deferred_parameter.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { defer func(target func()) { target() }(target) } }\n",
+        ),
+        (
+            "deferred_var_before_call.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { defer func() { var target func(); target() }() } }\n",
+        ),
+        (
+            "deferred_var_after_call.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { defer func() { target(); var target func(); _ = target }() } }\n",
+        ),
+        (
+            "deferred_const_before_call.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { defer func() { const target = 1; target() }() } }\n",
+        ),
+        (
+            "deferred_const_after_call.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { defer func() { target(); const target = 1; _ = target }() } }\n",
+        ),
+        (
+            "deferred_type_before_call.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { defer func() { type target int; target() }() } }\n",
+        ),
+        (
+            "deferred_type_after_call.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { defer func() { target(); type target int; var _ target }() } }\n",
+        ),
+        (
+            "deferred_short_before_call.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { defer func() { target := func() {}; target() }() } }\n",
+        ),
+        (
+            "deferred_short_after_call.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { defer func() { target(); target := func() {}; _ = target }() } }\n",
+        ),
+        (
+            "deferred_assignment_before_call.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { defer func() { target = func() {}; target() }() } }\n",
+        ),
+        (
+            "deferred_assignment_after_call.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { defer func() { target(); target = func() {} }() } }\n",
         ),
         (
             "outer_parameter.go",
@@ -3198,6 +3295,10 @@ fn go_returned_closure_h2_closes_closure_and_outer_lexical_capture_domains() -> 
         (
             "outer_local.go",
             "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { target := func() {}; return func() { target() } }\n",
+        ),
+        (
+            "outer_var.go",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { var target func(); return func() { target() } }\n",
         ),
         (
             "outer_const.go",
@@ -3269,6 +3370,7 @@ fn go_returned_closure_h2_closes_closure_and_outer_lexical_capture_domains() -> 
                 "func unrelated(other func()) Handler { return func() { other(); target() } }\n",
                 "func lateUnrelated() Handler { return func() { target() }; var other func(); _ = other }\n",
                 "func lateDisjoint() Handler { return func() { target() }; { var target func(); _ = target } }\n",
+                "func deferredVisible(other func()) Handler { return func() { defer func() { { var target func(); _ = target }; other(); target() }() } }\n",
             ),
         )],
     )?;
@@ -3283,8 +3385,8 @@ fn go_returned_closure_h2_closes_closure_and_outer_lexical_capture_domains() -> 
             .iter()
             .filter(|fact| fact.status == ProofResolutionStatus::Exact)
             .count(),
-        4,
-        "a disjoint binding and an unrelated capture must preserve both package calls: {target_facts:#?}"
+        5,
+        "disjoint bindings and unrelated captures must preserve package calls in both supported closure domains: {target_facts:#?}"
     );
     Ok(())
 }
@@ -3300,7 +3402,7 @@ fn go_returned_closure_requires_the_outer_to_be_the_sole_containing_graph_callab
             &mut store,
             &[(
                 "main.go",
-                "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { target() } }\n",
+                "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { defer func() { target() }() } }\n",
             )],
         )?;
         if mutate_after_seal {
@@ -3494,7 +3596,7 @@ fn go_returned_closure_h4_requires_one_matching_raw_call_edge_and_one_syntax_fac
                     "type Handler func()\n",
                     "func target() {}\n",
                     "func sibling() {}\n",
-                    "func outer() Handler { return func() { target() } }\n",
+                    "func outer() Handler { return func() { defer func() { target() }() } }\n",
                 ),
             )],
         )?;
@@ -3573,7 +3675,7 @@ fn go_returned_closure_h4_requires_one_matching_raw_call_edge_and_one_syntax_fac
         &mut store,
         &[(
             "main.go",
-            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { target() } }\n",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { defer func() { target() }() } }\n",
         )],
     )?;
     store.get_connection().execute(
@@ -3595,7 +3697,7 @@ fn go_returned_closure_h4_requires_one_matching_raw_call_edge_and_one_syntax_fac
         &mut store,
         &[(
             "main.go",
-            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { target() } }\n",
+            "package proof\ntype Handler func()\nfunc target() {}\nfunc outer() Handler { return func() { defer func() { target() }() } }\n",
         )],
     )?;
     let artifact_blob = store.get_connection().query_row(
@@ -3629,9 +3731,11 @@ fn go_returned_closure_h5_preserves_repeated_native_source_coordinates() -> anyh
         "type Handler func()\r\n",
         "func target() {}\r\n",
         "func outer() Handler { return func() {\r\n",
-        "\t// λλ\r\n",
-        "\ttarget(); target(); target()\r\n",
-        "\ttarget()\r\n",
+        "\tdefer func() {\r\n",
+        "\t\t// λλ\r\n",
+        "\t\ttarget(); target(); target()\r\n",
+        "\t\ttarget()\r\n",
+        "\t}()\r\n",
         "} }\r\n",
     );
     index_files(project.path(), &mut store, &[("main.go", source)])?;
@@ -3670,7 +3774,7 @@ fn go_returned_closure_h5_preserves_repeated_native_source_coordinates() -> anyh
             .iter()
             .map(|fact| fact.callsite.line)
             .collect::<Vec<_>>(),
-        [6, 6, 6, 7]
+        [7, 7, 7, 8]
     );
     for fact in &facts {
         assert_eq!(
@@ -3692,7 +3796,7 @@ fn go_returned_closure_h6_seals_current_go_cache_and_fact_provenance() -> anyhow
         &[
             (
                 "main.go",
-                "package proof\ntype Handler func()\nfunc outer() Handler { return func() { target() } }\n",
+                "package proof\ntype Handler func()\nfunc outer() Handler { return func() { defer func() { target() }() } }\n",
             ),
             ("target.go", "package proof\nfunc target() {}\n"),
         ],
@@ -3706,7 +3810,7 @@ fn go_returned_closure_h6_seals_current_go_cache_and_fact_provenance() -> anyhow
         .expect("sealed returned-closure fact");
     assert_eq!(fact.status, ProofResolutionStatus::Exact, "{fact:#?}");
     assert_eq!(fact.provenance.language_adapter, "go");
-    assert_eq!(fact.provenance.language_adapter_version, "reference-v16");
+    assert_eq!(fact.provenance.language_adapter_version, "reference-v17");
     assert_eq!(fact.provenance.parser_fingerprint.len(), 64);
     assert_eq!(fact.provenance.dependency_file_hashes.len(), 2);
     assert_eq!(fact.provenance.evidence_sha256.len(), 64);

--- a/crates/codestory-indexer/tests/proof_resolution.rs
+++ b/crates/codestory-indexer/tests/proof_resolution.rs
@@ -3551,21 +3551,18 @@ fn go_returned_closure_h4_requires_one_matching_raw_call_edge_and_one_syntax_fac
             }
             _ => unreachable!(),
         }
-        match rematerialize_proof_resolution_projection(&mut store, &publication(1)) {
-            Ok(_) => {
-                let matching = store
-                    .get_proof_resolution_facts()?
-                    .into_iter()
-                    .filter(|fact| fact.callsite.raw_target == "target")
-                    .collect::<Vec<_>>();
-                assert!(
-                    matching
-                        .iter()
-                        .all(|fact| fact.status != ProofResolutionStatus::Exact),
-                    "graph/fact mutation {mutation} retained Exact: {matching:#?}"
-                );
-            }
-            Err(_) => {}
+        if rematerialize_proof_resolution_projection(&mut store, &publication(1)).is_ok() {
+            let matching = store
+                .get_proof_resolution_facts()?
+                .into_iter()
+                .filter(|fact| fact.callsite.raw_target == "target")
+                .collect::<Vec<_>>();
+            assert!(
+                matching
+                    .iter()
+                    .all(|fact| fact.status != ProofResolutionStatus::Exact),
+                "graph/fact mutation {mutation} retained Exact: {matching:#?}"
+            );
         }
     }
 


### PR DESCRIPTION
## Context

CodeStory already had exact proof authorization for ordinary Go calls, but the frozen Q2 corpus exposed a narrow blind spot: calls in a directly returned closure—and in one immediately invoked `defer func() { ... }()` child of that closure—were indexed for navigation but could not receive proof-authoritative resolution facts.

This closes that measured availability class without changing proof semantics or broadening public surfaces.

Closes #2054
Refs #2023

## What changed

- resolve supported Go package calls inside a directly returned function literal;
- resolve the same calls inside exactly one immediate deferred child literal;
- map both supported literal shapes to the enclosing named callable;
- preserve fail-closed behavior for IIFEs, `go` literals, assigned/passed/stored literals, indirect defer, deeper nesting, late or shadowing bindings, incomplete domains, and inconsistent graph/fact data;
- select repeated callsite witnesses in native source order and keep construction linear-time;
- bump only the internal Go adapter provenance from `reference-v16` to `reference-v17`.

The change is limited to the proof-resolution indexer and its tests. It adds no schema, graph, public DTO, CLI, MCP, packet, context, search, navigation, or release change.

## Review history

The complete hostile matrix was written before implementation. One consolidated adversarial review covered language-domain closure, parser provenance, graph/fact correlation, repeated callsites, source coordinates, native ordering, storage integrity, and complexity. Its three findings—late bindings, overlapping callable ownership, and repeated ancestor lookup—were corrected as one batch before the accepted candidate was frozen.

The first local qualification then showed that the two corpus calls were in an immediate deferred child rather than directly in the returned literal. The issue contract was corrected first, the already bounded matrix was extended to that one measured shape, and the candidate was rebuilt without another review round or adapter expansion.

## Exact candidate

- base: `ff71647a83f3a3d62f0eeb98dd664d87d2525296`
- head: `6a2a386abdc19f552c6da8af816b8bcbe01855e1`
- tree: `86f7a3ea9552d47428cf1ed73d071e6b22da8a72`

## Verification

Focused:

- proof-resolution integration tests: 118/118 passed;
- Go complexity tests: 3/3 passed;
- focused lint, formatting, and diff checks passed.

Accepted-head serial gates:

- `cargo fmt --all -- --check`
- `cargo check --locked --workspace`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo nextest run --locked --workspace --no-fail-fast` — 4073 passed, 34 skipped;
- `cargo test --locked --workspace --doc`
- `cargo test --locked -p codestory-indexer --test fidelity_regression` — 8 passed;
- `cargo test --locked -p codestory-indexer --test tictactoe_language_coverage` — 13 passed;
- sealed four-revision Q1 conformance check passed;
- production-unreachability architecture fences passed.

Local frozen Q2 qualification `20260825T054356Z-6a2a386abdc1`:

- 87/120 complete proofs, up from 85;
- Go 26/30, up from 24;
- 223/312 exact positive steps, up from 220;
- `gin-go-04` and `gin-go-30` are now fully proven;
- 220/220 prior authoritative receipts remained exact and all newly admitted receipts were exact;
- zero false `ContractProven`, non-exact receipts, unclassified positive steps, disposition mismatches, invalid results, transport errors, over-cap results, or provenance failures;
- maximum response: 29,865 bytes;
- decision remains `keep_proof_dark`.

Locked qualification binary SHA-256: `3d52bab044f9afe92bd413d6749a80b884d8b810f94648ae80f60683a6903151`.

## Risk and non-claims

The main risk is accepting an escaping or differently invoked closure as the supported immediate shape. The hostile matrix rejects those forms and all soundness blockers across the outer, returned, and deferred scopes.

This PR does not activate proof, change qualification thresholds, claim public availability, or touch the 0.17 release lane, `main`, or `dev/codestory-next`.
