### PR TITLE
resolve rust local calls beside glob imports

### DIFF
--- a/crates/codestory-indexer/src/cache.rs
+++ b/crates/codestory-indexer/src/cache.rs
@@ -45,6 +45,8 @@ pub(crate) struct CachedCallResolutionInput {
 pub(crate) enum CachedResolutionBinding {
     SameFile {
         declaration: NodeId,
+        #[serde(default)]
+        rust_glob_local_module: Option<Vec<String>>,
     },
     StaticImport {
         import: NodeId,

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -4304,11 +4304,13 @@ fn rebase_cached_index_artifact(
             .map(|caller| id_remap.get(&caller).copied().unwrap_or(caller));
         use cache::CachedResolutionBinding;
         input.binding = match input.binding.clone() {
-            CachedResolutionBinding::SameFile { declaration } => {
-                CachedResolutionBinding::SameFile {
-                    declaration: id_remap.get(&declaration).copied().unwrap_or(declaration),
-                }
-            }
+            CachedResolutionBinding::SameFile {
+                declaration,
+                rust_glob_local_module,
+            } => CachedResolutionBinding::SameFile {
+                declaration: id_remap.get(&declaration).copied().unwrap_or(declaration),
+                rust_glob_local_module,
+            },
             CachedResolutionBinding::StaticImport {
                 import,
                 module_specifier,

--- a/crates/codestory-indexer/src/proof_resolution.rs
+++ b/crates/codestory-indexer/src/proof_resolution.rs
@@ -89,13 +89,14 @@ fn python_resolution_work() -> usize {
 const ADAPTER_VERSION: &str = "reference-v15";
 const GO_ADAPTER_VERSION: &str = "reference-v17";
 const PYTHON_ADAPTER_VERSION: &str = "reference-v17";
+const RUST_ADAPTER_VERSION: &str = "reference-v17";
 const TYPESCRIPT_ADAPTER_VERSION: &str = "reference-v17";
 const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 14;
 const INSTALLED_ADAPTERS: &[(&str, &str)] = &[
     ("go", GO_ADAPTER_VERSION),
     ("javascript", ADAPTER_VERSION),
     ("python", PYTHON_ADAPTER_VERSION),
-    ("rust", ADAPTER_VERSION),
+    ("rust", RUST_ADAPTER_VERSION),
     ("tsx", TYPESCRIPT_ADAPTER_VERSION),
     ("typescript", TYPESCRIPT_ADAPTER_VERSION),
 ];
@@ -2670,6 +2671,7 @@ impl<'tree> PythonResolutionIndex<'tree> {
                     if let [declaration] = declarations {
                         CachedResolutionBinding::SameFile {
                             declaration: *declaration,
+                            rust_glob_local_module: None,
                         }
                     } else if declarations.len() > 1 {
                         CachedResolutionBinding::Ambiguous
@@ -4154,6 +4156,7 @@ impl<'tree> JavascriptResolutionIndex<'tree> {
         let binding = match &binding.kind {
             JavascriptBindingKind::SameFile { declaration } => CachedResolutionBinding::SameFile {
                 declaration: *declaration,
+                rust_glob_local_module: None,
             },
             JavascriptBindingKind::StaticImport {
                 import,
@@ -4983,6 +4986,7 @@ struct RustResolutionIndex<'tree> {
     uses_by_module_name: HashMap<(Vec<String>, String), Vec<CachedRustUseBinding>>,
     module_complete: HashMap<Vec<String>, bool>,
     identifier_module_complete: HashMap<Vec<String>, bool>,
+    module_has_glob_import: HashSet<Vec<String>>,
     module_value_blockers: HashMap<Vec<String>, HashSet<String>>,
     module_incomplete_value_names: HashMap<Vec<String>, HashSet<String>>,
     module_unsupported_value_names: HashMap<Vec<String>, HashSet<String>>,
@@ -5016,6 +5020,7 @@ impl<'tree> RustResolutionIndex<'tree> {
             uses_by_module_name: HashMap::new(),
             module_complete: HashMap::new(),
             identifier_module_complete: HashMap::new(),
+            module_has_glob_import: HashSet::new(),
             module_value_blockers: HashMap::new(),
             module_incomplete_value_names: HashMap::new(),
             module_unsupported_value_names: HashMap::new(),
@@ -5031,7 +5036,14 @@ impl<'tree> RustResolutionIndex<'tree> {
             callable_start_bytes: HashMap::new(),
             attributed_items: HashSet::new(),
         };
-        result.collect_module(tree.root_node(), Vec::new(), None, source, &graph_nodes);
+        result.collect_module(
+            tree.root_node(),
+            Vec::new(),
+            None,
+            false,
+            source,
+            &graph_nodes,
+        );
         for method in &mut result.methods {
             if result
                 .incomplete_inherent_owners
@@ -5078,11 +5090,12 @@ impl<'tree> RustResolutionIndex<'tree> {
         body: TsNode<'tree>,
         module_path: Vec<String>,
         declaration: Option<NodeId>,
+        inherited_attributed: bool,
         source: &str,
         graph_nodes: &RustGraphNodeIndex,
     ) {
-        let mut domain_complete = true;
-        let mut identifier_module_complete = true;
+        let mut domain_complete = !inherited_attributed;
+        let mut identifier_module_complete = !inherited_attributed;
         let mut file_children = Vec::new();
         let mut value_blockers = HashSet::new();
         let mut incomplete_value_names = HashSet::new();
@@ -5235,7 +5248,7 @@ impl<'tree> RustResolutionIndex<'tree> {
                     } else {
                         if node_text(*item, source).is_some_and(|surface| surface.contains('*')) {
                             domain_complete = false;
-                            identifier_module_complete = false;
+                            self.module_has_glob_import.insert(module_path.clone());
                         }
                         value_blockers.extend(rust_use_bound_names(*item, source));
                     }
@@ -5244,6 +5257,14 @@ impl<'tree> RustResolutionIndex<'tree> {
                     if let Some(name) = declaration_name(*item, source) {
                         value_blockers.insert(name.to_string());
                     }
+                }
+                "type_item" => {
+                    if let Some(name) = declaration_name(*item, source) {
+                        value_blockers.insert(name.to_string());
+                    }
+                }
+                "foreign_mod_item" => {
+                    value_blockers.extend(rust_foreign_function_names(*item, source));
                 }
                 "mod_item" => {
                     let Some(name) = declaration_name(*item, source).map(str::to_string) else {
@@ -5262,10 +5283,14 @@ impl<'tree> RustResolutionIndex<'tree> {
                             child_body,
                             child_path,
                             module_declaration,
+                            inherited_attributed || attributed_items.contains(&item.id()),
                             source,
                             graph_nodes,
                         );
                     } else {
+                        if inherited_attributed || attributed_items.contains(&item.id()) {
+                            continue;
+                        }
                         let Some(declaration) = module_declaration else {
                             domain_complete = false;
                             identifier_module_complete = false;
@@ -5354,6 +5379,9 @@ impl<'tree> RustResolutionIndex<'tree> {
                 .insert((module_path.to_vec(), owner_name.clone()));
         }
         for method in direct_impl_functions(impl_item) {
+            if impl_attributed {
+                self.attributed_items.insert(method.id());
+            }
             let (Some(method_name), Some(declaration)) = (
                 declaration_name(method, source).map(str::to_string),
                 graph_nodes.callable(method, source),
@@ -5687,6 +5715,13 @@ impl<'tree> RustResolutionIndex<'tree> {
                     return (Some(caller), CachedResolutionBinding::Ambiguous);
                 }
                 if self
+                    .callable_type_blockers
+                    .get(&callable_id)
+                    .is_some_and(|blockers| blockers.contains(raw_target))
+                {
+                    return (Some(caller), CachedResolutionBinding::Unsupported);
+                }
+                if self
                     .module_value_blockers
                     .get(&module_path)
                     .is_some_and(|blockers| blockers.contains(raw_target))
@@ -5708,6 +5743,10 @@ impl<'tree> RustResolutionIndex<'tree> {
                         Some(caller),
                         CachedResolutionBinding::SameFile {
                             declaration: *declaration,
+                            rust_glob_local_module: self
+                                .module_has_glob_import
+                                .contains(&module_path)
+                                .then_some(module_path),
                         },
                     ),
                     ([], [binding]) => (
@@ -6268,43 +6307,89 @@ fn rust_use_is_renamed(declaration: TsNode<'_>, source: &str) -> bool {
 }
 
 fn rust_use_bound_names(declaration: TsNode<'_>, source: &str) -> Vec<String> {
-    let Some(surface) = node_text(declaration, source) else {
+    let Some(argument) = declaration.child_by_field_name("argument") else {
         return Vec::new();
     };
-    let surface = surface
-        .trim()
-        .strip_prefix("pub ")
-        .unwrap_or(surface.trim())
-        .strip_prefix("use ")
-        .unwrap_or(surface.trim())
-        .trim_end_matches(';');
     let mut names = Vec::new();
-    if let Some((_, group)) = surface.split_once("::{") {
-        if let Some(group) = group.strip_suffix('}') {
-            for leaf in group.split(',') {
-                let leaf = leaf.trim();
-                if leaf == "self" || leaf == "*" {
-                    continue;
-                }
-                let local = leaf
-                    .rsplit_once(" as ")
-                    .map_or(leaf, |(_, alias)| alias)
-                    .trim();
-                if rust_simple_identifier(local) {
-                    names.push(local.to_string());
-                }
+    rust_collect_use_bound_names(argument, None, source, &mut names);
+    names.sort();
+    names.dedup();
+    names
+}
+
+fn rust_collect_use_bound_names(
+    clause: TsNode<'_>,
+    scoped_name: Option<&str>,
+    source: &str,
+    names: &mut Vec<String>,
+) {
+    match clause.kind() {
+        "use_as_clause" => {
+            if let Some(alias) = clause
+                .child_by_field_name("alias")
+                .and_then(|alias| node_text(alias, source))
+                .filter(|alias| rust_simple_identifier(alias))
+            {
+                names.push(alias.to_string());
             }
         }
+        "scoped_use_list" => {
+            let path_name = clause
+                .child_by_field_name("path")
+                .and_then(|path| rust_use_terminal_name(path, source));
+            if let Some(list) = clause.child_by_field_name("list") {
+                rust_collect_use_bound_names(list, path_name.as_deref(), source, names);
+            }
+        }
+        "use_list" => {
+            let mut cursor = clause.walk();
+            for child in clause.named_children(&mut cursor) {
+                rust_collect_use_bound_names(child, scoped_name, source, names);
+            }
+        }
+        "scoped_identifier" => {
+            if let Some(name) = rust_use_terminal_name(clause, source) {
+                names.push(name);
+            }
+        }
+        "identifier" => {
+            if let Some(name) =
+                node_text(clause, source).filter(|name| rust_simple_identifier(name))
+            {
+                names.push(name.to_string());
+            }
+        }
+        "self" => {
+            if let Some(name) = scoped_name {
+                names.push(name.to_string());
+            }
+        }
+        "use_wildcard" | "crate" | "super" | "metavariable" => {}
+        _ => {}
+    }
+}
+
+fn rust_use_terminal_name(path: TsNode<'_>, source: &str) -> Option<String> {
+    let name = if path.kind() == "scoped_identifier" {
+        path.child_by_field_name("name")?
     } else {
-        let local = surface
-            .rsplit_once(" as ")
-            .map_or_else(
-                || surface.rsplit("::").next().unwrap_or(surface),
-                |(_, alias)| alias,
-            )
-            .trim();
-        if rust_simple_identifier(local) {
-            names.push(local.to_string());
+        path
+    };
+    node_text(name, source)
+        .filter(|name| rust_simple_identifier(name))
+        .map(str::to_string)
+}
+
+fn rust_foreign_function_names(declaration: TsNode<'_>, source: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    if let Some(body) = declaration.child_by_field_name("body") {
+        let mut cursor = body.walk();
+        for item in body.named_children(&mut cursor) {
+            if item.kind() == "function_signature_item"
+                && let Some(name) = declaration_name(item, source)
+            {
+                names.push(name.to_string());
+            }
         }
     }
     names.sort();
@@ -8971,6 +9056,7 @@ struct RustModuleMatch<'a> {
 struct RustRecordOrigin {
     root: PathBuf,
     base_module: Vec<String>,
+    dependency_files: Vec<FileId>,
 }
 
 #[derive(Clone)]
@@ -9188,6 +9274,24 @@ impl<'a> RustProjectionIndex<'a> {
             .copied()
     }
 
+    fn glob_local_module_dependencies(
+        &self,
+        record: &ResolutionCacheRecord,
+        relative_module: &[String],
+    ) -> Option<Vec<FileId>> {
+        count_rust_resolution_work(1);
+        let origin = self.origins.get(&record.file.file_id.0)?;
+        let mut absolute_module = origin.base_module.clone();
+        absolute_module.extend_from_slice(relative_module);
+        let modules = self.modules.get(&(origin.root.clone(), absolute_module))?;
+        let [module_match] = modules.as_slice() else {
+            return None;
+        };
+        (module_match.record.file.file_id == record.file.file_id
+            && module_match.relative_module == relative_module)
+            .then(|| origin.dependency_files.clone())
+    }
+
     fn declarations(
         &self,
         record: &ResolutionCacheRecord,
@@ -9346,6 +9450,7 @@ fn resolve_rust_record_origin(
         (Some(root), []) => Some(RustRecordOrigin {
             root: root.clone(),
             base_module: Vec::new(),
+            dependency_files: vec![FileId(file_id)],
         }),
         (None, [claim]) if records.contains_key(&claim.parent_file_id) => {
             resolve_rust_record_origin(
@@ -9359,9 +9464,12 @@ fn resolve_rust_record_origin(
             .map(|parent| {
                 let mut base_module = parent.base_module;
                 base_module.extend(claim.relative_child_module.clone());
+                let mut dependency_files = parent.dependency_files;
+                dependency_files.push(FileId(file_id));
                 RustRecordOrigin {
                     root: parent.root,
                     base_module,
+                    dependency_files,
                 }
             })
         }
@@ -10271,7 +10379,10 @@ fn resolve_syntax_claim(
     let mut exact_node_file_expectations = vec![(caller, input.callsite.file_id)];
     let mut exact_dependency_files = vec![input.callsite.file_id];
     match &input.binding {
-        CachedResolutionBinding::SameFile { declaration } => {
+        CachedResolutionBinding::SameFile {
+            declaration,
+            rust_glob_local_module,
+        } => {
             let declaration_is_recorded = if source_record.file.language == "python" {
                 python_index
                     .declarations(input.callsite.file_id, &input.callsite.raw_target)
@@ -10296,6 +10407,22 @@ fn resolve_syntax_claim(
             } else if !declaration_is_recorded {
                 status = ProofResolutionStatus::Ambiguous;
                 reason = ProofResolutionReason::MultipleBindings;
+            } else if let Some(module_path) = rust_glob_local_module {
+                if let Some(dependencies) =
+                    rust_index.glob_local_module_dependencies(source_record, module_path)
+                {
+                    status = ProofResolutionStatus::Exact;
+                    reason = ProofResolutionReason::ExactResolution;
+                    target = Some(*declaration);
+                    evidence_chain.push(ResolutionEvidence::SameFileDeclaration {
+                        declaration: *declaration,
+                    });
+                    exact_node_file_expectations.push((*declaration, input.callsite.file_id));
+                    exact_dependency_files = dependencies;
+                } else {
+                    status = ProofResolutionStatus::IncompleteDomain;
+                    reason = ProofResolutionReason::LookupDomainIncomplete;
+                }
             } else {
                 status = ProofResolutionStatus::Exact;
                 reason = ProofResolutionReason::ExactResolution;
@@ -11598,6 +11725,17 @@ mod rust_complexity_tests {
         source
     }
 
+    fn glob_local_source(count: usize) -> String {
+        let mut source = String::from("use crate::*;\nuse std::prelude::rust_2024::*;\n");
+        for index in 0..count {
+            source.push_str(&format!("fn target_{index}() {{}}\n"));
+        }
+        for index in 0..count {
+            source.push_str(&format!("fn caller_{index}() {{ target_{index}(); }}\n"));
+        }
+        source
+    }
+
     fn measured_projection_work(count: usize) -> usize {
         let temp = tempfile::tempdir().expect("tempdir");
         let path = temp.path().join("lib.rs");
@@ -11658,7 +11796,7 @@ mod rust_complexity_tests {
                 file_id: NodeId(1),
                 source_sha256: "0".repeat(64),
                 language: "rust".to_string(),
-                adapter_version: ADAPTER_VERSION.to_string(),
+                adapter_version: RUST_ADAPTER_VERSION.to_string(),
                 parser_fingerprint: "parser".to_string(),
                 complete: true,
                 lookup_input_complete: true,
@@ -11709,6 +11847,17 @@ mod rust_complexity_tests {
         assert!(
             large_nested <= small_nested * 2 + 64,
             "nested-callable work grew superlinearly: {small_nested} -> {large_nested}"
+        );
+
+        let small_glob = measured_source_work(&glob_local_source(64));
+        let large_glob = measured_source_work(&glob_local_source(128));
+        assert!(
+            small_glob >= 64 * 8,
+            "glob-local declaration and call work was not fully counted: {small_glob}"
+        );
+        assert!(
+            large_glob <= small_glob * 2 + 128,
+            "glob-local declaration and call work grew superlinearly: {small_glob} -> {large_glob}"
         );
     }
 

--- a/crates/codestory-indexer/tests/proof_resolution.rs
+++ b/crates/codestory-indexer/tests/proof_resolution.rs
@@ -189,13 +189,13 @@ fn repeated_call_facts_after_graph_mutation(
         &mut store,
         &[(
             "src/lib.rs",
-            "fn target() {}\nfn source() { target(); target(); }\n",
+            "use crate::*;\nfn target() {}\nfn source() { target(); target(); }\n",
         )],
     )?;
     let mut calls = store
         .get_edges()?
         .into_iter()
-        .filter(|edge| edge.kind == EdgeKind::CALL && edge.line == Some(2))
+        .filter(|edge| edge.kind == EdgeKind::CALL && edge.line == Some(3))
         .collect::<Vec<_>>();
     calls.sort_by_key(|edge| {
         edge.callsite_identity
@@ -7330,11 +7330,267 @@ fn rust_closed_expression_macros_only_relax_bare_same_file_calls() -> anyhow::Re
 }
 
 #[test]
-fn rust_identifier_local_closure_keeps_glob_import_domains_incomplete() -> anyhow::Result<()> {
+fn rust_local_function_precedence_over_globs_is_closed_and_name_specific() -> anyhow::Result<()> {
+    for files in [
+        vec![(
+            "src/lib.rs",
+            "use crate::*;\nfn target() {}\nfn caller() { target(); }\n",
+        )],
+        vec![(
+            "src/lib.rs",
+            "use crate::*;\nuse std::prelude::rust_2024::*;\nfn target() {}\nfn caller() { target(); }\n",
+        )],
+        vec![(
+            "src/lib.rs",
+            "mod other { fn target() {} }\nmod child { use super::*; fn target() {} fn caller() { target(); } }\n",
+        )],
+        vec![
+            ("src/lib.rs", "mod child;\n"),
+            (
+                "src/child.rs",
+                "use super::*;\nfn target() {}\nfn caller() { target(); }\n",
+            ),
+        ],
+        vec![(
+            "src/lib.rs",
+            "use crate::*;\nstruct Unrelated;\nconst OTHER: usize = 0;\nfn helper() {}\nfn target() {}\nfn caller() { target(); }\n",
+        )],
+    ] {
+        assert_only_call_is_exact(&files)?;
+    }
+
+    for source in [
+        "use crate::*;\nfn caller() { target(); }\n",
+        "use crate::*;\nfn target() {}\nfn target() {}\nfn caller() { target(); }\n",
+        "mod other { pub fn target() {} }\nuse crate::*;\nuse crate::other::target;\nfn target() {}\nfn caller() { target(); }\n",
+        "mod other { pub fn different() {} }\nuse crate::*;\nuse crate::other::different as target;\nfn target() {}\nfn caller() { target(); }\n",
+        "use crate::*;\nconst target: fn() = || {};\nfn target() {}\nfn caller() { target(); }\n",
+        "use crate::*;\nstatic target: fn() = target;\nfn target() {}\nfn caller() { target(); }\n",
+        "use crate::*;\nstruct target;\nfn target() {}\nfn caller() { target(); }\n",
+        "use crate::*;\nenum target { Value }\nfn target() {}\nfn caller() { target(); }\n",
+        "use crate::*;\ntype target = fn();\nfn target() {}\nfn caller() { target(); }\n",
+        "use crate::*;\nunsafe extern \"C\" { fn target(); }\nfn target() {}\nfn caller() { target(); }\n",
+        "use crate::*;\nfn target() {}\nfn caller() { fn target() {} target(); }\n",
+        "use crate::*;\nfn target() {}\nfn caller(target: fn()) { target(); }\n",
+        "use crate::*;\nfn target() {}\nfn caller() { let target: fn() = || {}; target(); }\n",
+        "use crate::*;\nfn target() {}\nfn caller<target>() { target(); }\n",
+    ] {
+        assert_only_call_is_not_exact(&[("src/lib.rs", source)])?;
+    }
+    Ok(())
+}
+
+#[test]
+fn rust_glob_local_nested_explicit_imports_remain_same_name_blockers() -> anyhow::Result<()> {
+    for source in [
+        "mod other { pub fn target() {} }\nuse crate::{other::{target}, *};\nfn target() {}\nfn caller() { target(); }\n",
+        "mod other { pub fn target() {} }\nuse crate::{other::target, *};\nfn target() {}\nfn caller() { target(); }\n",
+        "mod other { pub fn different() {} }\nuse crate::{other::{different as target}, *};\nfn target() {}\nfn caller() { target(); }\n",
+        "mod other { pub fn target() {} }\nuse crate::*;\nfn target() {}\nfn caller() { use crate::{other::{target}}; target(); }\n",
+    ] {
+        assert_only_call_is_not_exact(&[("src/lib.rs", source)])?;
+    }
+    Ok(())
+}
+
+#[test]
+fn rust_glob_local_precedence_keeps_attributes_macros_and_incomplete_domains_closed()
+-> anyhow::Result<()> {
+    for source in [
+        "use crate::*;\n#[cfg(any())]\nfn target() {}\nfn caller() { target(); }\n",
+        "use crate::*;\nfn target() {}\n#[cfg(any())]\nfn caller() { target(); }\n",
+        "use crate::*;\nfn target() {}\nfn caller() { #[cfg(any())] { target(); } }\n",
+        "use crate::*;\nmacro_rules! duplicate { () => { fn target() {} }; }\nduplicate!();\nfn target() {}\nfn caller() { target(); }\n",
+        "use crate::*;\nmacro_rules! shadow { () => { let target: fn() = || {}; }; }\nfn target() {}\nfn caller() { shadow!(); target(); }\n",
+        "use crate::*;\ninclude!(\"generated.rs\");\nfn target() {}\nfn caller() { target(); }\n",
+        "#![unknown]\nuse crate::*;\nfn target() {}\nfn caller() { target(); }\n",
+        "use crate::*;\n#[unknown]\nstruct Other;\nfn target() {}\nfn caller() { target(); }\n",
+        "use crate::*;\nfn target() {}\nfn caller() { target(); }\n<",
+        "#[cfg(any())]\nmod child { use super::*; fn target() {} fn caller() { target(); } }\n",
+        "#[unresolved_attribute_macro]\nmod child { use super::*; fn target() {} fn caller() { target(); } }\n",
+        "use crate::*;\nfn target() {}\nstruct Worker;\n#[cfg(any())]\nimpl Worker { fn caller() { target(); } }\n",
+    ] {
+        assert_only_call_is_not_exact(&[("src/lib.rs", source)])?;
+    }
     assert_only_call_is_not_exact(&[(
         "src/lib.rs",
-        "use crate::*;\nfn target() {}\nfn caller() { target(); }\n",
-    )])
+        "mod possible { pub fn target() {} }\nuse possible::*;\nfn caller() { target(); }\n",
+    )])?;
+    Ok(())
+}
+
+#[test]
+fn rust_glob_local_file_modules_require_unique_authenticated_parent_ownership() -> anyhow::Result<()>
+{
+    for files in [
+        vec![(
+            "src/child.rs",
+            "use super::*;\nfn target() {}\nfn caller() { target(); }\n",
+        )],
+        vec![
+            ("src/lib.rs", "#[cfg(any())]\nmod child;\n"),
+            (
+                "src/child.rs",
+                "use super::*;\nfn target() {}\nfn caller() { target(); }\n",
+            ),
+        ],
+        vec![
+            ("src/lib.rs", "#[path = \"actual.rs\"]\nmod selected;\n"),
+            (
+                "src/actual.rs",
+                "use super::*;\nfn target() {}\nfn caller() { target(); }\n",
+            ),
+        ],
+        vec![
+            ("src/lib.rs", "mod foo;\n"),
+            (
+                "src/foo.rs",
+                "use super::*;\nfn target() {}\nfn caller() { target(); }\n",
+            ),
+            ("src/foo/mod.rs", "fn unrelated() {}\n"),
+        ],
+    ] {
+        assert_only_call_is_not_exact(&files)?;
+    }
+
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(
+        project.path(),
+        &mut store,
+        &[
+            ("src/lib.rs", "mod child;\n"),
+            (
+                "src/child.rs",
+                "use super::*;\nfn target() {}\nfn caller() { target(); }\n",
+            ),
+        ],
+    )?;
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    let fact = store
+        .get_proof_resolution_facts()?
+        .into_iter()
+        .find(|fact| fact.callsite.raw_target == "target")
+        .expect("file-module call fact");
+    assert_eq!(fact.status, ProofResolutionStatus::Exact, "{fact:#?}");
+    assert!(matches!(
+        fact.evidence_chain.as_slice(),
+        [ResolutionEvidence::SameFileDeclaration { declaration }]
+            if Some(*declaration) == fact.target
+    ));
+    assert_eq!(
+        fact.provenance.dependency_file_hashes.len(),
+        2,
+        "the parent module declaration must be hash-bound: {fact:#?}"
+    );
+    let mut parent = store
+        .get_files()?
+        .into_iter()
+        .find(|file| file.path.ends_with("src/lib.rs"))
+        .expect("parent module file");
+    parent.path = project.path().join("unrelated/lib.rs");
+    store.insert_file(&parent)?;
+    let error = store
+        .validate_proof_resolution_publication(&publication(1))
+        .expect_err("a non-ancestor dependency path must not replay as module ownership");
+    assert!(error.to_string().contains("dependency hashes"), "{error}");
+    Ok(())
+}
+
+#[test]
+fn rust_glob_local_calls_preserve_repeated_source_coordinates_and_provenance() -> anyhow::Result<()>
+{
+    let source = "use crate::*;\r\nfn target() {}\r\nfn caller() { /* é */\ttarget(); target(); target(); }\r\n";
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(project.path(), &mut store, &[("src/lib.rs", source)])?;
+    let first = rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    store.validate_proof_resolution_publication(&publication(1))?;
+    let mut facts = store
+        .get_proof_resolution_facts()?
+        .into_iter()
+        .filter(|fact| fact.callsite.raw_target == "target")
+        .collect::<Vec<_>>();
+    facts.sort_by_key(|fact| fact.callsite.start_byte);
+    assert_eq!(facts.len(), 3, "one fact per repeated callsite: {facts:#?}");
+    assert!(
+        facts
+            .iter()
+            .all(|fact| fact.status == ProofResolutionStatus::Exact),
+        "glob-local calls must all be exact: {facts:#?}"
+    );
+    assert_eq!(
+        facts
+            .iter()
+            .filter_map(|fact| fact.edge_id)
+            .collect::<BTreeSet<_>>()
+            .len(),
+        3,
+        "one ordinary edge per repeated callsite"
+    );
+    let expected_starts = source
+        .match_indices("target();")
+        .map(|(start, _)| start as u64)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        facts
+            .iter()
+            .map(|fact| fact.callsite.start_byte)
+            .collect::<Vec<_>>(),
+        expected_starts
+    );
+    assert!(facts.iter().all(|fact| {
+        fact.provenance.language_adapter == "rust"
+            && fact.provenance.language_adapter_version == "reference-v17"
+            && fact.provenance.dependency_file_hashes.len() == 1
+            && matches!(
+                fact.evidence_chain.as_slice(),
+                [ResolutionEvidence::SameFileDeclaration { declaration }] if Some(*declaration) == fact.target
+            )
+    }));
+
+    let second = rematerialize_proof_resolution_projection(&mut store, &publication(2))?;
+    assert_eq!(first.fact_count, second.fact_count);
+    assert_eq!(first.fact_digest, second.fact_digest);
+    Ok(())
+}
+
+#[test]
+fn stale_rust_glob_local_adapter_inputs_reject_rematerialization() -> anyhow::Result<()> {
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(
+        project.path(),
+        &mut store,
+        &[(
+            "src/lib.rs",
+            "use crate::*;\nfn target() {}\nfn caller() { target(); }\n",
+        )],
+    )?;
+    let artifact_blob = store.get_connection().query_row(
+        "SELECT artifact_blob FROM index_artifact_cache",
+        [],
+        |row| row.get::<_, Vec<u8>>(0),
+    )?;
+    let mut artifact: serde_json::Value = serde_json::from_slice(&artifact_blob)?;
+    artifact["resolution_file"]["adapter_version"] = "reference-v16".into();
+    for call in artifact["call_resolution_inputs"]
+        .as_array_mut()
+        .expect("call inputs")
+    {
+        call["adapter_version"] = "reference-v16".into();
+    }
+    store.get_connection().execute(
+        "UPDATE index_artifact_cache SET artifact_blob = ?1",
+        [serde_json::to_vec(&artifact)?],
+    )?;
+    let error = rematerialize_proof_resolution_projection(&mut store, &publication(1))
+        .expect_err("stale Rust adapter inputs must not authenticate changed lookup semantics");
+    assert!(
+        error.to_string().contains("adapter") || error.to_string().contains("stale"),
+        "{error}"
+    );
+    Ok(())
 }
 
 #[test]
@@ -7359,7 +7615,7 @@ fn proof_resolution_roster_tracks_the_current_adapter_version() -> anyhow::Resul
             .iter()
             .find(|adapter| adapter.language == "rust")
             .map(|adapter| adapter.adapter_version.as_str()),
-        Some("reference-v15")
+        Some("reference-v17")
     );
     assert_eq!(
         receipt

--- a/crates/codestory-store/src/storage_impl/proof_resolution.rs
+++ b/crates/codestory-store/src/storage_impl/proof_resolution.rs
@@ -251,6 +251,8 @@ fn dependency_file_ids(fact: &CallResolutionFact) -> BTreeSet<FileId> {
 struct ProofResolutionValidationContext {
     file_by_id: HashMap<i64, FileInfo>,
     file_content_hash_by_id: HashMap<i64, String>,
+    rust_file_ids_by_path: HashMap<PathBuf, Vec<FileId>>,
+    rust_root_count_by_directory: HashMap<PathBuf, usize>,
     node_by_id: HashMap<NodeId, Node>,
     edges: Vec<Edge>,
     edge_index_by_id: HashMap<EdgeId, usize>,
@@ -267,6 +269,125 @@ struct ProofResolutionValidationContext {
     go_dependency_ids_by_package: HashMap<GoPackageIdentity, BTreeSet<FileId>>,
     go_attestation_error_by_file: HashMap<i64, String>,
     live_go_sources_authenticated: bool,
+}
+
+fn prepare_rust_file_identity(
+    file_by_id: &HashMap<i64, FileInfo>,
+) -> (HashMap<PathBuf, Vec<FileId>>, HashMap<PathBuf, usize>) {
+    let mut file_ids_by_path = HashMap::<PathBuf, Vec<FileId>>::new();
+    let mut root_count_by_directory = HashMap::<PathBuf, usize>::new();
+    for file in file_by_id.values().filter(|file| file.language == "rust") {
+        count_store_replay_work(1);
+        file_ids_by_path
+            .entry(file.path.clone())
+            .or_default()
+            .push(FileId(file.id));
+        if matches!(
+            file.path.file_name().and_then(|name| name.to_str()),
+            Some("lib.rs" | "main.rs")
+        ) && let Some(directory) = file.path.parent()
+        {
+            *root_count_by_directory
+                .entry(directory.to_path_buf())
+                .or_default() += 1;
+        }
+    }
+    (file_ids_by_path, root_count_by_directory)
+}
+
+fn rust_dependency_path_is_ancestor(
+    source: &FileInfo,
+    dependency: &FileInfo,
+    context: &ProofResolutionValidationContext,
+) -> bool {
+    if dependency.language != "rust" || dependency.id == source.id {
+        return false;
+    }
+    if context
+        .rust_file_ids_by_path
+        .get(&dependency.path)
+        .is_none_or(|files| files.len() != 1)
+    {
+        return false;
+    }
+    let Some(file_name) = dependency.path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    let Some(directory) = dependency.path.parent() else {
+        return false;
+    };
+    let (module_base, conflicting_form) = match file_name {
+        "lib.rs" | "main.rs" => {
+            if context.rust_root_count_by_directory.get(directory).copied() != Some(1) {
+                return false;
+            }
+            (directory.to_path_buf(), None)
+        }
+        "mod.rs" => {
+            let Some(module_directory) = directory.parent() else {
+                return false;
+            };
+            (
+                directory.to_path_buf(),
+                Some(module_directory.join(format!(
+                    "{}.rs",
+                    directory.file_name().and_then(|name| name.to_str()).unwrap_or("")
+                ))),
+            )
+        }
+        name if name.ends_with(".rs") => (
+            dependency.path.with_extension(""),
+            Some(dependency.path.with_extension("").join("mod.rs")),
+        ),
+        _ => return false,
+    };
+    if conflicting_form.is_some_and(|path| {
+        context
+            .rust_file_ids_by_path
+            .get(&path)
+            .is_some_and(|files| !files.is_empty())
+    }) {
+        return false;
+    }
+    source.path.starts_with(&module_base) && source.path != dependency.path
+}
+
+fn rust_same_file_dependency_ids(
+    fact: &CallResolutionFact,
+    required: &BTreeSet<FileId>,
+    observed: &BTreeSet<FileId>,
+    context: &ProofResolutionValidationContext,
+) -> Option<BTreeSet<FileId>> {
+    if fact.provenance.language_adapter != "rust"
+        || fact.callsite.callee_form != CalleeForm::Identifier
+        || !matches!(
+            fact.evidence_chain.as_slice(),
+            [ResolutionEvidence::SameFileDeclaration { declaration }]
+                if Some(*declaration) == fact.target
+        )
+        || !required.is_subset(observed)
+    {
+        return None;
+    }
+    let source = context.file_by_id.get(&fact.callsite.file_id.0)?;
+    if context
+        .rust_file_ids_by_path
+        .get(&source.path)
+        .is_none_or(|files| files.as_slice() != [fact.callsite.file_id])
+    {
+        return None;
+    }
+    observed
+        .difference(required)
+        .all(|file_id| {
+            context
+                .file_by_id
+                .get(&file_id.0)
+                .is_some_and(|dependency| {
+                    rust_dependency_path_is_ancestor(source, dependency, context)
+                })
+        })
+        .then(|| observed.clone())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1003,6 +1124,8 @@ mod go_replay_complexity_tests {
         let context = ProofResolutionValidationContext {
             file_by_id,
             file_content_hash_by_id,
+            rust_file_ids_by_path: HashMap::new(),
+            rust_root_count_by_directory: HashMap::new(),
             node_by_id: HashMap::new(),
             edges: Vec::new(),
             edge_index_by_id: HashMap::new(),
@@ -1165,6 +1288,8 @@ mod python_replay_complexity_tests {
         let context = ProofResolutionValidationContext {
             file_content_hash_by_id,
             file_by_id,
+            rust_file_ids_by_path: HashMap::new(),
+            rust_root_count_by_directory: HashMap::new(),
             node_by_id: HashMap::new(),
             edges: Vec::new(),
             edge_index_by_id: HashMap::new(),
@@ -1300,6 +1425,8 @@ impl ProofResolutionValidationContext {
             .into_iter()
             .map(|file| (file.id, file))
             .collect();
+        let (rust_file_ids_by_path, rust_root_count_by_directory) =
+            prepare_rust_file_identity(&file_by_id);
         let python_file_ids_by_path = prepare_python_file_ids_by_path(&file_by_id);
         let file_content_hash_by_id = storage.get_file_content_hashes()?;
         let python_attestation_error_by_file = prepare_python_source_attestation(
@@ -1460,6 +1587,8 @@ impl ProofResolutionValidationContext {
         Ok(Self {
             file_by_id,
             file_content_hash_by_id,
+            rust_file_ids_by_path,
+            rust_root_count_by_directory,
             node_by_id,
             edges,
             edge_index_by_id,
@@ -1896,6 +2025,14 @@ impl Storage {
                 &observed_dependency_ids,
                 context,
             )?;
+        }
+        if let Some(rust_dependencies) = rust_same_file_dependency_ids(
+            fact,
+            &required_dependency_ids,
+            &observed_dependency_ids,
+            context,
+        ) {
+            required_dependency_ids = rust_dependencies;
         }
         if observed_dependency_ids != required_dependency_ids {
             return Err(proof_error(format!(


### PR DESCRIPTION
## Context

Rust unqualified calls to unique same-file declarations were conservatively withheld whenever the file also contained an unrelated glob import. That left five Rust Q2 paths incomplete even though the local declaration already closed the lookup domain.

This is the bounded Rust glob/local precedence slice from the minimal exact-resolution roadmap. It targets only `dev/codestory-0.18`, remains production-unreachable, and does not register a public proof route.

Base: `02527a70b234a9ad0508eca2d36c424af546131a`

Head: `d368369ca7a473487db97a900e7b884114ce4e63`

Tree: `299b53536fef2aaf2fc5b8c5c00e2798ac540ba5`

## What changed

- Prefer one declaration-first same-file Rust binding over unrelated glob uncertainty.
- Propagate attributed language-domain closure across supported ancestors.
- Treat type aliases, foreign functions, nested explicit import leaves, and competing same-name declarations as blockers.
- Authenticate standard Rust file-module ownership with ancestor dependency hashes.
- Preserve `SameFileDeclaration` as the only evidence kind for this slice.
- Keep proof fact replay fail-closed for non-ancestor dependency files.
- Select repeated-call witnesses by native source identity, callsite start byte, then edge ID.

No graph wire behavior, retrieval/navigation behavior, schema table, adapter breadth, or public surface changed.

## Review

Implementation was frozen and reviewed once across the complete trust boundary: language-domain closure, parser provenance, graph/fact correlation, repeated callsites, source coordinates, native ordering, storage integrity, and complexity. All findings were batched into one correction. The accepted code remains linear-time and production-unreachable.

## Verification

Focused:

- proof resolution: 123/123
- Rust complexity: 2/2
- store proof integrity: 25/25
- dark architecture: 2/2
- fidelity regression: 8/8
- language coverage: 13/13
- focused clippy with warnings denied, format, and diff check

Accepted-candidate serial gate:

- `cargo fmt --all -- --check`
- `cargo check --locked --workspace`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo nextest run --locked --workspace --no-fail-fast`: 4078 passed, 34 skipped
- `cargo test --locked --workspace --doc`
- full fidelity and language-coverage binaries
- sealed four-revision evidence checks

Local Q2 `20260825T073804Z-d368369ca7a4`:

- release binary SHA-256: `0ec3aedb057b498d65840b998fabafd389c30e65f2b12ef5c58b96d626a4591c`
- results SHA-256: `2bc51a0ad01c7d45ebea2739ffe8b3312e96029bb1013702126d9e6290345789`
- complete proofs: 92/120
- Rust: 21/30
- exact positive steps: 231/312
- complete or useful partial: 96/120
- every hard gate: zero
- decision: `keep_proof_dark`

The remaining failures are unchanged availability and latency thresholds. This PR makes no public activation or release claim.

## Risk and rollback

The risk is limited to over-authorizing a local call when another binding domain is still live. The hostile matrix covers attributed ancestors, same-name blockers, nested imports, file-module ownership, dependency tampering, coordinates, repeated callsites, and graph/fact disagreement. Reverting this commit removes the new authorization without migrating graph data.

Closes #2056
Refs #2023
