### PR TITLE
[proof availability] Preserve Go receiver-qualified method identity

### DIFF
--- a/crates/codestory-indexer/src/cache.rs
+++ b/crates/codestory-indexer/src/cache.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::path::{Component, Path, PathBuf};
 
 // Versioned with proof-input semantics so older parser artifacts fail closed.
-const INDEX_ARTIFACT_CACHE_VERSION: u32 = 14;
+const INDEX_ARTIFACT_CACHE_VERSION: u32 = 16;
 const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
 const FNV_PRIME: u64 = 0x00000100000001B3;
 

--- a/crates/codestory-indexer/src/languages/go.rs
+++ b/crates/codestory-indexer/src/languages/go.rs
@@ -110,90 +110,109 @@ fn go_language() -> tree_sitter::Language {
 
 pub(crate) fn member_edge_specs(tree: &Tree, source: &str) -> Vec<ManualMemberEdgeSpec> {
     let mut edges = Vec::new();
-    walk_tree_nodes(tree.root_node(), &mut |node| match node.kind() {
-        "method_declaration" => {
-            let Some(method_name_node) = node.child_by_field_name("name") else {
-                return;
-            };
-            let Some(receiver_node) = node.child_by_field_name("receiver") else {
-                return;
-            };
-            let Some(source_name) = go_receiver_owner_name(receiver_node, source) else {
-                return;
-            };
-            let Some(target_name) = trimmed_node_text(method_name_node, source) else {
-                return;
-            };
+    let owner_specs = go_package_type_specs_by_name(tree.root_node(), source);
+    walk_tree_nodes(tree.root_node(), &mut |node| {
+        count_go_navigation_resolution_work(1);
+        match node.kind() {
+            "method_declaration" => {
+                if node.has_error() || node.is_error() || node.is_missing() {
+                    return;
+                }
+                let Some(method_name_node) = node.child_by_field_name("name") else {
+                    return;
+                };
+                let Some(receiver_node) = node.child_by_field_name("receiver") else {
+                    return;
+                };
+                let Some(source_name) = go_declared_receiver_owner_name(receiver_node, source)
+                else {
+                    return;
+                };
+                let Some(target_name) = trimmed_node_text(method_name_node, source) else {
+                    return;
+                };
+                let source_span = owner_specs
+                    .get(&source_name)
+                    .copied()
+                    .flatten()
+                    .and_then(|owner| owner.parent())
+                    .filter(|parent| parent.kind() == "type_declaration")
+                    .map(ts_node_graph_span)
+                    .unwrap_or_else(|| ts_node_graph_span(receiver_node));
 
-            edges.push(ManualMemberEdgeSpec {
-                source_name,
-                target_name,
-                source_span: ts_node_graph_span(
-                    receiver_owner_declaration_node(tree.root_node(), source, receiver_node)
-                        .unwrap_or(receiver_node),
-                ),
-                target_span: ts_node_graph_span(node),
-                line: Some(node.start_position().row as u32 + 1),
-            });
-        }
-        "method_elem" => {
-            let Some(owner_node) = enclosing_node_with_kind(node, &["type_declaration"]) else {
-                return;
-            };
-            let Some(owner_name_node) = descendant_by_field_name(owner_node, "name") else {
-                return;
-            };
-            let Some(source_name) = trimmed_node_text(owner_name_node, source) else {
-                return;
-            };
-            let Some(method_name_node) = node.child_by_field_name("name") else {
-                return;
-            };
-            let Some(target_name) = trimmed_node_text(method_name_node, source) else {
-                return;
-            };
+                edges.push(ManualMemberEdgeSpec {
+                    source_name,
+                    target_name,
+                    source_span,
+                    target_span: ts_node_graph_span(node),
+                    line: Some(node.start_position().row as u32 + 1),
+                });
+            }
+            "method_elem" => {
+                let Some(owner_node) = enclosing_node_with_kind(node, &["type_declaration"]) else {
+                    return;
+                };
+                let Some(owner_name_node) = descendant_by_field_name(owner_node, "name") else {
+                    return;
+                };
+                let Some(source_name) = trimmed_node_text(owner_name_node, source) else {
+                    return;
+                };
+                let Some(method_name_node) = node.child_by_field_name("name") else {
+                    return;
+                };
+                let Some(target_name) = trimmed_node_text(method_name_node, source) else {
+                    return;
+                };
 
-            edges.push(ManualMemberEdgeSpec {
-                source_name,
-                target_name,
-                source_span: ts_node_graph_span(owner_node),
-                target_span: ts_node_graph_span(node),
-                line: Some(node.start_position().row as u32 + 1),
-            });
+                edges.push(ManualMemberEdgeSpec {
+                    source_name,
+                    target_name,
+                    source_span: ts_node_graph_span(owner_node),
+                    target_span: ts_node_graph_span(node),
+                    line: Some(node.start_position().row as u32 + 1),
+                });
+            }
+            _ => {}
         }
-        _ => {}
     });
     edges
 }
 
-fn receiver_owner_declaration_node<'tree>(
+fn go_package_type_specs_by_name<'tree>(
     root: TsNode<'tree>,
     source: &str,
-    receiver_node: TsNode<'tree>,
-) -> Option<TsNode<'tree>> {
-    let owner_name = go_receiver_owner_name(receiver_node, source)?;
-    find_go_type_declaration_by_name(root, source, &owner_name)
-}
-
-fn find_go_type_declaration_by_name<'tree>(
-    node: TsNode<'tree>,
-    source: &str,
-    owner_name: &str,
-) -> Option<TsNode<'tree>> {
-    if node.kind() == "type_declaration"
-        && let Some(name_node) = descendant_by_field_name(node, "name")
-        && trimmed_node_text(name_node, source).as_deref() == Some(owner_name)
-    {
-        return Some(node);
-    }
-
-    let mut cursor = node.walk();
-    for child in node.named_children(&mut cursor) {
-        if let Some(found) = find_go_type_declaration_by_name(child, source, owner_name) {
-            return Some(found);
+) -> HashMap<String, Option<TsNode<'tree>>> {
+    let mut specs = HashMap::new();
+    let mut root_cursor = root.walk();
+    for declaration in root.named_children(&mut root_cursor) {
+        count_go_navigation_resolution_work(1);
+        if declaration.kind() != "type_declaration" {
+            continue;
+        }
+        let mut declaration_cursor = declaration.walk();
+        for spec in declaration.named_children(&mut declaration_cursor) {
+            count_go_navigation_resolution_work(1);
+            if spec.kind() != "type_spec" {
+                continue;
+            }
+            let Some(name) = spec
+                .child_by_field_name("name")
+                .and_then(|name_node| trimmed_node_text(name_node, source))
+            else {
+                continue;
+            };
+            match specs.entry(name) {
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    entry.insert(Some(spec));
+                }
+                std::collections::hash_map::Entry::Occupied(mut entry) => {
+                    entry.insert(None);
+                }
+            }
         }
     }
-    None
+    specs
 }
 
 fn go_receiver_owner_name(receiver_node: TsNode<'_>, source: &str) -> Option<String> {
@@ -205,6 +224,69 @@ fn go_receiver_owner_name(receiver_node: TsNode<'_>, source: &str) -> Option<Str
         .trim();
     let raw_owner = inner.split_whitespace().last()?.trim();
     normalize_go_type_surface(raw_owner)
+}
+
+fn go_declared_receiver_owner_name(receiver_node: TsNode<'_>, source: &str) -> Option<String> {
+    if receiver_node.kind() != "parameter_list"
+        || receiver_node.has_error()
+        || receiver_node.is_error()
+        || receiver_node.is_missing()
+    {
+        return None;
+    }
+    let mut receiver_cursor = receiver_node.walk();
+    let parameters = receiver_node
+        .named_children(&mut receiver_cursor)
+        .collect::<Vec<_>>();
+    let [parameter] = parameters.as_slice() else {
+        return None;
+    };
+    if parameter.kind() != "parameter_declaration"
+        || parameter.has_error()
+        || parameter.is_error()
+        || parameter.is_missing()
+    {
+        return None;
+    }
+    let mut name_cursor = parameter.walk();
+    if parameter
+        .children_by_field_name("name", &mut name_cursor)
+        .count()
+        > 1
+    {
+        return None;
+    }
+    let type_node = parameter.child_by_field_name("type")?;
+    if type_node.has_error() || type_node.is_error() || type_node.is_missing() {
+        return None;
+    }
+    let owner_node = match type_node.kind() {
+        "type_identifier" => type_node,
+        "pointer_type" => {
+            let mut pointer_cursor = type_node.walk();
+            let children = type_node
+                .named_children(&mut pointer_cursor)
+                .collect::<Vec<_>>();
+            let [owner] = children.as_slice() else {
+                return None;
+            };
+            if owner.kind() != "type_identifier"
+                || owner.has_error()
+                || owner.is_error()
+                || owner.is_missing()
+            {
+                return None;
+            }
+            *owner
+        }
+        _ => return None,
+    };
+    let owner = trimmed_node_text(owner_node, source)?;
+    if normalize_parameter_name(&owner).as_deref() == Some(owner.as_str()) {
+        Some(owner)
+    } else {
+        None
+    }
 }
 
 fn normalize_go_type_surface(raw: &str) -> Option<String> {
@@ -245,6 +327,8 @@ fn go_exact_type_surface(raw: &str) -> Option<(Option<String>, String)> {
 pub(crate) fn receiver_call_specs(tree: &Tree, source: &str) -> Vec<ManualReceiverCallSpec> {
     let mut edges = Vec::new();
     let import_bindings = collect_go_import_bindings(source);
+    let package_owner_specs = go_package_type_specs_by_name(tree.root_node(), source);
+    let file_scope_names = go_file_scope_names(tree.root_node(), source);
     walk_tree_nodes(tree.root_node(), &mut |callable| {
         count_go_navigation_resolution_work(1);
         if !matches!(
@@ -269,14 +353,15 @@ pub(crate) fn receiver_call_specs(tree: &Tree, source: &str) -> Vec<ManualReceiv
                 span: call_source.span,
             },
             &import_bindings,
+            &file_scope_names,
             &mut local_binding_callsites,
             &mut edges,
         );
         let method_receiver_bindings = collect_go_method_receiver_bindings(
             callable,
-            tree.root_node(),
             source,
             &import_bindings,
+            &package_owner_specs,
         );
         let mut receiver_types = method_receiver_bindings
             .iter()
@@ -324,13 +409,14 @@ fn collect_go_local_composite_receiver_call_specs(
     source: &str,
     call_source: ManualReceiverSource<'_>,
     import_bindings: &HashMap<String, String>,
+    file_scope_names: &HashSet<String>,
     local_binding_callsites: &mut HashSet<ReceiverCallSiteKey>,
     edges: &mut Vec<ManualReceiverCallSpec>,
 ) {
     let mut calls = Vec::new();
     let mut intervals = Vec::new();
     let builtin_new_unshadowed = !import_bindings.contains_key("new")
-        && !go_file_scope_name_is_shadowed(callable, "new", source)
+        && !file_scope_names.contains("new")
         && !go_callable_declares_name(callable, "new", source);
     walk_tree_nodes(callable, &mut |node| {
         count_go_navigation_resolution_work(1);
@@ -488,7 +574,12 @@ fn collect_go_local_composite_receiver_call_specs(
             owner: None,
         });
     });
-    let decisions = go_navigation_binding_decisions(source.len(), &intervals, &calls);
+    let decisions = go_navigation_binding_decisions(
+        callable.start_byte(),
+        callable.end_byte(),
+        &intervals,
+        &calls,
+    );
     for call in calls {
         let Some(owner) = decisions.get(&call.node.id()) else {
             continue;
@@ -542,22 +633,26 @@ enum GoNavigationEvent {
 }
 
 fn go_navigation_binding_decisions(
-    source_len: usize,
+    range_start: usize,
+    range_end: usize,
     intervals: &[GoNavigationBindingInterval],
     calls: &[GoNavigationCall<'_>],
 ) -> HashMap<usize, OptionalReceiverOwnerBinding> {
-    let mut events = vec![Vec::new(); source_len.saturating_add(1)];
+    let mut events = vec![Vec::new(); range_end.saturating_sub(range_start).saturating_add(1)];
     for (index, interval) in intervals.iter().enumerate() {
-        if interval.start_byte >= interval.end_byte || interval.end_byte > source_len {
+        if interval.start_byte < range_start
+            || interval.start_byte >= interval.end_byte
+            || interval.end_byte > range_end
+        {
             continue;
         }
-        events[interval.start_byte].push(GoNavigationEvent::Start(index));
-        events[interval.end_byte].push(GoNavigationEvent::End(index));
+        events[interval.start_byte - range_start].push(GoNavigationEvent::Start(index));
+        events[interval.end_byte - range_start].push(GoNavigationEvent::End(index));
         count_go_navigation_resolution_work(2);
     }
     for (index, call) in calls.iter().enumerate() {
-        if call.node.start_byte() <= source_len {
-            events[call.node.start_byte()].push(GoNavigationEvent::Call(index));
+        if (range_start..=range_end).contains(&call.node.start_byte()) {
+            events[call.node.start_byte() - range_start].push(GoNavigationEvent::Call(index));
             count_go_navigation_resolution_work(1);
         }
     }
@@ -863,43 +958,47 @@ fn go_callable_declares_name(callable: TsNode<'_>, name: &str, source: &str) -> 
     shadowed
 }
 
-fn go_file_scope_name_is_shadowed(call: TsNode<'_>, name: &str, source: &str) -> bool {
-    let mut root = call;
-    while let Some(parent) = root.parent() {
-        root = parent;
-    }
+fn go_file_scope_names(root: TsNode<'_>, source: &str) -> HashSet<String> {
+    let mut names = HashSet::new();
     let mut cursor = root.walk();
-    root.named_children(&mut cursor)
-        .any(|declaration| match declaration.kind() {
+    for declaration in root.named_children(&mut cursor) {
+        count_go_navigation_resolution_work(1);
+        match declaration.kind() {
             "function_declaration" => {
-                declaration
+                if let Some(name) = declaration
                     .child_by_field_name("name")
                     .and_then(|node| trimmed_node_text(node, source))
-                    .as_deref()
-                    == Some(name)
+                {
+                    names.insert(name);
+                }
             }
             "type_declaration" | "var_declaration" | "const_declaration" => {
-                let mut found = false;
-                walk_tree_nodes(declaration, &mut |node| {
-                    if found || !matches!(node.kind(), "type_spec" | "var_spec" | "const_spec") {
-                        return;
+                let mut declaration_cursor = declaration.walk();
+                let mut pending = declaration
+                    .named_children(&mut declaration_cursor)
+                    .collect::<Vec<_>>();
+                while let Some(spec) = pending.pop() {
+                    count_go_navigation_resolution_work(1);
+                    if spec.kind() == "var_spec_list" {
+                        let mut list_cursor = spec.walk();
+                        pending.extend(spec.named_children(&mut list_cursor));
+                        continue;
                     }
-                    let boundary = node
-                        .child_by_field_name("type")
-                        .or_else(|| node.child_by_field_name("value"))
-                        .map(|child| child.start_byte())
-                        .unwrap_or(usize::MAX);
-                    let mut cursor = node.walk();
-                    found = node.named_children(&mut cursor).any(|child| {
-                        child.start_byte() < boundary
-                            && matches!(child.kind(), "identifier" | "field_identifier")
-                            && normalized_receiver_variable(child, source).as_deref() == Some(name)
-                    });
-                });
-                found
+                    if !matches!(spec.kind(), "type_spec" | "var_spec" | "const_spec") {
+                        continue;
+                    }
+                    let mut name_cursor = spec.walk();
+                    for name_node in spec.children_by_field_name("name", &mut name_cursor) {
+                        if let Some(name) = normalized_receiver_variable(name_node, source) {
+                            names.insert(name);
+                        }
+                    }
+                }
             }
-            _ => false,
-        })
+            _ => {}
+        }
+    }
+    names
 }
 
 fn go_composite_literal_owner_binding_from_type(
@@ -922,11 +1021,11 @@ fn go_composite_literal_owner_binding_from_type(
     Some((owner_name, None))
 }
 
-fn collect_go_method_receiver_bindings(
+fn collect_go_method_receiver_bindings<'tree>(
     callable: TsNode<'_>,
-    root: TsNode<'_>,
     source: &str,
     import_bindings: &HashMap<String, String>,
+    package_owner_specs: &HashMap<String, Option<TsNode<'tree>>>,
 ) -> HashMap<String, ReceiverOwnerBinding> {
     let mut receiver_types = HashMap::new();
     if callable.kind() != "method_declaration" {
@@ -942,11 +1041,11 @@ fn collect_go_method_receiver_bindings(
         return receiver_types;
     };
     receiver_types.insert(receiver_name.clone(), (owner_name.clone(), None));
-    let Some(owner_node) = find_go_type_declaration_by_name(root, source, &owner_name) else {
+    let Some(Some(owner_node)) = package_owner_specs.get(&owner_name) else {
         return receiver_types;
     };
     for (field_name, field_owner) in
-        collect_go_struct_field_types(owner_node, source, import_bindings)
+        collect_go_struct_field_types(*owner_node, source, import_bindings)
     {
         receiver_types.insert(format!("{receiver_name}.{field_name}"), field_owner);
     }
@@ -1268,6 +1367,55 @@ mod complexity_tests {
         go_navigation_resolution_work()
     }
 
+    fn measured_method_identity_collection_work(owner_count: usize) -> usize {
+        let mut source = String::from("package proof\ntype (\n");
+        for index in 0..owner_count {
+            source.push_str(&format!("  Owner{index} struct{{}}\n"));
+        }
+        source.push_str(")\n");
+        for index in 0..owner_count {
+            source.push_str(&format!("func (Owner{index}) Method{index}() {{}}\n"));
+        }
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_go::LANGUAGE.into())
+            .expect("Go grammar must load");
+        let tree = parser.parse(&source, None).expect("Go source must parse");
+        reset_go_navigation_resolution_work();
+        let specs = member_edge_specs(&tree, &source);
+        assert_eq!(specs.len(), owner_count);
+        go_navigation_resolution_work()
+    }
+
+    fn measured_complete_receiver_call_work(callable_count: usize) -> usize {
+        let mut source = String::from("package proof\ntype (\n");
+        for index in 0..callable_count {
+            if index % 2 == 0 {
+                source.push_str(&format!("  Owner{index} struct{{}}\n"));
+            }
+        }
+        source.push_str(")\n");
+        for index in 0..callable_count {
+            let owner = if index % 2 == 0 {
+                format!("Owner{index}")
+            } else {
+                format!("CrossFileOwner{index}")
+            };
+            source.push_str(&format!(
+                "func (value *{owner}) Method{index}() {{ copy := new({owner}); copy.Method{index}() }}\n"
+            ));
+        }
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_go::LANGUAGE.into())
+            .expect("Go grammar must load");
+        let tree = parser.parse(&source, None).expect("Go source must parse");
+        reset_go_navigation_resolution_work();
+        let specs = receiver_call_specs(&tree, &source);
+        assert_eq!(specs.len(), callable_count);
+        go_navigation_resolution_work()
+    }
+
     #[test]
     fn receiver_binding_preparation_and_lookup_work_is_independently_linear() {
         let baseline = measured_receiver_work(32, 32);
@@ -1286,6 +1434,28 @@ mod complexity_tests {
         assert!(
             combined <= baseline * 2 + 256,
             "combined Go receiver work grew superlinearly: {baseline} -> {combined}"
+        );
+    }
+
+    #[test]
+    fn grouped_method_identity_collection_work_is_linear() {
+        let baseline = measured_method_identity_collection_work(64);
+        let doubled = measured_method_identity_collection_work(128);
+        assert!(baseline > 0, "Go method identity work was not counted");
+        assert!(
+            doubled <= baseline * 2 + 64,
+            "Go method identity collection grew superlinearly: {baseline} -> {doubled}"
+        );
+    }
+
+    #[test]
+    fn complete_receiver_call_collection_work_is_linear() {
+        let baseline = measured_complete_receiver_call_work(24);
+        let doubled = measured_complete_receiver_call_work(48);
+        assert!(baseline > 0, "Go receiver-call work was not counted");
+        assert!(
+            doubled <= baseline * 2 + 512,
+            "complete Go receiver-call collection grew superlinearly: {baseline} -> {doubled}"
         );
     }
 }

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -40,6 +40,7 @@ use tree_sitter_graph::{ExecutionConfig, NoCancellation, Variables};
 #[cfg(test)]
 thread_local! {
     static MANUAL_RECEIVER_LOOKUP_WORK: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static GO_METHOD_IDENTITY_WORK: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
 
 #[inline]
@@ -58,6 +59,24 @@ fn reset_manual_receiver_lookup_work() {
 #[cfg(test)]
 fn manual_receiver_lookup_work() -> usize {
     MANUAL_RECEIVER_LOOKUP_WORK.with(std::cell::Cell::get)
+}
+
+#[inline]
+fn count_go_method_identity_work(amount: usize) {
+    #[cfg(test)]
+    GO_METHOD_IDENTITY_WORK.with(|work| work.set(work.get().saturating_add(amount)));
+    #[cfg(not(test))]
+    let _ = amount;
+}
+
+#[cfg(test)]
+fn reset_go_method_identity_work() {
+    GO_METHOD_IDENTITY_WORK.with(|work| work.set(0));
+}
+
+#[cfg(test)]
+fn go_method_identity_work() -> usize {
+    GO_METHOD_IDENTITY_WORK.with(std::cell::Cell::get)
 }
 
 mod cache;
@@ -8380,9 +8399,7 @@ fn language_member_specs(
 }
 
 struct ManualMemberEdgeContext<'a> {
-    language_name: &'a str,
-    tree: &'a Tree,
-    source: &'a str,
+    specs: &'a [ManualMemberEdgeSpec],
     unique_nodes: &'a HashMap<NodeId, Node>,
     file_id: NodeId,
     flags: IndexFeatureFlags,
@@ -8392,8 +8409,9 @@ fn append_manual_member_edges(
     context: ManualMemberEdgeContext<'_>,
     result_edges: &mut Vec<Edge>,
     edge_keys: &mut HashSet<EdgeDedupKey>,
-) {
-    for spec in language_member_specs(context.language_name, context.tree, context.source) {
+) -> HashSet<NodeId> {
+    let mut target_ids = HashSet::new();
+    for spec in context.specs {
         let Some(source_id) = node_id_by_name_and_span(
             context.unique_nodes,
             &spec.source_name,
@@ -8411,6 +8429,7 @@ fn append_manual_member_edges(
             continue;
         };
 
+        target_ids.insert(target_id);
         let mut edge = Edge {
             id: EdgeId(0),
             source: source_id,
@@ -8426,6 +8445,74 @@ fn append_manual_member_edges(
         }
         edge.id = EdgeId(generate_edge_id_for_edge(&edge, context.flags));
         result_edges.push(edge);
+    }
+    target_ids
+}
+
+fn apply_go_receiver_method_identities(
+    language_name: &str,
+    nodes: &mut HashMap<NodeId, Node>,
+    specs: &[ManualMemberEdgeSpec],
+    local_member_targets: &HashSet<NodeId>,
+    canonical_roles: &HashMap<NodeId, CanonicalNodeRole>,
+) {
+    if language_name != "go" || specs.is_empty() {
+        return;
+    }
+
+    let mut methods_by_span = HashMap::<(u32, u32, u32, u32, String), Vec<NodeId>>::new();
+    for node in nodes.values() {
+        count_go_method_identity_work(1);
+        if node.kind != NodeKind::METHOD
+            || !matches!(
+                canonical_roles.get(&node.id),
+                Some(
+                    CanonicalNodeRole::Definition
+                        | CanonicalNodeRole::Declaration
+                        | CanonicalNodeRole::ForwardDeclaration
+                )
+            )
+        {
+            continue;
+        }
+        let (Some(start_line), Some(start_col), Some(end_line), Some(end_col)) =
+            (node.start_line, node.start_col, node.end_line, node.end_col)
+        else {
+            continue;
+        };
+        methods_by_span
+            .entry((
+                start_line,
+                start_col,
+                end_line,
+                end_col,
+                short_member_name(&node.serialized_name).to_string(),
+            ))
+            .or_default()
+            .push(node.id);
+    }
+
+    for spec in specs {
+        count_go_method_identity_work(1);
+        let key = (
+            spec.target_span.start_line,
+            spec.target_span.start_col,
+            spec.target_span.end_line,
+            spec.target_span.end_col,
+            spec.target_name.clone(),
+        );
+        let Some([method_id]) = methods_by_span.get(&key).map(Vec::as_slice) else {
+            continue;
+        };
+        if local_member_targets.contains(method_id) {
+            continue;
+        }
+        let Some(method) = nodes.get_mut(method_id) else {
+            continue;
+        };
+        let receiver_qualified = format!("{}.{}", spec.source_name, spec.target_name);
+        method.serialized_name = receiver_qualified.clone();
+        method.qualified_name = Some(receiver_qualified);
     }
 }
 
@@ -15945,11 +16032,10 @@ fn index_file_with_resolution_inputs(
         &mut edge_keys,
         flags,
     );
-    append_manual_member_edges(
+    let manual_member_specs = language_member_specs(language_config.language_name, &tree, source);
+    let local_member_targets = append_manual_member_edges(
         ManualMemberEdgeContext {
-            language_name: language_config.language_name,
-            tree: &tree,
-            source,
+            specs: &manual_member_specs,
             unique_nodes: &unique_nodes,
             file_id,
             flags,
@@ -16065,6 +16151,14 @@ fn index_file_with_resolution_inputs(
     if language_config.language_name == "rust" {
         apply_rust_receiver_call_hints(&tree, source, &mut unique_nodes);
     }
+
+    apply_go_receiver_method_identities(
+        language_config.language_name,
+        &mut unique_nodes,
+        &manual_member_specs,
+        &local_member_targets,
+        &canonical_role_by_node_id,
+    );
 
     if !unique_nodes.is_empty() {
         result_nodes.extend(unique_nodes.values().cloned());

--- a/crates/codestory-indexer/src/proof_resolution.rs
+++ b/crates/codestory-indexer/src/proof_resolution.rs
@@ -87,7 +87,7 @@ fn python_resolution_work() -> usize {
 }
 
 const ADAPTER_VERSION: &str = "reference-v15";
-const GO_ADAPTER_VERSION: &str = "reference-v17";
+const GO_ADAPTER_VERSION: &str = "reference-v19";
 const PYTHON_ADAPTER_VERSION: &str = "reference-v17";
 const RUST_ADAPTER_VERSION: &str = "reference-v18";
 const TYPESCRIPT_ADAPTER_VERSION: &str = "reference-v17";

--- a/crates/codestory-indexer/src/tests/mod.rs
+++ b/crates/codestory-indexer/src/tests/mod.rs
@@ -16,6 +16,200 @@ use rusqlite::types::Value;
 use std::collections::HashSet;
 use tempfile::tempdir;
 
+fn measured_go_method_identity_qualification_work(method_count: usize) -> usize {
+    let mut nodes = HashMap::new();
+    let mut roles = HashMap::new();
+    let mut specs = Vec::new();
+    for index in 0..method_count {
+        let id = NodeId(i64::try_from(index + 1).expect("method id"));
+        let line = u32::try_from(index + 1).expect("method line");
+        nodes.insert(
+            id,
+            Node {
+                id,
+                kind: NodeKind::METHOD,
+                serialized_name: format!("Method{index}"),
+                start_line: Some(line),
+                start_col: Some(1),
+                end_line: Some(line),
+                end_col: Some(20),
+                ..Default::default()
+            },
+        );
+        roles.insert(id, CanonicalNodeRole::Definition);
+        specs.push(ManualMemberEdgeSpec {
+            source_name: format!("Owner{index}"),
+            target_name: format!("Method{index}"),
+            source_span: GraphNodeSpan {
+                start_line: line,
+                start_col: 1,
+                end_line: line,
+                end_col: 5,
+            },
+            target_span: GraphNodeSpan {
+                start_line: line,
+                start_col: 1,
+                end_line: line,
+                end_col: 20,
+            },
+            line: Some(line),
+        });
+    }
+
+    reset_go_method_identity_work();
+    apply_go_receiver_method_identities("go", &mut nodes, &specs, &HashSet::new(), &roles);
+    assert!(
+        nodes
+            .values()
+            .all(|node| node.serialized_name.starts_with("Owner"))
+    );
+    go_method_identity_work()
+}
+
+#[test]
+fn go_method_identity_qualification_work_is_linear() {
+    let baseline = measured_go_method_identity_qualification_work(128);
+    let doubled = measured_go_method_identity_qualification_work(256);
+    assert!(baseline >= 256, "Go identity work was not fully counted");
+    assert!(
+        doubled <= baseline * 2 + 16,
+        "Go identity qualification grew superlinearly: {baseline} -> {doubled}"
+    );
+}
+
+#[test]
+fn go_builtin_new_package_and_local_shadowing_matrix_is_closed() -> Result<()> {
+    struct Case {
+        name: &'static str,
+        declarations: &'static str,
+        expect_receiver_resolution: bool,
+    }
+
+    let cases = [
+        Case {
+            name: "direct package var",
+            declarations: "var new func(int)\n",
+            expect_receiver_resolution: false,
+        },
+        Case {
+            name: "grouped package var",
+            declarations: "var (\n  new func(int)\n)\n",
+            expect_receiver_resolution: false,
+        },
+        Case {
+            name: "direct package const",
+            declarations: "const new = 1\n",
+            expect_receiver_resolution: false,
+        },
+        Case {
+            name: "grouped package const",
+            declarations: "const (\n  new = 1\n)\n",
+            expect_receiver_resolution: false,
+        },
+        Case {
+            name: "direct package type",
+            declarations: "type new int\n",
+            expect_receiver_resolution: false,
+        },
+        Case {
+            name: "grouped package type",
+            declarations: "type (\n  new int\n)\n",
+            expect_receiver_resolution: false,
+        },
+        Case {
+            name: "unrelated package names",
+            declarations: "var otherVar func(int)\nconst otherConst = 1\ntype otherType int\n",
+            expect_receiver_resolution: true,
+        },
+        Case {
+            name: "local new in unrelated callable",
+            declarations: r#"
+func unrelated() {
+  { var new func(int); _ = new }
+  { const new = 1; _ = new }
+  { type new int; var _ new }
+}
+"#,
+            expect_receiver_resolution: true,
+        },
+        Case {
+            name: "local new in caller",
+            declarations: "",
+            expect_receiver_resolution: false,
+        },
+    ];
+
+    for case in cases {
+        let caller_shadow = if case.name == "local new in caller" {
+            "  var new func(int)\n"
+        } else {
+            ""
+        };
+        let source = format!(
+            r#"package proof
+
+type node struct{{}}
+func (*node) addRoute() {{}}
+
+{}
+func build() {{
+{}  root := new(node)
+  root.addRoute()
+}}
+"#,
+            case.declarations, caller_shadow
+        );
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_go::LANGUAGE.into())
+            .expect("Go parser language");
+        let tree = parser.parse(&source, None).expect("Go syntax tree");
+        assert!(
+            !tree.root_node().has_error(),
+            "case `{}` must be syntactically valid",
+            case.name
+        );
+
+        let has_receiver_spec = languages::go::receiver_call_specs(&tree, &source)
+            .iter()
+            .any(|spec| {
+                spec.source_name == "build"
+                    && spec.owner_name == "node"
+                    && spec.method_name == "addRoute"
+            });
+        assert_eq!(
+            has_receiver_spec, case.expect_receiver_resolution,
+            "case `{}` receiver-spec decision",
+            case.name
+        );
+
+        let language_config = get_language_for_ext("go").expect("Go language config");
+        let result = index_file(Path::new("main.go"), &source, &language_config, None, None)?;
+        let nodes_by_id = result
+            .nodes
+            .iter()
+            .map(|node| (node.id, node))
+            .collect::<HashMap<_, _>>();
+        let has_resolved_method_edge = result.edges.iter().any(|edge| {
+            edge.kind == EdgeKind::CALL
+                && edge
+                    .resolved_target
+                    .and_then(|target| nodes_by_id.get(&target))
+                    .is_some_and(|target| {
+                        target.serialized_name == "node.addRoute"
+                            || target.serialized_name.ends_with(".node.addRoute")
+                    })
+        });
+        assert_eq!(
+            has_resolved_method_edge, case.expect_receiver_resolution,
+            "case `{}` resolved-edge decision",
+            case.name
+        );
+    }
+
+    Ok(())
+}
+
 fn measured_manual_receiver_index_work(owner_count: usize, lookup_count: usize) -> usize {
     let file_id = NodeId(1);
     let mut nodes = HashMap::new();

--- a/crates/codestory-indexer/tests/native_rule_regressions.rs
+++ b/crates/codestory-indexer/tests/native_rule_regressions.rs
@@ -193,6 +193,380 @@ use crate::{Action, Thing};
 }
 
 #[test]
+fn go_method_identity_covers_standalone_grouped_and_cross_file_receivers() -> anyhow::Result<()> {
+    let cross_file_source = concat!(
+        "package proof\r\n",
+        "// λ keeps byte and column accounting honest\r\n",
+        "func (*Context) BindWith() {}\r\n",
+        "func caller(value *Context) { value.BindWith(); value.BindWith() }",
+    );
+    let (nodes, edges, occurrences) = index_project_with_occurrences(&[
+        (
+            "standalone.go",
+            concat!(
+                "package proof\n",
+                "type Standalone struct{}\n",
+                "func (value Standalone) NamedValue() {}\n",
+                "func (Standalone) UnnamedValue() {}\n",
+                "func (value *Standalone) NamedPointer() {}\n",
+                "func (*Standalone) UnnamedPointer() {}\n",
+            ),
+        ),
+        (
+            "grouped.go",
+            concat!(
+                "package proof\n",
+                "func (Before) BeforeOwner() {}\n",
+                "type (\n",
+                "    Before struct{}\n",
+                "    Alpha struct{}\n",
+                "    Beta struct{}\n",
+                ")\n",
+                "func (Alpha) Shared() {}\n",
+                "func (*Beta) Shared() {}\n",
+            ),
+        ),
+        ("owner.go", "package proof\ntype Context struct{}\n"),
+        ("method.go", cross_file_source),
+    ])?;
+
+    let exact_method = |name: &str| {
+        let matches = nodes
+            .iter()
+            .filter(|node| node.kind == NodeKind::METHOD && node.serialized_name == name)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            matches.len(),
+            1,
+            "expected one exact method `{name}`: {matches:#?}"
+        );
+        matches[0]
+    };
+    let exact_owner = |name: &str| {
+        nodes
+            .iter()
+            .find(|node| node.kind == NodeKind::STRUCT && node.serialized_name == name)
+            .unwrap_or_else(|| panic!("missing exact Go owner `{name}`"))
+    };
+    let has_exact_member = |owner: &str, method: &str| {
+        let owner = exact_owner(owner);
+        let method = exact_method(method);
+        edges.iter().any(|edge| {
+            edge.kind == EdgeKind::MEMBER && edge.source == owner.id && edge.target == method.id
+        })
+    };
+
+    for (owner, method) in [
+        ("Standalone", "Standalone.NamedValue"),
+        ("Standalone", "Standalone.UnnamedValue"),
+        ("Standalone", "Standalone.NamedPointer"),
+        ("Standalone", "Standalone.UnnamedPointer"),
+        ("Before", "Before.BeforeOwner"),
+        ("Alpha", "Alpha.Shared"),
+        ("Beta", "Beta.Shared"),
+    ] {
+        let method_node = exact_method(method);
+        assert_eq!(method_node.qualified_name.as_deref(), Some(method));
+        assert!(
+            has_exact_member(owner, method),
+            "missing exact same-file MEMBER {owner} -> {method}"
+        );
+    }
+
+    let cross_file_method = exact_method("Context.BindWith");
+    assert_eq!(
+        cross_file_method.qualified_name.as_deref(),
+        Some("Context.BindWith")
+    );
+    assert!(
+        !has_exact_member("Context", "Context.BindWith"),
+        "receiver syntax must not fabricate a cross-file MEMBER edge"
+    );
+    assert_eq!(cross_file_method.start_line, Some(3));
+    assert_eq!(cross_file_method.start_col, Some(1));
+    assert!(occurrences.iter().any(|occurrence| {
+        occurrence.kind == OccurrenceKind::DEFINITION
+            && occurrence.element_id == cross_file_method.id.0
+            && occurrence.location.start_line == 3
+            && occurrence.location.start_col == 1
+    }));
+
+    let mut repeated_calls = edges
+        .iter()
+        .filter(|edge| {
+            edge.kind == EdgeKind::CALL && edge.effective_target() == cross_file_method.id
+        })
+        .collect::<Vec<_>>();
+    repeated_calls.sort_by(|left, right| left.callsite_identity.cmp(&right.callsite_identity));
+    assert_eq!(repeated_calls.len(), 2, "{repeated_calls:#?}");
+    assert_ne!(
+        repeated_calls[0].callsite_identity,
+        repeated_calls[1].callsite_identity
+    );
+    assert!(
+        repeated_calls
+            .iter()
+            .all(|edge| edge.file_node_id == cross_file_method.file_node_id)
+    );
+
+    Ok(())
+}
+
+#[test]
+fn go_method_identity_keeps_duplicate_owners_distinct_and_unsupported_surfaces_leaf_named()
+-> anyhow::Result<()> {
+    let (nodes, edges) = index_project(&[(
+        "identity.go",
+        concat!(
+            "package proof\n",
+            "type (\n",
+            "    Left struct{}\n",
+            "    Right struct{}\n",
+            "    Generic[T any] struct{}\n",
+            ")\n",
+            "func (Left) Same() {}\n",
+            "func (*Right) Same() {}\n",
+            "func (Left) Duplicate() {}\n",
+            "func (*Left) Duplicate() {}\n",
+            "func (Generic[T]) GenericMethod() {}\n",
+            "func (external.Left) QualifiedMethod() {}\n",
+            "func (**Left) MultiplyIndirectMethod() {}\n",
+            "func ([]Left) CompositeMethod() {}\n",
+            "func (first, second Left) MultipleNamesMethod() {}\n",
+            "func (first Left, second Right) MultipleParametersMethod() {}\n",
+            "func () MissingReceiverMethod() {}\n",
+            "func plain() {}\n",
+            "type Contract interface { InterfaceMethod() }\n",
+            "func (Left) BrokenMethod( {}\n",
+        ),
+    )])?;
+
+    let method_nodes = |name: &str| {
+        nodes
+            .iter()
+            .filter(|node| node.kind == NodeKind::METHOD && node.serialized_name == name)
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(method_nodes("Left.Same").len(), 1);
+    assert_eq!(method_nodes("Right.Same").len(), 1);
+    let duplicates = method_nodes("Left.Duplicate");
+    assert_eq!(duplicates.len(), 2, "{duplicates:#?}");
+    assert_ne!(duplicates[0].id, duplicates[1].id);
+    assert_ne!(duplicates[0].canonical_id, duplicates[1].canonical_id);
+
+    for unsupported in [
+        "Generic.GenericMethod",
+        "Left.QualifiedMethod",
+        "Left.MultiplyIndirectMethod",
+        "Left.CompositeMethod",
+        "Left.MultipleNamesMethod",
+        "Right.MultipleParametersMethod",
+        "Left.MissingReceiverMethod",
+        "Left.BrokenMethod",
+    ] {
+        assert!(
+            nodes.iter().all(|node| {
+                node.serialized_name != unsupported
+                    && node.qualified_name.as_deref() != Some(unsupported)
+            }),
+            "unsupported receiver syntax gained identity `{unsupported}`"
+        );
+        assert!(
+            edges.iter().all(|edge| {
+                edge.kind != EdgeKind::MEMBER
+                    || nodes.iter().all(|node| {
+                        node.id != edge.target
+                            || node.serialized_name != unsupported
+                            || node.qualified_name.as_deref() != Some(unsupported)
+                    })
+            }),
+            "unsupported receiver syntax gained MEMBER `{unsupported}`"
+        );
+    }
+    assert!(has_node_kind(&nodes, "plain", NodeKind::FUNCTION));
+    assert!(has_node_kind(
+        &nodes,
+        "Contract.InterfaceMethod",
+        NodeKind::METHOD
+    ));
+    assert!(edge_between(
+        &nodes,
+        &edges,
+        EdgeKind::MEMBER,
+        "Contract",
+        "Contract.InterfaceMethod"
+    ));
+
+    Ok(())
+}
+
+#[test]
+fn go_method_identity_is_stable_across_file_order() -> anyhow::Result<()> {
+    let owners = "package proof\ntype (\n    First struct{}\n    Second struct{}\n)\n";
+    let methods = concat!(
+        "package proof\n",
+        "func (First) Same() {}\n",
+        "func (*Second) Same() {}\n",
+    );
+    let (forward, _) = index_project(&[("owners.go", owners), ("methods.go", methods)])?;
+    let (reverse, _) = index_project(&[("methods.go", methods), ("owners.go", owners)])?;
+
+    let identities = |nodes: &[Node]| {
+        let mut rows = nodes
+            .iter()
+            .filter(|node| {
+                node.kind == NodeKind::METHOD
+                    && matches!(node.serialized_name.as_str(), "First.Same" | "Second.Same")
+            })
+            .map(|node| {
+                (
+                    node.serialized_name.clone(),
+                    node.qualified_name.clone(),
+                    node.canonical_id.as_deref().and_then(|canonical_id| {
+                        canonical_id
+                            .split_once("methods.go:")
+                            .map(|(_, identity)| identity.to_string())
+                    }),
+                )
+            })
+            .collect::<Vec<_>>();
+        rows.sort_by(|left, right| left.0.cmp(&right.0));
+        assert_eq!(
+            rows.len(),
+            2,
+            "missing receiver-qualified identities: {rows:#?}"
+        );
+        rows
+    };
+    assert_eq!(identities(&forward), identities(&reverse));
+    Ok(())
+}
+
+#[test]
+fn go_method_member_ownership_ignores_local_type_shadows_in_both_orders() -> anyhow::Result<()> {
+    for source in [
+        concat!(
+            "package proof\n",
+            "func local() { type Owner struct{} }\n",
+            "func (Owner) Before() {}\n",
+            "type (\n",
+            "    Owner struct{}\n",
+            "    Sibling struct{}\n",
+            ")\n",
+            "func (*Owner) After() {}\n",
+            "func (Sibling) SiblingMethod() {}\n",
+        ),
+        concat!(
+            "package proof\n",
+            "func (Owner) Before() {}\n",
+            "type (\n",
+            "    Sibling struct{}\n",
+            "    Owner struct{}\n",
+            ")\n",
+            "func local() { type Owner struct{} }\n",
+            "func (*Owner) After() {}\n",
+            "func (Sibling) SiblingMethod() {}\n",
+        ),
+    ] {
+        let (nodes, edges) = index_project(&[("owners.go", source)])?;
+        for method in ["Owner.Before", "Owner.After", "Sibling.SiblingMethod"] {
+            assert!(
+                edge_between(
+                    &nodes,
+                    &edges,
+                    EdgeKind::MEMBER,
+                    method.split('.').next().unwrap(),
+                    method
+                ),
+                "package owner lost exact MEMBER for {method}: {edges:#?}"
+            );
+        }
+    }
+
+    let (local_only_nodes, local_only_edges) = index_project(&[(
+        "local-only.go",
+        concat!(
+            "package proof\n",
+            "func local() { type LocalOnly struct{} }\n",
+            "func (LocalOnly) Method() {}\n",
+        ),
+    )])?;
+    assert!(has_node_kind(
+        &local_only_nodes,
+        "LocalOnly.Method",
+        NodeKind::METHOD
+    ));
+    assert!(
+        !edge_between(
+            &local_only_nodes,
+            &local_only_edges,
+            EdgeKind::MEMBER,
+            "LocalOnly",
+            "LocalOnly.Method"
+        ),
+        "a block-local type must not own a package method"
+    );
+    Ok(())
+}
+
+#[test]
+fn go_cross_file_identity_ignores_local_shadows_and_duplicate_package_owners() -> anyhow::Result<()>
+{
+    let cross_files = [
+        (
+            "local.go",
+            "package proof\nfunc local() { type CrossOwner struct{} }\n",
+        ),
+        ("owner.go", "package proof\ntype CrossOwner struct{}\n"),
+        (
+            "method.go",
+            "package proof\nfunc (*CrossOwner) CrossFile() {}\n",
+        ),
+    ];
+    for files in [
+        cross_files,
+        [cross_files[2], cross_files[1], cross_files[0]],
+    ] {
+        let (nodes, edges) = index_project(&files)?;
+        assert!(has_node_kind(
+            &nodes,
+            "CrossOwner.CrossFile",
+            NodeKind::METHOD
+        ));
+        assert!(!edge_between(
+            &nodes,
+            &edges,
+            EdgeKind::MEMBER,
+            "CrossOwner",
+            "CrossOwner.CrossFile"
+        ));
+    }
+
+    let (duplicate_nodes, duplicate_edges) = index_project(&[(
+        "duplicate.go",
+        concat!(
+            "package proof\n",
+            "type Duplicate struct{}\n",
+            "type Duplicate struct{}\n",
+            "func (Duplicate) Method() {}\n",
+        ),
+    )])?;
+    assert!(has_node_kind(
+        &duplicate_nodes,
+        "Duplicate.Method",
+        NodeKind::METHOD
+    ));
+    assert!(!edge_between(
+        &duplicate_nodes,
+        &duplicate_edges,
+        EdgeKind::MEMBER,
+        "Duplicate",
+        "Duplicate.Method"
+    ));
+    Ok(())
+}
+
+#[test]
 fn test_rust_cross_file_inherent_impl_attaches_members_to_declared_type() -> anyhow::Result<()> {
     let (nodes, edges) = index_project(&[
         ("main.rs", "mod a; mod b;\n"),

--- a/crates/codestory-indexer/tests/proof_resolution.rs
+++ b/crates/codestory-indexer/tests/proof_resolution.rs
@@ -2651,6 +2651,139 @@ fn go_unsupported_shadowed_and_open_domains_never_authorize_exact_receipts() -> 
 }
 
 #[test]
+fn go_unsupported_receiver_declarations_gain_no_identity_member_or_exact_fact() -> anyhow::Result<()>
+{
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(
+        project.path(),
+        &mut store,
+        &[(
+            "receiver-shapes.go",
+            concat!(
+                "package proof\n",
+                "type Left struct{}\n",
+                "type Right struct{}\n",
+                "type Generic[T any] struct{}\n",
+                "func (Generic[T]) GenericMethod() {}\n",
+                "func (external.Left) QualifiedMethod() {}\n",
+                "func (**Left) MultiplyIndirectMethod() {}\n",
+                "func ([]Left) CompositeMethod() {}\n",
+                "func (first, second Left) MultipleNamesMethod() {}\n",
+                "func (first Left, second Right) MultipleParametersMethod() {}\n",
+                "func caller(left Left, right Right, generic Generic[int]) {\n",
+                "  generic.GenericMethod()\n",
+                "  left.QualifiedMethod()\n",
+                "  left.MultiplyIndirectMethod()\n",
+                "  left.CompositeMethod()\n",
+                "  left.MultipleNamesMethod()\n",
+                "  right.MultipleParametersMethod()\n",
+                "}\n",
+            ),
+        )],
+    )?;
+    let unsupported = [
+        ("GenericMethod", "Generic.GenericMethod"),
+        ("QualifiedMethod", "Left.QualifiedMethod"),
+        ("MultiplyIndirectMethod", "Left.MultiplyIndirectMethod"),
+        ("CompositeMethod", "Left.CompositeMethod"),
+        ("MultipleNamesMethod", "Left.MultipleNamesMethod"),
+        ("MultipleParametersMethod", "Right.MultipleParametersMethod"),
+    ];
+    let nodes = store.get_nodes()?;
+    let edges = store.get_edges()?;
+    for (leaf, qualified) in unsupported {
+        assert!(
+            nodes.iter().all(|node| {
+                node.serialized_name != qualified
+                    && node.qualified_name.as_deref() != Some(qualified)
+            }),
+            "unsupported receiver declaration gained identity `{qualified}`"
+        );
+        let method_ids = nodes
+            .iter()
+            .filter(|node| node.kind == NodeKind::METHOD && node.serialized_name == leaf)
+            .map(|node| node.id)
+            .collect::<BTreeSet<_>>();
+        assert!(
+            edges.iter().all(|edge| {
+                edge.kind != EdgeKind::MEMBER || !method_ids.contains(&edge.target)
+            }),
+            "unsupported receiver declaration gained MEMBER `{qualified}`"
+        );
+    }
+
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    let facts = store.get_proof_resolution_facts()?;
+    for (leaf, _) in unsupported {
+        let matching = facts
+            .iter()
+            .filter(|fact| fact.callsite.raw_target == leaf)
+            .collect::<Vec<_>>();
+        assert!(!matching.is_empty(), "missing hostile fact for `{leaf}`");
+        assert!(
+            matching
+                .iter()
+                .all(|fact| fact.status != ProofResolutionStatus::Exact),
+            "unsupported receiver declaration became Exact: {matching:#?}"
+        );
+    }
+
+    let malformed_project = tempfile::tempdir()?;
+    let mut malformed = Store::new_in_memory()?;
+    index_files(
+        malformed_project.path(),
+        &mut malformed,
+        &[(
+            "malformed.go",
+            concat!(
+                "package proof\n",
+                "type Left struct{}\n",
+                "func caller(left Left) { left.MissingReceiverMethod(); left.BrokenMethod() }\n",
+                "func () MissingReceiverMethod() {}\n",
+                "func (Left) BrokenMethod( {}\n",
+            ),
+        )],
+    )?;
+    let malformed_nodes = malformed.get_nodes()?;
+    let malformed_edges = malformed.get_edges()?;
+    for (leaf, qualified) in [
+        ("MissingReceiverMethod", "Left.MissingReceiverMethod"),
+        ("BrokenMethod", "Left.BrokenMethod"),
+    ] {
+        assert!(malformed_nodes.iter().all(|node| {
+            node.serialized_name != qualified && node.qualified_name.as_deref() != Some(qualified)
+        }));
+        let method_ids = malformed_nodes
+            .iter()
+            .filter(|node| node.kind == NodeKind::METHOD && node.serialized_name == leaf)
+            .map(|node| node.id)
+            .collect::<BTreeSet<_>>();
+        assert!(
+            malformed_edges.iter().all(|edge| {
+                edge.kind != EdgeKind::MEMBER || !method_ids.contains(&edge.target)
+            })
+        );
+    }
+    rematerialize_proof_resolution_projection(&mut malformed, &publication(1))?;
+    let malformed_facts = malformed.get_proof_resolution_facts()?;
+    for leaf in ["MissingReceiverMethod", "BrokenMethod"] {
+        let matching = malformed_facts
+            .iter()
+            .filter(|fact| fact.callsite.raw_target == leaf)
+            .collect::<Vec<_>>();
+        assert!(!matching.is_empty(), "missing recovery fact for `{leaf}`");
+        assert!(
+            matching
+                .iter()
+                .all(|fact| fact.status != ProofResolutionStatus::Exact),
+            "recovered receiver declaration became Exact: {matching:#?}"
+        );
+    }
+    Ok(())
+}
+
+#[test]
 fn go_lexical_shadowing_is_callsite_specific() -> anyhow::Result<()> {
     let project = tempfile::tempdir()?;
     let mut store = Store::new_in_memory()?;
@@ -3810,7 +3943,7 @@ fn go_returned_closure_h6_seals_current_go_cache_and_fact_provenance() -> anyhow
         .expect("sealed returned-closure fact");
     assert_eq!(fact.status, ProofResolutionStatus::Exact, "{fact:#?}");
     assert_eq!(fact.provenance.language_adapter, "go");
-    assert_eq!(fact.provenance.language_adapter_version, "reference-v17");
+    assert_eq!(fact.provenance.language_adapter_version, "reference-v19");
     assert_eq!(fact.provenance.parser_fingerprint.len(), 64);
     assert_eq!(fact.provenance.dependency_file_hashes.len(), 2);
     assert_eq!(fact.provenance.evidence_sha256.len(), 64);


### PR DESCRIPTION
## Context

Go method declarations lost `Owner.Method` identity when the receiver owner was declared in another package file or inside a grouped `type` declaration. That kept an otherwise exact Gin call path from resolving its start selector.

Closes #2060
Refs #2023

## What changed

- preserves receiver-qualified Go method identity across package files and grouped package-level type declarations;
- validates the exact supported receiver AST shapes and rejects recovered, qualified, generic, composite, and multiply indirect forms;
- correlates only package-level owner declarations, excluding nested local type specs;
- prepares package owner and file-scope shadow indexes once and sweeps callable byte ranges in source order;
- recognizes direct and grouped package `var`, `const`, and `type` shadows without descending into initializers or callable bodies;
- bumps the parser cache provenance to 16 and the Go proof adapter provenance to `reference-v19`.

The proof kernel, graph schema, packet/context/search/navigation surfaces, public routes, and release surfaces are unchanged.

## Frozen boundary

- base: `91da53fb7d635547dfc659a985c8f67f099130d7`
- head: `6a2f304dfc0204114fdf8540ca4a7d1ab4dad23b`
- tree: `3733ce945eec477a1f6deec51d0d0d5c35a220a5`
- final diff SHA-256: `473ece88c9c87bea07ccfa1f63d030119c5e20b7214f869e2281d63552753a72`

One consolidated adversarial review covered language-domain closure, parser provenance, graph/fact correlation, repeated callsites, source coordinates, native ordering, storage integrity, and complexity. Its accepted correction closed malformed receiver shapes, nested local owner impersonation, quadratic collection, and the complete package shadow class. No further review round was opened.

## Verification

Focused checks:

- Go native identity: 32 passed;
- indexer proof resolution: 132 passed;
- complexity contracts: 4 passed;
- store proof integrity: 25 passed;
- cache contracts: 23 passed;
- dark architecture: 4 passed;
- indexer fidelity: 8 passed;
- language coverage: 13 passed;
- formatting, lint, and diff checks passed.

Broad exact-head checks:

- `cargo fmt --all -- --check`;
- `cargo check --locked --workspace`;
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`;
- `cargo nextest run --locked --workspace --no-fail-fast`: 4096 passed, 34 skipped;
- `cargo test --locked --workspace --doc`;
- `cargo test --locked -p codestory-cli --test stdio_protocol_contracts`: 63 passed;
- no-default evidence-only Q1 build;
- sealed four-revision Q1 conformance: 1 passed;
- `git diff --check`.

Local Q2 qualification used release binary SHA-256 `773de696567c8fd269341c1f8183aec8f1ce627f60aa7f60f206935a200c8fea` and candidate `20260825T112805Z-6a2f304dfc02`. Materialize, run, and read-only verify each ran once.

Compared with Candidate 7:

- full proofs: 90/120 → 91/120;
- Gin: 26/30 → 27/30;
- exact positive steps: 229/312 → 230/312;
- full-or-useful-partial: 96/120 → 97/120;
- `gin-go-28` is `ContractProven` with one exact authoritative receipt;
- `gin-go-06` remains `Unknown` at step 0 because the lookup domain is intentionally incomplete under the repository build constraint;
- false proofs, non-exact receipts, unclassified positive steps, disposition mismatches, invalid results, certified absence, transport errors, and over-cap results: all zero.

Outcome remains `keep_proof_dark`: frozen stable recall and latency thresholds are not yet met.

## Non-claims

This PR does not publish `prove_call_path`, broaden the Go adapter, change qualification thresholds, touch the 0.17 release lane, or modify `main` / `dev/codestory-next`.
