### PR TITLE
[codex] resolve Rust documented proof targets

### DIFF
--- a/crates/codestory-indexer/src/cache.rs
+++ b/crates/codestory-indexer/src/cache.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::path::{Component, Path, PathBuf};
 
 // Versioned with proof-input semantics so older parser artifacts fail closed.
-const INDEX_ARTIFACT_CACHE_VERSION: u32 = 16;
+const INDEX_ARTIFACT_CACHE_VERSION: u32 = 17;
 const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
 const FNV_PRIME: u64 = 0x00000100000001B3;
 
@@ -288,7 +288,7 @@ impl CachedIndexArtifact {
         resolution_file: Option<CachedResolutionFile>,
     ) -> Self {
         Self {
-            resolution_input_schema_version: 15,
+            resolution_input_schema_version: 16,
             files: index_result.files,
             nodes: index_result.nodes,
             edges: index_result.edges,

--- a/crates/codestory-indexer/src/proof_resolution.rs
+++ b/crates/codestory-indexer/src/proof_resolution.rs
@@ -89,9 +89,9 @@ fn python_resolution_work() -> usize {
 const ADAPTER_VERSION: &str = "reference-v15";
 const GO_ADAPTER_VERSION: &str = "reference-v19";
 const PYTHON_ADAPTER_VERSION: &str = "reference-v17";
-const RUST_ADAPTER_VERSION: &str = "reference-v18";
+const RUST_ADAPTER_VERSION: &str = "reference-v19";
 const TYPESCRIPT_ADAPTER_VERSION: &str = "reference-v17";
-const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 15;
+const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 16;
 const INSTALLED_ADAPTERS: &[(&str, &str)] = &[
     ("go", GO_ADAPTER_VERSION),
     ("javascript", ADAPTER_VERSION),
@@ -5001,6 +5001,7 @@ struct RustResolutionIndex<'tree> {
     callable_module_paths: HashMap<usize, Vec<String>>,
     callable_start_bytes: HashMap<usize, usize>,
     attributed_items: HashSet<usize>,
+    documented_free_function_targets: HashSet<usize>,
     bounded_outer_attribute_ids: HashSet<usize>,
     bounded_attributed_callers: HashSet<usize>,
     bounded_attributed_callsites: HashSet<usize>,
@@ -5011,6 +5012,7 @@ impl<'tree> RustResolutionIndex<'tree> {
         let graph_nodes = RustGraphNodeIndex::prepare(file_id, nodes);
         let (
             attributed_items,
+            documented_free_function_targets,
             bounded_outer_attribute_ids,
             bounded_attributed_callers,
             bounded_attributed_callsites,
@@ -5044,6 +5046,7 @@ impl<'tree> RustResolutionIndex<'tree> {
             callable_module_paths: HashMap::new(),
             callable_start_bytes: HashMap::new(),
             attributed_items,
+            documented_free_function_targets,
             bounded_outer_attribute_ids,
             bounded_attributed_callers,
             bounded_attributed_callsites,
@@ -5151,7 +5154,9 @@ impl<'tree> RustResolutionIndex<'tree> {
             match item.kind() {
                 "function_item" => {
                     let name = declaration_name(*item, source).map(str::to_string);
-                    if self.attributed_items.contains(&item.id()) {
+                    if self.attributed_items.contains(&item.id())
+                        && !self.documented_free_function_targets.contains(&item.id())
+                    {
                         if let Some(name) = name {
                             incomplete_value_names.insert(name);
                         } else {
@@ -5998,6 +6003,7 @@ fn rust_struct_constructor_capabilities(item: TsNode<'_>) -> (bool, bool) {
     (!record && !tuple, record)
 }
 
+#[allow(clippy::type_complexity)]
 fn rust_prepare_attribute_index(
     root: TsNode<'_>,
     source: &str,
@@ -6006,11 +6012,14 @@ fn rust_prepare_attribute_index(
     HashSet<usize>,
     HashSet<usize>,
     HashSet<usize>,
+    HashSet<usize>,
 ) {
+    #[allow(clippy::too_many_arguments)]
     fn collect(
         node: TsNode<'_>,
         source: &str,
         attributed_items: &mut HashSet<usize>,
+        documented_free_function_targets: &mut HashSet<usize>,
         bounded_outer_attribute_ids: &mut HashSet<usize>,
         bounded_attributed_callers: &mut HashSet<usize>,
         bounded_attributed_callsites: &mut HashSet<usize>,
@@ -6022,11 +6031,28 @@ fn rust_prepare_attribute_index(
         let direct_method_owner = node
             .parent()
             .filter(|parent| matches!(parent.kind(), "impl_item" | "trait_item"));
+        let free_function_container = node.kind() == "source_file"
+            || node
+                .parent()
+                .is_some_and(|parent| parent.kind() == "mod_item");
         let mut attributes = Vec::new();
+        let mut attribute_group_tainted = false;
         for child in children {
             count_rust_resolution_work(1);
             if child.kind() == "attribute_item" || rust_is_outer_doc_comment(child, source) {
                 attributes.push(child);
+                continue;
+            }
+            if rust_is_ordinary_non_doc_comment(child, source) {
+                continue;
+            }
+            if !attributes.is_empty()
+                && (matches!(
+                    child.kind(),
+                    "line_comment" | "block_comment" | "inner_attribute_item"
+                ) || child.is_error())
+            {
+                attribute_group_tainted = true;
                 continue;
             }
             let direct_method = child.kind() == "function_item" && direct_method_owner.is_some();
@@ -6039,27 +6065,44 @@ fn rust_prepare_attribute_index(
             }
             if !attributes.is_empty() {
                 attributed_items.insert(child.id());
-                if rust_attribute_group_is_bounded(&attributes, child, source) {
+                if free_function_container
+                    && child.kind() == "function_item"
+                    && !attribute_group_tainted
+                    && !child.has_error()
+                    && attributes
+                        .iter()
+                        .all(|attribute| rust_is_outer_doc_comment(*attribute, source))
+                {
+                    count_rust_resolution_work(attributes.len());
+                    documented_free_function_targets.insert(child.id());
+                }
+                if !attribute_group_tainted
+                    && rust_attribute_group_is_bounded(&attributes, child, source)
+                {
                     bounded_outer_attribute_ids
                         .extend(attributes.iter().map(|attribute| attribute.id()));
                 }
-                if child.kind() == "function_item"
+                if !attribute_group_tainted
+                    && child.kind() == "function_item"
                     && !direct_method_ids.contains(&child.id())
                     && rust_attribute_group_preserves_caller(&attributes, source)
                 {
                     bounded_attributed_callers.insert(child.id());
                 }
-                if rust_bounded_callsite_category(child)
+                if !attribute_group_tainted
+                    && rust_bounded_callsite_category(child)
                     && rust_attribute_group_preserves_callsite(&attributes, source)
                 {
                     bounded_attributed_callsites.insert(child.id());
                 }
                 attributes.clear();
+                attribute_group_tainted = false;
             }
             collect(
                 child,
                 source,
                 attributed_items,
+                documented_free_function_targets,
                 bounded_outer_attribute_ids,
                 bounded_attributed_callers,
                 bounded_attributed_callsites,
@@ -6069,6 +6112,7 @@ fn rust_prepare_attribute_index(
     }
 
     let mut attributed_items = HashSet::new();
+    let mut documented_free_function_targets = HashSet::new();
     let mut bounded_outer_attribute_ids = HashSet::new();
     let mut bounded_attributed_callers = HashSet::new();
     let mut bounded_attributed_callsites = HashSet::new();
@@ -6077,6 +6121,7 @@ fn rust_prepare_attribute_index(
         root,
         source,
         &mut attributed_items,
+        &mut documented_free_function_targets,
         &mut bounded_outer_attribute_ids,
         &mut bounded_attributed_callers,
         &mut bounded_attributed_callsites,
@@ -6084,6 +6129,7 @@ fn rust_prepare_attribute_index(
     );
     (
         attributed_items,
+        documented_free_function_targets,
         bounded_outer_attribute_ids,
         bounded_attributed_callers,
         bounded_attributed_callsites,
@@ -6114,6 +6160,17 @@ fn rust_is_outer_doc_comment(node: TsNode<'_>, source: &str) -> bool {
     match node.kind() {
         "line_comment" => surface.starts_with("///") && !surface.starts_with("////"),
         "block_comment" => surface.starts_with("/**") && !surface.starts_with("/***"),
+        _ => false,
+    }
+}
+
+fn rust_is_ordinary_non_doc_comment(node: TsNode<'_>, source: &str) -> bool {
+    let Some(surface) = node_text(node, source).map(str::trim_start) else {
+        return false;
+    };
+    match node.kind() {
+        "line_comment" => !surface.starts_with("//!"),
+        "block_comment" => surface.ends_with("*/") && !surface.starts_with("/*!"),
         _ => false,
     }
 }
@@ -11932,6 +11989,26 @@ mod rust_complexity_tests {
         source
     }
 
+    fn documented_declaration_source(count: usize) -> String {
+        let mut source = String::new();
+        for index in 0..count {
+            source.push_str(&format!(
+                "/// documented target {index}\n/** bounded documentation {index} */\nfn target_{index}() {{}}\nfn caller_{index}() {{ target_{index}(); }}\n"
+            ));
+        }
+        source
+    }
+
+    fn interleaved_documented_group_source(count: usize) -> String {
+        let mut source = String::new();
+        for index in 0..count {
+            source.push_str(&format!(
+                "/// documented target {index}\n// ordinary {index}\n/** bounded documentation {index} */\n/* ordinary block {index} */\nfn target_{index}() {{}}\n#[cfg(any())]\n//// ordinary {index}\n/// documented but attributed {index}\nfn attributed_{index}() {{}}\nfn caller_{index}() {{ target_{index}(); attributed_{index}(); }}\n"
+            ));
+        }
+        source
+    }
+
     fn measured_projection_work(count: usize) -> usize {
         let temp = tempfile::tempdir().expect("tempdir");
         let path = temp.path().join("lib.rs");
@@ -12076,6 +12153,28 @@ mod rust_complexity_tests {
         assert!(
             large_modules <= small_modules * 2 + 128,
             "nested-module attribute preparation grew superlinearly: {small_modules} -> {large_modules}"
+        );
+
+        let small_documented = measured_source_work(&documented_declaration_source(64));
+        let large_documented = measured_source_work(&documented_declaration_source(128));
+        assert!(
+            small_documented >= 64 * 8,
+            "documented-declaration preparation and lookup work was not fully counted: {small_documented}"
+        );
+        assert!(
+            large_documented <= small_documented * 2 + 128,
+            "documented-declaration preparation and lookup work grew superlinearly: {small_documented} -> {large_documented}"
+        );
+
+        let small_interleaved = measured_source_work(&interleaved_documented_group_source(64));
+        let large_interleaved = measured_source_work(&interleaved_documented_group_source(128));
+        assert!(
+            small_interleaved >= 64 * 12,
+            "interleaved documented-group work was not fully counted: {small_interleaved}"
+        );
+        assert!(
+            large_interleaved <= small_interleaved * 2 + 128,
+            "interleaved documented-group work grew superlinearly: {small_interleaved} -> {large_interleaved}"
         );
     }
 

--- a/crates/codestory-indexer/tests/proof_resolution.rs
+++ b/crates/codestory-indexer/tests/proof_resolution.rs
@@ -7368,7 +7368,7 @@ fn complete_projection_rejects_cache_schema_adapter_and_language_mismatch() -> a
             .expect_err("cache provenance mismatch must reject the complete projection");
         let message = error.to_string();
         assert!(
-            ["stale", "schema-v15", "adapter", "language"]
+            ["stale", "schema-v16", "adapter", "language"]
                 .iter()
                 .any(|needle| message.contains(needle)),
             "{mutation}: {error}"
@@ -7696,7 +7696,7 @@ fn rust_glob_local_calls_preserve_repeated_source_coordinates_and_provenance() -
     );
     assert!(facts.iter().all(|fact| {
         fact.provenance.language_adapter == "rust"
-            && fact.provenance.language_adapter_version == "reference-v18"
+            && fact.provenance.language_adapter_version == "reference-v19"
             && fact.provenance.dependency_file_hashes.len() == 1
             && matches!(
                 fact.evidence_chain.as_slice(),
@@ -7728,12 +7728,12 @@ fn stale_rust_glob_local_adapter_inputs_reject_rematerialization() -> anyhow::Re
         |row| row.get::<_, Vec<u8>>(0),
     )?;
     let mut artifact: serde_json::Value = serde_json::from_slice(&artifact_blob)?;
-    artifact["resolution_file"]["adapter_version"] = "reference-v17".into();
+    artifact["resolution_file"]["adapter_version"] = "reference-v18".into();
     for call in artifact["call_resolution_inputs"]
         .as_array_mut()
         .expect("call inputs")
     {
-        call["adapter_version"] = "reference-v17".into();
+        call["adapter_version"] = "reference-v18".into();
     }
     store.get_connection().execute(
         "UPDATE index_artifact_cache SET artifact_blob = ?1",
@@ -7770,7 +7770,7 @@ fn proof_resolution_roster_tracks_the_current_adapter_version() -> anyhow::Resul
             .iter()
             .find(|adapter| adapter.language == "rust")
             .map(|adapter| adapter.adapter_version.as_str()),
-        Some("reference-v18")
+        Some("reference-v19")
     );
     assert_eq!(
         receipt
@@ -7866,7 +7866,7 @@ fn rust_bounded_callsite_regions_preserve_coordinates_order_and_provenance() -> 
             (start as usize - line_start + 1) as u32
         );
         assert_eq!(fact.provenance.language_adapter, "rust");
-        assert_eq!(fact.provenance.language_adapter_version, "reference-v18");
+        assert_eq!(fact.provenance.language_adapter_version, "reference-v19");
         assert_eq!(fact.provenance.dependency_file_hashes.len(), 1);
         assert!(matches!(
             fact.evidence_chain.as_slice(),
@@ -7920,8 +7920,6 @@ fn rust_bounded_attributes_do_not_authorize_attributed_targets_or_competing_bind
         "#[allow(dead_code)]",
         "#[doc = \"attributed target\"]",
         "#[inline]",
-        "/// attributed target",
-        "/** attributed target */",
     ] {
         let source = format!(
             "{target_attributes}\nfn target() {{}}\n#[allow(dead_code)]\nfn caller() {{ target(); }}\n"
@@ -8086,6 +8084,231 @@ fn rust_prepared_incompleteness_propagates_through_traits_and_nested_callables()
     assert_ne!(poisoned[0].status, ProofResolutionStatus::Exact);
     assert_eq!(safe.len(), 1, "{safe:#?}");
     assert_eq!(safe[0].status, ProofResolutionStatus::Exact, "{safe:#?}");
+    Ok(())
+}
+
+#[test]
+fn rust_documented_free_function_target_matrix_is_exact() -> anyhow::Result<()> {
+    for documentation in [
+        "/// one line",
+        "/// first line\n/// second line",
+        "/** one block */",
+        "/**\n * multiple block lines\n */",
+        "/// line\n/** block */\n/// line again",
+    ] {
+        let source = format!("{documentation}\nfn target() {{}}\nfn caller() {{ target(); }}\n");
+        assert_only_call_is_exact(&[("src/lib.rs", source.as_str())])?;
+    }
+
+    for ordinary_prefix in [
+        "//// ordinary line comment",
+        "/*** ordinary block comment */",
+        "// ordinary line comment",
+        "/* ordinary block comment */",
+        "// unrelated comment\n\n/* separated ordinary comment */",
+    ] {
+        let source = format!("{ordinary_prefix}\nfn target() {{}}\nfn caller() {{ target(); }}\n");
+        assert_only_call_is_exact(&[("src/lib.rs", source.as_str())])?;
+    }
+    Ok(())
+}
+
+#[test]
+fn rust_documented_targets_with_any_real_attribute_remain_incomplete() -> anyhow::Result<()> {
+    for actual_attribute in [
+        "#[doc = \"semantic doc attribute\"]",
+        "#[doc = include_str!(\"missing.md\")]",
+        "#[doc]",
+        "#[cfg(any())]",
+        "#[cfg_attr(any(), allow(dead_code))]",
+        "#[allow(dead_code)]",
+        "#[inline]",
+        "#[test]",
+        "#[tokio::test]",
+        "#[tool::instrument]",
+        "#[unresolved_attribute_macro]",
+    ] {
+        let source = format!(
+            "/// inert documentation\n{actual_attribute}\nfn target() {{}}\nfn caller() {{ target(); }}\n"
+        );
+        let facts = rust_call_facts(&source, "target")?;
+        assert_eq!(facts.len(), 1, "{actual_attribute}: {facts:#?}");
+        assert_eq!(
+            facts[0].status,
+            ProofResolutionStatus::IncompleteDomain,
+            "an actual Rust attribute must keep the documented target non-exact: {actual_attribute}: {facts:#?}"
+        );
+        assert!(facts[0].target.is_none(), "{actual_attribute}: {facts:#?}");
+        assert!(facts[0].edge_id.is_none(), "{actual_attribute}: {facts:#?}");
+    }
+    Ok(())
+}
+
+#[test]
+fn rust_documented_target_groups_survive_interposed_ordinary_comments() -> anyhow::Result<()> {
+    for ordinary_comment in [
+        "// ordinary line comment",
+        "/* ordinary block comment */",
+        "//// non-doc line comment",
+        "/*** non-doc block comment */",
+    ] {
+        for prefix in [
+            format!("#[cfg(any())]\n{ordinary_comment}\n/// docs"),
+            format!("/// docs\n#[cfg(any())]\n{ordinary_comment}"),
+            format!("#[cfg(any())]\n{ordinary_comment}"),
+        ] {
+            let source = format!("{prefix}\nfn target() {{}}\nfn caller() {{ target(); }}\n");
+            let facts = rust_call_facts(&source, "target")?;
+            assert_eq!(facts.len(), 1, "{prefix}: {facts:#?}");
+            assert_eq!(
+                facts[0].status,
+                ProofResolutionStatus::IncompleteDomain,
+                "ordinary comments must not discard a pending actual attribute: {prefix}: {facts:#?}"
+            );
+            assert!(facts[0].target.is_none(), "{prefix}: {facts:#?}");
+            assert!(facts[0].edge_id.is_none(), "{prefix}: {facts:#?}");
+        }
+
+        let docs_only = format!(
+            "/// first docs\n{ordinary_comment}\n/** second docs */\nfn target() {{}}\nfn caller() {{ target(); }}\n"
+        );
+        assert_only_call_is_exact(&[("src/lib.rs", docs_only.as_str())])?;
+    }
+    Ok(())
+}
+
+#[test]
+fn rust_documented_target_inner_dangling_and_recovery_barriers_stay_non_authoritative()
+-> anyhow::Result<()> {
+    for source in [
+        "#[cfg(any())]\n//! inner docs\n/// outer docs\nfn target() {}\nfn caller() { target(); }\n",
+        "#[cfg(any())]\n/*! inner docs */\n/** outer docs */\nfn target() {}\nfn caller() { target(); }\n",
+        "/// dangling docs\nstruct Marker;\n#[cfg(any())]\nfn target() {}\nfn caller() { target(); }\n",
+        "/// docs\n<\nfn target() {}\nfn caller() { target(); }\n",
+        "#[cfg(any())]\n// ordinary\n<\n/// docs\nfn target() {}\nfn caller() { target(); }\n",
+        "/// docs\n/* unterminated\nfn target() {}\nfn caller() { target(); }\n",
+    ] {
+        assert_no_exact_target_calls(&[("src/lib.rs", source)])?;
+    }
+    Ok(())
+}
+
+#[test]
+fn rust_tainted_attribute_groups_never_reach_bounded_caller_or_callsite_classification()
+-> anyhow::Result<()> {
+    let caller_source = "#[cfg(any())]\n//! inner docs\n/// outer docs\nfn caller() { target(); }\nfn target() {}\n";
+    let caller_facts = rust_call_facts(caller_source, "target")?;
+    assert_eq!(caller_facts.len(), 1, "{caller_facts:#?}");
+    assert_ne!(
+        caller_facts[0].status,
+        ProofResolutionStatus::Exact,
+        "an inner-doc barrier must prevent bounded-caller classification: {caller_facts:#?}"
+    );
+
+    for callsite_source in [
+        "fn target() {}\nfn caller() {\n#[cfg(any())]\n//! inner docs\n/// outer docs\n{ target(); }\n}\n",
+        "fn target() {}\nfn caller() {\n#[cfg(any())]\n<\n/// outer docs\n{ target(); }\n}\n",
+    ] {
+        let callsite_facts = rust_call_facts(callsite_source, "target")?;
+        assert_eq!(
+            callsite_facts.len(),
+            1,
+            "{callsite_source}: {callsite_facts:#?}"
+        );
+        assert_ne!(
+            callsite_facts[0].status,
+            ProofResolutionStatus::Exact,
+            "an inner or recovery barrier must prevent bounded-callsite classification: {callsite_source}: {callsite_facts:#?}"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn rust_documented_target_rule_stays_free_function_and_domain_specific() -> anyhow::Result<()> {
+    for source in [
+        "struct Worker;\nimpl Worker { /// docs\nfn target(&self) {} fn caller(&self) { self.target(); } }\n",
+        "struct Worker;\nimpl Worker { /// docs\nfn target() {} }\nfn caller() { Worker::target(); }\n",
+        "fn outer() { /// docs\nfn target() {} target(); }\n",
+        "trait Worker { /// docs\nfn target(&self); fn caller(&self) { self.target(); } }\n",
+        "/// docs\nstruct target;\nfn caller() { target(); }\n",
+        "/// docs\nmod target {}\nfn caller() { target(); }\n",
+        "/// docs for a different item\nstruct Marker;\n#[cfg(any())]\nfn target() {}\nfn caller() { target(); }\n",
+        "//! inner module documentation\n#[cfg(any())]\nfn target() {}\nfn caller() { target(); }\n",
+        "/*! inner module documentation */\n#[cfg(any())]\nfn target() {}\nfn caller() { target(); }\n",
+        "/// docs\nfn target() {}\nmacro_rules! tokens { ($value:expr) => {}; }\nfn caller() { tokens!(target()); }\n",
+    ] {
+        assert_no_exact_target_calls(&[("src/lib.rs", source)])?;
+    }
+
+    for source in [
+        "/// docs\nfn target() {}\nfn target() {}\nfn caller() { target(); }\n",
+        "mod other { pub fn target() {} }\nuse crate::other::target;\n/// docs\nfn target() {}\nfn caller() { target(); }\n",
+        "#[cfg(any())]\nfn target() {}\n/// docs\nfn target() {}\nfn caller() { target(); }\n",
+        "const target: fn() = || {};\n/// docs\nfn target() {}\nfn caller() { target(); }\n",
+        "/// docs\nfn target() {}\nfn caller(target: fn()) { target(); }\n",
+        "/// docs\nfn target() {}\nfn caller() { let target: fn() = || {}; target(); }\n",
+        "macro_rules! duplicate { () => { fn target() {} }; }\nduplicate!();\n/// docs\nfn target() {}\nfn caller() { target(); }\n",
+        "include!(\"generated.rs\");\n/// docs\nfn target() {}\nfn caller() { target(); }\n",
+        "/// docs\nfn target() {}\nfn caller() { target(); }\n<",
+    ] {
+        assert_only_call_is_not_exact(&[("src/lib.rs", source)])?;
+    }
+    Ok(())
+}
+
+#[test]
+fn rust_documented_targets_preserve_order_repetition_and_native_coordinates() -> anyhow::Result<()>
+{
+    let source = "fn before() { target(); }\r\n// é\r\n/// documented target é\r\n/** second document */\r\nfn target() {}\r\nfn after() { target(); target(); }";
+    let facts = rust_call_facts(source, "target")?;
+    let starts = source
+        .match_indices("target();")
+        .map(|(start, _)| start as u64)
+        .collect::<Vec<_>>();
+    assert_eq!(facts.len(), 3, "{facts:#?}");
+    assert_eq!(
+        facts
+            .iter()
+            .map(|fact| fact.callsite.start_byte)
+            .collect::<Vec<_>>(),
+        starts
+    );
+    assert_eq!(
+        facts
+            .iter()
+            .filter_map(|fact| fact.edge_id)
+            .collect::<BTreeSet<_>>()
+            .len(),
+        facts.len(),
+        "repeated documented-target calls require edge-distinct receipts"
+    );
+    for (fact, start) in facts.iter().zip(starts) {
+        let start = start as usize;
+        let line_start = source[..start].rfind('\n').map_or(0, |line| line + 1);
+        let line = source[..start]
+            .bytes()
+            .filter(|byte| *byte == b'\n')
+            .count() as u32
+            + 1;
+        assert_eq!(fact.status, ProofResolutionStatus::Exact, "{fact:#?}");
+        assert_eq!(fact.callsite.line, line, "{fact:#?}");
+        assert_eq!(
+            fact.callsite.column,
+            (start - line_start + 1) as u32,
+            "{fact:#?}"
+        );
+        assert_eq!(
+            fact.callsite.end_byte_exclusive,
+            fact.callsite.start_byte + "target".len() as u64,
+            "{fact:#?}"
+        );
+        assert!(matches!(
+            fact.evidence_chain.as_slice(),
+            [ResolutionEvidence::SameFileDeclaration { declaration }]
+                if Some(*declaration) == fact.target
+        ));
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Context

Q2 showed five Rust proof paths blocked because an inert outer doc comment prevented the same-file free-function target from entering the exact-resolution domain. This PR closes that measured class only. The proof surface remains dark and production-unreachable.

Base: `057b6410f87ffd4888715d9dae2855a052c96625`  
Head: `797b8d94de9d5ee27711459fc93fc0de760e63d9`  
Tree: `e44f95d3f2adfe1500dc1e1d415ba475bf332027`

## What changed

- Admit Rust same-file free-function targets preceded only by attached inert outer `///` or `/** */` documentation.
- Keep every real `#[...]` attribute, inner doc comment, recovery node, method/local/generated target, and incomplete domain non-exact.
- Carry attribute and documentation groups across ordinary comments so a real attribute cannot be hidden by comment ordering.
- Apply taint before every prepared classification, including documented targets, bounded IDs, callers, and callsites.
- Bump the Rust adapter, resolution schema, and parser artifact cache identities so stale prepared evidence cannot authenticate.
- Add the closed supported, unsupported, hostile, integrity, and linear-complexity matrix.

Only these files change:

- `crates/codestory-indexer/src/cache.rs`
- `crates/codestory-indexer/src/proof_resolution.rs`
- `crates/codestory-indexer/tests/proof_resolution.rs`

## How to review

Start with the pending attribute/doc group state machine in `cache.rs`, then verify `proof_resolution.rs` authorizes only prepared documented free-function targets. The hostile tests cover interleaved ordinary comments, inner docs, malformed/recovery syntax, every real attribute family, caller/callsite leakage, duplicate/reordered source coordinates, storage correlation, and 64/128-group linearity.

One consolidated adversarial review covered language-domain closure, parser provenance, graph/fact correlation, repeated callsites, source coordinates, native ordering, storage integrity, and complexity. Its complete soundness finding was batched into the final correction before this head was frozen.

## Verification

Focused checks passed:

- proof resolution: 139/139;
- Rust complexity: 2/2;
- store integrity: 25/25;
- dark architecture: 2/2;
- fidelity regression: 8/8;
- language coverage: 13/13;
- focused clippy, format, and diff checks.

Exact-head broad checks passed for format, workspace check, all-target/all-feature clippy, doc tests, the complete 63-test stdio protocol binary, the no-default evidence-separation feature build, and the sealed four-revision conformance probe.

The one permitted workspace nextest run completed 4,103 tests with 4,102 passing, 34 skipped, and one unchanged activation test failure. That exact test passed immediately in isolation and again in the full 63-test stdio binary. No unrelated source correction was made and the broad suite was not rerun.

Local Q2 candidate `20260825T130519Z-797b8d94de9d` materialized, ran, and verified once with binary SHA-256 `87858a9c3270a8bdb8b72b7e0192a6a9f7c0a50eaf7380656e28177b02f6e7e8`:

- 96/120 full proofs: Rust 24, Flask 16, Gin 27, Vite 29;
- 242/312 exact positive steps and 242/242 exact authoritative receipts;
- 101/120 full or useful partial;
- zero false proofs, non-exact receipts, unclassified positive steps, disposition mismatches, invalid cases, transport errors, or over-cap responses;
- maximum response 29,841 bytes; unknown warm p95 2,863 ms.

The frozen evaluator outcome is `keep_proof_dark`.

## Risk and nonclaims

The risk is confined to Rust prepared evidence. Cache/schema identity bumps force rematerialization instead of accepting stale artifacts. This does not register a public tool, change packet/context/search/navigation, weaken proof admission, activate retrieval, change protocol or wire contracts, alter a release version, or touch the 0.17 lane.

Closes #2062
Refs #2023
