### PR TITLE
resolve rust calls inside bounded attributes

### DIFF
--- a/crates/codestory-indexer/src/cache.rs
+++ b/crates/codestory-indexer/src/cache.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::path::{Component, Path, PathBuf};
 
 // Versioned with proof-input semantics so older parser artifacts fail closed.
-const INDEX_ARTIFACT_CACHE_VERSION: u32 = 13;
+const INDEX_ARTIFACT_CACHE_VERSION: u32 = 14;
 const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
 const FNV_PRIME: u64 = 0x00000100000001B3;
 
@@ -288,7 +288,7 @@ impl CachedIndexArtifact {
         resolution_file: Option<CachedResolutionFile>,
     ) -> Self {
         Self {
-            resolution_input_schema_version: 14,
+            resolution_input_schema_version: 15,
             files: index_result.files,
             nodes: index_result.nodes,
             edges: index_result.edges,

--- a/crates/codestory-indexer/src/proof_resolution.rs
+++ b/crates/codestory-indexer/src/proof_resolution.rs
@@ -89,9 +89,9 @@ fn python_resolution_work() -> usize {
 const ADAPTER_VERSION: &str = "reference-v15";
 const GO_ADAPTER_VERSION: &str = "reference-v17";
 const PYTHON_ADAPTER_VERSION: &str = "reference-v17";
-const RUST_ADAPTER_VERSION: &str = "reference-v17";
+const RUST_ADAPTER_VERSION: &str = "reference-v18";
 const TYPESCRIPT_ADAPTER_VERSION: &str = "reference-v17";
-const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 14;
+const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 15;
 const INSTALLED_ADAPTERS: &[(&str, &str)] = &[
     ("go", GO_ADAPTER_VERSION),
     ("javascript", ADAPTER_VERSION),
@@ -5001,11 +5001,20 @@ struct RustResolutionIndex<'tree> {
     callable_module_paths: HashMap<usize, Vec<String>>,
     callable_start_bytes: HashMap<usize, usize>,
     attributed_items: HashSet<usize>,
+    bounded_outer_attribute_ids: HashSet<usize>,
+    bounded_attributed_callers: HashSet<usize>,
+    bounded_attributed_callsites: HashSet<usize>,
 }
 
 impl<'tree> RustResolutionIndex<'tree> {
     fn build(tree: &'tree Tree, source: &str, file_id: NodeId, nodes: &[Node]) -> Self {
         let graph_nodes = RustGraphNodeIndex::prepare(file_id, nodes);
+        let (
+            attributed_items,
+            bounded_outer_attribute_ids,
+            bounded_attributed_callers,
+            bounded_attributed_callsites,
+        ) = rust_prepare_attribute_index(tree.root_node(), source);
         let mut result = Self {
             calls: Vec::new(),
             declarations: Vec::new(),
@@ -5034,7 +5043,10 @@ impl<'tree> RustResolutionIndex<'tree> {
             callable_nodes: HashMap::new(),
             callable_module_paths: HashMap::new(),
             callable_start_bytes: HashMap::new(),
-            attributed_items: HashSet::new(),
+            attributed_items,
+            bounded_outer_attribute_ids,
+            bounded_attributed_callers,
+            bounded_attributed_callsites,
         };
         result.collect_module(
             tree.root_node(),
@@ -5102,15 +5114,12 @@ impl<'tree> RustResolutionIndex<'tree> {
         let mut unsupported_value_names = HashSet::new();
         let mut cursor = body.walk();
         let items = body.named_children(&mut cursor).collect::<Vec<_>>();
-        let attributed_items = rust_attributed_item_ids(&items);
-        let bounded_attribute_ids = rust_bounded_outer_attribute_ids(&items, source);
-        self.attributed_items
-            .extend(attributed_items.iter().copied());
         for item in &items {
             let direct_domain_poison = item.kind() == "macro_invocation"
                 || (item.kind() == "inner_attribute_item"
                     && !rust_inner_allow_preserves_module_bindings(*item, source))
-                || (item.kind() == "attribute_item" && !bounded_attribute_ids.contains(&item.id()))
+                || (item.kind() == "attribute_item"
+                    && !self.bounded_outer_attribute_ids.contains(&item.id()))
                 || (item.kind() == "expression_statement"
                     && contains_node_kind(*item, "macro_invocation"));
             if direct_domain_poison {
@@ -5142,7 +5151,7 @@ impl<'tree> RustResolutionIndex<'tree> {
             match item.kind() {
                 "function_item" => {
                     let name = declaration_name(*item, source).map(str::to_string);
-                    if attributed_items.contains(&item.id()) {
+                    if self.attributed_items.contains(&item.id()) {
                         if let Some(name) = name {
                             incomplete_value_names.insert(name);
                         } else {
@@ -5176,7 +5185,7 @@ impl<'tree> RustResolutionIndex<'tree> {
                     if let Some(name) = declaration_name(*item, source) {
                         value_blockers.insert(name.to_string());
                     }
-                    if attributed_items.contains(&item.id()) {
+                    if self.attributed_items.contains(&item.id()) {
                         if let Some(name) = declaration_name(*item, source) {
                             incomplete_value_names.insert(name.to_string());
                         } else {
@@ -5217,13 +5226,13 @@ impl<'tree> RustResolutionIndex<'tree> {
                     self.collect_impl(
                         *item,
                         &module_path,
-                        attributed_items.contains(&item.id()),
+                        self.attributed_items.contains(&item.id()),
                         source,
                         graph_nodes,
                     );
                 }
                 "use_declaration" => {
-                    if attributed_items.contains(&item.id()) {
+                    if self.attributed_items.contains(&item.id()) {
                         let names = rust_use_bound_names(*item, source);
                         if names.is_empty() {
                             domain_complete = false;
@@ -5272,7 +5281,7 @@ impl<'tree> RustResolutionIndex<'tree> {
                         identifier_module_complete = false;
                         continue;
                     };
-                    if attributed_items.contains(&item.id()) {
+                    if self.attributed_items.contains(&item.id()) {
                         incomplete_value_names.insert(name.clone());
                     }
                     let module_declaration = graph_nodes.module(*item, &name);
@@ -5283,12 +5292,12 @@ impl<'tree> RustResolutionIndex<'tree> {
                             child_body,
                             child_path,
                             module_declaration,
-                            inherited_attributed || attributed_items.contains(&item.id()),
+                            inherited_attributed || self.attributed_items.contains(&item.id()),
                             source,
                             graph_nodes,
                         );
                     } else {
-                        if inherited_attributed || attributed_items.contains(&item.id()) {
+                        if inherited_attributed || self.attributed_items.contains(&item.id()) {
                             continue;
                         }
                         let Some(declaration) = module_declaration else {
@@ -5361,27 +5370,20 @@ impl<'tree> RustResolutionIndex<'tree> {
             .first()
             .copied()
             .filter(|_| owner_nodes.len() == 1);
-        let body_items = impl_item
-            .child_by_field_name("body")
-            .map(|body| {
-                let mut cursor = body.walk();
-                body.named_children(&mut cursor).collect::<Vec<_>>()
-            })
-            .unwrap_or_default();
-        let attributed_methods = rust_attributed_item_ids(&body_items);
-        self.attributed_items
-            .extend(attributed_methods.iter().copied());
+        let has_attributed_impl_item = impl_item.child_by_field_name("body").is_none_or(|body| {
+            let mut cursor = body.walk();
+            body.named_children(&mut cursor)
+                .any(|item| self.attributed_items.contains(&item.id()))
+        });
+        let methods = direct_impl_functions(impl_item);
         let impl_complete = !impl_attributed
-            && attributed_methods.is_empty()
+            && !has_attributed_impl_item
             && !rust_impl_has_direct_item_macro(impl_item);
         if !impl_complete {
             self.incomplete_inherent_owners
                 .insert((module_path.to_vec(), owner_name.clone()));
         }
-        for method in direct_impl_functions(impl_item) {
-            if impl_attributed {
-                self.attributed_items.insert(method.id());
-            }
+        for method in methods {
             let (Some(method_name), Some(declaration)) = (
                 declaration_name(method, source).map(str::to_string),
                 graph_nodes.callable(method, source),
@@ -5430,6 +5432,8 @@ impl<'tree> RustResolutionIndex<'tree> {
         let mut scope = current_scope;
 
         if node.kind() == "function_item" {
+            let inherited_domain_complete = current_callable
+                .is_none_or(|parent| self.callsite_domain_complete(parent, node.start_byte()));
             if let (Some(parent_callable), Some(parent_scope)) = (current_callable, current_scope) {
                 let callable_start = self
                     .callable_start_bytes
@@ -5455,10 +5459,22 @@ impl<'tree> RustResolutionIndex<'tree> {
                 .insert(node.id(), node.start_byte());
             self.callable_module_paths
                 .insert(node.id(), module_path.to_vec());
-            self.callable_complete
-                .insert(node.id(), !self.attributed_items.contains(&node.id()));
-            self.callable_poison_ranges
-                .insert(node.id(), rust_callable_poison_ranges(node, source));
+            let attributed = self.attributed_items.contains(&node.id());
+            let bounded_free_function = self.bounded_attributed_callers.contains(&node.id())
+                && !self.inherent_callable_contexts.contains_key(&node.id());
+            self.callable_complete.insert(
+                node.id(),
+                inherited_domain_complete && (!attributed || bounded_free_function),
+            );
+            self.callable_poison_ranges.insert(
+                node.id(),
+                rust_callable_poison_ranges(
+                    node,
+                    &self.bounded_outer_attribute_ids,
+                    &self.bounded_attributed_callers,
+                    &self.bounded_attributed_callsites,
+                ),
+            );
             self.callable_type_blockers
                 .insert(node.id(), rust_callable_type_parameter_names(node, source));
             self.lexical_bindings.entry(node.id()).or_default();
@@ -5982,36 +5998,168 @@ fn rust_struct_constructor_capabilities(item: TsNode<'_>) -> (bool, bool) {
     (!record && !tuple, record)
 }
 
-fn rust_attributed_item_ids(items: &[TsNode<'_>]) -> HashSet<usize> {
-    let mut result = HashSet::new();
-    let mut pending_attribute = false;
-    for item in items {
-        if item.kind() == "attribute_item" {
-            pending_attribute = true;
-        } else {
-            if pending_attribute {
-                result.insert(item.id());
+fn rust_prepare_attribute_index(
+    root: TsNode<'_>,
+    source: &str,
+) -> (
+    HashSet<usize>,
+    HashSet<usize>,
+    HashSet<usize>,
+    HashSet<usize>,
+) {
+    fn collect(
+        node: TsNode<'_>,
+        source: &str,
+        attributed_items: &mut HashSet<usize>,
+        bounded_outer_attribute_ids: &mut HashSet<usize>,
+        bounded_attributed_callers: &mut HashSet<usize>,
+        bounded_attributed_callsites: &mut HashSet<usize>,
+        direct_method_ids: &mut HashSet<usize>,
+    ) {
+        count_rust_resolution_work(1);
+        let mut cursor = node.walk();
+        let children = node.named_children(&mut cursor).collect::<Vec<_>>();
+        let direct_method_owner = node
+            .parent()
+            .filter(|parent| matches!(parent.kind(), "impl_item" | "trait_item"));
+        let mut attributes = Vec::new();
+        for child in children {
+            count_rust_resolution_work(1);
+            if child.kind() == "attribute_item" || rust_is_outer_doc_comment(child, source) {
+                attributes.push(child);
+                continue;
             }
-            pending_attribute = false;
+            let direct_method = child.kind() == "function_item" && direct_method_owner.is_some();
+            if direct_method {
+                count_rust_resolution_work(1);
+                direct_method_ids.insert(child.id());
+                if direct_method_owner.is_some_and(|owner| attributed_items.contains(&owner.id())) {
+                    attributed_items.insert(child.id());
+                }
+            }
+            if !attributes.is_empty() {
+                attributed_items.insert(child.id());
+                if rust_attribute_group_is_bounded(&attributes, child, source) {
+                    bounded_outer_attribute_ids
+                        .extend(attributes.iter().map(|attribute| attribute.id()));
+                }
+                if child.kind() == "function_item"
+                    && !direct_method_ids.contains(&child.id())
+                    && rust_attribute_group_preserves_caller(&attributes, source)
+                {
+                    bounded_attributed_callers.insert(child.id());
+                }
+                if rust_bounded_callsite_category(child)
+                    && rust_attribute_group_preserves_callsite(&attributes, source)
+                {
+                    bounded_attributed_callsites.insert(child.id());
+                }
+                attributes.clear();
+            }
+            collect(
+                child,
+                source,
+                attributed_items,
+                bounded_outer_attribute_ids,
+                bounded_attributed_callers,
+                bounded_attributed_callsites,
+                direct_method_ids,
+            );
         }
     }
-    result
+
+    let mut attributed_items = HashSet::new();
+    let mut bounded_outer_attribute_ids = HashSet::new();
+    let mut bounded_attributed_callers = HashSet::new();
+    let mut bounded_attributed_callsites = HashSet::new();
+    let mut direct_method_ids = HashSet::new();
+    collect(
+        root,
+        source,
+        &mut attributed_items,
+        &mut bounded_outer_attribute_ids,
+        &mut bounded_attributed_callers,
+        &mut bounded_attributed_callsites,
+        &mut direct_method_ids,
+    );
+    (
+        attributed_items,
+        bounded_outer_attribute_ids,
+        bounded_attributed_callers,
+        bounded_attributed_callsites,
+    )
 }
 
-fn rust_bounded_outer_attribute_ids(items: &[TsNode<'_>], source: &str) -> HashSet<usize> {
-    let mut result = HashSet::new();
-    let mut attributes = Vec::new();
-    for item in items {
-        if item.kind() == "attribute_item" {
-            attributes.push(*item);
-        } else {
-            if rust_attribute_group_is_bounded(&attributes, *item, source) {
-                result.extend(attributes.iter().map(|attribute| attribute.id()));
-            }
-            attributes.clear();
-        }
+fn rust_bounded_callsite_category(node: TsNode<'_>) -> bool {
+    node.kind() == "block"
+        || node.kind() == "expression_statement"
+        || node.kind().ends_with("_expression")
+}
+
+fn rust_attribute_body<'source>(
+    attribute: TsNode<'_>,
+    source: &'source str,
+) -> Option<&'source str> {
+    node_text(attribute, source)?
+        .trim()
+        .strip_prefix("#[")?
+        .strip_suffix(']')
+        .map(str::trim)
+}
+
+fn rust_is_outer_doc_comment(node: TsNode<'_>, source: &str) -> bool {
+    let Some(surface) = node_text(node, source).map(str::trim_start) else {
+        return false;
+    };
+    match node.kind() {
+        "line_comment" => surface.starts_with("///") && !surface.starts_with("////"),
+        "block_comment" => surface.starts_with("/**") && !surface.starts_with("/***"),
+        _ => false,
     }
-    result
+}
+
+fn rust_attribute_has_bounded_shape(attribute: TsNode<'_>, source: &str, name: &str) -> bool {
+    let Some(body) = rust_attribute_body(attribute, source) else {
+        return false;
+    };
+    let Some(remainder) = body.strip_prefix(name).map(str::trim) else {
+        return false;
+    };
+    match name {
+        "cfg" | "allow" => remainder
+            .strip_prefix('(')
+            .and_then(|arguments| arguments.strip_suffix(')'))
+            .is_some_and(|arguments| !arguments.trim().is_empty()),
+        "doc" => {
+            remainder
+                .strip_prefix('=')
+                .is_some_and(|value| !value.trim().is_empty())
+                || remainder
+                    .strip_prefix('(')
+                    .and_then(|arguments| arguments.strip_suffix(')'))
+                    .is_some_and(|arguments| !arguments.trim().is_empty())
+        }
+        "inline" => remainder.is_empty() || matches!(remainder, "(always)" | "(never)"),
+        _ => false,
+    }
+}
+
+fn rust_attribute_group_preserves_caller(attributes: &[TsNode<'_>], source: &str) -> bool {
+    attributes.iter().all(|attribute| {
+        rust_is_outer_doc_comment(*attribute, source)
+            || ["cfg", "allow", "doc", "inline"]
+                .into_iter()
+                .any(|name| rust_attribute_has_bounded_shape(*attribute, source, name))
+    })
+}
+
+fn rust_attribute_group_preserves_callsite(attributes: &[TsNode<'_>], source: &str) -> bool {
+    attributes.iter().all(|attribute| {
+        rust_is_outer_doc_comment(*attribute, source)
+            || ["cfg", "allow", "doc"]
+                .into_iter()
+                .any(|name| rust_attribute_has_bounded_shape(*attribute, source, name))
+    })
 }
 
 fn rust_attribute_group_is_bounded(
@@ -6029,6 +6177,9 @@ fn rust_attribute_group_is_bounded(
         })
     });
     attributes.iter().all(|attribute| {
+        if rust_is_outer_doc_comment(*attribute, source) {
+            return true;
+        }
         let Some(surface) = node_text(*attribute, source) else {
             return false;
         };
@@ -6075,12 +6226,19 @@ fn rust_inner_allow_preserves_module_bindings(attribute: TsNode<'_>, source: &st
         == Some("allow")
 }
 
-fn rust_callable_poison_ranges(function: TsNode<'_>, source: &str) -> Vec<(usize, usize)> {
+fn rust_callable_poison_ranges(
+    function: TsNode<'_>,
+    bounded_outer_attribute_ids: &HashSet<usize>,
+    bounded_attributed_callers: &HashSet<usize>,
+    bounded_attributed_callsites: &HashSet<usize>,
+) -> Vec<(usize, usize)> {
     fn collect(
         node: TsNode<'_>,
         root_id: usize,
         scope: (usize, usize),
-        source: &str,
+        bounded_outer_attribute_ids: &HashSet<usize>,
+        bounded_attributed_callers: &HashSet<usize>,
+        bounded_attributed_callsites: &HashSet<usize>,
         output: &mut Vec<(usize, usize)>,
     ) {
         count_rust_resolution_work(1);
@@ -6094,6 +6252,7 @@ fn rust_callable_poison_ranges(function: TsNode<'_>, source: &str) -> Vec<(usize
         };
         if node.kind() == "inner_attribute_item"
             || (node.kind() == "macro_invocation" && rust_macro_can_change_enclosing_bindings(node))
+            || (node.kind() == "use_declaration" && contains_node_kind(node, "use_wildcard"))
         {
             output.push(scope);
         }
@@ -6102,19 +6261,29 @@ fn rust_callable_poison_ranges(function: TsNode<'_>, source: &str) -> Vec<(usize
         let children = node.named_children(&mut cursor).collect::<Vec<_>>();
         let mut pending_attributes = Vec::new();
         for child in children {
-            if child.kind() == "attribute_item" {
+            if child.kind() == "attribute_item" || bounded_outer_attribute_ids.contains(&child.id())
+            {
                 pending_attributes.push(child);
                 continue;
             }
             if !pending_attributes.is_empty() {
-                if rust_attribute_group_is_bounded(&pending_attributes, child, source) {
-                    output.push((child.start_byte(), child.end_byte()));
-                } else {
+                if bounded_attributed_callers.contains(&child.id()) {
+                    output.push((scope.0, child.start_byte()));
+                    output.push((child.end_byte(), scope.1));
+                } else if !bounded_attributed_callsites.contains(&child.id()) {
                     output.push(scope);
                 }
                 pending_attributes.clear();
             }
-            collect(child, root_id, scope, source, output);
+            collect(
+                child,
+                root_id,
+                scope,
+                bounded_outer_attribute_ids,
+                bounded_attributed_callers,
+                bounded_attributed_callsites,
+                output,
+            );
         }
         if !pending_attributes.is_empty() {
             output.push(scope);
@@ -6126,7 +6295,9 @@ fn rust_callable_poison_ranges(function: TsNode<'_>, source: &str) -> Vec<(usize
         function,
         function.id(),
         (function.start_byte(), function.end_byte()),
-        source,
+        bounded_outer_attribute_ids,
+        bounded_attributed_callers,
+        bounded_attributed_callsites,
         &mut ranges,
     );
     ranges.sort_unstable();
@@ -11736,6 +11907,31 @@ mod rust_complexity_tests {
         source
     }
 
+    fn bounded_attribute_source(count: usize) -> String {
+        let mut source =
+            String::from("fn target() {}\n#[cfg(any())]\n#[allow(dead_code)]\nfn caller() {\n");
+        for _ in 0..count {
+            source.push_str(
+                "#[cfg(any())]\n#[allow(dead_code)]\n#[doc = \"bounded\"]\n{ target(); }\n",
+            );
+        }
+        source.push_str("}\n");
+        source
+    }
+
+    fn nested_attributed_module_source(depth: usize) -> String {
+        let mut source = String::new();
+        for index in 0..depth {
+            source.push_str(&format!(
+                "fn target_{index}() {{}}\n#[allow(dead_code)]\nfn caller_{index}() {{ target_{index}(); }}\nmod nested_{index} {{\n"
+            ));
+        }
+        for _ in 0..depth {
+            source.push_str("}\n");
+        }
+        source
+    }
+
     fn measured_projection_work(count: usize) -> usize {
         let temp = tempfile::tempdir().expect("tempdir");
         let path = temp.path().join("lib.rs");
@@ -11858,6 +12054,28 @@ mod rust_complexity_tests {
         assert!(
             large_glob <= small_glob * 2 + 128,
             "glob-local declaration and call work grew superlinearly: {small_glob} -> {large_glob}"
+        );
+
+        let small_attributes = measured_source_work(&bounded_attribute_source(64));
+        let large_attributes = measured_source_work(&bounded_attribute_source(128));
+        assert!(
+            small_attributes >= 64 * 8,
+            "bounded attribute preparation and lookup work was not fully counted: {small_attributes}"
+        );
+        assert!(
+            large_attributes <= small_attributes * 2 + 128,
+            "bounded attribute preparation and lookup work grew superlinearly: {small_attributes} -> {large_attributes}"
+        );
+
+        let small_modules = measured_source_work(&nested_attributed_module_source(64));
+        let large_modules = measured_source_work(&nested_attributed_module_source(128));
+        assert!(
+            small_modules >= 64 * 8,
+            "nested-module attribute preparation was not fully counted: {small_modules}"
+        );
+        assert!(
+            large_modules <= small_modules * 2 + 128,
+            "nested-module attribute preparation grew superlinearly: {small_modules} -> {large_modules}"
         );
     }
 

--- a/crates/codestory-indexer/tests/proof_resolution.rs
+++ b/crates/codestory-indexer/tests/proof_resolution.rs
@@ -5965,6 +5965,23 @@ fn assert_no_exact_target_calls(files: &[(&str, &str)]) -> anyhow::Result<()> {
     Ok(())
 }
 
+fn rust_call_facts(
+    source: &str,
+    raw_target: &str,
+) -> anyhow::Result<Vec<codestory_contracts::proof_resolution::CallResolutionFact>> {
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(project.path(), &mut store, &[("src/lib.rs", source)])?;
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    let mut facts = store
+        .get_proof_resolution_facts()?
+        .into_iter()
+        .filter(|fact| fact.callsite.raw_target == raw_target)
+        .collect::<Vec<_>>();
+    facts.sort_by_key(|fact| fact.callsite.start_byte);
+    Ok(facts)
+}
+
 fn rust_fact_after_forcing_call_target(
     files: &[(&str, &str)],
     raw_target: &str,
@@ -7218,7 +7235,7 @@ fn complete_projection_rejects_cache_schema_adapter_and_language_mismatch() -> a
             .expect_err("cache provenance mismatch must reject the complete projection");
         let message = error.to_string();
         assert!(
-            ["stale", "schema-v14", "adapter", "language"]
+            ["stale", "schema-v15", "adapter", "language"]
                 .iter()
                 .any(|needle| message.contains(needle)),
             "{mutation}: {error}"
@@ -7305,7 +7322,6 @@ fn rust_module_closure_ignores_unrelated_closed_expression_macros() -> anyhow::R
         "macro_rules! foreign_target { () => { fn target(); }; }\nunsafe extern \"C\" { foreign_target!(); }\nfn target() {}\nfn caller() { target(); }\n",
         "#![cfg(any())]\nfn target() {}\nfn caller() { target(); }\n",
         "#[cfg(any())]\nfn target() {}\nfn target() {}\nfn caller() { target(); }\n",
-        "fn target() {}\n#[cfg(any())]\nfn caller() { target(); }\n",
     ] {
         assert_only_call_is_not_exact(&[("src/lib.rs", source)])?;
     }
@@ -7398,8 +7414,6 @@ fn rust_glob_local_precedence_keeps_attributes_macros_and_incomplete_domains_clo
 -> anyhow::Result<()> {
     for source in [
         "use crate::*;\n#[cfg(any())]\nfn target() {}\nfn caller() { target(); }\n",
-        "use crate::*;\nfn target() {}\n#[cfg(any())]\nfn caller() { target(); }\n",
-        "use crate::*;\nfn target() {}\nfn caller() { #[cfg(any())] { target(); } }\n",
         "use crate::*;\nmacro_rules! duplicate { () => { fn target() {} }; }\nduplicate!();\nfn target() {}\nfn caller() { target(); }\n",
         "use crate::*;\nmacro_rules! shadow { () => { let target: fn() = || {}; }; }\nfn target() {}\nfn caller() { shadow!(); target(); }\n",
         "use crate::*;\ninclude!(\"generated.rs\");\nfn target() {}\nfn caller() { target(); }\n",
@@ -7415,6 +7429,14 @@ fn rust_glob_local_precedence_keeps_attributes_macros_and_incomplete_domains_clo
     assert_only_call_is_not_exact(&[(
         "src/lib.rs",
         "mod possible { pub fn target() {} }\nuse possible::*;\nfn caller() { target(); }\n",
+    )])?;
+    assert_only_call_is_exact(&[(
+        "src/lib.rs",
+        "use crate::*;\nfn target() {}\n#[cfg(any())]\nfn caller() { target(); }\n",
+    )])?;
+    assert_only_call_is_exact(&[(
+        "src/lib.rs",
+        "use crate::*;\nfn target() {}\nfn caller() { #[cfg(any())] { target(); } }\n",
     )])?;
     Ok(())
 }
@@ -7541,7 +7563,7 @@ fn rust_glob_local_calls_preserve_repeated_source_coordinates_and_provenance() -
     );
     assert!(facts.iter().all(|fact| {
         fact.provenance.language_adapter == "rust"
-            && fact.provenance.language_adapter_version == "reference-v17"
+            && fact.provenance.language_adapter_version == "reference-v18"
             && fact.provenance.dependency_file_hashes.len() == 1
             && matches!(
                 fact.evidence_chain.as_slice(),
@@ -7573,12 +7595,12 @@ fn stale_rust_glob_local_adapter_inputs_reject_rematerialization() -> anyhow::Re
         |row| row.get::<_, Vec<u8>>(0),
     )?;
     let mut artifact: serde_json::Value = serde_json::from_slice(&artifact_blob)?;
-    artifact["resolution_file"]["adapter_version"] = "reference-v16".into();
+    artifact["resolution_file"]["adapter_version"] = "reference-v17".into();
     for call in artifact["call_resolution_inputs"]
         .as_array_mut()
         .expect("call inputs")
     {
-        call["adapter_version"] = "reference-v16".into();
+        call["adapter_version"] = "reference-v17".into();
     }
     store.get_connection().execute(
         "UPDATE index_artifact_cache SET artifact_blob = ?1",
@@ -7615,7 +7637,7 @@ fn proof_resolution_roster_tracks_the_current_adapter_version() -> anyhow::Resul
             .iter()
             .find(|adapter| adapter.language == "rust")
             .map(|adapter| adapter.adapter_version.as_str()),
-        Some("reference-v17")
+        Some("reference-v18")
     );
     assert_eq!(
         receipt
@@ -7631,6 +7653,306 @@ fn proof_resolution_roster_tracks_the_current_adapter_version() -> anyhow::Resul
                 && adapter.adapter_version == fact.provenance.language_adapter_version
         }));
     }
+    Ok(())
+}
+
+#[test]
+fn rust_bounded_outer_attributes_preserve_plain_same_file_callers() -> anyhow::Result<()> {
+    for attributes in [
+        "#[cfg(any())]",
+        "#[allow(dead_code)]",
+        "#[doc = \"bounded caller\"]",
+        "#[inline]",
+        "#[cfg(any())]\n#[allow(dead_code)]\n#[doc = \"composed\"]\n#[inline(always)]",
+        "#[cfg(any())]\n// ordinary comment\n#[allow(dead_code)]",
+    ] {
+        let source = format!("fn target() {{}}\n{attributes}\nfn caller() {{ target(); }}\n");
+        assert_only_call_is_exact(&[("src/lib.rs", source.as_str())])?;
+    }
+    assert_only_call_is_exact(&[(
+        "src/lib.rs",
+        "fn target() {}\nfn outer() { #[allow(dead_code)] fn caller() { target(); } caller(); }\n",
+    )])?;
+    Ok(())
+}
+
+#[test]
+fn rust_bounded_callsite_regions_preserve_coordinates_order_and_provenance() -> anyhow::Result<()> {
+    let source = "// é\r\nfn target() {}\r\n#[cfg(any())]\r\n#[allow(dead_code)]\r\nfn caller() { target();\r\n#[cfg(any())]\r\n#[allow(dead_code)]\r\n#[doc = \"nested\"]\r\n{ target(); target(); }\r\n#[doc = \"last\"]\r\n{ target(); }\r\ntarget(); }";
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(project.path(), &mut store, &[("src/lib.rs", source)])?;
+    let first = rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    store.validate_proof_resolution_publication(&publication(1))?;
+    let mut facts = store
+        .get_proof_resolution_facts()?
+        .into_iter()
+        .filter(|fact| fact.callsite.raw_target == "target")
+        .collect::<Vec<_>>();
+    facts.sort_by_key(|fact| fact.callsite.start_byte);
+
+    let expected_starts = source
+        .match_indices("target();")
+        .map(|(start, _)| start as u64)
+        .collect::<Vec<_>>();
+    assert_eq!(facts.len(), expected_starts.len(), "{facts:#?}");
+    assert_eq!(
+        facts
+            .iter()
+            .map(|fact| fact.callsite.start_byte)
+            .collect::<Vec<_>>(),
+        expected_starts
+    );
+    assert_eq!(
+        facts
+            .iter()
+            .filter_map(|fact| fact.edge_id)
+            .collect::<BTreeSet<_>>()
+            .len(),
+        facts.len(),
+        "one ordinary edge must authorize one bounded callsite"
+    );
+    for (fact, start) in facts.iter().zip(expected_starts) {
+        let line_start = source[..start as usize]
+            .rfind('\n')
+            .map_or(0, |newline| newline + 1);
+        let line = source[..start as usize]
+            .bytes()
+            .filter(|byte| *byte == b'\n')
+            .count() as u32
+            + 1;
+        assert_eq!(fact.status, ProofResolutionStatus::Exact, "{fact:#?}");
+        assert_eq!(fact.callsite.start_byte, start);
+        assert_eq!(
+            fact.callsite.end_byte_exclusive,
+            start + "target".len() as u64
+        );
+        assert_eq!(fact.callsite.line, line);
+        assert_eq!(
+            fact.callsite.column,
+            (start as usize - line_start + 1) as u32
+        );
+        assert_eq!(fact.provenance.language_adapter, "rust");
+        assert_eq!(fact.provenance.language_adapter_version, "reference-v18");
+        assert_eq!(fact.provenance.dependency_file_hashes.len(), 1);
+        assert!(matches!(
+            fact.evidence_chain.as_slice(),
+            [ResolutionEvidence::SameFileDeclaration { declaration }]
+                if Some(*declaration) == fact.target
+        ));
+    }
+
+    let second = rematerialize_proof_resolution_projection(&mut store, &publication(2))?;
+    assert_eq!(first.fact_count, second.fact_count);
+    assert_eq!(first.fact_digest, second.fact_digest);
+    Ok(())
+}
+
+#[test]
+fn rust_unbounded_caller_and_callsite_attributes_remain_incomplete() -> anyhow::Result<()> {
+    for attributes in [
+        "#[cfg_attr(any(), allow(dead_code))]",
+        "#[unresolved_attribute_macro]",
+        "#[test]",
+        "#[tokio::test]",
+        "#[async_trait]",
+        "#[tool::instrument]",
+        "#[inline(sometimes)]",
+        "#[unresolved_attribute_macro]\n// ordinary comment",
+    ] {
+        let source = format!("fn target() {{}}\n{attributes}\nfn caller() {{ target(); }}\n");
+        assert_only_call_is_not_exact(&[("src/lib.rs", source.as_str())])?;
+    }
+    assert_only_call_is_not_exact(&[(
+        "src/lib.rs",
+        "fn target() {}\nfn outer() { #[unresolved_attribute_macro] fn caller() { target(); } caller(); }\n",
+    )])?;
+    for attributes in [
+        "#[cfg_attr(any(), allow(dead_code))]",
+        "#[unresolved_attribute_macro]",
+        "#[tokio::test]",
+        "#[inline]",
+    ] {
+        let source = format!("fn target() {{}}\nfn caller() {{ {attributes}\n{{ target(); }} }}\n");
+        assert_only_call_is_not_exact(&[("src/lib.rs", source.as_str())])?;
+    }
+    Ok(())
+}
+
+#[test]
+fn rust_bounded_attributes_do_not_authorize_attributed_targets_or_competing_bindings()
+-> anyhow::Result<()> {
+    for target_attributes in [
+        "#[cfg(any())]",
+        "#[allow(dead_code)]",
+        "#[doc = \"attributed target\"]",
+        "#[inline]",
+        "/// attributed target",
+        "/** attributed target */",
+    ] {
+        let source = format!(
+            "{target_attributes}\nfn target() {{}}\n#[allow(dead_code)]\nfn caller() {{ target(); }}\n"
+        );
+        assert_only_call_is_not_exact(&[("src/lib.rs", source.as_str())])?;
+    }
+
+    for source in [
+        "#[cfg(any())]\nfn target() {}\nfn target() {}\n#[allow(dead_code)]\nfn caller() { target(); }\n",
+        "mod other { pub fn target() {} }\n#[cfg(any())]\nuse other::target;\nfn target() {}\n#[allow(dead_code)]\nfn caller() { target(); }\n",
+        "fn target() {}\n#[allow(dead_code)]\nfn caller() { #[cfg(any())] { let target: fn() = || {}; target(); } }\n",
+        "fn target() {}\n#[allow(dead_code)]\nfn caller(target: fn()) { target(); }\n",
+        "fn target() {}\n#[allow(dead_code)]\nfn caller() { fn target() {} target(); }\n",
+        "struct Worker;\nimpl Worker { fn target(&self) {} #[allow(dead_code)] fn caller(&self) { self.target(); } }\n",
+        "fn target() {}\ntrait Worker { #[allow(dead_code)] fn caller(&self) { target(); } }\n",
+    ] {
+        assert_only_call_is_not_exact(&[("src/lib.rs", source)])?;
+    }
+    Ok(())
+}
+
+#[test]
+fn rust_bounded_attributes_keep_binding_macros_closed_without_poisoning_expression_macros()
+-> anyhow::Result<()> {
+    assert_only_call_is_not_exact(&[(
+        "src/lib.rs",
+        "macro_rules! shadow { () => { let target: fn() = || {}; }; }\nfn target() {}\n#[allow(dead_code)]\nfn caller() { shadow!(); target(); }\n",
+    )])?;
+    assert_only_call_is_exact(&[(
+        "src/lib.rs",
+        "fn target() {}\n#[allow(dead_code)]\nfn caller() { let _ = concat!(\"unrelated\", \"expression\"); target(); }\n",
+    )])?;
+    assert_no_exact_target_calls(&[(
+        "src/lib.rs",
+        "macro_rules! tokens { ($value:expr) => {}; }\nfn target() {}\n#[allow(dead_code)]\nfn caller() { tokens!(target()); }\n",
+    )])?;
+    Ok(())
+}
+
+#[test]
+fn rust_block_local_wildcard_imports_poison_their_complete_lexical_scope() -> anyhow::Result<()> {
+    for local_import in [
+        "use crate::*;",
+        "use crate::{*};",
+        "use crate::{self, *};",
+        "use crate::{nested::{*}};",
+        "use crate::{nested::{self, *}};",
+        "#[cfg(any())] use crate::*;",
+        "#[allow(unused_imports)] use crate::{*};",
+        "#[doc = \"conditional import\"] use crate::{self, *};",
+    ] {
+        let source = format!(
+            "mod nested {{ pub fn different() {{}} }}\nfn target() {{}}\nfn caller() {{ target(); {local_import} target(); }}\n"
+        );
+        let facts = rust_call_facts(&source, "target")?;
+        assert_eq!(facts.len(), 2, "{local_import}: {facts:#?}");
+        assert!(
+            facts
+                .iter()
+                .all(|fact| fact.status != ProofResolutionStatus::Exact),
+            "{local_import}: {facts:#?}"
+        );
+    }
+
+    let sibling_source =
+        "fn target() {}\nfn caller() {\n  { target(); }\n  { use crate::*; }\n  { target(); }\n}\n";
+    let sibling_facts = rust_call_facts(sibling_source, "target")?;
+    assert_eq!(sibling_facts.len(), 2, "{sibling_facts:#?}");
+    assert!(
+        sibling_facts
+            .iter()
+            .all(|fact| fact.status == ProofResolutionStatus::Exact),
+        "a wildcard import must not poison sibling lexical scopes: {sibling_facts:#?}"
+    );
+
+    let explicit_import = "mod nested { pub fn different() {} }\nfn target() {}\nfn caller() { target(); use crate::nested::different; target(); }\n";
+    let explicit_facts = rust_call_facts(explicit_import, "target")?;
+    assert_eq!(explicit_facts.len(), 2, "{explicit_facts:#?}");
+    assert!(
+        explicit_facts
+            .iter()
+            .all(|fact| fact.status == ProofResolutionStatus::Exact),
+        "an explicit different-name import remains name-specific: {explicit_facts:#?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn rust_bounded_preservation_never_authorizes_imports_or_declarations() -> anyhow::Result<()> {
+    for statement in [
+        "#[cfg(any())] use crate::nested::different;",
+        "#[allow(dead_code)] fn unrelated() {}",
+        "#[doc = \"conditional declaration\"] const UNRELATED: usize = 0;",
+    ] {
+        let source = format!(
+            "mod nested {{ pub fn different() {{}} }}\nfn target() {{}}\nfn caller() {{ target(); {statement} target(); }}\n"
+        );
+        let facts = rust_call_facts(&source, "target")?;
+        assert_eq!(facts.len(), 2, "{statement}: {facts:#?}");
+        assert!(
+            facts
+                .iter()
+                .all(|fact| fact.status != ProofResolutionStatus::Exact),
+            "bounded metadata cannot preserve a binding-changing declaration: {statement}: {facts:#?}"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn rust_prepared_incompleteness_propagates_through_traits_and_nested_callables()
+-> anyhow::Result<()> {
+    for trait_attribute in [
+        "#[cfg(any())]",
+        "#[allow(dead_code)]",
+        "#[doc = \"conditional trait\"]",
+    ] {
+        let source = format!(
+            "fn target() {{}}\n{trait_attribute}\ntrait Worker {{ fn direct(&self); fn caller(&self) {{ target(); }} }}\n"
+        );
+        let facts = rust_call_facts(&source, "target")?;
+        assert_eq!(facts.len(), 1, "{trait_attribute}: {facts:#?}");
+        assert_ne!(
+            facts[0].status,
+            ProofResolutionStatus::Exact,
+            "an attributed trait poisons its default method: {trait_attribute}: {facts:#?}"
+        );
+    }
+
+    for parent_region in [
+        "#[unresolved_attribute_macro] { fn child() { target(); } }",
+        "#[cfg_attr(any(), allow(dead_code))] { fn child() { target(); } }",
+        "#[tool::instrument] { fn child() { target(); } }",
+        "{ #![unresolved_attribute_macro] fn child() { target(); } }",
+        "{ shadow!(); fn child() { target(); } }",
+    ] {
+        let source = format!(
+            "macro_rules! shadow {{ () => {{ let target: fn() = || {{}}; }}; }}\nfn target() {{}}\nfn outer() {{ {parent_region} }}\n"
+        );
+        let facts = rust_call_facts(&source, "target")?;
+        assert_eq!(facts.len(), 1, "{parent_region}: {facts:#?}");
+        assert_ne!(
+            facts[0].status,
+            ProofResolutionStatus::Exact,
+            "a nested callable inherits its parent's prepared domain decision: {parent_region}: {facts:#?}"
+        );
+    }
+
+    assert_only_call_is_exact(&[(
+        "src/lib.rs",
+        "fn target() {}\nfn outer() { #[cfg(any())] { fn child() { target(); } } }\n",
+    )])?;
+    assert_only_call_is_exact(&[(
+        "src/lib.rs",
+        "fn target() {}\nfn outer() { let target: fn() = || {}; fn child() { target(); } child(); }\n",
+    )])?;
+
+    let sibling_source = "fn poisoned_target() {}\nfn safe_target() {}\nfn outer() {\n  { #[unresolved_attribute_macro] { fn poisoned() { poisoned_target(); } } }\n  { fn safe() { safe_target(); } }\n}\n";
+    let poisoned = rust_call_facts(sibling_source, "poisoned_target")?;
+    let safe = rust_call_facts(sibling_source, "safe_target")?;
+    assert_eq!(poisoned.len(), 1, "{poisoned:#?}");
+    assert_ne!(poisoned[0].status, ProofResolutionStatus::Exact);
+    assert_eq!(safe.len(), 1, "{safe:#?}");
+    assert_eq!(safe[0].status, ProofResolutionStatus::Exact, "{safe:#?}");
     Ok(())
 }
 


### PR DESCRIPTION
## Context

Rust's exact-resolution adapter previously treated every outer-attributed caller and callsite region as incomplete. This left deterministic same-file calls unavailable even when the attribute class was bounded and the target was one plain declaration.

This change targets `dev/codestory-0.18` only. The public proof route remains dark.

Closes #2058
Refs #2023

## What changed

- prepares one Rust attribute index and reuses it during module, callable, and callsite classification;
- admits bounded `cfg`, `allow`, `doc`, and function `inline` callers plus bounded `cfg`, `allow`, and `doc` callsite regions;
- keeps attributed targets, imports, modules, impls, methods, macros, and incomplete lexical domains non-exact;
- closes wildcard-import domains at their lexical scope, including all wildcard syntax forms;
- propagates attributed-domain incompleteness through traits and nested callables;
- classifies direct methods during the prepared traversal and keeps measured preparation/lookup linear;
- bumps the Rust adapter and parser-cache input versions together.

Changed source is limited to:

- `crates/codestory-indexer/src/cache.rs`
- `crates/codestory-indexer/src/proof_resolution.rs`
- `crates/codestory-indexer/tests/proof_resolution.rs`

## Review

One consolidated adversarial review covered language-domain closure, parser provenance, graph/fact correlation, repeated callsites, source coordinates, native ordering, storage integrity, and complexity. Its complete correction batch is in this head; no second stylistic review was started.

Review the attribute preparation and lexical poison ranges first, then the hostile matrix. The important negative boundary is that documentation is an outer target attribute: documented targets remain non-exact even when the caller is supported.

## Verification

Frozen head: `063ea37a614c3f605ae66e50960d0066a835f519`

Tree: `44dc27fc8d8f21abd48bbd7e7a6f9407ac41a23b`

Focused checks:

- proof-resolution: 131/131
- complexity: 2/2, including 64/128 nested-module scaling
- store integrity: 25/25
- dark architecture: 2/2
- fidelity: 8/8
- language coverage: 13/13

Accepted exact-head checks:

- `cargo fmt --all -- --check`
- `cargo check --locked --workspace`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo nextest run --locked --workspace --no-fail-fast`: 4,086 passed, 34 skipped, 2 slow, zero failed
- `cargo test --locked --workspace --doc`
- no-default evidence-separation build and sealed four-revision conformance probe
- `git diff --check`

Qualification binary SHA-256: `554c5b661bf56b26326bde0fd60d21607033e98be2d8371a9e91975b6aaa06dc`

Q2 `20260825T092530Z-063ea37a614c` materialized, ran, and verified once. Results digest: `6b34c466f3ee9803f0c2ed12a63e6ac4151a33ecaf69796893616d2a3ded3c6a`.

- 90/120 full proofs; Rust 19/30
- 229/312 exact steps
- 96/120 full-or-useful partials
- every hard gate is zero
- decision: `keep_proof_dark`

The issue's 95/120 expectation was measurement, not authority. The consolidated soundness fix correctly withdraws prior receipts whose targets carry outer doc attributes, as H6 requires. The supported slice still adds Rust 01 steps 0 and 3 and completes Rust 08 and 16. Rust 19 remains unknown because its target is documented. No threshold, corpus, graph, DTO, runtime route, or release surface changed.

## Risk

The risk is conservative Rust proof availability. Retrieval and navigation keep their existing graph behavior, and the proof route remains production-unreachable. No 0.17 source or release surface is touched.
