### PR TITLE
activate public exact call path verifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Added an observational exact call-path verifier to the CLI and MCP. It checks
+  a complete host-supplied typed contract against one pinned indexed
+  publication, reports proof-domain uncertainty explicitly, and never treats
+  packet, context, or search output as proof authority.
 - Packet, context, and search now return closed CodeStory schema-3 evidence
   projections. They report concrete evidence, gaps, retrieval state, and one
   bounded continuation without claiming that an arbitrary natural-language

--- a/crates/codestory-agent/Cargo.toml
+++ b/crates/codestory-agent/Cargo.toml
@@ -4,11 +4,12 @@ version = "0.17.4"
 edition = "2024"
 
 [features]
+default = ["proof-qualification-support"]
 # Compiles the eval/holdout probe hooks for downstream unit tests. No product
 # build enables it.
 test-support = ["dep:sha2"]
-# Compiles the sealed proof-qualification facade for codestory-bench. No
-# product dependency enables it.
+# Compiles the private exact-verifier kernel and its qualification facade. The
+# public CLI/runtime use the same sealed implementation that benchmarks inspect.
 proof-qualification-support = ["dep:sha2"]
 # Compiles only the dark v3 evidence planner needed by the Q1 separability
 # gate. It has no proof-kernel edge and registers no product surface.

--- a/crates/codestory-agent/src/indexed_source_call_path_v1.rs
+++ b/crates/codestory-agent/src/indexed_source_call_path_v1.rs
@@ -469,7 +469,9 @@ pub enum ValidationOutcome {
         rendering: ValidatedContractRendering,
     },
     Unknown {
+        spec: CallPathSpec,
         hashes: ProofHashes,
+        rendering: ValidatedContractRendering,
         gaps: Vec<TranslationGap>,
     },
 }
@@ -605,7 +607,12 @@ fn validate_contract_with_domain(
             rendering: ValidatedContractRendering { normalized_clauses },
         })
     } else {
-        Ok(ValidationOutcome::Unknown { hashes, gaps })
+        Ok(ValidationOutcome::Unknown {
+            spec,
+            hashes,
+            rendering: ValidatedContractRendering { normalized_clauses },
+            gaps,
+        })
     }
 }
 
@@ -4241,31 +4248,129 @@ fn validate_compact_gaps(gaps: &[Value], step_count: usize) -> Result<(), String
     for gap in gaps {
         let gap = compact_object(gap, "compact_disposition_gap_invalid")?;
         let kind = compact_string(gap, "kind", "compact_disposition_gap_invalid")?;
-        let (rank, index, index_field) = match kind {
-            "selector_missing" => (0_u8, selector_gap_index(gap, step_count)?, "selector_index"),
-            "selector_ambiguous" => (1, selector_gap_index(gap, step_count)?, "selector_index"),
-            "non_callable_selector" => (2, selector_gap_index(gap, step_count)?, "selector_index"),
-            "direct_call_missing" => (3, step_gap_index(gap, step_count)?, "step_index"),
-            "recursive_call_not_representable" => {
-                (4, step_gap_index(gap, step_count)?, "step_index")
+        let (rank, identity, fields): (u8, String, &[&str]) = match kind {
+            "unclassified_source_text" => (0, String::new(), &["kind"]),
+            "unresolved_material_clause" => {
+                let clause_id =
+                    compact_string(gap, "clause_id", "compact_disposition_gap_invalid")?;
+                let reason = compact_string(gap, "reason", "compact_disposition_gap_invalid")?;
+                if clause_id.is_empty()
+                    || !matches!(
+                        reason,
+                        "missing_selector_resolution"
+                            | "ambiguous_selector_resolution"
+                            | "unsupported_interpretation"
+                    )
+                {
+                    return Err("compact_disposition_gap_invalid".to_owned());
+                }
+                (
+                    1,
+                    format!("{clause_id}\0{reason}"),
+                    &["kind", "clause_id", "reason"],
+                )
             }
-            "source_window_too_large" => (5, step_gap_index(gap, step_count)?, "step_index"),
-            "invalid_utf8" => (6, step_gap_index(gap, step_count)?, "step_index"),
-            "source_line_out_of_range" => (7, step_gap_index(gap, step_count)?, "step_index"),
-            "edge_containment_unproven" => (8, step_gap_index(gap, step_count)?, "step_index"),
-            "missing_direct_call_receipt" => (9, step_gap_index(gap, step_count)?, "step_index"),
-            "receipt_or_edge_already_used" => (10, step_gap_index(gap, step_count)?, "step_index"),
-            "projection_exclusion_conflicts_with_required_receipt" => {
-                (11, step_gap_index(gap, step_count)?, "step_index")
+            "material_token_misclassified" => {
+                let clause_id =
+                    compact_string(gap, "clause_id", "compact_disposition_gap_invalid")?;
+                let families =
+                    compact_array(gap.get("guard_families"), "compact_disposition_gap_invalid")?;
+                if clause_id.is_empty() || families.is_empty() || families.len() > 8 {
+                    return Err("compact_disposition_gap_invalid".to_owned());
+                }
+                let mut prior_family = None;
+                let mut family_names = Vec::with_capacity(families.len());
+                for family in families {
+                    let family = family
+                        .as_str()
+                        .ok_or_else(|| "compact_disposition_gap_invalid".to_owned())?;
+                    let rank = match family {
+                        "quoted_or_backticked_identifier" => 0,
+                        "arrow_or_relation_notation" => 1,
+                        "directness" => 2,
+                        "ordering_or_ordinal" => 3,
+                        "only" => 4,
+                        "negation_or_exclusion" => 5,
+                        "path_like_string" => 6,
+                        "qualified_symbol_notation" => 7,
+                        _ => return Err("compact_disposition_gap_invalid".to_owned()),
+                    };
+                    if prior_family.is_some_and(|prior| prior >= rank) {
+                        return Err("compact_disposition_gap_invalid".to_owned());
+                    }
+                    prior_family = Some(rank);
+                    family_names.push(family);
+                }
+                (
+                    2,
+                    format!("{clause_id}\0{}", family_names.join("\0")),
+                    &["kind", "clause_id", "guard_families"],
+                )
             }
+            "selector_missing" => (
+                3,
+                format!("{:020}", selector_gap_index(gap, step_count)?),
+                &["kind", "selector_index"],
+            ),
+            "selector_ambiguous" => (
+                4,
+                format!("{:020}", selector_gap_index(gap, step_count)?),
+                &["kind", "selector_index"],
+            ),
+            "non_callable_selector" => (
+                5,
+                format!("{:020}", selector_gap_index(gap, step_count)?),
+                &["kind", "selector_index"],
+            ),
+            "direct_call_missing" => (
+                6,
+                format!("{:020}", step_gap_index(gap, step_count)?),
+                &["kind", "step_index"],
+            ),
+            "recursive_call_not_representable" => (
+                7,
+                format!("{:020}", step_gap_index(gap, step_count)?),
+                &["kind", "step_index"],
+            ),
+            "source_window_too_large" => (
+                8,
+                format!("{:020}", step_gap_index(gap, step_count)?),
+                &["kind", "step_index"],
+            ),
+            "invalid_utf8" => (
+                9,
+                format!("{:020}", step_gap_index(gap, step_count)?),
+                &["kind", "step_index"],
+            ),
+            "source_line_out_of_range" => (
+                10,
+                format!("{:020}", step_gap_index(gap, step_count)?),
+                &["kind", "step_index"],
+            ),
+            "edge_containment_unproven" => (
+                11,
+                format!("{:020}", step_gap_index(gap, step_count)?),
+                &["kind", "step_index"],
+            ),
+            "missing_direct_call_receipt" => (
+                12,
+                format!("{:020}", step_gap_index(gap, step_count)?),
+                &["kind", "step_index"],
+            ),
+            "receipt_or_edge_already_used" => (
+                13,
+                format!("{:020}", step_gap_index(gap, step_count)?),
+                &["kind", "step_index"],
+            ),
+            "projection_exclusion_conflicts_with_required_receipt" => (
+                14,
+                format!("{:020}", step_gap_index(gap, step_count)?),
+                &["kind", "step_index"],
+            ),
             _ => return Err("compact_disposition_gap_invalid".to_owned()),
         };
-        compact_closed_object(
-            gap,
-            &["kind", index_field],
-            "compact_disposition_gap_invalid",
-        )?;
-        let key = (rank, index);
+        compact_closed_object(gap, fields, "compact_disposition_gap_invalid")?;
+        let key = (rank, identity);
         if prior.is_some_and(|prior| prior >= key) {
             return Err("compact_disposition_gaps_noncanonical".to_owned());
         }
@@ -4382,6 +4487,81 @@ pub fn project_internal_call_path_result(
         serialized_size: serialized_json_size(&complete)?,
         root: complete,
     })
+}
+
+pub fn project_translation_unknown_result(
+    spec: &CallPathSpec,
+    hashes: &ProofHashes,
+    rendering: &ValidatedContractRendering,
+    gaps: &[TranslationGap],
+    publication: &InternalCorePublicationIdentity,
+) -> Result<InternalProjection, InternalProjectionError> {
+    let identities = CompactIdentityTables::default();
+    let complete = json!({
+        "kind": "complete",
+        "schema_version": PROOF_CONTRACT_SCHEMA_VERSION,
+        "domain": PROOF_DOMAIN,
+        "contract_interpretation": "host_supplied",
+        "guard_version": CLAUSE_GUARD_VERSION,
+        "source_text_sha256": hashes.source_text_sha256,
+        "contract_digest": hashes.contract_digest,
+        "core_publication": publication_json(publication),
+        "identities": identities.json(),
+        "spec": compact_spec_json(spec, &[], &identities)?,
+        "clauses": grouped_clauses_json(&rendering.normalized_clauses),
+        "disposition": {
+            "kind": "unknown",
+            "contract_digest": hashes.contract_digest,
+            "gaps": gaps.iter().map(translation_gap_json).collect::<Vec<_>>(),
+            "connected_receipts": [],
+        },
+        "steps": spec.steps.iter().enumerate().map(|(step_index, _)| json!({
+            "step_index": step_index,
+            "status": "unknown",
+            "receipt": null,
+        })).collect::<Vec<_>>(),
+        "receipts": [],
+    });
+    validate_compact_projection(&complete)
+        .map_err(InternalProjectionError::InvalidCompactProjection)?;
+    Ok(InternalProjection::Complete {
+        serialized_size: serialized_json_size(&complete)?,
+        root: complete,
+    })
+}
+
+fn translation_gap_json(gap: &TranslationGap) -> Value {
+    match gap {
+        TranslationGap::UnclassifiedSourceText => {
+            json!({ "kind": "unclassified_source_text" })
+        }
+        TranslationGap::UnresolvedMaterialClause { clause_id, reason } => json!({
+            "kind": "unresolved_material_clause",
+            "clause_id": clause_id,
+            "reason": reason.canonical_name(),
+        }),
+        TranslationGap::MaterialTokenMisclassified {
+            clause_id,
+            guard_families,
+        } => json!({
+            "kind": "material_token_misclassified",
+            "clause_id": clause_id,
+            "guard_families": guard_families.iter().map(clause_guard_family_name).collect::<Vec<_>>(),
+        }),
+    }
+}
+
+fn clause_guard_family_name(family: &ClauseGuardFamily) -> &'static str {
+    match family {
+        ClauseGuardFamily::QuotedOrBacktickedIdentifier => "quoted_or_backticked_identifier",
+        ClauseGuardFamily::ArrowOrRelationNotation => "arrow_or_relation_notation",
+        ClauseGuardFamily::Directness => "directness",
+        ClauseGuardFamily::OrderingOrOrdinal => "ordering_or_ordinal",
+        ClauseGuardFamily::Only => "only",
+        ClauseGuardFamily::NegationOrExclusion => "negation_or_exclusion",
+        ClauseGuardFamily::PathLikeString => "path_like_string",
+        ClauseGuardFamily::QualifiedSymbolNotation => "qualified_symbol_notation",
+    }
 }
 
 fn grouped_clauses_json(clauses: &[NormalizedClause]) -> Vec<Value> {

--- a/crates/codestory-agent/src/lib.rs
+++ b/crates/codestory-agent/src/lib.rs
@@ -29,18 +29,19 @@ pub mod proof_qualification_support {
     use serde::Serialize;
 
     pub use super::indexed_source_call_path_v1::{
-        AdmittedRawCallEdge, BuiltCallPathFacts, CallableContainmentEvidence,
+        AdmittedRawCallEdge, BuiltCallPathFacts, CallPathSpec, CallableContainmentEvidence,
         CheckedBuiltCallPathIntegration, ClauseAnchor, ClauseClassification, ExactScopeSelector,
         ExactSymbolSelector, FactBuildGap, IndexedCallEdgeReceipt, IndexedLineWindow,
         InternalCorePublicationIdentity, InternalProjection, NonMaterialKind, PROOF_DOMAIN,
         PinnedNodeIdentity, ProofContractField, ProofHashes, RawAdmissionFailure,
-        RawCallEdgeAdmission, ReceiptRef, ResolvedNodeIdentity, UnavailableReason,
+        RawCallEdgeAdmission, ReceiptRef, ResolvedNodeIdentity, TranslationGap, UnavailableReason,
         UnresolvedMaterialReason, UnvalidatedCallPathContract, UnvalidatedCallPathSpec,
         UnvalidatedDirectCallStep, UnvalidatedExactScopeSelector, UnvalidatedExactSymbolSelector,
         ValidatedCallPathContract, ValidatedContractRendering, ValidationOutcome,
         VerifiedDirectCallFact, VerifiedProofFact, admit_raw_call_edge,
         check_built_call_path_integration, diagnose_raw_call_edge,
-        project_internal_call_path_result, validate_compact_projection, validate_contract,
+        project_internal_call_path_result, project_translation_unknown_result,
+        validate_compact_projection, validate_contract,
     };
 
     /// Identifies the sealed request domain observed by benchmark qualification.
@@ -58,17 +59,18 @@ pub mod proof_qualification_support {
 #[doc(hidden)]
 pub mod proof_qualification_test_support {
     pub use super::indexed_source_call_path_v1::{
-        AdmittedRawCallEdge, BuiltCallPathFacts, CallableContainmentEvidence,
+        AdmittedRawCallEdge, BuiltCallPathFacts, CallPathSpec, CallableContainmentEvidence,
         CheckedBuiltCallPathIntegration, ClauseAnchor, ClauseClassification, ExactScopeSelector,
         ExactSymbolSelector, FactBuildGap, IndexedCallEdgeReceipt, IndexedLineWindow,
         InternalCorePublicationIdentity, InternalProjection, PROOF_DOMAIN, PinnedNodeIdentity,
         ProofContractField, ProofDisposition, ProofGap, ProofHashes, RawAdmissionFailure,
-        RawCallEdgeAdmission, ReceiptRef, Refutation, ResolvedNodeIdentity, UnavailableReason,
-        UnvalidatedCallPathContract, UnvalidatedCallPathSpec, UnvalidatedDirectCallStep,
-        UnvalidatedExactScopeSelector, UnvalidatedExactSymbolSelector, ValidatedCallPathContract,
-        ValidatedContractRendering, ValidationOutcome, VerifiedDirectCallFact, VerifiedProofFact,
-        admit_raw_call_edge, check_built_call_path_integration, check_call_path,
-        diagnose_raw_call_edge, project_internal_call_path_result, validate_contract,
+        RawCallEdgeAdmission, ReceiptRef, Refutation, ResolvedNodeIdentity, TranslationGap,
+        UnavailableReason, UnvalidatedCallPathContract, UnvalidatedCallPathSpec,
+        UnvalidatedDirectCallStep, UnvalidatedExactScopeSelector, UnvalidatedExactSymbolSelector,
+        ValidatedCallPathContract, ValidatedContractRendering, ValidationOutcome,
+        VerifiedDirectCallFact, VerifiedProofFact, admit_raw_call_edge,
+        check_built_call_path_integration, check_call_path, diagnose_raw_call_edge,
+        project_internal_call_path_result, project_translation_unknown_result, validate_contract,
     };
 }
 pub mod packet_citations;

--- a/crates/codestory-cli/src/app.rs
+++ b/crates/codestory-cli/src/app.rs
@@ -79,6 +79,7 @@ mod drill;
 mod ground_smoke;
 mod index_command;
 mod lifecycle;
+mod prove_call_path;
 mod readiness_commands;
 pub(crate) mod rendering;
 pub(crate) mod resolution;
@@ -201,6 +202,7 @@ async fn run_cli(cli: Cli) -> Result<()> {
         Command::Report(cmd) => report::run_report(cmd),
         Command::Context(cmd) => agent_context::run_context(cmd),
         Command::Packet(cmd) => agent_context::run_packet(cmd),
+        Command::ProveCallPath(cmd) => prove_call_path::run_prove_call_path(cmd),
         Command::Task(cmd) => agent_context::run_task(cmd),
         Command::Doctor(cmd) => readiness_commands::run_doctor(cmd),
         Command::Ready(cmd) => readiness_commands::run_ready(cmd),

--- a/crates/codestory-cli/src/app/lifecycle.rs
+++ b/crates/codestory-cli/src/app/lifecycle.rs
@@ -15,6 +15,9 @@ pub(super) fn embedding_client_transport_mode(
 ) -> Option<embedding_server_transport::ClientTransportMode> {
     match command {
         Command::Ground(_) => Some(embedding_server_transport::ClientTransportMode::ObserveOnly),
+        Command::ProveCallPath(_) => {
+            Some(embedding_server_transport::ClientTransportMode::ObserveOnly)
+        }
         Command::Retrieval(args::RetrievalCommand {
             action: args::RetrievalAction::Status(_),
         }) => Some(embedding_server_transport::ClientTransportMode::ObserveOnly),

--- a/crates/codestory-cli/src/app/prove_call_path.rs
+++ b/crates/codestory-cli/src/app/prove_call_path.rs
@@ -1,0 +1,68 @@
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+
+use anyhow::{Context, Result};
+
+use crate::args::{OutputFormat, ProjectArgs, ProveCallPathCommand};
+use crate::output::emit;
+use crate::prove_call_path::{
+    internal_projection_root, parse_request, projection_root, read_bounded_spec, validate_request,
+};
+use crate::runtime::{RuntimeContext, map_api_error};
+
+pub(super) fn run_prove_call_path(cmd: ProveCallPathCommand) -> Result<()> {
+    let bytes = read_bounded_spec(&cmd.spec)?;
+    let value = serde_json::from_slice(&bytes).context("parse proof spec JSON")?;
+    let request = parse_request(value).map_err(anyhow::Error::msg)?;
+    let validation = validate_request(request).map_err(anyhow::Error::msg)?;
+    let project = ProjectArgs {
+        project: cmd.project,
+        cache_dir: None,
+    };
+    let runtime = RuntimeContext::new_inspect_only(&project)?;
+    runtime
+        .activation
+        .bind_existing_complete_core_for_observation(
+            &runtime.project_root,
+            &runtime.storage_path,
+            Arc::new(AtomicBool::new(false)),
+        )
+        .map_err(map_api_error)?;
+    let root = match validation {
+        codestory_runtime::proof_qualification_support::ValidationOutcome::Validated {
+            contract,
+            hashes,
+            rendering,
+        } => {
+            let operation = codestory_runtime::proof_qualification_support::
+                run_observed_call_path_public_operation(
+                    &runtime.runtime,
+                    &contract,
+                    &hashes,
+                    &rendering,
+                    Arc::new(AtomicBool::new(false)),
+                )
+                .map_err(map_api_error)?;
+            projection_root(&operation).map_err(anyhow::Error::msg)?
+        }
+        codestory_runtime::proof_qualification_support::ValidationOutcome::Unknown {
+            spec,
+            hashes,
+            rendering,
+            gaps,
+        } => {
+            let operation = codestory_runtime::proof_qualification_support::
+                run_translation_unknown_public_operation(
+                    &runtime.runtime,
+                    &spec,
+                    &hashes,
+                    &rendering,
+                    &gaps,
+                    Arc::new(AtomicBool::new(false)),
+                )
+                .map_err(map_api_error)?;
+            internal_projection_root(&operation.value)
+        }
+    };
+    emit(OutputFormat::Json, &root, String::new(), None)
+}

--- a/crates/codestory-cli/src/app/resolution/failure.rs
+++ b/crates/codestory-cli/src/app/resolution/failure.rs
@@ -69,6 +69,7 @@ pub(in crate::app) fn json_output_requested(args: &[OsString]) -> bool {
     args.windows(2)
         .any(|pair| pair[0] == OsStr::new("--format") && pair[1] == OsStr::new("json"))
         || args.iter().any(|arg| arg == OsStr::new("--format=json"))
+        || args.iter().any(|arg| arg == OsStr::new("prove-call-path"))
 }
 
 pub(in crate::app) fn requested_output_file(args: &[OsString]) -> Option<&Path> {

--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -69,6 +69,8 @@ pub(crate) enum Command {
     Context(ContextCommand),
     #[command(about = "Answer a broad repository question with evidence.")]
     Packet(PacketCommand),
+    #[command(about = "Verify one host-supplied exact indexed source call path.")]
+    ProveCallPath(ProveCallPathCommand),
     #[command(about = "Build owner-directed task workflow packets.")]
     Task(TaskCommand),
     #[command(about = "Check cache, index, and retrieval health.")]
@@ -127,6 +129,14 @@ pub(crate) enum Command {
     InternalEmbeddingServer,
     #[command(name = "internal-embedding-qualification-worker", hide = true)]
     InternalEmbeddingQualificationWorker(InternalEmbeddingQualificationCommand),
+}
+
+#[derive(Args, Debug)]
+pub(crate) struct ProveCallPathCommand {
+    #[arg(long, value_name = "ROOT")]
+    pub(crate) project: PathBuf,
+    #[arg(long, value_name = "PATH")]
+    pub(crate) spec: PathBuf,
 }
 
 #[derive(Args, Debug)]

--- a/crates/codestory-cli/src/lib.rs
+++ b/crates/codestory-cli/src/lib.rs
@@ -21,6 +21,7 @@ mod http_transport;
 mod local_refresh_status;
 #[allow(dead_code)]
 mod output;
+mod prove_call_path;
 mod readiness;
 mod report;
 mod retrieval;

--- a/crates/codestory-cli/src/prove_call_path.rs
+++ b/crates/codestory-cli/src/prove_call_path.rs
@@ -1,0 +1,343 @@
+use std::io::Read;
+use std::path::Path;
+
+use anyhow::{Context, Result, bail};
+use serde::Deserialize;
+use serde_json::Value;
+
+use codestory_runtime::proof_qualification_support as proof;
+
+pub(crate) const PROVE_CALL_PATH_INPUT_MAX_BYTES: usize = 64 * 1024;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ProveCallPathRequestDto {
+    source_text: String,
+    clauses: Vec<ClauseAnchorDto>,
+    spec: CallPathSpecDto,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ClauseAnchorDto {
+    clause_id: String,
+    start_byte: u32,
+    end_byte_exclusive: u32,
+    quote: String,
+    classification: ClauseClassificationDto,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+#[allow(clippy::enum_variant_names)]
+enum ClauseClassificationDto {
+    ResolvedMaterial { fields: Vec<ProofContractFieldDto> },
+    UnresolvedMaterial { reason: UnresolvedMaterialReasonDto },
+    NonMaterial { reason: NonMaterialReasonDto },
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+enum ProofContractFieldDto {
+    Start,
+    StepTarget { step: u8 },
+    Directness { step: u8 },
+    Ordering { step: u8 },
+    Relation { step: u8 },
+    TraversalProhibition { index: u8 },
+    ProjectionExclusion { index: u8 },
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum UnresolvedMaterialReasonDto {
+    MissingSelectorResolution,
+    AmbiguousSelectorResolution,
+    UnsupportedInterpretation,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum NonMaterialReasonDto {
+    Whitespace,
+    Punctuation,
+    Connector,
+    Commentary,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CallPathSpecDto {
+    start: ExactSymbolSelectorDto,
+    steps: Vec<DirectCallStepDto>,
+    prohibit_traversal_through: Vec<ExactScopeSelectorDto>,
+    exclude_from_projection: Vec<ExactScopeSelectorDto>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DirectCallStepDto {
+    target: ExactSymbolSelectorDto,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+enum ExactSymbolSelectorDto {
+    PinnedNode {
+        project_id: String,
+        core_generation_id: String,
+        core_run_id: String,
+        node_id: String,
+    },
+    CanonicalId {
+        canonical_id: String,
+    },
+    QualifiedName {
+        qualified_name: String,
+        project_file_components: Option<Vec<String>>,
+    },
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+enum ExactScopeSelectorDto {
+    PinnedNode {
+        project_id: String,
+        core_generation_id: String,
+        core_run_id: String,
+        node_id: String,
+    },
+    CanonicalId {
+        canonical_id: String,
+    },
+    QualifiedName {
+        qualified_name: String,
+        project_file_components: Option<Vec<String>>,
+    },
+}
+
+impl ProveCallPathRequestDto {
+    fn into_contract(self) -> proof::UnvalidatedCallPathContract {
+        proof::UnvalidatedCallPathContract::new(
+            self.source_text,
+            self.clauses
+                .into_iter()
+                .map(ClauseAnchorDto::into_contract)
+                .collect(),
+            self.spec.into_contract(),
+        )
+    }
+}
+
+impl ClauseAnchorDto {
+    fn into_contract(self) -> proof::ClauseAnchor {
+        proof::ClauseAnchor {
+            clause_id: self.clause_id,
+            start: self.start_byte as usize,
+            end: self.end_byte_exclusive as usize,
+            quote: self.quote,
+            classification: match self.classification {
+                ClauseClassificationDto::ResolvedMaterial { fields } => {
+                    proof::ClauseClassification::ResolvedMaterial {
+                        fields: fields.into_iter().map(Into::into).collect(),
+                    }
+                }
+                ClauseClassificationDto::UnresolvedMaterial { reason } => {
+                    proof::ClauseClassification::UnresolvedMaterial {
+                        reason: reason.into(),
+                    }
+                }
+                ClauseClassificationDto::NonMaterial { reason } => {
+                    proof::ClauseClassification::NonMaterial {
+                        kind: reason.into(),
+                    }
+                }
+            },
+        }
+    }
+}
+
+impl CallPathSpecDto {
+    fn into_contract(self) -> proof::UnvalidatedCallPathSpec {
+        proof::UnvalidatedCallPathSpec {
+            start: self.start.into_contract(),
+            steps: self
+                .steps
+                .into_iter()
+                .map(|step| proof::UnvalidatedDirectCallStep {
+                    target: step.target.into_contract(),
+                })
+                .collect(),
+            prohibit_traversal_through: self
+                .prohibit_traversal_through
+                .into_iter()
+                .map(ExactScopeSelectorDto::into_contract)
+                .collect(),
+            exclude_from_projection: self
+                .exclude_from_projection
+                .into_iter()
+                .map(ExactScopeSelectorDto::into_contract)
+                .collect(),
+        }
+    }
+}
+
+impl ExactSymbolSelectorDto {
+    fn into_contract(self) -> proof::UnvalidatedExactSymbolSelector {
+        match self {
+            Self::PinnedNode {
+                project_id,
+                core_generation_id,
+                core_run_id,
+                node_id,
+            } => proof::UnvalidatedExactSymbolSelector::PinnedNode(proof::PinnedNodeIdentity {
+                project_id,
+                core_generation_id,
+                core_run_id,
+                node_id,
+            }),
+            Self::CanonicalId { canonical_id } => {
+                proof::UnvalidatedExactSymbolSelector::CanonicalId(canonical_id)
+            }
+            Self::QualifiedName {
+                qualified_name,
+                project_file_components,
+            } => proof::UnvalidatedExactSymbolSelector::QualifiedName {
+                qualified_name,
+                project_file_components,
+            },
+        }
+    }
+}
+
+impl ExactScopeSelectorDto {
+    fn into_contract(self) -> proof::UnvalidatedExactScopeSelector {
+        match self {
+            Self::PinnedNode {
+                project_id,
+                core_generation_id,
+                core_run_id,
+                node_id,
+            } => proof::UnvalidatedExactScopeSelector::PinnedNode(proof::PinnedNodeIdentity {
+                project_id,
+                core_generation_id,
+                core_run_id,
+                node_id,
+            }),
+            Self::CanonicalId { canonical_id } => {
+                proof::UnvalidatedExactScopeSelector::CanonicalId(canonical_id)
+            }
+            Self::QualifiedName {
+                qualified_name,
+                project_file_components,
+            } => proof::UnvalidatedExactScopeSelector::QualifiedName {
+                qualified_name,
+                project_file_components,
+            },
+        }
+    }
+}
+
+impl From<ProofContractFieldDto> for proof::ProofContractField {
+    fn from(value: ProofContractFieldDto) -> Self {
+        match value {
+            ProofContractFieldDto::Start => Self::Start,
+            ProofContractFieldDto::StepTarget { step } => Self::StepTarget { step },
+            ProofContractFieldDto::Directness { step } => Self::Directness { step },
+            ProofContractFieldDto::Ordering { step } => Self::Ordering { step },
+            ProofContractFieldDto::Relation { step } => Self::Relation { step },
+            ProofContractFieldDto::TraversalProhibition { index } => {
+                Self::TraversalProhibition { index }
+            }
+            ProofContractFieldDto::ProjectionExclusion { index } => {
+                Self::ProjectionExclusion { index }
+            }
+        }
+    }
+}
+
+impl From<UnresolvedMaterialReasonDto> for proof::UnresolvedMaterialReason {
+    fn from(value: UnresolvedMaterialReasonDto) -> Self {
+        match value {
+            UnresolvedMaterialReasonDto::MissingSelectorResolution => {
+                Self::MissingSelectorResolution
+            }
+            UnresolvedMaterialReasonDto::AmbiguousSelectorResolution => {
+                Self::AmbiguousSelectorResolution
+            }
+            UnresolvedMaterialReasonDto::UnsupportedInterpretation => {
+                Self::UnsupportedInterpretation
+            }
+        }
+    }
+}
+
+impl From<NonMaterialReasonDto> for proof::NonMaterialKind {
+    fn from(value: NonMaterialReasonDto) -> Self {
+        match value {
+            NonMaterialReasonDto::Whitespace => Self::Whitespace,
+            NonMaterialReasonDto::Punctuation => Self::Punctuation,
+            NonMaterialReasonDto::Connector => Self::Connector,
+            NonMaterialReasonDto::Commentary => Self::Commentary,
+        }
+    }
+}
+
+pub(crate) fn parse_request(value: Value) -> Result<ProveCallPathRequestDto, String> {
+    serde_json::from_value(value).map_err(|error| error.to_string())
+}
+
+pub(crate) fn validate_request(
+    request: ProveCallPathRequestDto,
+) -> Result<proof::ValidationOutcome, String> {
+    proof::validate_contract(request.into_contract()).map_err(|error| format!("{error:?}"))
+}
+
+pub(crate) fn projection_root(
+    operation: &codestory_runtime::PublicOperation<
+        proof::ObservedIntegratedProjectedCallPathResult,
+    >,
+) -> Result<Value, String> {
+    let result = operation
+        .value
+        .result
+        .as_ref()
+        .map_err(|error| error.message.clone())?;
+    let root = match &result.projection {
+        proof::InternalProjection::Complete { root, .. }
+        | proof::InternalProjection::BudgetExceeded { root, .. } => root,
+    };
+    Ok(root.clone())
+}
+
+pub(crate) fn internal_projection_root(projection: &proof::InternalProjection) -> Value {
+    match projection {
+        proof::InternalProjection::Complete { root, .. }
+        | proof::InternalProjection::BudgetExceeded { root, .. } => root.clone(),
+    }
+}
+
+pub(crate) fn read_bounded_spec(path: &Path) -> Result<Vec<u8>> {
+    if path.as_os_str() == "-" {
+        read_bounded(std::io::stdin().lock(), "stdin")
+    } else {
+        let file = std::fs::File::open(path)
+            .with_context(|| format!("open proof spec {}", path.display()))?;
+        read_bounded(file, &format!("proof spec {}", path.display()))
+    }
+}
+
+fn read_bounded(reader: impl Read, source: &str) -> Result<Vec<u8>> {
+    let mut bytes = Vec::with_capacity(PROVE_CALL_PATH_INPUT_MAX_BYTES.min(8 * 1024));
+    reader
+        .take((PROVE_CALL_PATH_INPUT_MAX_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)
+        .with_context(|| format!("read {source}"))?;
+    if bytes.len() > PROVE_CALL_PATH_INPUT_MAX_BYTES {
+        bail!(
+            "proof spec exceeds the {} byte input limit",
+            PROVE_CALL_PATH_INPUT_MAX_BYTES
+        );
+    }
+    Ok(bytes)
+}

--- a/crates/codestory-cli/src/runtime.rs
+++ b/crates/codestory-cli/src/runtime.rs
@@ -59,6 +59,7 @@ pub(crate) struct RefreshDecision {
 /// artifact paths. Product surfaces initialize the shared embedded engine when
 /// they need semantic work; inspect-only surfaces remain observational.
 pub(crate) struct RuntimeContext {
+    pub(crate) runtime: Runtime,
     pub(crate) activation: ActivationService,
     pub(crate) public_operation: PublicOperationService,
     pub(crate) project: ProjectService,
@@ -182,6 +183,7 @@ impl RuntimeContextConfiguration {
             ));
         let events = runtime.events();
         RuntimeContext {
+            runtime: runtime.clone(),
             activation: runtime.activation_service(),
             public_operation: runtime.public_operation_service(),
             project: runtime.project_service(),

--- a/crates/codestory-cli/src/stdio_arguments.rs
+++ b/crates/codestory-cli/src/stdio_arguments.rs
@@ -94,8 +94,17 @@ pub(crate) fn validate_tool_arguments(
     tool: &str,
     arguments: Option<&Value>,
 ) -> Result<(), Vec<ArgumentViolation>> {
-    let Some(schema) = crate::stdio_catalog::tool_input_schema(tool) else {
-        return Ok(());
+    let proof_schema;
+    let schema = if tool == "prove_call_path" {
+        proof_schema = crate::stdio_v3::catalog::proof_tool_source_v3();
+        proof_schema
+            .get("inputSchema")
+            .expect("proof tool source declares inputSchema")
+    } else {
+        let Some(schema) = crate::stdio_catalog::tool_input_schema(tool) else {
+            return Ok(());
+        };
+        schema
     };
     // The dispatcher deliberately admits absent and null arguments; both mean
     // "no arguments supplied", which the schema still has to accept or reject.

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -1665,7 +1665,7 @@ fn handle_stdio_request(
                     "Invalid params: missing tool name",
                 ));
             };
-            if !is_stdio_tool_name(name) {
+            if !is_stdio_tool_name(name) && name != "prove_call_path" {
                 return Some(stdio_jsonrpc_error(
                     id,
                     -32602,
@@ -1688,6 +1688,12 @@ fn handle_stdio_request(
             }
             let prepared = match prepare_stdio_tool_call(session, name, &request) {
                 Ok(prepared) => prepared,
+                Err(error) if name == "prove_call_path" => {
+                    return Some(crate::stdio_v3::jsonrpc_invalid_params_v3(
+                        id,
+                        &error.message,
+                    ));
+                }
                 Err(error) => {
                     return Some(stdio_jsonrpc_success(
                         id,
@@ -1729,7 +1735,15 @@ fn handle_stdio_request(
                     });
                     return Some(stdio_jsonrpc_success(id, stdio_tool_call_error_v3(&error)));
                 }
-                let activation = if observes_complete_core {
+                let activation = if name == "prove_call_path" {
+                    runtime
+                        .activation
+                        .bind_existing_complete_core_for_observation(
+                            &runtime.project_root,
+                            &runtime.storage_path,
+                            Arc::clone(cancelled),
+                        )
+                } else if observes_complete_core {
                     runtime.activation.ensure_complete_core_for_observation(
                         &runtime.project_root,
                         &runtime.storage_path,
@@ -1855,6 +1869,82 @@ fn handle_stdio_request(
                     }
                 }
                 state.status_cache = None;
+            }
+            if name == "prove_call_path" {
+                let PreparedStdioToolCall::ProveCallPath(proof_request) = &prepared else {
+                    return Some(stdio_jsonrpc_error(id, -32603, "Internal error"));
+                };
+                let validation =
+                    match crate::prove_call_path::validate_request(proof_request.clone()) {
+                        Ok(validation) => validation,
+                        Err(message) => {
+                            return Some(stdio_jsonrpc_success(
+                                id,
+                                crate::stdio_v3::semantic_tool_error_v3(&message),
+                            ));
+                        }
+                    };
+                let root = match validation {
+                    codestory_runtime::proof_qualification_support::ValidationOutcome::Validated {
+                        contract,
+                        hashes,
+                        rendering,
+                    } => {
+                        let operation = match codestory_runtime::proof_qualification_support::
+                            run_observed_call_path_public_operation(
+                                &runtime.runtime,
+                                &contract,
+                                &hashes,
+                                &rendering,
+                                Arc::clone(cancelled),
+                            ) {
+                            Ok(operation) => operation,
+                            Err(error) => {
+                                return Some(stdio_jsonrpc_success(
+                                    id,
+                                    crate::stdio_v3::semantic_tool_error_v3(&error.message),
+                                ));
+                            }
+                        };
+                        match crate::prove_call_path::projection_root(&operation) {
+                            Ok(root) => root,
+                            Err(_) => {
+                                return Some(stdio_jsonrpc_error(id, -32603, "Internal error"));
+                            }
+                        }
+                    }
+                    codestory_runtime::proof_qualification_support::ValidationOutcome::Unknown {
+                        spec,
+                        hashes,
+                        rendering,
+                        gaps,
+                    } => {
+                        let operation = match codestory_runtime::proof_qualification_support::
+                            run_translation_unknown_public_operation(
+                                &runtime.runtime,
+                                &spec,
+                                &hashes,
+                                &rendering,
+                                &gaps,
+                                Arc::clone(cancelled),
+                            ) {
+                            Ok(operation) => operation,
+                            Err(error) => {
+                                return Some(stdio_jsonrpc_success(
+                                    id,
+                                    crate::stdio_v3::semantic_tool_error_v3(&error.message),
+                                ));
+                            }
+                        };
+                        crate::prove_call_path::internal_projection_root(&operation.value)
+                    }
+                };
+                return Some(
+                    match crate::stdio_v3::build_proof_tool_result_v3(revision, &root) {
+                        Ok(result) => stdio_jsonrpc_success(id, result),
+                        Err(error) => crate::stdio_v3::jsonrpc_internal_error_v3(id, &error),
+                    },
+                );
             }
             // Public-operation retry belongs to codestory-runtime's pinned
             // retrieval wrapper. The transport executes one logical operation
@@ -2632,7 +2722,7 @@ fn stdio_tool_reads_publication(name: &str) -> bool {
 }
 
 fn stdio_tool_observes_complete_core(name: &str) -> bool {
-    name == "affected"
+    matches!(name, "affected" | "prove_call_path")
 }
 
 fn stdio_public_operation_name<'a>(name: &'a str, request: &serde_json::Value) -> &'a str {
@@ -3456,6 +3546,7 @@ enum PreparedStdioToolCall {
     Raw,
     Affected(AffectedAnalysisRequest),
     Snippet(StdioSnippetRequest),
+    ProveCallPath(crate::prove_call_path::ProveCallPathRequestDto),
 }
 
 #[derive(Debug, Clone)]
@@ -3478,6 +3569,19 @@ fn prepare_stdio_tool_call(
             Ok(PreparedStdioToolCall::Affected(affected))
         }
         "snippet" => stdio_snippet_request(request).map(PreparedStdioToolCall::Snippet),
+        "prove_call_path" => {
+            let mut arguments = request
+                .pointer("/params/arguments")
+                .cloned()
+                .ok_or_else(|| ApiError::invalid_argument("proof arguments must be an object"))?;
+            arguments
+                .as_object_mut()
+                .ok_or_else(|| ApiError::invalid_argument("proof arguments must be an object"))?
+                .remove("project");
+            crate::prove_call_path::parse_request(arguments)
+                .map(PreparedStdioToolCall::ProveCallPath)
+                .map_err(ApiError::invalid_argument)
+        }
         _ => Ok(PreparedStdioToolCall::Raw),
     }
 }

--- a/crates/codestory-cli/src/stdio_v3/catalog.rs
+++ b/crates/codestory-cli/src/stdio_v3/catalog.rs
@@ -7,7 +7,7 @@ const PROJECTION_ROWS_MAX_V3: usize = 256;
 const PROJECTION_REFERENCES_MAX_V3: usize = 256;
 
 pub(crate) fn tools_for_revision_v3(revision: McpRevisionV3) -> Vec<Value> {
-    tools_for_surface_v3(revision, V3SurfaceSet::EvidenceOnly)
+    tools_for_surface_v3(revision, V3SurfaceSet::WithProof)
 }
 
 pub(crate) fn tools_for_surface_v3(revision: McpRevisionV3, surface: V3SurfaceSet) -> Vec<Value> {
@@ -209,6 +209,45 @@ fn proof_gap_schema_v3() -> Value {
     json!({
         "type":"object",
         "oneOf":[
+            closed_object_schema_v3(vec![(
+                "kind",
+                enum_schema_v3(&["unclassified_source_text"]),
+            )]),
+            closed_object_schema_v3(vec![
+                ("kind", enum_schema_v3(&["unresolved_material_clause"])),
+                ("clause_id", string_schema_v3()),
+                (
+                    "reason",
+                    enum_schema_v3(&[
+                        "missing_selector_resolution",
+                        "ambiguous_selector_resolution",
+                        "unsupported_interpretation",
+                    ]),
+                ),
+            ]),
+            closed_object_schema_v3(vec![
+                ("kind", enum_schema_v3(&["material_token_misclassified"])),
+                ("clause_id", string_schema_v3()),
+                (
+                    "guard_families",
+                    json!({
+                        "type":"array",
+                        "items":enum_schema_v3(&[
+                            "quoted_or_backticked_identifier",
+                            "arrow_or_relation_notation",
+                            "directness",
+                            "ordering_or_ordinal",
+                            "only",
+                            "negation_or_exclusion",
+                            "path_like_string",
+                            "qualified_symbol_notation",
+                        ]),
+                        "minItems":1,
+                        "maxItems":8,
+                        "uniqueItems":true,
+                    }),
+                ),
+            ]),
             selector_gap("selector_missing"),
             selector_gap("selector_ambiguous"),
             selector_gap("non_callable_selector"),
@@ -912,27 +951,157 @@ fn successful_with_preparing_schema_v3(success: Value) -> Value {
     })
 }
 
-fn proof_tool_source_v3() -> Value {
+pub(crate) fn proof_tool_source_v3() -> Value {
     json!({
         "name": "prove_call_path",
         "description": "Verify one host-translated exact indexed source call-path contract against a pinned publication.",
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "project": {"type":"string","minLength":1},
-                "source_text": {"type":"string","minLength":1},
-                "clauses": {"type":"array"},
-                "spec": {"type":"object"}
-            },
-            "required": ["project", "source_text", "clauses", "spec"],
-            "additionalProperties": false
-        },
+        "inputSchema": proof_input_schema_v3(),
         "outputSchema": proof_output_schema_v3(),
         "safety": {
             "effect": "read_only",
             "activatesProject": false,
             "sideEffects": false
         }
+    })
+}
+
+fn proof_input_schema_v3() -> Value {
+    closed_object_schema_v3(vec![
+        ("project", json!({"type":"string","minLength":1})),
+        ("source_text", json!({"type":"string","minLength":1})),
+        (
+            "clauses",
+            json!({"type":"array","items":proof_clause_anchor_input_schema_v3()}),
+        ),
+        ("spec", proof_spec_input_schema_v3()),
+    ])
+}
+
+fn proof_clause_anchor_input_schema_v3() -> Value {
+    closed_object_schema_v3(vec![
+        ("clause_id", json!({"type":"string","minLength":1})),
+        ("start_byte", unsigned_integer_schema_v3()),
+        ("end_byte_exclusive", unsigned_integer_schema_v3()),
+        ("quote", string_schema_v3()),
+        (
+            "classification",
+            proof_clause_classification_input_schema_v3(),
+        ),
+    ])
+}
+
+fn proof_clause_classification_input_schema_v3() -> Value {
+    json!({
+        "type":"object",
+        "oneOf":[
+            closed_object_schema_v3(vec![
+                ("kind", enum_schema_v3(&["resolved_material"])),
+                ("fields", json!({
+                    "type":"array",
+                    "items":proof_contract_field_input_schema_v3(),
+                    "minItems":1,
+                })),
+            ]),
+            closed_object_schema_v3(vec![
+                ("kind", enum_schema_v3(&["unresolved_material"])),
+                ("reason", enum_schema_v3(&[
+                    "missing_selector_resolution",
+                    "ambiguous_selector_resolution",
+                    "unsupported_interpretation",
+                ])),
+            ]),
+            closed_object_schema_v3(vec![
+                ("kind", enum_schema_v3(&["non_material"])),
+                ("reason", enum_schema_v3(&[
+                    "whitespace",
+                    "punctuation",
+                    "connector",
+                    "commentary",
+                ])),
+            ]),
+        ],
+    })
+}
+
+fn proof_contract_field_input_schema_v3() -> Value {
+    let step = |kind| {
+        closed_object_schema_v3(vec![
+            ("kind", enum_schema_v3(&[kind])),
+            ("step", json!({"type":"integer","minimum":0,"maximum":5})),
+        ])
+    };
+    let scope = |kind| {
+        closed_object_schema_v3(vec![
+            ("kind", enum_schema_v3(&[kind])),
+            ("index", json!({"type":"integer","minimum":0,"maximum":255})),
+        ])
+    };
+    json!({
+        "type":"object",
+        "oneOf":[
+            closed_object_schema_v3(vec![("kind", enum_schema_v3(&["start"]))]),
+            step("step_target"),
+            step("directness"),
+            step("ordering"),
+            step("relation"),
+            scope("traversal_prohibition"),
+            scope("projection_exclusion"),
+        ],
+    })
+}
+
+fn proof_spec_input_schema_v3() -> Value {
+    closed_object_schema_v3(vec![
+        ("start", proof_selector_input_schema_v3()),
+        (
+            "steps",
+            json!({
+                "type":"array",
+                "items":closed_object_schema_v3(vec![("target", proof_selector_input_schema_v3())]),
+                "minItems":1,
+                "maxItems":6,
+            }),
+        ),
+        (
+            "prohibit_traversal_through",
+            json!({"type":"array","items":proof_selector_input_schema_v3(),"maxItems":256}),
+        ),
+        (
+            "exclude_from_projection",
+            json!({"type":"array","items":proof_selector_input_schema_v3(),"maxItems":256}),
+        ),
+    ])
+}
+
+fn proof_selector_input_schema_v3() -> Value {
+    let file_components = json!({
+        "type":["array","null"],
+        "items":{"type":"string","minLength":1},
+    });
+    json!({
+        "type":"object",
+        "oneOf":[
+            closed_object_schema_v3(vec![
+                ("kind", enum_schema_v3(&["pinned_node"])),
+                ("project_id", string_schema_v3()),
+                ("core_generation_id", string_schema_v3()),
+                ("core_run_id", string_schema_v3()),
+                ("node_id", string_schema_v3()),
+            ]),
+            closed_object_schema_v3(vec![
+                ("kind", enum_schema_v3(&["canonical_id"])),
+                ("canonical_id", string_schema_v3()),
+            ]),
+            closed_object_schema_v3(vec![
+                ("kind", enum_schema_v3(&["qualified_name"])),
+                ("qualified_name", string_schema_v3()),
+            ]),
+            closed_object_schema_v3(vec![
+                ("kind", enum_schema_v3(&["qualified_name"])),
+                ("qualified_name", string_schema_v3()),
+                ("project_file_components", file_components),
+            ]),
+        ],
     })
 }
 

--- a/crates/codestory-cli/src/stdio_v3/discovery.rs
+++ b/crates/codestory-cli/src/stdio_v3/discovery.rs
@@ -32,7 +32,7 @@ impl NativeSessionV3 {
             .and_then(McpRevisionV3::parse)
             .unwrap_or_else(McpRevisionV3::preferred);
         let discovery_identity =
-            discovery_contract_for_surface_v3(negotiated_revision, V3SurfaceSet::EvidenceOnly);
+            discovery_contract_for_surface_v3(negotiated_revision, V3SurfaceSet::WithProof);
         Self {
             requested_revision,
             negotiated_revision,
@@ -226,9 +226,7 @@ mod tests {
     fn discovery_contracts_are_deterministic_distinct_and_initialize_bound() {
         let identities = McpRevisionV3::all()
             .iter()
-            .map(|revision| {
-                discovery_contract_for_surface_v3(*revision, V3SurfaceSet::EvidenceOnly)
-            })
+            .map(|revision| discovery_contract_for_surface_v3(*revision, V3SurfaceSet::WithProof))
             .collect::<Vec<_>>();
         assert_eq!(
             identities
@@ -242,7 +240,7 @@ mod tests {
             assert_eq!(identity.sha256.len(), 64);
             assert!(identity.sha256.bytes().all(|byte| byte.is_ascii_hexdigit()));
             assert_eq!(
-                discovery_contract_for_surface_v3(identity.revision, V3SurfaceSet::EvidenceOnly),
+                discovery_contract_for_surface_v3(identity.revision, V3SurfaceSet::WithProof),
                 *identity
             );
 

--- a/crates/codestory-cli/src/stdio_v3/mod.rs
+++ b/crates/codestory-cli/src/stdio_v3/mod.rs
@@ -1,4 +1,4 @@
-mod catalog;
+pub(crate) mod catalog;
 mod diagnostics;
 mod discovery;
 mod profile;
@@ -13,8 +13,8 @@ pub(crate) use discovery::NativeSessionV3;
 pub(crate) use discovery::discovery_contract_v3;
 pub(crate) use profile::McpRevisionV3;
 pub(crate) use transport::{
-    FrameResponseV3, build_tool_result_v3, jsonrpc_internal_error_v3, process_jsonrpc_frame_v3,
-    semantic_tool_error_v3,
+    FrameResponseV3, build_proof_tool_result_v3, build_tool_result_v3, jsonrpc_internal_error_v3,
+    jsonrpc_invalid_params_v3, process_jsonrpc_frame_v3, semantic_tool_error_v3,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/codestory-cli/src/stdio_v3/transport.rs
+++ b/crates/codestory-cli/src/stdio_v3/transport.rs
@@ -95,7 +95,6 @@ pub(crate) fn build_proof_tool_result_v3(
     {
         return Err(StdioV3InternalError::OutputSchemaViolation);
     }
-    #[cfg(feature = "proof-qualification-support")]
     codestory_runtime::proof_qualification_support::validate_compact_projection(root)
         .map_err(|_| StdioV3InternalError::InvalidProjection("prove_call_path".to_owned()))?;
     let result = build_tool_result_for_surface_v3(
@@ -119,7 +118,6 @@ pub(crate) fn build_proof_tool_result_v3(
     {
         return Err(StdioV3InternalError::OutputSchemaViolation);
     }
-    #[cfg(feature = "proof-qualification-support")]
     codestory_runtime::proof_qualification_support::validate_compact_projection(&fallback)
         .map_err(|_| StdioV3InternalError::InvalidProjection("prove_call_path".to_owned()))?;
     let fallback_result = build_tool_result_for_surface_v3(

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -633,8 +633,8 @@ const AGENT_PLANNING_MODULES: [&str; 28] = [
 ///   `agent_eval_hooks_stay_on_for_runtime_tests_and_off_for_product_builds`
 ///   pins how it compiles. Listing it as a planning module would hand the
 ///   import-DAG guard a file no product build links.
-/// - `indexed_source_call_path_v1.rs` is the dark v3 proof kernel. Task 2 keeps
-///   it behind the same test-support gate until the atomic public v3 cut.
+/// - `indexed_source_call_path_v1.rs` is the private v3 proof kernel. Public
+///   callers reach it only through the sealed exact-verifier facades.
 const AGENT_MODULE_ALLOWLIST_EXCLUSIONS: [&str; 3] =
     ["lib.rs", "eval_probes.rs", "indexed_source_call_path_v1.rs"];
 
@@ -838,7 +838,7 @@ fn legacy_dark_packet_v3_preparation_stays_inert_and_unshipped() {
 }
 
 #[test]
-fn proof_qualification_transport_measurement_is_bench_only_and_unregistered() {
+fn public_exact_verifier_uses_the_revision_native_transport_once() {
     let cli_lib = read("crates/codestory-cli/src/lib.rs");
     assert!(
         cli_lib.contains("mod stdio_v3;"),
@@ -853,7 +853,7 @@ fn proof_qualification_transport_measurement_is_bench_only_and_unregistered() {
     ] {
         assert!(
             facade.contains(required),
-            "the dark stdio v3 facade lost its qualification seam via {required}"
+            "the stdio v3 facade lost its verifier transport seam via {required}"
         );
     }
 
@@ -875,28 +875,30 @@ fn proof_qualification_transport_measurement_is_bench_only_and_unregistered() {
     ] {
         assert!(
             !production_cli.contains(forbidden),
-            "a production CLI module references the dark qualification seam via {forbidden}"
+            "a production CLI module references the transport measurement seam via {forbidden}"
         );
     }
 
-    for surface in [
-        "crates/codestory-cli/src/args.rs",
-        "crates/codestory-cli/src/http_transport.rs",
-        "plugins/codestory/generated-mcp-catalog.json",
-        "plugins/codestory/skills/codestory-grounding/references/generated-mcp-syntax.md",
-    ] {
-        let source = read(surface);
-        for forbidden in [
-            "measure_revision_native_proof_result_v3",
-            "RevisionNativeToolResultMeasurementV3",
-            "prove_call_path",
-        ] {
-            assert!(
-                !source.contains(forbidden),
-                "{surface} registers or exposes the dark transport seam via {forbidden}"
-            );
-        }
-    }
+    let args = read("crates/codestory-cli/src/args.rs");
+    assert_eq!(
+        args.matches("ProveCallPath(ProveCallPathCommand)").count(),
+        1,
+        "the public CLI verifier command must be registered exactly once"
+    );
+    let catalog = read("crates/codestory-cli/src/stdio_v3/catalog.rs");
+    assert_eq!(
+        catalog
+            .matches("sources.push(proof_tool_source_v3());")
+            .count(),
+        1,
+        "the exact verifier must enter every revision catalog through one owning registration"
+    );
+    let stdio_catalog = read("crates/codestory-cli/src/stdio_catalog.rs");
+    let legacy_catalog = source_between(&stdio_catalog, "static TOOLS:", "static RESOURCES:");
+    assert!(
+        !legacy_catalog.contains("prove_call_path"),
+        "the legacy Supported catalog must not reach the v3 verifier response"
+    );
 
     let launcher = read("plugins/codestory/scripts/codestory-mcp.cjs");
     let live_launcher = source_between(
@@ -927,170 +929,30 @@ fn proof_qualification_transport_measurement_is_bench_only_and_unregistered() {
 }
 
 #[test]
-fn proof_qualification_support_is_bench_only_and_never_a_product_feature() {
+fn public_exact_verifier_compiles_through_the_sealed_proof_facades() {
     const SUPPORT_FEATURE: &str = "proof-qualification-support";
-    const BENCHMARK_FEATURE: &str = "benchmark-support";
-
-    for crate_manifest in [
+    for manifest_path in [
         "crates/codestory-agent/Cargo.toml",
         "crates/codestory-runtime/Cargo.toml",
-        "crates/codestory-cli/Cargo.toml",
     ] {
-        let crate_manifest_value = manifest(crate_manifest);
-        let features = crate_manifest_value
+        let crate_manifest = manifest(manifest_path);
+        let features = crate_manifest
             .get("features")
             .and_then(Value::as_table)
-            .expect("qualification crate must declare features");
+            .expect("exact verifier features");
         assert!(
-            features.contains_key(SUPPORT_FEATURE),
-            "{crate_manifest} must declare the sealed {SUPPORT_FEATURE} feature"
+            features
+                .get("default")
+                .is_some_and(|default| default.to_string().contains(SUPPORT_FEATURE)),
+            "{manifest_path} must compile the sealed proof facade for the public verifier"
         );
     }
-
-    let agent_lib = read("crates/codestory-agent/src/lib.rs");
-    assert!(
-        agent_lib.contains("feature = \"proof-qualification-support\"")
-            && agent_lib.contains("pub mod proof_qualification_support"),
-        "the agent qualification facade must be feature-gated rather than public by default"
-    );
     let runtime_lib = read("crates/codestory-runtime/src/lib.rs");
-    assert!(
-        runtime_lib.contains("feature = \"proof-qualification-support\"")
-            && runtime_lib.contains("pub mod proof_qualification_support;"),
-        "the runtime qualification facade must be feature-gated rather than public by default"
-    );
-    let cli_lib = read("crates/codestory-cli/src/lib.rs");
-    assert!(
-        cli_lib.contains("feature = \"proof-qualification-support\"")
-            && cli_lib.contains("pub mod proof_qualification_support"),
-        "the CLI qualification facade must be feature-gated rather than public by default"
-    );
-
-    let bench = manifest("crates/codestory-bench/Cargo.toml");
-    let dependencies = bench
-        .get("dependencies")
-        .and_then(Value::as_table)
-        .expect("qualification dependencies must be normal benchmark dependencies");
-    for required in [
-        "codestory-agent",
-        "codestory-runtime",
-        "codestory-cli",
-        "codestory-store",
-        "codestory-indexer",
-        "codestory-contracts",
-    ] {
-        assert!(
-            dependencies.contains_key(required),
-            "{required} must be a normal codestory-bench dependency"
-        );
-    }
-    for (dependency, expected) in [
-        ("codestory-agent", BTreeSet::from([SUPPORT_FEATURE])),
-        (
-            "codestory-runtime",
-            BTreeSet::from([SUPPORT_FEATURE, BENCHMARK_FEATURE]),
-        ),
-        ("codestory-cli", BTreeSet::from([SUPPORT_FEATURE])),
-    ] {
-        let enabled = dependencies
-            .get(dependency)
-            .and_then(Value::as_table)
-            .and_then(|entry| entry.get("features"))
-            .and_then(Value::as_array)
-            .expect("qualification dependency must declare its enabled features")
-            .iter()
-            .filter_map(Value::as_str)
-            .collect::<BTreeSet<_>>();
-        assert!(
-            enabled.contains(SUPPORT_FEATURE),
-            "{dependency} must receive the sealed qualification feature from codestory-bench"
-        );
-        assert!(
-            !enabled.contains("test-support"),
-            "{dependency} must not receive test-support from codestory-bench"
-        );
-        assert_eq!(
-            enabled, expected,
-            "{dependency} must enable exactly the sealed benchmark features"
-        );
-    }
-
-    for crate_manifest in [
-        "crates/codestory-agent/Cargo.toml",
-        "crates/codestory-runtime/Cargo.toml",
-        "crates/codestory-cli/Cargo.toml",
-    ] {
-        for table in ["dependencies", "dev-dependencies", "build-dependencies"] {
-            let crate_manifest_value = manifest(crate_manifest);
-            let Some(entries) = crate_manifest_value.get(table).and_then(Value::as_table) else {
-                continue;
-            };
-            for (dependency, entry) in entries {
-                let enabled = entry
-                    .as_table()
-                    .and_then(|entry| entry.get("features"))
-                    .and_then(Value::as_array)
-                    .into_iter()
-                    .flatten()
-                    .filter_map(Value::as_str);
-                assert!(
-                    !enabled.clone().any(|feature| feature == SUPPORT_FEATURE),
-                    "{crate_manifest} enables {SUPPORT_FEATURE} for {dependency}; only codestory-bench may do that"
-                );
-            }
-        }
-    }
-
-    let runtime_manifest = manifest("crates/codestory-runtime/Cargo.toml");
-    let runtime_features = runtime_manifest
-        .get("features")
-        .and_then(Value::as_table)
-        .expect("runtime features");
-    assert!(
-        runtime_features
-            .get(SUPPORT_FEATURE)
-            .is_some_and(|feature| feature
-                .to_string()
-                .contains("codestory-agent/proof-qualification-support")),
-        "runtime qualification support must carry the sealed agent feature"
-    );
-    let cli_manifest = manifest("crates/codestory-cli/Cargo.toml");
-    let cli_features = cli_manifest
-        .get("features")
-        .and_then(Value::as_table)
-        .expect("CLI features");
-    assert!(
-        cli_features
-            .get(SUPPORT_FEATURE)
-            .is_some_and(|feature| feature
-                .to_string()
-                .contains("codestory-runtime/proof-qualification-support")),
-        "CLI qualification support must carry the sealed runtime feature"
-    );
-
-    for surface in [
-        "crates/codestory-cli/src/args.rs",
-        "crates/codestory-cli/src/http_transport.rs",
-        "plugins/codestory/generated-mcp-catalog.json",
-        "plugins/codestory/skills/codestory-grounding/references/generated-mcp-syntax.md",
-        "plugins/codestory/plugin.json",
-        "plugins/codestory/.codex-plugin/plugin.json",
-        "plugins/codestory/.cursor-plugin/plugin.json",
-        "plugins/codestory/.claude-plugin/plugin.json",
-        "plugins/codestory/.github/plugin/plugin.json",
-    ] {
-        let source = read(surface);
-        for forbidden in [
-            SUPPORT_FEATURE,
-            "proof_qualification_support",
-            "prove_call_path",
-        ] {
-            assert!(
-                !source.contains(forbidden),
-                "{surface} exposes qualification-only behavior via {forbidden}"
-            );
-        }
-    }
+    assert!(runtime_lib.contains("pub mod proof_qualification_support;"));
+    let cli = read_source_tree("crates/codestory-cli/src");
+    assert!(cli.contains("run_observed_call_path_public_operation"));
+    assert!(cli.contains("run_translation_unknown_public_operation"));
+    assert!(!read("crates/codestory-cli/src/http_transport.rs").contains("prove_call_path"));
 
     let launcher = read("plugins/codestory/scripts/codestory-mcp.cjs");
     let launcher_revisions = ["2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25"];
@@ -1379,86 +1241,36 @@ fn exact_resolution_facts_are_a_one_way_proof_overlay() {
     }
 }
 
-fn dark_call_path_release_surface_violations() -> Vec<String> {
-    const DARK_TOKENS: [&str; 5] = [
-        "indexed_source_call_path_v1",
-        "ValidatedCallPathContract",
-        "InternalProjection",
-        "InternalCorePublicationIdentity",
-        "IntegratedProjectedCallPathResult",
-    ];
-    let mut surfaces = vec![
-        (
-            "cli command/dispatcher/ToolSpec/HTTP/serializer source",
-            read_source_tree_excluding_many(
-                "crates/codestory-cli/src",
-                &[
-                    "stdio_v3/catalog.rs",
-                    "stdio_v3/diagnostics.rs",
-                    "stdio_v3/discovery.rs",
-                    "stdio_v3/mod.rs",
-                    "stdio_v3/profile.rs",
-                    "stdio_v3/transport.rs",
-                ],
-            ),
-        ),
-        (
-            "public API DTO source",
-            format!(
-                "{}\n{}",
-                read("crates/codestory-contracts/src/api.rs"),
-                read_source_tree("crates/codestory-contracts/src/api")
-            ),
-        ),
-        (
-            "generated MCP catalog",
-            read("plugins/codestory/generated-mcp-catalog.json"),
-        ),
-        ("plugin manifest", read("plugins/codestory/plugin.json")),
-        (
-            "Codex plugin manifest",
-            read("plugins/codestory/.codex-plugin/plugin.json"),
-        ),
-        (
-            "Cursor plugin manifest",
-            read("plugins/codestory/.cursor-plugin/plugin.json"),
-        ),
-        (
-            "Claude plugin manifest",
-            read("plugins/codestory/.claude-plugin/plugin.json"),
-        ),
-        (
-            "grounding skill syntax",
-            read("plugins/codestory/skills/codestory-grounding/SKILL.md"),
-        ),
-        (
-            "generated MCP skill syntax",
-            read("plugins/codestory/skills/codestory-grounding/references/generated-mcp-syntax.md"),
-        ),
-    ];
-    let gate = "#[cfg(any(\n    test,\n    feature = \"test-support\",\n    feature = \"proof-qualification-support\"\n))]\nmod indexed_source_call_path_v1;";
-    let runtime_facade = read("crates/codestory-runtime/src/lib.rs").replace(gate, "");
-    surfaces.push(("public runtime facade", runtime_facade));
-    surfaces.push((
-        "public runtime services",
-        production_source(&read("crates/codestory-runtime/src/services.rs")),
-    ));
+#[test]
+fn public_call_path_release_surfaces_are_unique_and_legacy_unreachable() {
+    let args = read("crates/codestory-cli/src/args.rs");
+    assert_eq!(
+        args.matches("ProveCallPath(ProveCallPathCommand)").count(),
+        1
+    );
 
-    let mut violations = Vec::new();
-    for (surface, source) in surfaces {
-        for token in DARK_TOKENS {
-            if source.contains(token) {
-                violations.push(format!("{surface}: {token}"));
-            }
-        }
-    }
+    let catalog = read("crates/codestory-cli/src/stdio_v3/catalog.rs");
+    assert_eq!(
+        catalog
+            .matches("sources.push(proof_tool_source_v3());")
+            .count(),
+        1
+    );
 
-    let adapter = production_source(&read(
-        "crates/codestory-runtime/src/indexed_source_call_path_v1.rs",
-    ));
-    if contains_word(&adapter, "source_text") {
-        violations.push("dark runtime adapter: raw source_text".to_owned());
-    }
+    let dispatcher = read("crates/codestory-cli/src/stdio_transport.rs");
+    let stdio_catalog = read("crates/codestory-cli/src/stdio_catalog.rs");
+    let legacy_tools = source_between(&stdio_catalog, "static TOOLS:", "static RESOURCES:");
+    assert!(!legacy_tools.contains("prove_call_path"));
+    let public_proof = source_between(
+        &dispatcher,
+        "if name == \"prove_call_path\"",
+        "// Public-operation retry belongs",
+    );
+    assert_eq!(
+        public_proof.matches("build_proof_tool_result_v3").count(),
+        1
+    );
+    assert!(!public_proof.contains("Supported"));
 
     for consumer in [
         "crates/codestory-runtime/Cargo.toml",
@@ -1473,21 +1285,11 @@ fn dark_call_path_release_surface_violations() -> Vec<String> {
             .and_then(Value::as_array)
             .map(|values| values.iter().filter_map(Value::as_str).collect::<Vec<_>>())
             .unwrap_or_default();
-        if features.contains(&"test-support") {
-            violations.push(format!("{consumer}: ships codestory-agent/test-support"));
-        }
+        assert!(
+            !features.contains(&"test-support"),
+            "{consumer} must not ship codestory-agent/test-support"
+        );
     }
-    violations
-}
-
-#[test]
-fn dark_call_path_release_surfaces_remain_v2_only_and_test_support_unshipped() {
-    let violations = dark_call_path_release_surface_violations();
-    assert!(
-        violations.is_empty(),
-        "dark v3 call-path symbols reached a production route, DTO, serializer, manifest, skill, or shipping feature edge:\n{}",
-        violations.join("\n")
-    );
 }
 
 /// Packet planning lives in `codestory-agent`, and the crate DAG is what keeps

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -49,7 +49,7 @@ const GROUNDING_ORIENTATION_UNCERTAINTY_WIRE_VALUES: [&str; 7] = {
 };
 
 #[test]
-fn public_v3_outcome_c_negotiates_revision_native_evidence_only_discovery() {
+fn public_v3_outcome_a_negotiates_revision_native_discovery_with_exact_proof() {
     let profiles: Value = serde_json::from_str(include_str!("fixtures/mcp_protocol_profiles.json"))
         .expect("compatibility profile fixture json");
     let revisions = profiles
@@ -160,15 +160,32 @@ fn public_v3_outcome_c_negotiates_revision_native_evidence_only_discovery() {
         let tools = assert_success_envelope(&listed, json!("list"))["tools"]
             .as_array()
             .expect("tools array");
-        assert_eq!(tools.len(), 20);
-        for route in ["packet", "context", "search"] {
+        assert_eq!(tools.len(), 21);
+        for route in ["packet", "context", "search", "prove_call_path"] {
             assert_eq!(
                 tools.iter().filter(|tool| tool["name"] == route).count(),
                 1,
                 "{route} must register exactly once"
             );
         }
-        assert!(!tools.iter().any(|tool| tool["name"] == "prove_call_path"));
+        let proof = tools
+            .iter()
+            .find(|tool| tool["name"] == "prove_call_path")
+            .expect("exact proof tool");
+        assert!(proof.get("safety").is_none());
+        if revision >= "2025-03-26" {
+            assert_eq!(
+                proof.pointer("/annotations/readOnlyHint"),
+                Some(&json!(true))
+            );
+        } else {
+            assert!(proof.get("annotations").is_none());
+        }
+        if revision >= "2025-06-18" {
+            assert_eq!(proof.pointer("/outputSchema/type"), Some(&json!("object")));
+        } else {
+            assert!(proof.get("outputSchema").is_none());
+        }
         let packet = tools
             .iter()
             .find(|tool| tool["name"] == "packet")
@@ -229,6 +246,119 @@ fn public_v3_outcome_c_negotiates_revision_native_evidence_only_discovery() {
         );
         assert_eq!(invalid.pointer("/error/code"), Some(&json!(-32602)));
     }
+}
+
+#[test]
+fn public_exact_proof_call_is_revision_native_and_keeps_uncertainty_successful() {
+    let fixture = indexed_proof_fixture();
+    let exact = exact_proof_arguments(&fixture);
+    for revision in ["2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25"] {
+        let mut server = spawn_stdio_server(&fixture);
+        let initialized = send_json(
+            &mut server,
+            json!({
+                "jsonrpc":"2.0",
+                "id":"init",
+                "method":"initialize",
+                "params":{
+                    "protocolVersion":revision,
+                    "capabilities":{},
+                    "clientInfo":{"name":"proof-contract","version":"0"}
+                }
+            }),
+        );
+        assert_success_envelope(&initialized, json!("init"));
+
+        let proven = send_json(
+            &mut server,
+            json!({
+                "jsonrpc":"2.0",
+                "id":"proven",
+                "method":"tools/call",
+                "params":{"name":"prove_call_path","arguments":exact}
+            }),
+        );
+        let result = assert_success_envelope(&proven, json!("proven"));
+        assert_eq!(result["isError"], false, "{proven}");
+        let text_root = serde_json::from_str::<Value>(
+            result
+                .pointer("/content/0/text")
+                .and_then(Value::as_str)
+                .unwrap(),
+        )
+        .expect("proof text JSON");
+        assert_eq!(
+            text_root.pointer("/disposition/kind"),
+            Some(&json!("contract_proven")),
+            "{text_root}"
+        );
+        if revision >= "2025-06-18" {
+            assert_eq!(result["structuredContent"], text_root);
+        } else {
+            assert!(result.get("structuredContent").is_none());
+        }
+
+        let mut unknown_arguments = exact.clone();
+        unknown_arguments["spec"]["steps"][0]["target"]["canonical_id"] =
+            json!("rust:missing-proof-target");
+        let unknown = send_json(
+            &mut server,
+            json!({
+                "jsonrpc":"2.0",
+                "id":"unknown",
+                "method":"tools/call",
+                "params":{"name":"prove_call_path","arguments":unknown_arguments}
+            }),
+        );
+        let result = assert_success_envelope(&unknown, json!("unknown"));
+        assert_eq!(result["isError"], false, "{unknown}");
+        let root = serde_json::from_str::<Value>(result["content"][0]["text"].as_str().unwrap())
+            .expect("unknown proof JSON");
+        assert_eq!(root.pointer("/disposition/kind"), Some(&json!("unknown")));
+
+        let mut incomplete_translation = exact.clone();
+        incomplete_translation["source_text"] = json!(format!(
+            "{} extra",
+            incomplete_translation["source_text"].as_str().unwrap()
+        ));
+        let incomplete_translation = send_json(
+            &mut server,
+            json!({
+                "jsonrpc":"2.0",
+                "id":"translation-unknown",
+                "method":"tools/call",
+                "params":{"name":"prove_call_path","arguments":incomplete_translation}
+            }),
+        );
+        let result = assert_success_envelope(&incomplete_translation, json!("translation-unknown"));
+        assert_eq!(result["isError"], false, "{incomplete_translation}");
+        let root = serde_json::from_str::<Value>(result["content"][0]["text"].as_str().unwrap())
+            .expect("translation unknown proof JSON");
+        assert_eq!(root.pointer("/disposition/kind"), Some(&json!("unknown")));
+        assert_eq!(
+            root.pointer("/disposition/gaps/0/kind"),
+            Some(&json!("unclassified_source_text"))
+        );
+
+        let mut invalid = exact.clone();
+        invalid["clauses"][0]["quote"] = json!("different text");
+        let invalid = send_json(
+            &mut server,
+            json!({
+                "jsonrpc":"2.0",
+                "id":"semantic",
+                "method":"tools/call",
+                "params":{"name":"prove_call_path","arguments":invalid}
+            }),
+        );
+        let result = assert_success_envelope(&invalid, json!("semantic"));
+        assert_eq!(result["isError"], true, "{invalid}");
+        assert!(result.get("structuredContent").is_none());
+    }
+    assert!(
+        !fixture.cache_dir.path().join("search-generations").exists(),
+        "proof execution must not initialize semantic retrieval"
+    );
 }
 
 #[test]
@@ -379,7 +509,7 @@ fn native_v3_rejects_the_launcher_invalid_argument_parity_matrix() {
 }
 
 #[test]
-fn public_v3_packet_cli_exposes_diagnostics_without_evidence_or_proof_switches() {
+fn public_v3_cli_exposes_exact_proof_without_packet_proof_switches() {
     let output = test_support::cli_command()
         .args(["packet", "--help"])
         .output()
@@ -396,6 +526,193 @@ fn public_v3_packet_cli_exposes_diagnostics_without_evidence_or_proof_switches()
     );
     assert!(!help.contains("--no-evidence"), "{help}");
     assert!(!help.contains("prove-call-path"), "{help}");
+
+    let output = test_support::cli_command()
+        .args(["prove-call-path", "--help"])
+        .output()
+        .expect("run prove-call-path help");
+    assert!(
+        output.status.success(),
+        "prove-call-path help failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let help = String::from_utf8(output.stdout).expect("UTF-8 prove-call-path help");
+    assert!(help.contains("--project <ROOT>"), "{help}");
+    assert!(help.contains("--spec <PATH>"), "{help}");
+    for forbidden in [
+        "--profile",
+        "--run-id",
+        "--retrieval-generation",
+        "--latency-budget",
+        "--evidence",
+    ] {
+        assert!(!help.contains(forbidden), "{help}");
+    }
+}
+
+#[test]
+fn prove_call_path_cli_keeps_file_stdin_dto_parity_and_caps_before_deserialization() {
+    let workspace = tempfile::tempdir().expect("CLI proof workspace");
+    let cache_root = tempfile::tempdir().expect("CLI proof cache root");
+    let spec_root = tempfile::tempdir().expect("CLI proof spec root");
+    write_tiny_rust_workspace(workspace.path());
+    let mut index = test_support::cli_command();
+    index
+        .args([
+            "index",
+            "--refresh",
+            "full",
+            "--format",
+            "json",
+            "--project",
+        ])
+        .arg(workspace.path())
+        .env("CODESTORY_CACHE_ROOT", cache_root.path())
+        .env("CODESTORY_STDIO_CACHE_ROOT", cache_root.path());
+    allow_explicit_cpu_embeddings(&mut index);
+    let indexed = index.output().expect("index CLI proof workspace");
+    assert!(
+        indexed.status.success(),
+        "index failed: {}",
+        String::from_utf8_lossy(&indexed.stderr)
+    );
+
+    let spec = unknown_proof_spec();
+    let spec_file = spec_root.path().join("proof-spec.json");
+    fs::write(&spec_file, serde_json::to_vec(&spec).unwrap()).expect("write proof spec");
+    let mut from_file = test_support::cli_command();
+    from_file
+        .args(["prove-call-path", "--project"])
+        .arg(workspace.path())
+        .arg("--spec")
+        .arg(&spec_file)
+        .env("CODESTORY_CACHE_ROOT", cache_root.path())
+        .env("CODESTORY_STDIO_CACHE_ROOT", cache_root.path());
+    let from_file = from_file.output().expect("run file proof");
+    assert!(
+        from_file.status.success(),
+        "file proof failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&from_file.stdout),
+        String::from_utf8_lossy(&from_file.stderr)
+    );
+
+    let mut from_stdin = test_support::cli_command();
+    from_stdin
+        .args(["prove-call-path", "--project"])
+        .arg(workspace.path())
+        .args(["--spec", "-"])
+        .env("CODESTORY_CACHE_ROOT", cache_root.path())
+        .env("CODESTORY_STDIO_CACHE_ROOT", cache_root.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped());
+    let mut child = from_stdin.spawn().expect("spawn stdin proof");
+    child
+        .stdin
+        .take()
+        .expect("proof stdin")
+        .write_all(&serde_json::to_vec(&spec).unwrap())
+        .expect("write stdin proof");
+    let from_stdin = child.wait_with_output().expect("wait stdin proof");
+    assert!(
+        from_stdin.status.success(),
+        "stdin proof failed: {}",
+        String::from_utf8_lossy(&from_stdin.stderr)
+    );
+    let file_root: Value = serde_json::from_slice(&from_file.stdout).expect("file proof JSON");
+    let stdin_root: Value = serde_json::from_slice(&from_stdin.stdout).expect("stdin proof JSON");
+    assert_eq!(file_root, stdin_root);
+    assert_eq!(
+        file_root.pointer("/disposition/kind"),
+        Some(&json!("unknown"))
+    );
+
+    let mut capped = unknown_proof_spec();
+    capped["padding"] = json!("");
+    let baseline = serde_json::to_vec(&capped).unwrap().len();
+    capped["padding"] = json!("x".repeat(64 * 1024 - baseline));
+    let capped = serde_json::to_vec(&capped).unwrap();
+    assert_eq!(capped.len(), 64 * 1024);
+    for (label, bytes, exceeds) in [
+        ("cap", capped.clone(), false),
+        ("cap-plus-one", [capped, vec![b' ']].concat(), true),
+    ] {
+        let path = spec_root.path().join(format!("{label}.json"));
+        fs::write(&path, bytes).expect("write capped proof input");
+        let mut command = test_support::cli_command();
+        command
+            .args(["prove-call-path", "--project"])
+            .arg(workspace.path())
+            .arg("--spec")
+            .arg(path)
+            .env("CODESTORY_CACHE_ROOT", cache_root.path())
+            .env("CODESTORY_STDIO_CACHE_ROOT", cache_root.path());
+        let output = command.output().expect("run capped proof input");
+        assert!(!output.status.success(), "padding is intentionally invalid");
+        let combined = format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(
+            combined.contains("exceeds the 65536 byte input limit"),
+            exceeds
+        );
+    }
+}
+
+#[test]
+fn public_exact_proof_never_activates_a_cold_project() {
+    let fixture = unindexed_fixture();
+    let cli_cache = fixture
+        .cache_dir
+        .path()
+        .join(codestory_workspace::workspace_id_v3_for_root(
+            fixture.workspace.path(),
+        ));
+    let spec_root = tempfile::tempdir().expect("cold proof spec root");
+    let spec_file = spec_root.path().join("proof-spec.json");
+    fs::write(
+        &spec_file,
+        serde_json::to_vec(&unknown_proof_spec()).unwrap(),
+    )
+    .expect("write cold proof spec");
+
+    let mut cli = test_support::cli_command();
+    cli.args(["prove-call-path", "--project"])
+        .arg(fixture.workspace.path())
+        .arg("--spec")
+        .arg(&spec_file)
+        .env("CODESTORY_CACHE_ROOT", fixture.cache_dir.path())
+        .env("CODESTORY_STDIO_CACHE_ROOT", fixture.cache_dir.path());
+    let cli = cli.output().expect("run cold CLI proof");
+    assert!(!cli.status.success(), "cold CLI proof must be unavailable");
+
+    let mut server = spawn_stdio_server(&fixture);
+    let mut arguments = unknown_proof_spec();
+    arguments["project"] = json!(fixture.workspace.path());
+    let response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc":"2.0",
+            "id":"cold-proof",
+            "method":"tools/call",
+            "params":{"name":"prove_call_path","arguments":arguments}
+        }),
+    );
+    let result = assert_success_envelope(&response, json!("cold-proof"));
+    assert_eq!(result["isError"], true, "{response}");
+    assert!(result.get("structuredContent").is_none(), "{response}");
+    assert!(!result.to_string().contains("preparing"), "{response}");
+    assert!(
+        !fixture.cache_dir.path().join("codestory.db").exists()
+            && !cli_cache.join("codestory.db").exists(),
+        "strict proof observation must not create a core store"
+    );
+    assert!(
+        !fixture.cache_dir.path().join("search-generations").exists()
+            && !cli_cache.join("search-generations").exists(),
+        "strict proof observation must not initialize semantic retrieval"
+    );
 }
 
 struct StdioFixture {
@@ -515,6 +832,49 @@ fn indexed_fixture() -> StdioFixture {
     assert!(
         output.status.success(),
         "index failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    StdioFixture {
+        workspace,
+        cache_dir,
+        latest_release_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+        disable_release_probe: false,
+        disable_installed_cli_probe: false,
+        plugin_data_dir: None,
+        plugin_cli_source: None,
+        dirty_marker_path: None,
+        dirty_marker_project_root: None,
+        local_refresh_timeout_ms: None,
+    }
+}
+
+fn indexed_proof_fixture() -> StdioFixture {
+    let workspace = tempfile::tempdir().expect("workspace dir");
+    let cache_dir = tempfile::tempdir().expect("cache dir");
+    write_tiny_rust_workspace(workspace.path());
+    let source_path = workspace.path().join("src/lib.rs");
+    let mut source = fs::read_to_string(&source_path).expect("read proof fixture source");
+    source.push_str("\npub fn exact_callee() {}\npub fn exact_caller() { exact_callee(); }\n");
+    fs::write(source_path, source).expect("write proof fixture source");
+
+    let mut command = test_support::cli_command();
+    command
+        .arg("index")
+        .arg("--refresh")
+        .arg("full")
+        .arg("--format")
+        .arg("json")
+        .arg("--project")
+        .arg(workspace.path())
+        .arg("--cache-dir")
+        .arg(cache_dir.path());
+    allow_explicit_cpu_embeddings(&mut command);
+    let output = command.output().expect("run proof fixture index");
+    assert!(
+        output.status.success(),
+        "proof fixture index failed\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
@@ -945,6 +1305,85 @@ fn assert_error_code(error: &Value, code: i64) {
     );
 }
 
+fn proof_canonical_id(fixture: &StdioFixture, name: &str) -> String {
+    let connection = rusqlite::Connection::open(fixture.cache_dir.path().join("codestory.db"))
+        .expect("open indexed proof fixture");
+    connection
+        .query_row(
+            "SELECT canonical_id FROM node WHERE serialized_name = ?1 AND kind = 13 AND canonical_id IS NOT NULL ORDER BY id LIMIT 1",
+            [name],
+            |row| row.get(0),
+        )
+        .unwrap_or_else(|error| panic!("fixture function {name}: {error}"))
+}
+
+fn exact_proof_arguments(fixture: &StdioFixture) -> Value {
+    let source_text = "exact direct ordered call path";
+    json!({
+        "project": fixture.workspace.path(),
+        "source_text": source_text,
+        "clauses": [{
+            "clause_id": "contract",
+            "start_byte": 0,
+            "end_byte_exclusive": source_text.len(),
+            "quote": source_text,
+            "classification": {
+                "kind": "resolved_material",
+                "fields": [
+                    {"kind":"start"},
+                    {"kind":"step_target","step":0},
+                    {"kind":"directness","step":0},
+                    {"kind":"ordering","step":0},
+                    {"kind":"relation","step":0}
+                ]
+            }
+        }],
+        "spec": {
+            "start": {
+                "kind": "canonical_id",
+                "canonical_id": proof_canonical_id(fixture, "exact_caller")
+            },
+            "steps": [{
+                "target": {
+                    "kind": "canonical_id",
+                    "canonical_id": proof_canonical_id(fixture, "exact_callee")
+                }
+            }],
+            "prohibit_traversal_through": [],
+            "exclude_from_projection": []
+        }
+    })
+}
+
+fn unknown_proof_spec() -> Value {
+    let source_text = "exact direct ordered call path";
+    json!({
+        "source_text": source_text,
+        "clauses": [{
+            "clause_id":"contract",
+            "start_byte":0,
+            "end_byte_exclusive":source_text.len(),
+            "quote":source_text,
+            "classification":{
+                "kind":"resolved_material",
+                "fields":[
+                    {"kind":"start"},
+                    {"kind":"step_target","step":0},
+                    {"kind":"directness","step":0},
+                    {"kind":"ordering","step":0},
+                    {"kind":"relation","step":0}
+                ]
+            }
+        }],
+        "spec":{
+            "start":{"kind":"canonical_id","canonical_id":"missing:start"},
+            "steps":[{"target":{"kind":"canonical_id","canonical_id":"missing:target"}}],
+            "prohibit_traversal_through":[],
+            "exclude_from_projection":[]
+        }
+    })
+}
+
 /// True when activation terminated instead of staying retryable.
 ///
 /// Activation can end terminally for more than one environment reason: the package may
@@ -1322,7 +1761,7 @@ fn project_resource_uri(base_uri: &str, project: &Path) -> String {
 
 fn assert_tool_safety_metadata(tool: &Value) {
     let name = tool["name"].as_str().expect("tool name");
-    let observational = name == "status";
+    let observational = matches!(name, "status" | "prove_call_path");
     let safety = tool
         .pointer("/_meta/com.thegreencedar.codestory~1safety")
         .unwrap_or_else(|| panic!("{name} should include namespaced safety metadata: {tool}"));
@@ -2323,6 +2762,7 @@ fn tool_catalog_keeps_stable_product_tool_names() {
             "ground",
             "neighbors",
             "packet",
+            "prove_call_path",
             "query_subgraph",
             "references",
             "search",

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.17.4"
 edition = "2024"
 
 [features]
+default = ["proof-qualification-support"]
 benchmark-support = []
 proof-qualification-support = ["codestory-agent/proof-qualification-support"]
 v3-evidence-separation-support = ["codestory-agent/v3-evidence-separation-support"]

--- a/crates/codestory-runtime/src/proof_qualification_support.rs
+++ b/crates/codestory-runtime/src/proof_qualification_support.rs
@@ -1,8 +1,7 @@
-//! Sealed observations used only by the proof-qualification benchmark.
+//! Sealed runtime facade for exact call-path verification and qualification.
 //!
-//! This facade is intentionally feature-gated and owns no product route. The
-//! benchmark receives its domain identity and gate observations through this
-//! module without exposing the dark kernel or registering a product route.
+//! The CLI and benchmark share this pinned-core operation without exposing the
+//! private proof kernel or allowing transport adapters to own orchestration.
 
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -20,15 +19,17 @@ pub use crate::indexed_source_call_path_v1::{
 pub use codestory_agent::proof_qualification_support::{
     BuiltCallPathFacts, CallableContainmentEvidence, ClauseAnchor, ClauseClassification,
     IndexedCallEdgeReceipt, IndexedLineWindow, InternalCorePublicationIdentity, InternalProjection,
-    PinnedNodeIdentity, ProofContractField, ReceiptRef, ResolvedNodeIdentity,
-    UnvalidatedCallPathContract, UnvalidatedCallPathSpec, UnvalidatedDirectCallStep,
-    UnvalidatedExactSymbolSelector, ValidationOutcome, VerifiedDirectCallFact, VerifiedProofFact,
-    check_built_call_path_integration, project_internal_call_path_result, validate_contract,
+    NonMaterialKind, PinnedNodeIdentity, ProofContractField, ReceiptRef, ResolvedNodeIdentity,
+    UnresolvedMaterialReason, UnvalidatedCallPathContract, UnvalidatedCallPathSpec,
+    UnvalidatedDirectCallStep, UnvalidatedExactScopeSelector, UnvalidatedExactSymbolSelector,
+    ValidationOutcome, VerifiedDirectCallFact, VerifiedProofFact,
+    check_built_call_path_integration, project_internal_call_path_result,
+    project_translation_unknown_result, validate_contract,
 };
 
-/// Executes one observed proof through the runtime's existing core-only public
-/// operation. The benchmark cannot obtain the controller or add a second
-/// publication retry around this call.
+/// Executes one proof through the runtime's existing core-only public
+/// operation. Callers cannot obtain the controller or add a second publication
+/// retry around this call.
 pub fn run_observed_call_path_public_operation(
     runtime: &crate::Runtime,
     contract: &codestory_agent::proof_qualification_support::ValidatedCallPathContract,
@@ -58,6 +59,45 @@ pub fn run_observed_call_path_public_operation(
         .controller
         .finish_proof_publication_validation_operation();
     result
+}
+
+/// Projects an incomplete host translation against the same pinned core
+/// publication without reading graph or retrieval state.
+pub fn run_translation_unknown_public_operation(
+    runtime: &crate::Runtime,
+    spec: &codestory_agent::proof_qualification_support::CallPathSpec,
+    hashes: &codestory_agent::proof_qualification_support::ProofHashes,
+    rendering: &codestory_agent::proof_qualification_support::ValidatedContractRendering,
+    gaps: &[codestory_agent::proof_qualification_support::TranslationGap],
+    cancelled: Arc<AtomicBool>,
+) -> Result<crate::PublicOperation<InternalProjection>, ApiError> {
+    runtime
+        .public_operation_service()
+        .run_observational_with_cancel(proof_domain(), cancelled, || {
+            let publication = runtime
+                .controller
+                .active_core_publication()
+                .ok_or_else(|| {
+                    ApiError::new(
+                        "proof_semantic_projection_unavailable",
+                        "the exact proof core publication is unavailable",
+                    )
+                })?;
+            let project_root = runtime.controller.require_project_root()?;
+            let project_id = codestory_workspace::project_identity_v3(&project_root).project_id;
+            project_translation_unknown_result(
+                spec,
+                hashes,
+                rendering,
+                gaps,
+                &InternalCorePublicationIdentity {
+                    project_id,
+                    generation_id: publication.generation_id,
+                    run_id: publication.run_id,
+                },
+            )
+            .map_err(|error| ApiError::new("invalid_proof_projection", format!("{error:?}")))
+        })
 }
 
 /// Identifies the request domain observed by proof qualification.

--- a/crates/codestory-runtime/src/services.rs
+++ b/crates/codestory-runtime/src/services.rs
@@ -742,6 +742,36 @@ impl ActivationService {
         }
     }
 
+    /// Bind an already-complete core publication without starting managed
+    /// activation. Strictly observational tools use this path so a cold or
+    /// fenced cache stays unavailable instead of triggering indexing or
+    /// retrieval preparation.
+    pub fn bind_existing_complete_core_for_observation(
+        &self,
+        project_root: &Path,
+        storage_path: &Path,
+        cancelled: Arc<AtomicBool>,
+    ) -> Result<(), ApiError> {
+        if cancelled.load(Ordering::Acquire) {
+            return Err(ApiError::new(
+                "cancelled",
+                "request cancelled before observational core admission",
+            ));
+        }
+        match self.classify_complete_core_admission(project_root, storage_path) {
+            CompleteCoreAdmission::Complete => Ok(()),
+            CompleteCoreAdmission::Corrupt(error) => Err(error),
+            CompleteCoreAdmission::Cold => Err(ApiError::new(
+                "proof_semantic_projection_unavailable",
+                "no complete exact-proof core publication is available",
+            )),
+            CompleteCoreAdmission::Fenced => Err(ApiError::new(
+                "proof_semantic_projection_unavailable",
+                "the exact-proof core publication is fenced by an incomplete index run",
+            )),
+        }
+    }
+
     fn classify_complete_core_admission(
         &self,
         project_root: &Path,

--- a/docs/users/cli-reference.md
+++ b/docs/users/cli-reference.md
@@ -76,6 +76,22 @@ when minimizing context matters more than keeping the fuller evidence set.
 
 Degraded retrieval is navigation help only. See [Glossary](../glossary.md#retrieval-mode).
 
+## Exact call-path verification
+
+Use the exact verifier only with a complete host-supplied translation containing
+the original source text, typed clause anchors, and exact ordered call spec:
+
+```sh
+codestory-cli prove-call-path --project <repo> --spec <request.json>
+cat request.json | codestory-cli prove-call-path --project <repo> --spec -
+```
+
+The command is observational and does not start broad semantic retrieval.
+`contract_proven` and `contract_refuted` apply only to the supplied indexed
+source-call contract. Translation gaps and unsupported proof-domain cases return
+typed `unknown` or `unavailable` results. CodeStory does not translate prose or
+recommend automatic verifier invocation.
+
 ## Stale local cache
 
 ```sh

--- a/docs/users/trust-and-readiness.md
+++ b/docs/users/trust-and-readiness.md
@@ -28,6 +28,7 @@ old or new publication.
 | Repo-text or semantic suggestion without a resolved symbol | Navigation hint to verify in source |
 | `working_locally` state | Use local graph tools; broad search is still preparing |
 | `unavailable` state | Fall back to focused source inspection and state the gap |
+| Exact verifier `contract_proven` / `contract_refuted` | Authority only for the complete host-supplied indexed source-call contract; it does not prove runtime execution or translate prose |
 
 `retrieval_mode=full` proves that the retrieval infrastructure is coherent. It
 does not guarantee that a particular answer found enough evidence. The packet's

--- a/plugins/codestory/generated-mcp-catalog.json
+++ b/plugins/codestory/generated-mcp-catalog.json
@@ -10,15 +10,15 @@
     ],
     "preferredMcpProtocolVersion": "2025-11-25",
     "discoveryContracts": {
-      "2024-11-05": "afe6f4cd28e40dbe68a22cd088fef8790a0515a67b433b4c47d5ed8e33600961",
-      "2025-03-26": "af9179dcdab3f7fee0b8b2b990cfb8ee170dac24e203e789764f68dd9d11ffad",
-      "2025-06-18": "33143a34100c4e2381aa72cf716823d9d88145963d306efa1f47b44c918f146f",
-      "2025-11-25": "c7690622aeb7288d57d4973632e1bd2e3a349cfe234285a332d1dd828b3efa3e"
+      "2024-11-05": "e6491ad17e3f77bdd934521985ee28b2b739fcae0b6eb9dab00716b5cd23fd26",
+      "2025-03-26": "7213f725efc783303c76b7704e8c3a495ad9ff4f9f0c1a9baafcc444d5d4e62b",
+      "2025-06-18": "77db6a843501bf420d08c369863f7b43558f89089fc5347e6c406b4b96c6ff7b",
+      "2025-11-25": "b13b23eb2a07d5fcbbe3c682c4c786621cf1ad19b96ae0098b5aac85d225f6b6"
     }
   },
   "revisionProfiles": {
     "2024-11-05": {
-      "discoveryContractSha256": "afe6f4cd28e40dbe68a22cd088fef8790a0515a67b433b4c47d5ed8e33600961",
+      "discoveryContractSha256": "e6491ad17e3f77bdd934521985ee28b2b739fcae0b6eb9dab00716b5cd23fd26",
       "tools": [
         {
           "description": "Inspect CodeStory readiness for the requested repository when diagnostics are needed. CodeStory effect: observational and does not activate managed state.",
@@ -1716,6 +1716,731 @@
             "type": "object"
           },
           "name": "context"
+        },
+        {
+          "description": "Verify one host-translated exact indexed source call-path contract against a pinned publication. CodeStory effect: observational and does not activate managed state.",
+          "inputSchema": {
+            "additionalProperties": false,
+            "properties": {
+              "clauses": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "classification": {
+                      "oneOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fields": {
+                              "items": {
+                                "oneOf": [
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "kind": {
+                                        "enum": [
+                                          "start"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "kind": {
+                                        "enum": [
+                                          "step_target"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "step": {
+                                        "maximum": 5,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "step"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "kind": {
+                                        "enum": [
+                                          "directness"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "step": {
+                                        "maximum": 5,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "step"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "kind": {
+                                        "enum": [
+                                          "ordering"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "step": {
+                                        "maximum": 5,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "step"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "kind": {
+                                        "enum": [
+                                          "relation"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "step": {
+                                        "maximum": 5,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "step"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "index": {
+                                        "maximum": 255,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      },
+                                      "kind": {
+                                        "enum": [
+                                          "traversal_prohibition"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "index"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "index": {
+                                        "maximum": 255,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      },
+                                      "kind": {
+                                        "enum": [
+                                          "projection_exclusion"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "index"
+                                    ],
+                                    "type": "object"
+                                  }
+                                ],
+                                "type": "object"
+                              },
+                              "minItems": 1,
+                              "type": "array"
+                            },
+                            "kind": {
+                              "enum": [
+                                "resolved_material"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "fields"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "kind": {
+                              "enum": [
+                                "unresolved_material"
+                              ],
+                              "type": "string"
+                            },
+                            "reason": {
+                              "enum": [
+                                "missing_selector_resolution",
+                                "ambiguous_selector_resolution",
+                                "unsupported_interpretation"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "reason"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "kind": {
+                              "enum": [
+                                "non_material"
+                              ],
+                              "type": "string"
+                            },
+                            "reason": {
+                              "enum": [
+                                "whitespace",
+                                "punctuation",
+                                "connector",
+                                "commentary"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "reason"
+                          ],
+                          "type": "object"
+                        }
+                      ],
+                      "type": "object"
+                    },
+                    "clause_id": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "end_byte_exclusive": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "quote": {
+                      "type": "string"
+                    },
+                    "start_byte": {
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "clause_id",
+                    "start_byte",
+                    "end_byte_exclusive",
+                    "quote",
+                    "classification"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "project": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "source_text": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "spec": {
+                "additionalProperties": false,
+                "properties": {
+                  "exclude_from_projection": {
+                    "items": {
+                      "oneOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "core_generation_id": {
+                              "type": "string"
+                            },
+                            "core_run_id": {
+                              "type": "string"
+                            },
+                            "kind": {
+                              "enum": [
+                                "pinned_node"
+                              ],
+                              "type": "string"
+                            },
+                            "node_id": {
+                              "type": "string"
+                            },
+                            "project_id": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "project_id",
+                            "core_generation_id",
+                            "core_run_id",
+                            "node_id"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "canonical_id": {
+                              "type": "string"
+                            },
+                            "kind": {
+                              "enum": [
+                                "canonical_id"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "canonical_id"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "kind": {
+                              "enum": [
+                                "qualified_name"
+                              ],
+                              "type": "string"
+                            },
+                            "qualified_name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "qualified_name"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "kind": {
+                              "enum": [
+                                "qualified_name"
+                              ],
+                              "type": "string"
+                            },
+                            "project_file_components": {
+                              "items": {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "type": [
+                                "array",
+                                "null"
+                              ]
+                            },
+                            "qualified_name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "qualified_name",
+                            "project_file_components"
+                          ],
+                          "type": "object"
+                        }
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 256,
+                    "type": "array"
+                  },
+                  "prohibit_traversal_through": {
+                    "items": {
+                      "oneOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "core_generation_id": {
+                              "type": "string"
+                            },
+                            "core_run_id": {
+                              "type": "string"
+                            },
+                            "kind": {
+                              "enum": [
+                                "pinned_node"
+                              ],
+                              "type": "string"
+                            },
+                            "node_id": {
+                              "type": "string"
+                            },
+                            "project_id": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "project_id",
+                            "core_generation_id",
+                            "core_run_id",
+                            "node_id"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "canonical_id": {
+                              "type": "string"
+                            },
+                            "kind": {
+                              "enum": [
+                                "canonical_id"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "canonical_id"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "kind": {
+                              "enum": [
+                                "qualified_name"
+                              ],
+                              "type": "string"
+                            },
+                            "qualified_name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "qualified_name"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "kind": {
+                              "enum": [
+                                "qualified_name"
+                              ],
+                              "type": "string"
+                            },
+                            "project_file_components": {
+                              "items": {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "type": [
+                                "array",
+                                "null"
+                              ]
+                            },
+                            "qualified_name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "qualified_name",
+                            "project_file_components"
+                          ],
+                          "type": "object"
+                        }
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 256,
+                    "type": "array"
+                  },
+                  "start": {
+                    "oneOf": [
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "core_generation_id": {
+                            "type": "string"
+                          },
+                          "core_run_id": {
+                            "type": "string"
+                          },
+                          "kind": {
+                            "enum": [
+                              "pinned_node"
+                            ],
+                            "type": "string"
+                          },
+                          "node_id": {
+                            "type": "string"
+                          },
+                          "project_id": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "project_id",
+                          "core_generation_id",
+                          "core_run_id",
+                          "node_id"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "canonical_id": {
+                            "type": "string"
+                          },
+                          "kind": {
+                            "enum": [
+                              "canonical_id"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "canonical_id"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "kind": {
+                            "enum": [
+                              "qualified_name"
+                            ],
+                            "type": "string"
+                          },
+                          "qualified_name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "qualified_name"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "kind": {
+                            "enum": [
+                              "qualified_name"
+                            ],
+                            "type": "string"
+                          },
+                          "project_file_components": {
+                            "items": {
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "type": [
+                              "array",
+                              "null"
+                            ]
+                          },
+                          "qualified_name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "qualified_name",
+                          "project_file_components"
+                        ],
+                        "type": "object"
+                      }
+                    ],
+                    "type": "object"
+                  },
+                  "steps": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "target": {
+                          "oneOf": [
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "core_generation_id": {
+                                  "type": "string"
+                                },
+                                "core_run_id": {
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "enum": [
+                                    "pinned_node"
+                                  ],
+                                  "type": "string"
+                                },
+                                "node_id": {
+                                  "type": "string"
+                                },
+                                "project_id": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "project_id",
+                                "core_generation_id",
+                                "core_run_id",
+                                "node_id"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "canonical_id": {
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "enum": [
+                                    "canonical_id"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "canonical_id"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "kind": {
+                                  "enum": [
+                                    "qualified_name"
+                                  ],
+                                  "type": "string"
+                                },
+                                "qualified_name": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "qualified_name"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "kind": {
+                                  "enum": [
+                                    "qualified_name"
+                                  ],
+                                  "type": "string"
+                                },
+                                "project_file_components": {
+                                  "items": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "type": [
+                                    "array",
+                                    "null"
+                                  ]
+                                },
+                                "qualified_name": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "qualified_name",
+                                "project_file_components"
+                              ],
+                              "type": "object"
+                            }
+                          ],
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "target"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 6,
+                    "minItems": 1,
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "start",
+                  "steps",
+                  "prohibit_traversal_through",
+                  "exclude_from_projection"
+                ],
+                "type": "object"
+              }
+            },
+            "required": [
+              "project",
+              "source_text",
+              "clauses",
+              "spec"
+            ],
+            "type": "object"
+          },
+          "name": "prove_call_path"
         }
       ],
       "resources": [
@@ -1783,7 +2508,7 @@
       ]
     },
     "2025-03-26": {
-      "discoveryContractSha256": "af9179dcdab3f7fee0b8b2b990cfb8ee170dac24e203e789764f68dd9d11ffad",
+      "discoveryContractSha256": "7213f725efc783303c76b7704e8c3a495ad9ff4f9f0c1a9baafcc444d5d4e62b",
       "tools": [
         {
           "annotations": {
@@ -3582,6 +4307,737 @@
             "type": "object"
           },
           "name": "context"
+        },
+        {
+          "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": false,
+            "readOnlyHint": true
+          },
+          "description": "Verify one host-translated exact indexed source call-path contract against a pinned publication. CodeStory effect: observational and does not activate managed state.",
+          "inputSchema": {
+            "additionalProperties": false,
+            "properties": {
+              "clauses": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "classification": {
+                      "oneOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fields": {
+                              "items": {
+                                "oneOf": [
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "kind": {
+                                        "enum": [
+                                          "start"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "kind": {
+                                        "enum": [
+                                          "step_target"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "step": {
+                                        "maximum": 5,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "step"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "kind": {
+                                        "enum": [
+                                          "directness"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "step": {
+                                        "maximum": 5,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "step"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "kind": {
+                                        "enum": [
+                                          "ordering"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "step": {
+                                        "maximum": 5,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "step"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "kind": {
+                                        "enum": [
+                                          "relation"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "step": {
+                                        "maximum": 5,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "step"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "index": {
+                                        "maximum": 255,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      },
+                                      "kind": {
+                                        "enum": [
+                                          "traversal_prohibition"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "index"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "index": {
+                                        "maximum": 255,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      },
+                                      "kind": {
+                                        "enum": [
+                                          "projection_exclusion"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "index"
+                                    ],
+                                    "type": "object"
+                                  }
+                                ],
+                                "type": "object"
+                              },
+                              "minItems": 1,
+                              "type": "array"
+                            },
+                            "kind": {
+                              "enum": [
+                                "resolved_material"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "fields"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "kind": {
+                              "enum": [
+                                "unresolved_material"
+                              ],
+                              "type": "string"
+                            },
+                            "reason": {
+                              "enum": [
+                                "missing_selector_resolution",
+                                "ambiguous_selector_resolution",
+                                "unsupported_interpretation"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "reason"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "kind": {
+                              "enum": [
+                                "non_material"
+                              ],
+                              "type": "string"
+                            },
+                            "reason": {
+                              "enum": [
+                                "whitespace",
+                                "punctuation",
+                                "connector",
+                                "commentary"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "reason"
+                          ],
+                          "type": "object"
+                        }
+                      ],
+                      "type": "object"
+                    },
+                    "clause_id": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "end_byte_exclusive": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "quote": {
+                      "type": "string"
+                    },
+                    "start_byte": {
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "clause_id",
+                    "start_byte",
+                    "end_byte_exclusive",
+                    "quote",
+                    "classification"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "project": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "source_text": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "spec": {
+                "additionalProperties": false,
+                "properties": {
+                  "exclude_from_projection": {
+                    "items": {
+                      "oneOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "core_generation_id": {
+                              "type": "string"
+                            },
+                            "core_run_id": {
+                              "type": "string"
+                            },
+                            "kind": {
+                              "enum": [
+                                "pinned_node"
+                              ],
+                              "type": "string"
+                            },
+                            "node_id": {
+                              "type": "string"
+                            },
+                            "project_id": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "project_id",
+                            "core_generation_id",
+                            "core_run_id",
+                            "node_id"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "canonical_id": {
+                              "type": "string"
+                            },
+                            "kind": {
+                              "enum": [
+                                "canonical_id"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "canonical_id"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "kind": {
+                              "enum": [
+                                "qualified_name"
+                              ],
+                              "type": "string"
+                            },
+                            "qualified_name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "qualified_name"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "kind": {
+                              "enum": [
+                                "qualified_name"
+                              ],
+                              "type": "string"
+                            },
+                            "project_file_components": {
+                              "items": {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "type": [
+                                "array",
+                                "null"
+                              ]
+                            },
+                            "qualified_name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "qualified_name",
+                            "project_file_components"
+                          ],
+                          "type": "object"
+                        }
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 256,
+                    "type": "array"
+                  },
+                  "prohibit_traversal_through": {
+                    "items": {
+                      "oneOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "core_generation_id": {
+                              "type": "string"
+                            },
+                            "core_run_id": {
+                              "type": "string"
+                            },
+                            "kind": {
+                              "enum": [
+                                "pinned_node"
+                              ],
+                              "type": "string"
+                            },
+                            "node_id": {
+                              "type": "string"
+                            },
+                            "project_id": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "project_id",
+                            "core_generation_id",
+                            "core_run_id",
+                            "node_id"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "canonical_id": {
+                              "type": "string"
+                            },
+                            "kind": {
+                              "enum": [
+                                "canonical_id"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "canonical_id"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "kind": {
+                              "enum": [
+                                "qualified_name"
+                              ],
+                              "type": "string"
+                            },
+                            "qualified_name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "qualified_name"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "kind": {
+                              "enum": [
+                                "qualified_name"
+                              ],
+                              "type": "string"
+                            },
+                            "project_file_components": {
+                              "items": {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "type": [
+                                "array",
+                                "null"
+                              ]
+                            },
+                            "qualified_name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "qualified_name",
+                            "project_file_components"
+                          ],
+                          "type": "object"
+                        }
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 256,
+                    "type": "array"
+                  },
+                  "start": {
+                    "oneOf": [
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "core_generation_id": {
+                            "type": "string"
+                          },
+                          "core_run_id": {
+                            "type": "string"
+                          },
+                          "kind": {
+                            "enum": [
+                              "pinned_node"
+                            ],
+                            "type": "string"
+                          },
+                          "node_id": {
+                            "type": "string"
+                          },
+                          "project_id": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "project_id",
+                          "core_generation_id",
+                          "core_run_id",
+                          "node_id"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "canonical_id": {
+                            "type": "string"
+                          },
+                          "kind": {
+                            "enum": [
+                              "canonical_id"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "canonical_id"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "kind": {
+                            "enum": [
+                              "qualified_name"
+                            ],
+                            "type": "string"
+                          },
+                          "qualified_name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "qualified_name"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "kind": {
+                            "enum": [
+                              "qualified_name"
+                            ],
+                            "type": "string"
+                          },
+                          "project_file_components": {
+                            "items": {
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "type": [
+                              "array",
+                              "null"
+                            ]
+                          },
+                          "qualified_name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "qualified_name",
+                          "project_file_components"
+                        ],
+                        "type": "object"
+                      }
+                    ],
+                    "type": "object"
+                  },
+                  "steps": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "target": {
+                          "oneOf": [
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "core_generation_id": {
+                                  "type": "string"
+                                },
+                                "core_run_id": {
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "enum": [
+                                    "pinned_node"
+                                  ],
+                                  "type": "string"
+                                },
+                                "node_id": {
+                                  "type": "string"
+                                },
+                                "project_id": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "project_id",
+                                "core_generation_id",
+                                "core_run_id",
+                                "node_id"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "canonical_id": {
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "enum": [
+                                    "canonical_id"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "canonical_id"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "kind": {
+                                  "enum": [
+                                    "qualified_name"
+                                  ],
+                                  "type": "string"
+                                },
+                                "qualified_name": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "qualified_name"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "kind": {
+                                  "enum": [
+                                    "qualified_name"
+                                  ],
+                                  "type": "string"
+                                },
+                                "project_file_components": {
+                                  "items": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "type": [
+                                    "array",
+                                    "null"
+                                  ]
+                                },
+                                "qualified_name": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "qualified_name",
+                                "project_file_components"
+                              ],
+                              "type": "object"
+                            }
+                          ],
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "target"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 6,
+                    "minItems": 1,
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "start",
+                  "steps",
+                  "prohibit_traversal_through",
+                  "exclude_from_projection"
+                ],
+                "type": "object"
+              }
+            },
+            "required": [
+              "project",
+              "source_text",
+              "clauses",
+              "spec"
+            ],
+            "type": "object"
+          },
+          "name": "prove_call_path"
         }
       ],
       "resources": [
@@ -3649,7 +5105,7 @@
       ]
     },
     "2025-06-18": {
-      "discoveryContractSha256": "33143a34100c4e2381aa72cf716823d9d88145963d306efa1f47b44c918f146f",
+      "discoveryContractSha256": "77db6a843501bf420d08c369863f7b43558f89089fc5347e6c406b4b96c6ff7b",
       "tools": [
         {
           "_meta": {
@@ -10002,6 +11458,2557 @@
             "type": "object"
           },
           "title": "Context"
+        },
+        {
+          "_meta": {
+            "com.thegreencedar.codestory/safety": {
+              "activatesProject": false,
+              "destructive": false,
+              "effect": "read_only",
+              "idempotent": true,
+              "localOnly": true,
+              "openWorld": false,
+              "requiresConfirmation": false,
+              "sideEffects": false,
+              "writesRepository": false
+            }
+          },
+          "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": false,
+            "readOnlyHint": true
+          },
+          "description": "Verify one host-translated exact indexed source call-path contract against a pinned publication.",
+          "inputSchema": {
+            "additionalProperties": false,
+            "properties": {
+              "clauses": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "classification": {
+                      "oneOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fields": {
+                              "items": {
+                                "oneOf": [
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "kind": {
+                                        "enum": [
+                                          "start"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "kind": {
+                                        "enum": [
+                                          "step_target"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "step": {
+                                        "maximum": 5,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "step"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "kind": {
+                                        "enum": [
+                                          "directness"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "step": {
+                                        "maximum": 5,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "step"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "kind": {
+                                        "enum": [
+                                          "ordering"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "step": {
+                                        "maximum": 5,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "step"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "kind": {
+                                        "enum": [
+                                          "relation"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "step": {
+                                        "maximum": 5,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "step"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "index": {
+                                        "maximum": 255,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      },
+                                      "kind": {
+                                        "enum": [
+                                          "traversal_prohibition"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "index"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "index": {
+                                        "maximum": 255,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      },
+                                      "kind": {
+                                        "enum": [
+                                          "projection_exclusion"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "index"
+                                    ],
+                                    "type": "object"
+                                  }
+                                ],
+                                "type": "object"
+                              },
+                              "minItems": 1,
+                              "type": "array"
+                            },
+                            "kind": {
+                              "enum": [
+                                "resolved_material"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "fields"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "kind": {
+                              "enum": [
+                                "unresolved_material"
+                              ],
+                              "type": "string"
+                            },
+                            "reason": {
+                              "enum": [
+                                "missing_selector_resolution",
+                                "ambiguous_selector_resolution",
+                                "unsupported_interpretation"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "reason"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "kind": {
+                              "enum": [
+                                "non_material"
+                              ],
+                              "type": "string"
+                            },
+                            "reason": {
+                              "enum": [
+                                "whitespace",
+                                "punctuation",
+                                "connector",
+                                "commentary"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "reason"
+                          ],
+                          "type": "object"
+                        }
+                      ],
+                      "type": "object"
+                    },
+                    "clause_id": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "end_byte_exclusive": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "quote": {
+                      "type": "string"
+                    },
+                    "start_byte": {
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "clause_id",
+                    "start_byte",
+                    "end_byte_exclusive",
+                    "quote",
+                    "classification"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "project": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "source_text": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "spec": {
+                "additionalProperties": false,
+                "properties": {
+                  "exclude_from_projection": {
+                    "items": {
+                      "oneOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "core_generation_id": {
+                              "type": "string"
+                            },
+                            "core_run_id": {
+                              "type": "string"
+                            },
+                            "kind": {
+                              "enum": [
+                                "pinned_node"
+                              ],
+                              "type": "string"
+                            },
+                            "node_id": {
+                              "type": "string"
+                            },
+                            "project_id": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "project_id",
+                            "core_generation_id",
+                            "core_run_id",
+                            "node_id"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "canonical_id": {
+                              "type": "string"
+                            },
+                            "kind": {
+                              "enum": [
+                                "canonical_id"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "canonical_id"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "kind": {
+                              "enum": [
+                                "qualified_name"
+                              ],
+                              "type": "string"
+                            },
+                            "qualified_name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "qualified_name"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "kind": {
+                              "enum": [
+                                "qualified_name"
+                              ],
+                              "type": "string"
+                            },
+                            "project_file_components": {
+                              "items": {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "type": [
+                                "array",
+                                "null"
+                              ]
+                            },
+                            "qualified_name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "qualified_name",
+                            "project_file_components"
+                          ],
+                          "type": "object"
+                        }
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 256,
+                    "type": "array"
+                  },
+                  "prohibit_traversal_through": {
+                    "items": {
+                      "oneOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "core_generation_id": {
+                              "type": "string"
+                            },
+                            "core_run_id": {
+                              "type": "string"
+                            },
+                            "kind": {
+                              "enum": [
+                                "pinned_node"
+                              ],
+                              "type": "string"
+                            },
+                            "node_id": {
+                              "type": "string"
+                            },
+                            "project_id": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "project_id",
+                            "core_generation_id",
+                            "core_run_id",
+                            "node_id"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "canonical_id": {
+                              "type": "string"
+                            },
+                            "kind": {
+                              "enum": [
+                                "canonical_id"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "canonical_id"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "kind": {
+                              "enum": [
+                                "qualified_name"
+                              ],
+                              "type": "string"
+                            },
+                            "qualified_name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "qualified_name"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "kind": {
+                              "enum": [
+                                "qualified_name"
+                              ],
+                              "type": "string"
+                            },
+                            "project_file_components": {
+                              "items": {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "type": [
+                                "array",
+                                "null"
+                              ]
+                            },
+                            "qualified_name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "qualified_name",
+                            "project_file_components"
+                          ],
+                          "type": "object"
+                        }
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 256,
+                    "type": "array"
+                  },
+                  "start": {
+                    "oneOf": [
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "core_generation_id": {
+                            "type": "string"
+                          },
+                          "core_run_id": {
+                            "type": "string"
+                          },
+                          "kind": {
+                            "enum": [
+                              "pinned_node"
+                            ],
+                            "type": "string"
+                          },
+                          "node_id": {
+                            "type": "string"
+                          },
+                          "project_id": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "project_id",
+                          "core_generation_id",
+                          "core_run_id",
+                          "node_id"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "canonical_id": {
+                            "type": "string"
+                          },
+                          "kind": {
+                            "enum": [
+                              "canonical_id"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "canonical_id"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "kind": {
+                            "enum": [
+                              "qualified_name"
+                            ],
+                            "type": "string"
+                          },
+                          "qualified_name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "qualified_name"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "kind": {
+                            "enum": [
+                              "qualified_name"
+                            ],
+                            "type": "string"
+                          },
+                          "project_file_components": {
+                            "items": {
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "type": [
+                              "array",
+                              "null"
+                            ]
+                          },
+                          "qualified_name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "qualified_name",
+                          "project_file_components"
+                        ],
+                        "type": "object"
+                      }
+                    ],
+                    "type": "object"
+                  },
+                  "steps": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "target": {
+                          "oneOf": [
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "core_generation_id": {
+                                  "type": "string"
+                                },
+                                "core_run_id": {
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "enum": [
+                                    "pinned_node"
+                                  ],
+                                  "type": "string"
+                                },
+                                "node_id": {
+                                  "type": "string"
+                                },
+                                "project_id": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "project_id",
+                                "core_generation_id",
+                                "core_run_id",
+                                "node_id"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "canonical_id": {
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "enum": [
+                                    "canonical_id"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "canonical_id"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "kind": {
+                                  "enum": [
+                                    "qualified_name"
+                                  ],
+                                  "type": "string"
+                                },
+                                "qualified_name": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "qualified_name"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "kind": {
+                                  "enum": [
+                                    "qualified_name"
+                                  ],
+                                  "type": "string"
+                                },
+                                "project_file_components": {
+                                  "items": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "type": [
+                                    "array",
+                                    "null"
+                                  ]
+                                },
+                                "qualified_name": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "qualified_name",
+                                "project_file_components"
+                              ],
+                              "type": "object"
+                            }
+                          ],
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "target"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 6,
+                    "minItems": 1,
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "start",
+                  "steps",
+                  "prohibit_traversal_through",
+                  "exclude_from_projection"
+                ],
+                "type": "object"
+              }
+            },
+            "required": [
+              "project",
+              "source_text",
+              "clauses",
+              "spec"
+            ],
+            "type": "object"
+          },
+          "name": "prove_call_path",
+          "outputSchema": {
+            "oneOf": [
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "clauses": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "classification": {
+                          "enum": [
+                            "resolved_material",
+                            "unresolved_material",
+                            "non_material"
+                          ],
+                          "type": "string"
+                        },
+                        "clause_id": {
+                          "type": "string"
+                        },
+                        "end": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "fields": {
+                          "items": {
+                            "oneOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "kind": {
+                                    "enum": [
+                                      "start"
+                                    ],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "kind": {
+                                    "enum": [
+                                      "step_target",
+                                      "directness",
+                                      "ordering",
+                                      "relation"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "step": {
+                                    "minimum": 0,
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "step"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "index": {
+                                    "minimum": 0,
+                                    "type": "integer"
+                                  },
+                                  "kind": {
+                                    "enum": [
+                                      "traversal_prohibition",
+                                      "projection_exclusion"
+                                    ],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "index"
+                                ],
+                                "type": "object"
+                              }
+                            ],
+                            "type": "object"
+                          },
+                          "maxItems": 537,
+                          "type": "array"
+                        },
+                        "non_material_kind": {
+                          "enum": [
+                            "whitespace",
+                            "punctuation",
+                            "connector",
+                            "commentary"
+                          ],
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "quote": {
+                          "type": "string"
+                        },
+                        "reason": {
+                          "enum": [
+                            "missing_selector_resolution",
+                            "ambiguous_selector_resolution",
+                            "unsupported_interpretation"
+                          ],
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "start": {
+                          "minimum": 0,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "start",
+                        "end",
+                        "clause_id",
+                        "quote",
+                        "classification",
+                        "fields",
+                        "reason",
+                        "non_material_kind"
+                      ],
+                      "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                  },
+                  "contract_digest": {
+                    "maxLength": 64,
+                    "minLength": 64,
+                    "type": "string"
+                  },
+                  "contract_interpretation": {
+                    "enum": [
+                      "host_supplied"
+                    ],
+                    "type": "string"
+                  },
+                  "core_publication": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "generation_id": {
+                        "type": "string"
+                      },
+                      "project_id": {
+                        "type": "string"
+                      },
+                      "run_id": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "project_id",
+                      "generation_id",
+                      "run_id"
+                    ],
+                    "type": "object"
+                  },
+                  "disposition": {
+                    "oneOf": [
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "contract_digest": {
+                            "maxLength": 64,
+                            "minLength": 64,
+                            "type": "string"
+                          },
+                          "kind": {
+                            "enum": [
+                              "contract_proven"
+                            ],
+                            "type": "string"
+                          },
+                          "receipts": {
+                            "items": {
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "maxItems": 6,
+                            "type": "array",
+                            "uniqueItems": true
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "contract_digest",
+                          "receipts"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "connected_receipts": {
+                            "items": {
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "maxItems": 6,
+                            "type": "array",
+                            "uniqueItems": true
+                          },
+                          "contract_digest": {
+                            "maxLength": 64,
+                            "minLength": 64,
+                            "type": "string"
+                          },
+                          "gaps": {
+                            "items": {
+                              "oneOf": [
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "kind": {
+                                      "enum": [
+                                        "unclassified_source_text"
+                                      ],
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "clause_id": {
+                                      "type": "string"
+                                    },
+                                    "kind": {
+                                      "enum": [
+                                        "unresolved_material_clause"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "enum": [
+                                        "missing_selector_resolution",
+                                        "ambiguous_selector_resolution",
+                                        "unsupported_interpretation"
+                                      ],
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "clause_id",
+                                    "reason"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "clause_id": {
+                                      "type": "string"
+                                    },
+                                    "guard_families": {
+                                      "items": {
+                                        "enum": [
+                                          "quoted_or_backticked_identifier",
+                                          "arrow_or_relation_notation",
+                                          "directness",
+                                          "ordering_or_ordinal",
+                                          "only",
+                                          "negation_or_exclusion",
+                                          "path_like_string",
+                                          "qualified_symbol_notation"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "maxItems": 8,
+                                      "minItems": 1,
+                                      "type": "array",
+                                      "uniqueItems": true
+                                    },
+                                    "kind": {
+                                      "enum": [
+                                        "material_token_misclassified"
+                                      ],
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "clause_id",
+                                    "guard_families"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "kind": {
+                                      "enum": [
+                                        "selector_missing"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "selector_index": {
+                                      "maximum": 6,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "selector_index"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "kind": {
+                                      "enum": [
+                                        "selector_ambiguous"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "selector_index": {
+                                      "maximum": 6,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "selector_index"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "kind": {
+                                      "enum": [
+                                        "non_callable_selector"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "selector_index": {
+                                      "maximum": 6,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "selector_index"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "kind": {
+                                      "enum": [
+                                        "direct_call_missing"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "step_index": {
+                                      "maximum": 5,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "step_index"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "kind": {
+                                      "enum": [
+                                        "recursive_call_not_representable"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "step_index": {
+                                      "maximum": 5,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "step_index"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "kind": {
+                                      "enum": [
+                                        "source_window_too_large"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "step_index": {
+                                      "maximum": 5,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "step_index"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "kind": {
+                                      "enum": [
+                                        "invalid_utf8"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "step_index": {
+                                      "maximum": 5,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "step_index"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "kind": {
+                                      "enum": [
+                                        "source_line_out_of_range"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "step_index": {
+                                      "maximum": 5,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "step_index"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "kind": {
+                                      "enum": [
+                                        "edge_containment_unproven"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "step_index": {
+                                      "maximum": 5,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "step_index"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "kind": {
+                                      "enum": [
+                                        "missing_direct_call_receipt"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "step_index": {
+                                      "maximum": 5,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "step_index"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "kind": {
+                                      "enum": [
+                                        "receipt_or_edge_already_used"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "step_index": {
+                                      "maximum": 5,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "step_index"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "kind": {
+                                      "enum": [
+                                        "projection_exclusion_conflicts_with_required_receipt"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "step_index": {
+                                      "maximum": 5,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "step_index"
+                                  ],
+                                  "type": "object"
+                                }
+                              ],
+                              "type": "object"
+                            },
+                            "maxItems": 256,
+                            "minItems": 1,
+                            "type": "array",
+                            "uniqueItems": true
+                          },
+                          "kind": {
+                            "enum": [
+                              "unknown"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "contract_digest",
+                          "gaps",
+                          "connected_receipts"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "contract_digest": {
+                            "maxLength": 64,
+                            "minLength": 64,
+                            "type": "string"
+                          },
+                          "kind": {
+                            "enum": [
+                              "contract_refuted"
+                            ],
+                            "type": "string"
+                          },
+                          "refutation": {
+                            "oneOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "connected_receipts": {
+                                    "items": {
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    },
+                                    "maxItems": 6,
+                                    "type": "array",
+                                    "uniqueItems": true
+                                  },
+                                  "kind": {
+                                    "enum": [
+                                      "prohibited_scope_traversal"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "prohibition_index": {
+                                    "maximum": 255,
+                                    "minimum": 0,
+                                    "type": "integer"
+                                  },
+                                  "step_index": {
+                                    "maximum": 5,
+                                    "minimum": 0,
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "step_index",
+                                  "prohibition_index",
+                                  "connected_receipts"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "connected_receipts": {
+                                    "items": {
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    },
+                                    "maxItems": 6,
+                                    "type": "array",
+                                    "uniqueItems": true
+                                  },
+                                  "extractor_capability_receipt_id": {
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "enum": [
+                                      "certified_absence"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "step_index": {
+                                    "maximum": 5,
+                                    "minimum": 0,
+                                    "type": "integer"
+                                  },
+                                  "untruncated_enumeration_receipt_id": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "step_index",
+                                  "extractor_capability_receipt_id",
+                                  "untruncated_enumeration_receipt_id",
+                                  "connected_receipts"
+                                ],
+                                "type": "object"
+                              }
+                            ],
+                            "type": "object"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "contract_digest",
+                          "refutation"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "contract_digest": {
+                            "maxLength": 64,
+                            "minLength": 64,
+                            "type": "string"
+                          },
+                          "kind": {
+                            "enum": [
+                              "unavailable"
+                            ],
+                            "type": "string"
+                          },
+                          "reasons": {
+                            "items": {
+                              "enum": [
+                                "validated_contract_hash_mismatch",
+                                "publication_pin_mismatch",
+                                "source_not_bound_to_publication",
+                                "proof_facts_unavailable",
+                                "proof_semantic_projection_unavailable"
+                              ],
+                              "type": "string"
+                            },
+                            "maxItems": 5,
+                            "minItems": 1,
+                            "type": "array",
+                            "uniqueItems": true
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "contract_digest",
+                          "reasons"
+                        ],
+                        "type": "object"
+                      }
+                    ],
+                    "type": "object"
+                  },
+                  "domain": {
+                    "enum": [
+                      "indexed_source_call_path_v1"
+                    ],
+                    "type": "string"
+                  },
+                  "guard_version": {
+                    "enum": [
+                      "clause_guard_v1"
+                    ],
+                    "type": "string"
+                  },
+                  "identities": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "evidence": {
+                        "items": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "caller": {
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "callsite_identity": {
+                              "type": "string"
+                            },
+                            "chain": {
+                              "items": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "symbols": {
+                                    "items": {
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "symbols"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "edge_id": {
+                              "type": "string"
+                            },
+                            "fact_id": {
+                              "maxLength": 64,
+                              "minLength": 64,
+                              "type": "string"
+                            },
+                            "provenance": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "dependency_files": {
+                                  "items": {
+                                    "minimum": 0,
+                                    "type": "integer"
+                                  },
+                                  "type": "array"
+                                },
+                                "evidence_sha256": {
+                                  "maxLength": 64,
+                                  "minLength": 64,
+                                  "type": "string"
+                                },
+                                "profile": {
+                                  "minimum": 0,
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "profile",
+                                "dependency_files",
+                                "evidence_sha256"
+                              ],
+                              "type": "object"
+                            },
+                            "target": {
+                              "minimum": 0,
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "fact_id",
+                            "caller",
+                            "target",
+                            "edge_id",
+                            "callsite_identity",
+                            "chain",
+                            "provenance"
+                          ],
+                          "type": "object"
+                        },
+                        "maxItems": 65536,
+                        "type": "array"
+                      },
+                      "files": {
+                        "items": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "file_node_id": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "indexed_sha256": {
+                              "maxLength": 64,
+                              "minLength": 64,
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "observed_sha256": {
+                              "maxLength": 64,
+                              "minLength": 64,
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "project_file_components": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": [
+                                "array",
+                                "null"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "file_node_id",
+                            "project_file_components",
+                            "indexed_sha256",
+                            "observed_sha256"
+                          ],
+                          "type": "object"
+                        },
+                        "maxItems": 65536,
+                        "type": "array"
+                      },
+                      "provenance_profiles": {
+                        "items": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "algorithm": {
+                              "enum": [
+                                "exact-call-resolution-v1"
+                              ],
+                              "type": "string"
+                            },
+                            "fact_schema_version": {
+                              "enum": [
+                                1
+                              ],
+                              "type": "integer"
+                            },
+                            "language_adapter": {
+                              "type": "string"
+                            },
+                            "language_adapter_version": {
+                              "type": "string"
+                            },
+                            "parser_fingerprint": {
+                              "maxLength": 64,
+                              "minLength": 64,
+                              "type": "string"
+                            },
+                            "producer": {
+                              "enum": [
+                                "codestory-internal"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "producer",
+                            "fact_schema_version",
+                            "algorithm",
+                            "language_adapter",
+                            "language_adapter_version",
+                            "parser_fingerprint"
+                          ],
+                          "type": "object"
+                        },
+                        "maxItems": 6,
+                        "type": "array"
+                      },
+                      "symbols": {
+                        "items": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "canonical_id": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "file": {
+                              "minimum": 0,
+                              "type": [
+                                "integer",
+                                "null"
+                              ]
+                            },
+                            "node_id": {
+                              "type": "string"
+                            },
+                            "qualified_name": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "node_id",
+                            "canonical_id",
+                            "qualified_name",
+                            "file"
+                          ],
+                          "type": "object"
+                        },
+                        "maxItems": 65536,
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "files",
+                      "symbols",
+                      "provenance_profiles",
+                      "evidence"
+                    ],
+                    "type": "object"
+                  },
+                  "kind": {
+                    "enum": [
+                      "complete"
+                    ],
+                    "type": "string"
+                  },
+                  "receipts": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "callsite_identity": {
+                          "type": "string"
+                        },
+                        "column_or_ordinal": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "containment": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "end_line": {
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "file": {
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "owner": {
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "start_line": {
+                              "minimum": 0,
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "file",
+                            "owner",
+                            "start_line",
+                            "end_line"
+                          ],
+                          "type": "object"
+                        },
+                        "edge_id": {
+                          "type": "string"
+                        },
+                        "evidence": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "exact_callsite_start_byte": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "line_window": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "anchor_line": {
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "byte_end": {
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "byte_start": {
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "file": {
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "kind": {
+                              "enum": [
+                                "indexed_line_v1"
+                              ],
+                              "type": "string"
+                            },
+                            "text": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "file",
+                            "anchor_line",
+                            "byte_start",
+                            "byte_end",
+                            "text"
+                          ],
+                          "type": "object"
+                        },
+                        "receipt_id": {
+                          "type": "string"
+                        },
+                        "source": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "target": {
+                          "minimum": 0,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "receipt_id",
+                        "edge_id",
+                        "source",
+                        "target",
+                        "evidence",
+                        "exact_callsite_start_byte",
+                        "callsite_identity",
+                        "column_or_ordinal",
+                        "containment",
+                        "line_window"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 6,
+                    "type": "array"
+                  },
+                  "schema_version": {
+                    "enum": [
+                      1
+                    ],
+                    "type": "integer"
+                  },
+                  "source_text_sha256": {
+                    "maxLength": 64,
+                    "minLength": 64,
+                    "type": "string"
+                  },
+                  "spec": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "exclude_from_projection": {
+                        "items": {
+                          "oneOf": [
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "core_generation_id": {
+                                  "type": "string"
+                                },
+                                "core_run_id": {
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "enum": [
+                                    "pinned_node"
+                                  ],
+                                  "type": "string"
+                                },
+                                "node_id": {
+                                  "type": "string"
+                                },
+                                "project_id": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "project_id",
+                                "core_generation_id",
+                                "core_run_id",
+                                "node_id"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "canonical_id": {
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "enum": [
+                                    "canonical_id"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "canonical_id"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "kind": {
+                                  "enum": [
+                                    "qualified_name"
+                                  ],
+                                  "type": "string"
+                                },
+                                "project_file_components": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "minItems": 1,
+                                  "type": [
+                                    "array",
+                                    "null"
+                                  ]
+                                },
+                                "qualified_name": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "qualified_name",
+                                "project_file_components"
+                              ],
+                              "type": "object"
+                            }
+                          ],
+                          "type": "object"
+                        },
+                        "maxItems": 256,
+                        "type": "array"
+                      },
+                      "prohibit_traversal_through": {
+                        "items": {
+                          "oneOf": [
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "core_generation_id": {
+                                  "type": "string"
+                                },
+                                "core_run_id": {
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "enum": [
+                                    "pinned_node"
+                                  ],
+                                  "type": "string"
+                                },
+                                "node_id": {
+                                  "type": "string"
+                                },
+                                "project_id": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "project_id",
+                                "core_generation_id",
+                                "core_run_id",
+                                "node_id"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "canonical_id": {
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "enum": [
+                                    "canonical_id"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "canonical_id"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "kind": {
+                                  "enum": [
+                                    "qualified_name"
+                                  ],
+                                  "type": "string"
+                                },
+                                "project_file_components": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "minItems": 1,
+                                  "type": [
+                                    "array",
+                                    "null"
+                                  ]
+                                },
+                                "qualified_name": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "qualified_name",
+                                "project_file_components"
+                              ],
+                              "type": "object"
+                            }
+                          ],
+                          "type": "object"
+                        },
+                        "maxItems": 256,
+                        "type": "array"
+                      },
+                      "start": {
+                        "oneOf": [
+                          {
+                            "additionalProperties": false,
+                            "properties": {
+                              "core_generation_id": {
+                                "type": "string"
+                              },
+                              "core_run_id": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "enum": [
+                                  "pinned_node"
+                                ],
+                                "type": "string"
+                              },
+                              "node_id": {
+                                "type": "string"
+                              },
+                              "project_id": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "project_id",
+                              "core_generation_id",
+                              "core_run_id",
+                              "node_id"
+                            ],
+                            "type": "object"
+                          },
+                          {
+                            "additionalProperties": false,
+                            "properties": {
+                              "canonical_id": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "enum": [
+                                  "canonical_id"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "canonical_id"
+                            ],
+                            "type": "object"
+                          },
+                          {
+                            "additionalProperties": false,
+                            "properties": {
+                              "kind": {
+                                "enum": [
+                                  "qualified_name"
+                                ],
+                                "type": "string"
+                              },
+                              "project_file_components": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "minItems": 1,
+                                "type": [
+                                  "array",
+                                  "null"
+                                ]
+                              },
+                              "qualified_name": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "qualified_name",
+                              "project_file_components"
+                            ],
+                            "type": "object"
+                          },
+                          {
+                            "additionalProperties": false,
+                            "properties": {
+                              "kind": {
+                                "enum": [
+                                  "pinned_node_ref"
+                                ],
+                                "type": "string"
+                              },
+                              "symbol": {
+                                "minimum": 0,
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "symbol"
+                            ],
+                            "type": "object"
+                          },
+                          {
+                            "additionalProperties": false,
+                            "properties": {
+                              "kind": {
+                                "enum": [
+                                  "canonical_id_ref"
+                                ],
+                                "type": "string"
+                              },
+                              "symbol": {
+                                "minimum": 0,
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "symbol"
+                            ],
+                            "type": "object"
+                          },
+                          {
+                            "additionalProperties": false,
+                            "properties": {
+                              "kind": {
+                                "enum": [
+                                  "qualified_name_ref"
+                                ],
+                                "type": "string"
+                              },
+                              "path_binding": {
+                                "enum": [
+                                  "none",
+                                  "exact_file"
+                                ],
+                                "type": "string"
+                              },
+                              "symbol": {
+                                "minimum": 0,
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "symbol",
+                              "path_binding"
+                            ],
+                            "type": "object"
+                          }
+                        ],
+                        "type": "object"
+                      },
+                      "steps": {
+                        "items": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "relation": {
+                              "enum": [
+                                "direct_outgoing_call"
+                              ],
+                              "type": "string"
+                            },
+                            "target": {
+                              "oneOf": [
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "core_generation_id": {
+                                      "type": "string"
+                                    },
+                                    "core_run_id": {
+                                      "type": "string"
+                                    },
+                                    "kind": {
+                                      "enum": [
+                                        "pinned_node"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "node_id": {
+                                      "type": "string"
+                                    },
+                                    "project_id": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "project_id",
+                                    "core_generation_id",
+                                    "core_run_id",
+                                    "node_id"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "canonical_id": {
+                                      "type": "string"
+                                    },
+                                    "kind": {
+                                      "enum": [
+                                        "canonical_id"
+                                      ],
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "canonical_id"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "kind": {
+                                      "enum": [
+                                        "qualified_name"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "project_file_components": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "minItems": 1,
+                                      "type": [
+                                        "array",
+                                        "null"
+                                      ]
+                                    },
+                                    "qualified_name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "qualified_name",
+                                    "project_file_components"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "kind": {
+                                      "enum": [
+                                        "pinned_node_ref"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "symbol": {
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "symbol"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "kind": {
+                                      "enum": [
+                                        "canonical_id_ref"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "symbol": {
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "symbol"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "kind": {
+                                      "enum": [
+                                        "qualified_name_ref"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "path_binding": {
+                                      "enum": [
+                                        "none",
+                                        "exact_file"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "symbol": {
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "symbol",
+                                    "path_binding"
+                                  ],
+                                  "type": "object"
+                                }
+                              ],
+                              "type": "object"
+                            }
+                          },
+                          "required": [
+                            "relation",
+                            "target"
+                          ],
+                          "type": "object"
+                        },
+                        "maxItems": 6,
+                        "minItems": 1,
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "start",
+                      "steps",
+                      "prohibit_traversal_through",
+                      "exclude_from_projection"
+                    ],
+                    "type": "object"
+                  },
+                  "steps": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "receipt": {
+                          "minimum": 0,
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "status": {
+                          "enum": [
+                            "proven",
+                            "positive_contradiction",
+                            "certified_absence",
+                            "unavailable",
+                            "unknown"
+                          ],
+                          "type": "string"
+                        },
+                        "step_index": {
+                          "minimum": 0,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "step_index",
+                        "status",
+                        "receipt"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 6,
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "kind",
+                  "schema_version",
+                  "domain",
+                  "contract_interpretation",
+                  "guard_version",
+                  "source_text_sha256",
+                  "contract_digest",
+                  "core_publication",
+                  "disposition",
+                  "identities",
+                  "spec",
+                  "clauses",
+                  "steps",
+                  "receipts"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "cap_bytes": {
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "contract_digest": {
+                    "maxLength": 64,
+                    "minLength": 64,
+                    "type": "string"
+                  },
+                  "contract_interpretation": {
+                    "enum": [
+                      "host_supplied"
+                    ],
+                    "type": "string"
+                  },
+                  "core_publication": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "generation_id": {
+                        "type": "string"
+                      },
+                      "project_id": {
+                        "type": "string"
+                      },
+                      "run_id": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "project_id",
+                      "generation_id",
+                      "run_id"
+                    ],
+                    "type": "object"
+                  },
+                  "disposition": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "contract_digest": {
+                        "maxLength": 64,
+                        "minLength": 64,
+                        "type": "string"
+                      },
+                      "gaps": {
+                        "items": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "kind": {
+                              "enum": [
+                                "output_budget_exceeded"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind"
+                          ],
+                          "type": "object"
+                        },
+                        "maxItems": 1,
+                        "minItems": 1,
+                        "type": "array"
+                      },
+                      "kind": {
+                        "enum": [
+                          "unknown"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "contract_digest",
+                      "gaps"
+                    ],
+                    "type": "object"
+                  },
+                  "domain": {
+                    "enum": [
+                      "indexed_source_call_path_v1"
+                    ],
+                    "type": "string"
+                  },
+                  "guard_version": {
+                    "enum": [
+                      "clause_guard_v1"
+                    ],
+                    "type": "string"
+                  },
+                  "kind": {
+                    "enum": [
+                      "budget_exceeded"
+                    ],
+                    "type": "string"
+                  },
+                  "required_complete_size": {
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "schema_version": {
+                    "enum": [
+                      1
+                    ],
+                    "type": "integer"
+                  },
+                  "source_text_sha256": {
+                    "maxLength": 64,
+                    "minLength": 64,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "kind",
+                  "schema_version",
+                  "domain",
+                  "contract_interpretation",
+                  "guard_version",
+                  "source_text_sha256",
+                  "contract_digest",
+                  "core_publication",
+                  "disposition",
+                  "cap_bytes",
+                  "required_complete_size"
+                ],
+                "type": "object"
+              }
+            ],
+            "type": "object"
+          },
+          "title": "Prove Call Path"
         }
       ],
       "resources": [
@@ -10069,7 +14076,7 @@
       ]
     },
     "2025-11-25": {
-      "discoveryContractSha256": "c7690622aeb7288d57d4973632e1bd2e3a349cfe234285a332d1dd828b3efa3e",
+      "discoveryContractSha256": "b13b23eb2a07d5fcbbe3c682c4c786621cf1ad19b96ae0098b5aac85d225f6b6",
       "tools": [
         {
           "_meta": {
@@ -16422,6 +20429,2557 @@
             "type": "object"
           },
           "title": "Context"
+        },
+        {
+          "_meta": {
+            "com.thegreencedar.codestory/safety": {
+              "activatesProject": false,
+              "destructive": false,
+              "effect": "read_only",
+              "idempotent": true,
+              "localOnly": true,
+              "openWorld": false,
+              "requiresConfirmation": false,
+              "sideEffects": false,
+              "writesRepository": false
+            }
+          },
+          "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": false,
+            "readOnlyHint": true
+          },
+          "description": "Verify one host-translated exact indexed source call-path contract against a pinned publication.",
+          "inputSchema": {
+            "additionalProperties": false,
+            "properties": {
+              "clauses": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "classification": {
+                      "oneOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fields": {
+                              "items": {
+                                "oneOf": [
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "kind": {
+                                        "enum": [
+                                          "start"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "kind": {
+                                        "enum": [
+                                          "step_target"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "step": {
+                                        "maximum": 5,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "step"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "kind": {
+                                        "enum": [
+                                          "directness"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "step": {
+                                        "maximum": 5,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "step"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "kind": {
+                                        "enum": [
+                                          "ordering"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "step": {
+                                        "maximum": 5,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "step"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "kind": {
+                                        "enum": [
+                                          "relation"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "step": {
+                                        "maximum": 5,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "step"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "index": {
+                                        "maximum": 255,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      },
+                                      "kind": {
+                                        "enum": [
+                                          "traversal_prohibition"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "index"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "index": {
+                                        "maximum": 255,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      },
+                                      "kind": {
+                                        "enum": [
+                                          "projection_exclusion"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "index"
+                                    ],
+                                    "type": "object"
+                                  }
+                                ],
+                                "type": "object"
+                              },
+                              "minItems": 1,
+                              "type": "array"
+                            },
+                            "kind": {
+                              "enum": [
+                                "resolved_material"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "fields"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "kind": {
+                              "enum": [
+                                "unresolved_material"
+                              ],
+                              "type": "string"
+                            },
+                            "reason": {
+                              "enum": [
+                                "missing_selector_resolution",
+                                "ambiguous_selector_resolution",
+                                "unsupported_interpretation"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "reason"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "kind": {
+                              "enum": [
+                                "non_material"
+                              ],
+                              "type": "string"
+                            },
+                            "reason": {
+                              "enum": [
+                                "whitespace",
+                                "punctuation",
+                                "connector",
+                                "commentary"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "reason"
+                          ],
+                          "type": "object"
+                        }
+                      ],
+                      "type": "object"
+                    },
+                    "clause_id": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "end_byte_exclusive": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "quote": {
+                      "type": "string"
+                    },
+                    "start_byte": {
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "clause_id",
+                    "start_byte",
+                    "end_byte_exclusive",
+                    "quote",
+                    "classification"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "project": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "source_text": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "spec": {
+                "additionalProperties": false,
+                "properties": {
+                  "exclude_from_projection": {
+                    "items": {
+                      "oneOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "core_generation_id": {
+                              "type": "string"
+                            },
+                            "core_run_id": {
+                              "type": "string"
+                            },
+                            "kind": {
+                              "enum": [
+                                "pinned_node"
+                              ],
+                              "type": "string"
+                            },
+                            "node_id": {
+                              "type": "string"
+                            },
+                            "project_id": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "project_id",
+                            "core_generation_id",
+                            "core_run_id",
+                            "node_id"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "canonical_id": {
+                              "type": "string"
+                            },
+                            "kind": {
+                              "enum": [
+                                "canonical_id"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "canonical_id"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "kind": {
+                              "enum": [
+                                "qualified_name"
+                              ],
+                              "type": "string"
+                            },
+                            "qualified_name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "qualified_name"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "kind": {
+                              "enum": [
+                                "qualified_name"
+                              ],
+                              "type": "string"
+                            },
+                            "project_file_components": {
+                              "items": {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "type": [
+                                "array",
+                                "null"
+                              ]
+                            },
+                            "qualified_name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "qualified_name",
+                            "project_file_components"
+                          ],
+                          "type": "object"
+                        }
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 256,
+                    "type": "array"
+                  },
+                  "prohibit_traversal_through": {
+                    "items": {
+                      "oneOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "core_generation_id": {
+                              "type": "string"
+                            },
+                            "core_run_id": {
+                              "type": "string"
+                            },
+                            "kind": {
+                              "enum": [
+                                "pinned_node"
+                              ],
+                              "type": "string"
+                            },
+                            "node_id": {
+                              "type": "string"
+                            },
+                            "project_id": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "project_id",
+                            "core_generation_id",
+                            "core_run_id",
+                            "node_id"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "canonical_id": {
+                              "type": "string"
+                            },
+                            "kind": {
+                              "enum": [
+                                "canonical_id"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "canonical_id"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "kind": {
+                              "enum": [
+                                "qualified_name"
+                              ],
+                              "type": "string"
+                            },
+                            "qualified_name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "qualified_name"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "kind": {
+                              "enum": [
+                                "qualified_name"
+                              ],
+                              "type": "string"
+                            },
+                            "project_file_components": {
+                              "items": {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "type": [
+                                "array",
+                                "null"
+                              ]
+                            },
+                            "qualified_name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "qualified_name",
+                            "project_file_components"
+                          ],
+                          "type": "object"
+                        }
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 256,
+                    "type": "array"
+                  },
+                  "start": {
+                    "oneOf": [
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "core_generation_id": {
+                            "type": "string"
+                          },
+                          "core_run_id": {
+                            "type": "string"
+                          },
+                          "kind": {
+                            "enum": [
+                              "pinned_node"
+                            ],
+                            "type": "string"
+                          },
+                          "node_id": {
+                            "type": "string"
+                          },
+                          "project_id": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "project_id",
+                          "core_generation_id",
+                          "core_run_id",
+                          "node_id"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "canonical_id": {
+                            "type": "string"
+                          },
+                          "kind": {
+                            "enum": [
+                              "canonical_id"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "canonical_id"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "kind": {
+                            "enum": [
+                              "qualified_name"
+                            ],
+                            "type": "string"
+                          },
+                          "qualified_name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "qualified_name"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "kind": {
+                            "enum": [
+                              "qualified_name"
+                            ],
+                            "type": "string"
+                          },
+                          "project_file_components": {
+                            "items": {
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "type": [
+                              "array",
+                              "null"
+                            ]
+                          },
+                          "qualified_name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "qualified_name",
+                          "project_file_components"
+                        ],
+                        "type": "object"
+                      }
+                    ],
+                    "type": "object"
+                  },
+                  "steps": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "target": {
+                          "oneOf": [
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "core_generation_id": {
+                                  "type": "string"
+                                },
+                                "core_run_id": {
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "enum": [
+                                    "pinned_node"
+                                  ],
+                                  "type": "string"
+                                },
+                                "node_id": {
+                                  "type": "string"
+                                },
+                                "project_id": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "project_id",
+                                "core_generation_id",
+                                "core_run_id",
+                                "node_id"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "canonical_id": {
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "enum": [
+                                    "canonical_id"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "canonical_id"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "kind": {
+                                  "enum": [
+                                    "qualified_name"
+                                  ],
+                                  "type": "string"
+                                },
+                                "qualified_name": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "qualified_name"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "kind": {
+                                  "enum": [
+                                    "qualified_name"
+                                  ],
+                                  "type": "string"
+                                },
+                                "project_file_components": {
+                                  "items": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "type": [
+                                    "array",
+                                    "null"
+                                  ]
+                                },
+                                "qualified_name": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "qualified_name",
+                                "project_file_components"
+                              ],
+                              "type": "object"
+                            }
+                          ],
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "target"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 6,
+                    "minItems": 1,
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "start",
+                  "steps",
+                  "prohibit_traversal_through",
+                  "exclude_from_projection"
+                ],
+                "type": "object"
+              }
+            },
+            "required": [
+              "project",
+              "source_text",
+              "clauses",
+              "spec"
+            ],
+            "type": "object"
+          },
+          "name": "prove_call_path",
+          "outputSchema": {
+            "oneOf": [
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "clauses": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "classification": {
+                          "enum": [
+                            "resolved_material",
+                            "unresolved_material",
+                            "non_material"
+                          ],
+                          "type": "string"
+                        },
+                        "clause_id": {
+                          "type": "string"
+                        },
+                        "end": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "fields": {
+                          "items": {
+                            "oneOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "kind": {
+                                    "enum": [
+                                      "start"
+                                    ],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "kind": {
+                                    "enum": [
+                                      "step_target",
+                                      "directness",
+                                      "ordering",
+                                      "relation"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "step": {
+                                    "minimum": 0,
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "step"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "index": {
+                                    "minimum": 0,
+                                    "type": "integer"
+                                  },
+                                  "kind": {
+                                    "enum": [
+                                      "traversal_prohibition",
+                                      "projection_exclusion"
+                                    ],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "index"
+                                ],
+                                "type": "object"
+                              }
+                            ],
+                            "type": "object"
+                          },
+                          "maxItems": 537,
+                          "type": "array"
+                        },
+                        "non_material_kind": {
+                          "enum": [
+                            "whitespace",
+                            "punctuation",
+                            "connector",
+                            "commentary"
+                          ],
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "quote": {
+                          "type": "string"
+                        },
+                        "reason": {
+                          "enum": [
+                            "missing_selector_resolution",
+                            "ambiguous_selector_resolution",
+                            "unsupported_interpretation"
+                          ],
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "start": {
+                          "minimum": 0,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "start",
+                        "end",
+                        "clause_id",
+                        "quote",
+                        "classification",
+                        "fields",
+                        "reason",
+                        "non_material_kind"
+                      ],
+                      "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                  },
+                  "contract_digest": {
+                    "maxLength": 64,
+                    "minLength": 64,
+                    "type": "string"
+                  },
+                  "contract_interpretation": {
+                    "enum": [
+                      "host_supplied"
+                    ],
+                    "type": "string"
+                  },
+                  "core_publication": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "generation_id": {
+                        "type": "string"
+                      },
+                      "project_id": {
+                        "type": "string"
+                      },
+                      "run_id": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "project_id",
+                      "generation_id",
+                      "run_id"
+                    ],
+                    "type": "object"
+                  },
+                  "disposition": {
+                    "oneOf": [
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "contract_digest": {
+                            "maxLength": 64,
+                            "minLength": 64,
+                            "type": "string"
+                          },
+                          "kind": {
+                            "enum": [
+                              "contract_proven"
+                            ],
+                            "type": "string"
+                          },
+                          "receipts": {
+                            "items": {
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "maxItems": 6,
+                            "type": "array",
+                            "uniqueItems": true
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "contract_digest",
+                          "receipts"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "connected_receipts": {
+                            "items": {
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "maxItems": 6,
+                            "type": "array",
+                            "uniqueItems": true
+                          },
+                          "contract_digest": {
+                            "maxLength": 64,
+                            "minLength": 64,
+                            "type": "string"
+                          },
+                          "gaps": {
+                            "items": {
+                              "oneOf": [
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "kind": {
+                                      "enum": [
+                                        "unclassified_source_text"
+                                      ],
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "clause_id": {
+                                      "type": "string"
+                                    },
+                                    "kind": {
+                                      "enum": [
+                                        "unresolved_material_clause"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "enum": [
+                                        "missing_selector_resolution",
+                                        "ambiguous_selector_resolution",
+                                        "unsupported_interpretation"
+                                      ],
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "clause_id",
+                                    "reason"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "clause_id": {
+                                      "type": "string"
+                                    },
+                                    "guard_families": {
+                                      "items": {
+                                        "enum": [
+                                          "quoted_or_backticked_identifier",
+                                          "arrow_or_relation_notation",
+                                          "directness",
+                                          "ordering_or_ordinal",
+                                          "only",
+                                          "negation_or_exclusion",
+                                          "path_like_string",
+                                          "qualified_symbol_notation"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "maxItems": 8,
+                                      "minItems": 1,
+                                      "type": "array",
+                                      "uniqueItems": true
+                                    },
+                                    "kind": {
+                                      "enum": [
+                                        "material_token_misclassified"
+                                      ],
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "clause_id",
+                                    "guard_families"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "kind": {
+                                      "enum": [
+                                        "selector_missing"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "selector_index": {
+                                      "maximum": 6,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "selector_index"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "kind": {
+                                      "enum": [
+                                        "selector_ambiguous"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "selector_index": {
+                                      "maximum": 6,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "selector_index"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "kind": {
+                                      "enum": [
+                                        "non_callable_selector"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "selector_index": {
+                                      "maximum": 6,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "selector_index"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "kind": {
+                                      "enum": [
+                                        "direct_call_missing"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "step_index": {
+                                      "maximum": 5,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "step_index"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "kind": {
+                                      "enum": [
+                                        "recursive_call_not_representable"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "step_index": {
+                                      "maximum": 5,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "step_index"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "kind": {
+                                      "enum": [
+                                        "source_window_too_large"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "step_index": {
+                                      "maximum": 5,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "step_index"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "kind": {
+                                      "enum": [
+                                        "invalid_utf8"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "step_index": {
+                                      "maximum": 5,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "step_index"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "kind": {
+                                      "enum": [
+                                        "source_line_out_of_range"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "step_index": {
+                                      "maximum": 5,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "step_index"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "kind": {
+                                      "enum": [
+                                        "edge_containment_unproven"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "step_index": {
+                                      "maximum": 5,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "step_index"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "kind": {
+                                      "enum": [
+                                        "missing_direct_call_receipt"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "step_index": {
+                                      "maximum": 5,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "step_index"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "kind": {
+                                      "enum": [
+                                        "receipt_or_edge_already_used"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "step_index": {
+                                      "maximum": 5,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "step_index"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "kind": {
+                                      "enum": [
+                                        "projection_exclusion_conflicts_with_required_receipt"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "step_index": {
+                                      "maximum": 5,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "step_index"
+                                  ],
+                                  "type": "object"
+                                }
+                              ],
+                              "type": "object"
+                            },
+                            "maxItems": 256,
+                            "minItems": 1,
+                            "type": "array",
+                            "uniqueItems": true
+                          },
+                          "kind": {
+                            "enum": [
+                              "unknown"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "contract_digest",
+                          "gaps",
+                          "connected_receipts"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "contract_digest": {
+                            "maxLength": 64,
+                            "minLength": 64,
+                            "type": "string"
+                          },
+                          "kind": {
+                            "enum": [
+                              "contract_refuted"
+                            ],
+                            "type": "string"
+                          },
+                          "refutation": {
+                            "oneOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "connected_receipts": {
+                                    "items": {
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    },
+                                    "maxItems": 6,
+                                    "type": "array",
+                                    "uniqueItems": true
+                                  },
+                                  "kind": {
+                                    "enum": [
+                                      "prohibited_scope_traversal"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "prohibition_index": {
+                                    "maximum": 255,
+                                    "minimum": 0,
+                                    "type": "integer"
+                                  },
+                                  "step_index": {
+                                    "maximum": 5,
+                                    "minimum": 0,
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "step_index",
+                                  "prohibition_index",
+                                  "connected_receipts"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "connected_receipts": {
+                                    "items": {
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    },
+                                    "maxItems": 6,
+                                    "type": "array",
+                                    "uniqueItems": true
+                                  },
+                                  "extractor_capability_receipt_id": {
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "enum": [
+                                      "certified_absence"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "step_index": {
+                                    "maximum": 5,
+                                    "minimum": 0,
+                                    "type": "integer"
+                                  },
+                                  "untruncated_enumeration_receipt_id": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "step_index",
+                                  "extractor_capability_receipt_id",
+                                  "untruncated_enumeration_receipt_id",
+                                  "connected_receipts"
+                                ],
+                                "type": "object"
+                              }
+                            ],
+                            "type": "object"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "contract_digest",
+                          "refutation"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "contract_digest": {
+                            "maxLength": 64,
+                            "minLength": 64,
+                            "type": "string"
+                          },
+                          "kind": {
+                            "enum": [
+                              "unavailable"
+                            ],
+                            "type": "string"
+                          },
+                          "reasons": {
+                            "items": {
+                              "enum": [
+                                "validated_contract_hash_mismatch",
+                                "publication_pin_mismatch",
+                                "source_not_bound_to_publication",
+                                "proof_facts_unavailable",
+                                "proof_semantic_projection_unavailable"
+                              ],
+                              "type": "string"
+                            },
+                            "maxItems": 5,
+                            "minItems": 1,
+                            "type": "array",
+                            "uniqueItems": true
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "contract_digest",
+                          "reasons"
+                        ],
+                        "type": "object"
+                      }
+                    ],
+                    "type": "object"
+                  },
+                  "domain": {
+                    "enum": [
+                      "indexed_source_call_path_v1"
+                    ],
+                    "type": "string"
+                  },
+                  "guard_version": {
+                    "enum": [
+                      "clause_guard_v1"
+                    ],
+                    "type": "string"
+                  },
+                  "identities": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "evidence": {
+                        "items": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "caller": {
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "callsite_identity": {
+                              "type": "string"
+                            },
+                            "chain": {
+                              "items": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "symbols": {
+                                    "items": {
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "symbols"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "edge_id": {
+                              "type": "string"
+                            },
+                            "fact_id": {
+                              "maxLength": 64,
+                              "minLength": 64,
+                              "type": "string"
+                            },
+                            "provenance": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "dependency_files": {
+                                  "items": {
+                                    "minimum": 0,
+                                    "type": "integer"
+                                  },
+                                  "type": "array"
+                                },
+                                "evidence_sha256": {
+                                  "maxLength": 64,
+                                  "minLength": 64,
+                                  "type": "string"
+                                },
+                                "profile": {
+                                  "minimum": 0,
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "profile",
+                                "dependency_files",
+                                "evidence_sha256"
+                              ],
+                              "type": "object"
+                            },
+                            "target": {
+                              "minimum": 0,
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "fact_id",
+                            "caller",
+                            "target",
+                            "edge_id",
+                            "callsite_identity",
+                            "chain",
+                            "provenance"
+                          ],
+                          "type": "object"
+                        },
+                        "maxItems": 65536,
+                        "type": "array"
+                      },
+                      "files": {
+                        "items": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "file_node_id": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "indexed_sha256": {
+                              "maxLength": 64,
+                              "minLength": 64,
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "observed_sha256": {
+                              "maxLength": 64,
+                              "minLength": 64,
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "project_file_components": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": [
+                                "array",
+                                "null"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "file_node_id",
+                            "project_file_components",
+                            "indexed_sha256",
+                            "observed_sha256"
+                          ],
+                          "type": "object"
+                        },
+                        "maxItems": 65536,
+                        "type": "array"
+                      },
+                      "provenance_profiles": {
+                        "items": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "algorithm": {
+                              "enum": [
+                                "exact-call-resolution-v1"
+                              ],
+                              "type": "string"
+                            },
+                            "fact_schema_version": {
+                              "enum": [
+                                1
+                              ],
+                              "type": "integer"
+                            },
+                            "language_adapter": {
+                              "type": "string"
+                            },
+                            "language_adapter_version": {
+                              "type": "string"
+                            },
+                            "parser_fingerprint": {
+                              "maxLength": 64,
+                              "minLength": 64,
+                              "type": "string"
+                            },
+                            "producer": {
+                              "enum": [
+                                "codestory-internal"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "producer",
+                            "fact_schema_version",
+                            "algorithm",
+                            "language_adapter",
+                            "language_adapter_version",
+                            "parser_fingerprint"
+                          ],
+                          "type": "object"
+                        },
+                        "maxItems": 6,
+                        "type": "array"
+                      },
+                      "symbols": {
+                        "items": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "canonical_id": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "file": {
+                              "minimum": 0,
+                              "type": [
+                                "integer",
+                                "null"
+                              ]
+                            },
+                            "node_id": {
+                              "type": "string"
+                            },
+                            "qualified_name": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "node_id",
+                            "canonical_id",
+                            "qualified_name",
+                            "file"
+                          ],
+                          "type": "object"
+                        },
+                        "maxItems": 65536,
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "files",
+                      "symbols",
+                      "provenance_profiles",
+                      "evidence"
+                    ],
+                    "type": "object"
+                  },
+                  "kind": {
+                    "enum": [
+                      "complete"
+                    ],
+                    "type": "string"
+                  },
+                  "receipts": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "callsite_identity": {
+                          "type": "string"
+                        },
+                        "column_or_ordinal": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "containment": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "end_line": {
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "file": {
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "owner": {
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "start_line": {
+                              "minimum": 0,
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "file",
+                            "owner",
+                            "start_line",
+                            "end_line"
+                          ],
+                          "type": "object"
+                        },
+                        "edge_id": {
+                          "type": "string"
+                        },
+                        "evidence": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "exact_callsite_start_byte": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "line_window": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "anchor_line": {
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "byte_end": {
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "byte_start": {
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "file": {
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "kind": {
+                              "enum": [
+                                "indexed_line_v1"
+                              ],
+                              "type": "string"
+                            },
+                            "text": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "file",
+                            "anchor_line",
+                            "byte_start",
+                            "byte_end",
+                            "text"
+                          ],
+                          "type": "object"
+                        },
+                        "receipt_id": {
+                          "type": "string"
+                        },
+                        "source": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "target": {
+                          "minimum": 0,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "receipt_id",
+                        "edge_id",
+                        "source",
+                        "target",
+                        "evidence",
+                        "exact_callsite_start_byte",
+                        "callsite_identity",
+                        "column_or_ordinal",
+                        "containment",
+                        "line_window"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 6,
+                    "type": "array"
+                  },
+                  "schema_version": {
+                    "enum": [
+                      1
+                    ],
+                    "type": "integer"
+                  },
+                  "source_text_sha256": {
+                    "maxLength": 64,
+                    "minLength": 64,
+                    "type": "string"
+                  },
+                  "spec": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "exclude_from_projection": {
+                        "items": {
+                          "oneOf": [
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "core_generation_id": {
+                                  "type": "string"
+                                },
+                                "core_run_id": {
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "enum": [
+                                    "pinned_node"
+                                  ],
+                                  "type": "string"
+                                },
+                                "node_id": {
+                                  "type": "string"
+                                },
+                                "project_id": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "project_id",
+                                "core_generation_id",
+                                "core_run_id",
+                                "node_id"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "canonical_id": {
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "enum": [
+                                    "canonical_id"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "canonical_id"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "kind": {
+                                  "enum": [
+                                    "qualified_name"
+                                  ],
+                                  "type": "string"
+                                },
+                                "project_file_components": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "minItems": 1,
+                                  "type": [
+                                    "array",
+                                    "null"
+                                  ]
+                                },
+                                "qualified_name": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "qualified_name",
+                                "project_file_components"
+                              ],
+                              "type": "object"
+                            }
+                          ],
+                          "type": "object"
+                        },
+                        "maxItems": 256,
+                        "type": "array"
+                      },
+                      "prohibit_traversal_through": {
+                        "items": {
+                          "oneOf": [
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "core_generation_id": {
+                                  "type": "string"
+                                },
+                                "core_run_id": {
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "enum": [
+                                    "pinned_node"
+                                  ],
+                                  "type": "string"
+                                },
+                                "node_id": {
+                                  "type": "string"
+                                },
+                                "project_id": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "project_id",
+                                "core_generation_id",
+                                "core_run_id",
+                                "node_id"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "canonical_id": {
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "enum": [
+                                    "canonical_id"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "canonical_id"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "kind": {
+                                  "enum": [
+                                    "qualified_name"
+                                  ],
+                                  "type": "string"
+                                },
+                                "project_file_components": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "minItems": 1,
+                                  "type": [
+                                    "array",
+                                    "null"
+                                  ]
+                                },
+                                "qualified_name": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "qualified_name",
+                                "project_file_components"
+                              ],
+                              "type": "object"
+                            }
+                          ],
+                          "type": "object"
+                        },
+                        "maxItems": 256,
+                        "type": "array"
+                      },
+                      "start": {
+                        "oneOf": [
+                          {
+                            "additionalProperties": false,
+                            "properties": {
+                              "core_generation_id": {
+                                "type": "string"
+                              },
+                              "core_run_id": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "enum": [
+                                  "pinned_node"
+                                ],
+                                "type": "string"
+                              },
+                              "node_id": {
+                                "type": "string"
+                              },
+                              "project_id": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "project_id",
+                              "core_generation_id",
+                              "core_run_id",
+                              "node_id"
+                            ],
+                            "type": "object"
+                          },
+                          {
+                            "additionalProperties": false,
+                            "properties": {
+                              "canonical_id": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "enum": [
+                                  "canonical_id"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "canonical_id"
+                            ],
+                            "type": "object"
+                          },
+                          {
+                            "additionalProperties": false,
+                            "properties": {
+                              "kind": {
+                                "enum": [
+                                  "qualified_name"
+                                ],
+                                "type": "string"
+                              },
+                              "project_file_components": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "minItems": 1,
+                                "type": [
+                                  "array",
+                                  "null"
+                                ]
+                              },
+                              "qualified_name": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "qualified_name",
+                              "project_file_components"
+                            ],
+                            "type": "object"
+                          },
+                          {
+                            "additionalProperties": false,
+                            "properties": {
+                              "kind": {
+                                "enum": [
+                                  "pinned_node_ref"
+                                ],
+                                "type": "string"
+                              },
+                              "symbol": {
+                                "minimum": 0,
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "symbol"
+                            ],
+                            "type": "object"
+                          },
+                          {
+                            "additionalProperties": false,
+                            "properties": {
+                              "kind": {
+                                "enum": [
+                                  "canonical_id_ref"
+                                ],
+                                "type": "string"
+                              },
+                              "symbol": {
+                                "minimum": 0,
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "symbol"
+                            ],
+                            "type": "object"
+                          },
+                          {
+                            "additionalProperties": false,
+                            "properties": {
+                              "kind": {
+                                "enum": [
+                                  "qualified_name_ref"
+                                ],
+                                "type": "string"
+                              },
+                              "path_binding": {
+                                "enum": [
+                                  "none",
+                                  "exact_file"
+                                ],
+                                "type": "string"
+                              },
+                              "symbol": {
+                                "minimum": 0,
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "symbol",
+                              "path_binding"
+                            ],
+                            "type": "object"
+                          }
+                        ],
+                        "type": "object"
+                      },
+                      "steps": {
+                        "items": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "relation": {
+                              "enum": [
+                                "direct_outgoing_call"
+                              ],
+                              "type": "string"
+                            },
+                            "target": {
+                              "oneOf": [
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "core_generation_id": {
+                                      "type": "string"
+                                    },
+                                    "core_run_id": {
+                                      "type": "string"
+                                    },
+                                    "kind": {
+                                      "enum": [
+                                        "pinned_node"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "node_id": {
+                                      "type": "string"
+                                    },
+                                    "project_id": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "project_id",
+                                    "core_generation_id",
+                                    "core_run_id",
+                                    "node_id"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "canonical_id": {
+                                      "type": "string"
+                                    },
+                                    "kind": {
+                                      "enum": [
+                                        "canonical_id"
+                                      ],
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "canonical_id"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "kind": {
+                                      "enum": [
+                                        "qualified_name"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "project_file_components": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "minItems": 1,
+                                      "type": [
+                                        "array",
+                                        "null"
+                                      ]
+                                    },
+                                    "qualified_name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "qualified_name",
+                                    "project_file_components"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "kind": {
+                                      "enum": [
+                                        "pinned_node_ref"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "symbol": {
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "symbol"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "kind": {
+                                      "enum": [
+                                        "canonical_id_ref"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "symbol": {
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "symbol"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "kind": {
+                                      "enum": [
+                                        "qualified_name_ref"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "path_binding": {
+                                      "enum": [
+                                        "none",
+                                        "exact_file"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "symbol": {
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "symbol",
+                                    "path_binding"
+                                  ],
+                                  "type": "object"
+                                }
+                              ],
+                              "type": "object"
+                            }
+                          },
+                          "required": [
+                            "relation",
+                            "target"
+                          ],
+                          "type": "object"
+                        },
+                        "maxItems": 6,
+                        "minItems": 1,
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "start",
+                      "steps",
+                      "prohibit_traversal_through",
+                      "exclude_from_projection"
+                    ],
+                    "type": "object"
+                  },
+                  "steps": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "receipt": {
+                          "minimum": 0,
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "status": {
+                          "enum": [
+                            "proven",
+                            "positive_contradiction",
+                            "certified_absence",
+                            "unavailable",
+                            "unknown"
+                          ],
+                          "type": "string"
+                        },
+                        "step_index": {
+                          "minimum": 0,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "step_index",
+                        "status",
+                        "receipt"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 6,
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "kind",
+                  "schema_version",
+                  "domain",
+                  "contract_interpretation",
+                  "guard_version",
+                  "source_text_sha256",
+                  "contract_digest",
+                  "core_publication",
+                  "disposition",
+                  "identities",
+                  "spec",
+                  "clauses",
+                  "steps",
+                  "receipts"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "cap_bytes": {
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "contract_digest": {
+                    "maxLength": 64,
+                    "minLength": 64,
+                    "type": "string"
+                  },
+                  "contract_interpretation": {
+                    "enum": [
+                      "host_supplied"
+                    ],
+                    "type": "string"
+                  },
+                  "core_publication": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "generation_id": {
+                        "type": "string"
+                      },
+                      "project_id": {
+                        "type": "string"
+                      },
+                      "run_id": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "project_id",
+                      "generation_id",
+                      "run_id"
+                    ],
+                    "type": "object"
+                  },
+                  "disposition": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "contract_digest": {
+                        "maxLength": 64,
+                        "minLength": 64,
+                        "type": "string"
+                      },
+                      "gaps": {
+                        "items": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "kind": {
+                              "enum": [
+                                "output_budget_exceeded"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind"
+                          ],
+                          "type": "object"
+                        },
+                        "maxItems": 1,
+                        "minItems": 1,
+                        "type": "array"
+                      },
+                      "kind": {
+                        "enum": [
+                          "unknown"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "contract_digest",
+                      "gaps"
+                    ],
+                    "type": "object"
+                  },
+                  "domain": {
+                    "enum": [
+                      "indexed_source_call_path_v1"
+                    ],
+                    "type": "string"
+                  },
+                  "guard_version": {
+                    "enum": [
+                      "clause_guard_v1"
+                    ],
+                    "type": "string"
+                  },
+                  "kind": {
+                    "enum": [
+                      "budget_exceeded"
+                    ],
+                    "type": "string"
+                  },
+                  "required_complete_size": {
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "schema_version": {
+                    "enum": [
+                      1
+                    ],
+                    "type": "integer"
+                  },
+                  "source_text_sha256": {
+                    "maxLength": 64,
+                    "minLength": 64,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "kind",
+                  "schema_version",
+                  "domain",
+                  "contract_interpretation",
+                  "guard_version",
+                  "source_text_sha256",
+                  "contract_digest",
+                  "core_publication",
+                  "disposition",
+                  "cap_bytes",
+                  "required_complete_size"
+                ],
+                "type": "object"
+              }
+            ],
+            "type": "object"
+          },
+          "title": "Prove Call Path"
         }
       ],
       "resources": [
@@ -22841,6 +29399,2557 @@
         "type": "object"
       },
       "title": "Context"
+    },
+    {
+      "_meta": {
+        "com.thegreencedar.codestory/safety": {
+          "activatesProject": false,
+          "destructive": false,
+          "effect": "read_only",
+          "idempotent": true,
+          "localOnly": true,
+          "openWorld": false,
+          "requiresConfirmation": false,
+          "sideEffects": false,
+          "writesRepository": false
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "description": "Verify one host-translated exact indexed source call-path contract against a pinned publication.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "clauses": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "classification": {
+                  "oneOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "fields": {
+                          "items": {
+                            "oneOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "kind": {
+                                    "enum": [
+                                      "start"
+                                    ],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "kind": {
+                                    "enum": [
+                                      "step_target"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "step": {
+                                    "maximum": 5,
+                                    "minimum": 0,
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "step"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "kind": {
+                                    "enum": [
+                                      "directness"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "step": {
+                                    "maximum": 5,
+                                    "minimum": 0,
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "step"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "kind": {
+                                    "enum": [
+                                      "ordering"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "step": {
+                                    "maximum": 5,
+                                    "minimum": 0,
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "step"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "kind": {
+                                    "enum": [
+                                      "relation"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "step": {
+                                    "maximum": 5,
+                                    "minimum": 0,
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "step"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "index": {
+                                    "maximum": 255,
+                                    "minimum": 0,
+                                    "type": "integer"
+                                  },
+                                  "kind": {
+                                    "enum": [
+                                      "traversal_prohibition"
+                                    ],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "index"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "index": {
+                                    "maximum": 255,
+                                    "minimum": 0,
+                                    "type": "integer"
+                                  },
+                                  "kind": {
+                                    "enum": [
+                                      "projection_exclusion"
+                                    ],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "index"
+                                ],
+                                "type": "object"
+                              }
+                            ],
+                            "type": "object"
+                          },
+                          "minItems": 1,
+                          "type": "array"
+                        },
+                        "kind": {
+                          "enum": [
+                            "resolved_material"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "fields"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "kind": {
+                          "enum": [
+                            "unresolved_material"
+                          ],
+                          "type": "string"
+                        },
+                        "reason": {
+                          "enum": [
+                            "missing_selector_resolution",
+                            "ambiguous_selector_resolution",
+                            "unsupported_interpretation"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "reason"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "kind": {
+                          "enum": [
+                            "non_material"
+                          ],
+                          "type": "string"
+                        },
+                        "reason": {
+                          "enum": [
+                            "whitespace",
+                            "punctuation",
+                            "connector",
+                            "commentary"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "reason"
+                      ],
+                      "type": "object"
+                    }
+                  ],
+                  "type": "object"
+                },
+                "clause_id": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "end_byte_exclusive": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "quote": {
+                  "type": "string"
+                },
+                "start_byte": {
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "clause_id",
+                "start_byte",
+                "end_byte_exclusive",
+                "quote",
+                "classification"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "project": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "source_text": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "spec": {
+            "additionalProperties": false,
+            "properties": {
+              "exclude_from_projection": {
+                "items": {
+                  "oneOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "core_generation_id": {
+                          "type": "string"
+                        },
+                        "core_run_id": {
+                          "type": "string"
+                        },
+                        "kind": {
+                          "enum": [
+                            "pinned_node"
+                          ],
+                          "type": "string"
+                        },
+                        "node_id": {
+                          "type": "string"
+                        },
+                        "project_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "project_id",
+                        "core_generation_id",
+                        "core_run_id",
+                        "node_id"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "canonical_id": {
+                          "type": "string"
+                        },
+                        "kind": {
+                          "enum": [
+                            "canonical_id"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "canonical_id"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "kind": {
+                          "enum": [
+                            "qualified_name"
+                          ],
+                          "type": "string"
+                        },
+                        "qualified_name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "qualified_name"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "kind": {
+                          "enum": [
+                            "qualified_name"
+                          ],
+                          "type": "string"
+                        },
+                        "project_file_components": {
+                          "items": {
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "type": [
+                            "array",
+                            "null"
+                          ]
+                        },
+                        "qualified_name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "qualified_name",
+                        "project_file_components"
+                      ],
+                      "type": "object"
+                    }
+                  ],
+                  "type": "object"
+                },
+                "maxItems": 256,
+                "type": "array"
+              },
+              "prohibit_traversal_through": {
+                "items": {
+                  "oneOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "core_generation_id": {
+                          "type": "string"
+                        },
+                        "core_run_id": {
+                          "type": "string"
+                        },
+                        "kind": {
+                          "enum": [
+                            "pinned_node"
+                          ],
+                          "type": "string"
+                        },
+                        "node_id": {
+                          "type": "string"
+                        },
+                        "project_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "project_id",
+                        "core_generation_id",
+                        "core_run_id",
+                        "node_id"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "canonical_id": {
+                          "type": "string"
+                        },
+                        "kind": {
+                          "enum": [
+                            "canonical_id"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "canonical_id"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "kind": {
+                          "enum": [
+                            "qualified_name"
+                          ],
+                          "type": "string"
+                        },
+                        "qualified_name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "qualified_name"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "kind": {
+                          "enum": [
+                            "qualified_name"
+                          ],
+                          "type": "string"
+                        },
+                        "project_file_components": {
+                          "items": {
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "type": [
+                            "array",
+                            "null"
+                          ]
+                        },
+                        "qualified_name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "qualified_name",
+                        "project_file_components"
+                      ],
+                      "type": "object"
+                    }
+                  ],
+                  "type": "object"
+                },
+                "maxItems": 256,
+                "type": "array"
+              },
+              "start": {
+                "oneOf": [
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "core_generation_id": {
+                        "type": "string"
+                      },
+                      "core_run_id": {
+                        "type": "string"
+                      },
+                      "kind": {
+                        "enum": [
+                          "pinned_node"
+                        ],
+                        "type": "string"
+                      },
+                      "node_id": {
+                        "type": "string"
+                      },
+                      "project_id": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "project_id",
+                      "core_generation_id",
+                      "core_run_id",
+                      "node_id"
+                    ],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "canonical_id": {
+                        "type": "string"
+                      },
+                      "kind": {
+                        "enum": [
+                          "canonical_id"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "canonical_id"
+                    ],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "kind": {
+                        "enum": [
+                          "qualified_name"
+                        ],
+                        "type": "string"
+                      },
+                      "qualified_name": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "qualified_name"
+                    ],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "kind": {
+                        "enum": [
+                          "qualified_name"
+                        ],
+                        "type": "string"
+                      },
+                      "project_file_components": {
+                        "items": {
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "type": [
+                          "array",
+                          "null"
+                        ]
+                      },
+                      "qualified_name": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "qualified_name",
+                      "project_file_components"
+                    ],
+                    "type": "object"
+                  }
+                ],
+                "type": "object"
+              },
+              "steps": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "target": {
+                      "oneOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "core_generation_id": {
+                              "type": "string"
+                            },
+                            "core_run_id": {
+                              "type": "string"
+                            },
+                            "kind": {
+                              "enum": [
+                                "pinned_node"
+                              ],
+                              "type": "string"
+                            },
+                            "node_id": {
+                              "type": "string"
+                            },
+                            "project_id": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "project_id",
+                            "core_generation_id",
+                            "core_run_id",
+                            "node_id"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "canonical_id": {
+                              "type": "string"
+                            },
+                            "kind": {
+                              "enum": [
+                                "canonical_id"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "canonical_id"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "kind": {
+                              "enum": [
+                                "qualified_name"
+                              ],
+                              "type": "string"
+                            },
+                            "qualified_name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "qualified_name"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "kind": {
+                              "enum": [
+                                "qualified_name"
+                              ],
+                              "type": "string"
+                            },
+                            "project_file_components": {
+                              "items": {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "type": [
+                                "array",
+                                "null"
+                              ]
+                            },
+                            "qualified_name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "qualified_name",
+                            "project_file_components"
+                          ],
+                          "type": "object"
+                        }
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "target"
+                  ],
+                  "type": "object"
+                },
+                "maxItems": 6,
+                "minItems": 1,
+                "type": "array"
+              }
+            },
+            "required": [
+              "start",
+              "steps",
+              "prohibit_traversal_through",
+              "exclude_from_projection"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "project",
+          "source_text",
+          "clauses",
+          "spec"
+        ],
+        "type": "object"
+      },
+      "name": "prove_call_path",
+      "outputSchema": {
+        "oneOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "clauses": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "classification": {
+                      "enum": [
+                        "resolved_material",
+                        "unresolved_material",
+                        "non_material"
+                      ],
+                      "type": "string"
+                    },
+                    "clause_id": {
+                      "type": "string"
+                    },
+                    "end": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "fields": {
+                      "items": {
+                        "oneOf": [
+                          {
+                            "additionalProperties": false,
+                            "properties": {
+                              "kind": {
+                                "enum": [
+                                  "start"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind"
+                            ],
+                            "type": "object"
+                          },
+                          {
+                            "additionalProperties": false,
+                            "properties": {
+                              "kind": {
+                                "enum": [
+                                  "step_target",
+                                  "directness",
+                                  "ordering",
+                                  "relation"
+                                ],
+                                "type": "string"
+                              },
+                              "step": {
+                                "minimum": 0,
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "step"
+                            ],
+                            "type": "object"
+                          },
+                          {
+                            "additionalProperties": false,
+                            "properties": {
+                              "index": {
+                                "minimum": 0,
+                                "type": "integer"
+                              },
+                              "kind": {
+                                "enum": [
+                                  "traversal_prohibition",
+                                  "projection_exclusion"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "index"
+                            ],
+                            "type": "object"
+                          }
+                        ],
+                        "type": "object"
+                      },
+                      "maxItems": 537,
+                      "type": "array"
+                    },
+                    "non_material_kind": {
+                      "enum": [
+                        "whitespace",
+                        "punctuation",
+                        "connector",
+                        "commentary"
+                      ],
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "quote": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "enum": [
+                        "missing_selector_resolution",
+                        "ambiguous_selector_resolution",
+                        "unsupported_interpretation"
+                      ],
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "start": {
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "start",
+                    "end",
+                    "clause_id",
+                    "quote",
+                    "classification",
+                    "fields",
+                    "reason",
+                    "non_material_kind"
+                  ],
+                  "type": "object"
+                },
+                "minItems": 1,
+                "type": "array"
+              },
+              "contract_digest": {
+                "maxLength": 64,
+                "minLength": 64,
+                "type": "string"
+              },
+              "contract_interpretation": {
+                "enum": [
+                  "host_supplied"
+                ],
+                "type": "string"
+              },
+              "core_publication": {
+                "additionalProperties": false,
+                "properties": {
+                  "generation_id": {
+                    "type": "string"
+                  },
+                  "project_id": {
+                    "type": "string"
+                  },
+                  "run_id": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "project_id",
+                  "generation_id",
+                  "run_id"
+                ],
+                "type": "object"
+              },
+              "disposition": {
+                "oneOf": [
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "contract_digest": {
+                        "maxLength": 64,
+                        "minLength": 64,
+                        "type": "string"
+                      },
+                      "kind": {
+                        "enum": [
+                          "contract_proven"
+                        ],
+                        "type": "string"
+                      },
+                      "receipts": {
+                        "items": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "maxItems": 6,
+                        "type": "array",
+                        "uniqueItems": true
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "contract_digest",
+                      "receipts"
+                    ],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "connected_receipts": {
+                        "items": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "maxItems": 6,
+                        "type": "array",
+                        "uniqueItems": true
+                      },
+                      "contract_digest": {
+                        "maxLength": 64,
+                        "minLength": 64,
+                        "type": "string"
+                      },
+                      "gaps": {
+                        "items": {
+                          "oneOf": [
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "kind": {
+                                  "enum": [
+                                    "unclassified_source_text"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "clause_id": {
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "enum": [
+                                    "unresolved_material_clause"
+                                  ],
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "enum": [
+                                    "missing_selector_resolution",
+                                    "ambiguous_selector_resolution",
+                                    "unsupported_interpretation"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "clause_id",
+                                "reason"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "clause_id": {
+                                  "type": "string"
+                                },
+                                "guard_families": {
+                                  "items": {
+                                    "enum": [
+                                      "quoted_or_backticked_identifier",
+                                      "arrow_or_relation_notation",
+                                      "directness",
+                                      "ordering_or_ordinal",
+                                      "only",
+                                      "negation_or_exclusion",
+                                      "path_like_string",
+                                      "qualified_symbol_notation"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "maxItems": 8,
+                                  "minItems": 1,
+                                  "type": "array",
+                                  "uniqueItems": true
+                                },
+                                "kind": {
+                                  "enum": [
+                                    "material_token_misclassified"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "clause_id",
+                                "guard_families"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "kind": {
+                                  "enum": [
+                                    "selector_missing"
+                                  ],
+                                  "type": "string"
+                                },
+                                "selector_index": {
+                                  "maximum": 6,
+                                  "minimum": 0,
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "selector_index"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "kind": {
+                                  "enum": [
+                                    "selector_ambiguous"
+                                  ],
+                                  "type": "string"
+                                },
+                                "selector_index": {
+                                  "maximum": 6,
+                                  "minimum": 0,
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "selector_index"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "kind": {
+                                  "enum": [
+                                    "non_callable_selector"
+                                  ],
+                                  "type": "string"
+                                },
+                                "selector_index": {
+                                  "maximum": 6,
+                                  "minimum": 0,
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "selector_index"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "kind": {
+                                  "enum": [
+                                    "direct_call_missing"
+                                  ],
+                                  "type": "string"
+                                },
+                                "step_index": {
+                                  "maximum": 5,
+                                  "minimum": 0,
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "step_index"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "kind": {
+                                  "enum": [
+                                    "recursive_call_not_representable"
+                                  ],
+                                  "type": "string"
+                                },
+                                "step_index": {
+                                  "maximum": 5,
+                                  "minimum": 0,
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "step_index"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "kind": {
+                                  "enum": [
+                                    "source_window_too_large"
+                                  ],
+                                  "type": "string"
+                                },
+                                "step_index": {
+                                  "maximum": 5,
+                                  "minimum": 0,
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "step_index"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "kind": {
+                                  "enum": [
+                                    "invalid_utf8"
+                                  ],
+                                  "type": "string"
+                                },
+                                "step_index": {
+                                  "maximum": 5,
+                                  "minimum": 0,
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "step_index"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "kind": {
+                                  "enum": [
+                                    "source_line_out_of_range"
+                                  ],
+                                  "type": "string"
+                                },
+                                "step_index": {
+                                  "maximum": 5,
+                                  "minimum": 0,
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "step_index"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "kind": {
+                                  "enum": [
+                                    "edge_containment_unproven"
+                                  ],
+                                  "type": "string"
+                                },
+                                "step_index": {
+                                  "maximum": 5,
+                                  "minimum": 0,
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "step_index"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "kind": {
+                                  "enum": [
+                                    "missing_direct_call_receipt"
+                                  ],
+                                  "type": "string"
+                                },
+                                "step_index": {
+                                  "maximum": 5,
+                                  "minimum": 0,
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "step_index"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "kind": {
+                                  "enum": [
+                                    "receipt_or_edge_already_used"
+                                  ],
+                                  "type": "string"
+                                },
+                                "step_index": {
+                                  "maximum": 5,
+                                  "minimum": 0,
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "step_index"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "kind": {
+                                  "enum": [
+                                    "projection_exclusion_conflicts_with_required_receipt"
+                                  ],
+                                  "type": "string"
+                                },
+                                "step_index": {
+                                  "maximum": 5,
+                                  "minimum": 0,
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "step_index"
+                              ],
+                              "type": "object"
+                            }
+                          ],
+                          "type": "object"
+                        },
+                        "maxItems": 256,
+                        "minItems": 1,
+                        "type": "array",
+                        "uniqueItems": true
+                      },
+                      "kind": {
+                        "enum": [
+                          "unknown"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "contract_digest",
+                      "gaps",
+                      "connected_receipts"
+                    ],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "contract_digest": {
+                        "maxLength": 64,
+                        "minLength": 64,
+                        "type": "string"
+                      },
+                      "kind": {
+                        "enum": [
+                          "contract_refuted"
+                        ],
+                        "type": "string"
+                      },
+                      "refutation": {
+                        "oneOf": [
+                          {
+                            "additionalProperties": false,
+                            "properties": {
+                              "connected_receipts": {
+                                "items": {
+                                  "minimum": 0,
+                                  "type": "integer"
+                                },
+                                "maxItems": 6,
+                                "type": "array",
+                                "uniqueItems": true
+                              },
+                              "kind": {
+                                "enum": [
+                                  "prohibited_scope_traversal"
+                                ],
+                                "type": "string"
+                              },
+                              "prohibition_index": {
+                                "maximum": 255,
+                                "minimum": 0,
+                                "type": "integer"
+                              },
+                              "step_index": {
+                                "maximum": 5,
+                                "minimum": 0,
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "step_index",
+                              "prohibition_index",
+                              "connected_receipts"
+                            ],
+                            "type": "object"
+                          },
+                          {
+                            "additionalProperties": false,
+                            "properties": {
+                              "connected_receipts": {
+                                "items": {
+                                  "minimum": 0,
+                                  "type": "integer"
+                                },
+                                "maxItems": 6,
+                                "type": "array",
+                                "uniqueItems": true
+                              },
+                              "extractor_capability_receipt_id": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "enum": [
+                                  "certified_absence"
+                                ],
+                                "type": "string"
+                              },
+                              "step_index": {
+                                "maximum": 5,
+                                "minimum": 0,
+                                "type": "integer"
+                              },
+                              "untruncated_enumeration_receipt_id": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "step_index",
+                              "extractor_capability_receipt_id",
+                              "untruncated_enumeration_receipt_id",
+                              "connected_receipts"
+                            ],
+                            "type": "object"
+                          }
+                        ],
+                        "type": "object"
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "contract_digest",
+                      "refutation"
+                    ],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "contract_digest": {
+                        "maxLength": 64,
+                        "minLength": 64,
+                        "type": "string"
+                      },
+                      "kind": {
+                        "enum": [
+                          "unavailable"
+                        ],
+                        "type": "string"
+                      },
+                      "reasons": {
+                        "items": {
+                          "enum": [
+                            "validated_contract_hash_mismatch",
+                            "publication_pin_mismatch",
+                            "source_not_bound_to_publication",
+                            "proof_facts_unavailable",
+                            "proof_semantic_projection_unavailable"
+                          ],
+                          "type": "string"
+                        },
+                        "maxItems": 5,
+                        "minItems": 1,
+                        "type": "array",
+                        "uniqueItems": true
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "contract_digest",
+                      "reasons"
+                    ],
+                    "type": "object"
+                  }
+                ],
+                "type": "object"
+              },
+              "domain": {
+                "enum": [
+                  "indexed_source_call_path_v1"
+                ],
+                "type": "string"
+              },
+              "guard_version": {
+                "enum": [
+                  "clause_guard_v1"
+                ],
+                "type": "string"
+              },
+              "identities": {
+                "additionalProperties": false,
+                "properties": {
+                  "evidence": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "caller": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "callsite_identity": {
+                          "type": "string"
+                        },
+                        "chain": {
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "kind": {
+                                "type": "string"
+                              },
+                              "symbols": {
+                                "items": {
+                                  "minimum": 0,
+                                  "type": "integer"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "symbols"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "edge_id": {
+                          "type": "string"
+                        },
+                        "fact_id": {
+                          "maxLength": 64,
+                          "minLength": 64,
+                          "type": "string"
+                        },
+                        "provenance": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "dependency_files": {
+                              "items": {
+                                "minimum": 0,
+                                "type": "integer"
+                              },
+                              "type": "array"
+                            },
+                            "evidence_sha256": {
+                              "maxLength": 64,
+                              "minLength": 64,
+                              "type": "string"
+                            },
+                            "profile": {
+                              "minimum": 0,
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "profile",
+                            "dependency_files",
+                            "evidence_sha256"
+                          ],
+                          "type": "object"
+                        },
+                        "target": {
+                          "minimum": 0,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "fact_id",
+                        "caller",
+                        "target",
+                        "edge_id",
+                        "callsite_identity",
+                        "chain",
+                        "provenance"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 65536,
+                    "type": "array"
+                  },
+                  "files": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "file_node_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "indexed_sha256": {
+                          "maxLength": 64,
+                          "minLength": 64,
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "observed_sha256": {
+                          "maxLength": 64,
+                          "minLength": 64,
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "project_file_components": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": [
+                            "array",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "file_node_id",
+                        "project_file_components",
+                        "indexed_sha256",
+                        "observed_sha256"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 65536,
+                    "type": "array"
+                  },
+                  "provenance_profiles": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "algorithm": {
+                          "enum": [
+                            "exact-call-resolution-v1"
+                          ],
+                          "type": "string"
+                        },
+                        "fact_schema_version": {
+                          "enum": [
+                            1
+                          ],
+                          "type": "integer"
+                        },
+                        "language_adapter": {
+                          "type": "string"
+                        },
+                        "language_adapter_version": {
+                          "type": "string"
+                        },
+                        "parser_fingerprint": {
+                          "maxLength": 64,
+                          "minLength": 64,
+                          "type": "string"
+                        },
+                        "producer": {
+                          "enum": [
+                            "codestory-internal"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "producer",
+                        "fact_schema_version",
+                        "algorithm",
+                        "language_adapter",
+                        "language_adapter_version",
+                        "parser_fingerprint"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 6,
+                    "type": "array"
+                  },
+                  "symbols": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "canonical_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "file": {
+                          "minimum": 0,
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "node_id": {
+                          "type": "string"
+                        },
+                        "qualified_name": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "node_id",
+                        "canonical_id",
+                        "qualified_name",
+                        "file"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 65536,
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "files",
+                  "symbols",
+                  "provenance_profiles",
+                  "evidence"
+                ],
+                "type": "object"
+              },
+              "kind": {
+                "enum": [
+                  "complete"
+                ],
+                "type": "string"
+              },
+              "receipts": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "callsite_identity": {
+                      "type": "string"
+                    },
+                    "column_or_ordinal": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "containment": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "end_line": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "file": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "owner": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "start_line": {
+                          "minimum": 0,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "file",
+                        "owner",
+                        "start_line",
+                        "end_line"
+                      ],
+                      "type": "object"
+                    },
+                    "edge_id": {
+                      "type": "string"
+                    },
+                    "evidence": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "exact_callsite_start_byte": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "line_window": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "anchor_line": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "byte_end": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "byte_start": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "file": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "kind": {
+                          "enum": [
+                            "indexed_line_v1"
+                          ],
+                          "type": "string"
+                        },
+                        "text": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "file",
+                        "anchor_line",
+                        "byte_start",
+                        "byte_end",
+                        "text"
+                      ],
+                      "type": "object"
+                    },
+                    "receipt_id": {
+                      "type": "string"
+                    },
+                    "source": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "target": {
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "receipt_id",
+                    "edge_id",
+                    "source",
+                    "target",
+                    "evidence",
+                    "exact_callsite_start_byte",
+                    "callsite_identity",
+                    "column_or_ordinal",
+                    "containment",
+                    "line_window"
+                  ],
+                  "type": "object"
+                },
+                "maxItems": 6,
+                "type": "array"
+              },
+              "schema_version": {
+                "enum": [
+                  1
+                ],
+                "type": "integer"
+              },
+              "source_text_sha256": {
+                "maxLength": 64,
+                "minLength": 64,
+                "type": "string"
+              },
+              "spec": {
+                "additionalProperties": false,
+                "properties": {
+                  "exclude_from_projection": {
+                    "items": {
+                      "oneOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "core_generation_id": {
+                              "type": "string"
+                            },
+                            "core_run_id": {
+                              "type": "string"
+                            },
+                            "kind": {
+                              "enum": [
+                                "pinned_node"
+                              ],
+                              "type": "string"
+                            },
+                            "node_id": {
+                              "type": "string"
+                            },
+                            "project_id": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "project_id",
+                            "core_generation_id",
+                            "core_run_id",
+                            "node_id"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "canonical_id": {
+                              "type": "string"
+                            },
+                            "kind": {
+                              "enum": [
+                                "canonical_id"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "canonical_id"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "kind": {
+                              "enum": [
+                                "qualified_name"
+                              ],
+                              "type": "string"
+                            },
+                            "project_file_components": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "minItems": 1,
+                              "type": [
+                                "array",
+                                "null"
+                              ]
+                            },
+                            "qualified_name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "qualified_name",
+                            "project_file_components"
+                          ],
+                          "type": "object"
+                        }
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 256,
+                    "type": "array"
+                  },
+                  "prohibit_traversal_through": {
+                    "items": {
+                      "oneOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "core_generation_id": {
+                              "type": "string"
+                            },
+                            "core_run_id": {
+                              "type": "string"
+                            },
+                            "kind": {
+                              "enum": [
+                                "pinned_node"
+                              ],
+                              "type": "string"
+                            },
+                            "node_id": {
+                              "type": "string"
+                            },
+                            "project_id": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "project_id",
+                            "core_generation_id",
+                            "core_run_id",
+                            "node_id"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "canonical_id": {
+                              "type": "string"
+                            },
+                            "kind": {
+                              "enum": [
+                                "canonical_id"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "canonical_id"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "kind": {
+                              "enum": [
+                                "qualified_name"
+                              ],
+                              "type": "string"
+                            },
+                            "project_file_components": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "minItems": 1,
+                              "type": [
+                                "array",
+                                "null"
+                              ]
+                            },
+                            "qualified_name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "qualified_name",
+                            "project_file_components"
+                          ],
+                          "type": "object"
+                        }
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 256,
+                    "type": "array"
+                  },
+                  "start": {
+                    "oneOf": [
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "core_generation_id": {
+                            "type": "string"
+                          },
+                          "core_run_id": {
+                            "type": "string"
+                          },
+                          "kind": {
+                            "enum": [
+                              "pinned_node"
+                            ],
+                            "type": "string"
+                          },
+                          "node_id": {
+                            "type": "string"
+                          },
+                          "project_id": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "project_id",
+                          "core_generation_id",
+                          "core_run_id",
+                          "node_id"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "canonical_id": {
+                            "type": "string"
+                          },
+                          "kind": {
+                            "enum": [
+                              "canonical_id"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "canonical_id"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "kind": {
+                            "enum": [
+                              "qualified_name"
+                            ],
+                            "type": "string"
+                          },
+                          "project_file_components": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "minItems": 1,
+                            "type": [
+                              "array",
+                              "null"
+                            ]
+                          },
+                          "qualified_name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "qualified_name",
+                          "project_file_components"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "kind": {
+                            "enum": [
+                              "pinned_node_ref"
+                            ],
+                            "type": "string"
+                          },
+                          "symbol": {
+                            "minimum": 0,
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "symbol"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "kind": {
+                            "enum": [
+                              "canonical_id_ref"
+                            ],
+                            "type": "string"
+                          },
+                          "symbol": {
+                            "minimum": 0,
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "symbol"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "kind": {
+                            "enum": [
+                              "qualified_name_ref"
+                            ],
+                            "type": "string"
+                          },
+                          "path_binding": {
+                            "enum": [
+                              "none",
+                              "exact_file"
+                            ],
+                            "type": "string"
+                          },
+                          "symbol": {
+                            "minimum": 0,
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "symbol",
+                          "path_binding"
+                        ],
+                        "type": "object"
+                      }
+                    ],
+                    "type": "object"
+                  },
+                  "steps": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "relation": {
+                          "enum": [
+                            "direct_outgoing_call"
+                          ],
+                          "type": "string"
+                        },
+                        "target": {
+                          "oneOf": [
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "core_generation_id": {
+                                  "type": "string"
+                                },
+                                "core_run_id": {
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "enum": [
+                                    "pinned_node"
+                                  ],
+                                  "type": "string"
+                                },
+                                "node_id": {
+                                  "type": "string"
+                                },
+                                "project_id": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "project_id",
+                                "core_generation_id",
+                                "core_run_id",
+                                "node_id"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "canonical_id": {
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "enum": [
+                                    "canonical_id"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "canonical_id"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "kind": {
+                                  "enum": [
+                                    "qualified_name"
+                                  ],
+                                  "type": "string"
+                                },
+                                "project_file_components": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "minItems": 1,
+                                  "type": [
+                                    "array",
+                                    "null"
+                                  ]
+                                },
+                                "qualified_name": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "qualified_name",
+                                "project_file_components"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "kind": {
+                                  "enum": [
+                                    "pinned_node_ref"
+                                  ],
+                                  "type": "string"
+                                },
+                                "symbol": {
+                                  "minimum": 0,
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "symbol"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "kind": {
+                                  "enum": [
+                                    "canonical_id_ref"
+                                  ],
+                                  "type": "string"
+                                },
+                                "symbol": {
+                                  "minimum": 0,
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "symbol"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "kind": {
+                                  "enum": [
+                                    "qualified_name_ref"
+                                  ],
+                                  "type": "string"
+                                },
+                                "path_binding": {
+                                  "enum": [
+                                    "none",
+                                    "exact_file"
+                                  ],
+                                  "type": "string"
+                                },
+                                "symbol": {
+                                  "minimum": 0,
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "symbol",
+                                "path_binding"
+                              ],
+                              "type": "object"
+                            }
+                          ],
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "relation",
+                        "target"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 6,
+                    "minItems": 1,
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "start",
+                  "steps",
+                  "prohibit_traversal_through",
+                  "exclude_from_projection"
+                ],
+                "type": "object"
+              },
+              "steps": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "receipt": {
+                      "minimum": 0,
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "status": {
+                      "enum": [
+                        "proven",
+                        "positive_contradiction",
+                        "certified_absence",
+                        "unavailable",
+                        "unknown"
+                      ],
+                      "type": "string"
+                    },
+                    "step_index": {
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "step_index",
+                    "status",
+                    "receipt"
+                  ],
+                  "type": "object"
+                },
+                "maxItems": 6,
+                "type": "array"
+              }
+            },
+            "required": [
+              "kind",
+              "schema_version",
+              "domain",
+              "contract_interpretation",
+              "guard_version",
+              "source_text_sha256",
+              "contract_digest",
+              "core_publication",
+              "disposition",
+              "identities",
+              "spec",
+              "clauses",
+              "steps",
+              "receipts"
+            ],
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "cap_bytes": {
+                "minimum": 1,
+                "type": "integer"
+              },
+              "contract_digest": {
+                "maxLength": 64,
+                "minLength": 64,
+                "type": "string"
+              },
+              "contract_interpretation": {
+                "enum": [
+                  "host_supplied"
+                ],
+                "type": "string"
+              },
+              "core_publication": {
+                "additionalProperties": false,
+                "properties": {
+                  "generation_id": {
+                    "type": "string"
+                  },
+                  "project_id": {
+                    "type": "string"
+                  },
+                  "run_id": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "project_id",
+                  "generation_id",
+                  "run_id"
+                ],
+                "type": "object"
+              },
+              "disposition": {
+                "additionalProperties": false,
+                "properties": {
+                  "contract_digest": {
+                    "maxLength": 64,
+                    "minLength": 64,
+                    "type": "string"
+                  },
+                  "gaps": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "kind": {
+                          "enum": [
+                            "output_budget_exceeded"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 1,
+                    "minItems": 1,
+                    "type": "array"
+                  },
+                  "kind": {
+                    "enum": [
+                      "unknown"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "kind",
+                  "contract_digest",
+                  "gaps"
+                ],
+                "type": "object"
+              },
+              "domain": {
+                "enum": [
+                  "indexed_source_call_path_v1"
+                ],
+                "type": "string"
+              },
+              "guard_version": {
+                "enum": [
+                  "clause_guard_v1"
+                ],
+                "type": "string"
+              },
+              "kind": {
+                "enum": [
+                  "budget_exceeded"
+                ],
+                "type": "string"
+              },
+              "required_complete_size": {
+                "minimum": 1,
+                "type": "integer"
+              },
+              "schema_version": {
+                "enum": [
+                  1
+                ],
+                "type": "integer"
+              },
+              "source_text_sha256": {
+                "maxLength": 64,
+                "minLength": 64,
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "schema_version",
+              "domain",
+              "contract_interpretation",
+              "guard_version",
+              "source_text_sha256",
+              "contract_digest",
+              "core_publication",
+              "disposition",
+              "cap_bytes",
+              "required_complete_size"
+            ],
+            "type": "object"
+          }
+        ],
+        "type": "object"
+      },
+      "title": "Prove Call Path"
     }
   ],
   "resources": [

--- a/plugins/codestory/skills/codestory-grounding/SKILL.md
+++ b/plugins/codestory/skills/codestory-grounding/SKILL.md
@@ -55,6 +55,7 @@ plugin result unless the user explicitly asks.
 | Exact named file, path, or static asset with file-local evidence | Inspect it directly. When adding it to a packet, use an `exact_path` tagged probe; do not run broad grounding merely to rediscover the path. If the task asks about relationships, ownership, or impact, use the corresponding narrow tool. |
 | Find a symbol | `symbol`, then `definition` or `snippet`. |
 | Follow a call path | `callers`, `callees`, `trace`, or `trail`. Use `neighbors`, `shortest_path`, or `query_subgraph` only for a named node. |
+| Verify an already translated exact call-path contract | `prove_call_path`, only when the host or user supplied the complete `source_text`, typed clauses, and exact spec. Do not infer or assemble this contract automatically. |
 | Review change impact | `affected` with explicit Git-changed `paths` (or `changed_paths` / `change_records`). Never omit the path source. |
 | One graph node | `get_node`, `definition`, `references`, or `symbols`. |
 | Broad structural question | `packet`; answer only from its evidence rows, name its gaps, and stop unless it returns one bounded continuation. Use `search` or `context` only for a user-named exact target, not as packet recovery. |
@@ -71,6 +72,10 @@ plugin result unless the user explicitly asks.
   claim is true. Cite only the returned evidence rows and state every material
   returned gap. Never turn `available` into authority for a claim the rows do
   not establish.
+- `prove_call_path` is the only surface that returns `contract_proven` or
+  `contract_refuted`. It verifies a host-supplied interpretation; it does not
+  translate prose. Never call it automatically from a packet, search result,
+  context result, or guessed natural-language contract.
 - When `packet.status=continuation_available`, execute only the returned bounded
   continuation, once, against its pinned publication: repeat the question with
   `parent_packet_id=continuation.continuation_id`, use

--- a/plugins/codestory/skills/codestory-grounding/references/generated-cli-syntax.md
+++ b/plugins/codestory/skills/codestory-grounding/references/generated-cli-syntax.md
@@ -13,6 +13,7 @@ Root usage: `codestory-cli <COMMAND>`
 | `report` | `codestory-cli report [OPTIONS]` |
 | `context` | `codestory-cli context [OPTIONS] <--id <NODE_ID>|--query <QUERY>|--bookmark <BOOKMARK_ID>>` |
 | `packet` | `codestory-cli packet [OPTIONS] --question <QUESTION>` |
+| `prove-call-path` | `codestory-cli prove-call-path --project <ROOT> --spec <PATH>` |
 | `task` | `codestory-cli task <COMMAND>` |
 | `doctor` | `codestory-cli doctor [OPTIONS]` |
 | `ready` | `codestory-cli ready [OPTIONS]` |

--- a/plugins/codestory/skills/codestory-grounding/references/generated-mcp-syntax.md
+++ b/plugins/codestory/skills/codestory-grounding/references/generated-mcp-syntax.md
@@ -11,7 +11,7 @@ CLI docs. Do not send CLI flags as MCP arguments.
 Live tools: `status`, `packet`, `search`, `ground`, `files`, `affected`,
 `symbol`, `trail`, `callers`, `callees`, `trace`, `get_node`, `neighbors`,
 `shortest_path`, `query_subgraph`, `definition`, `references`, `symbols`,
-`snippet`, `context`.
+`snippet`, `context`, `prove_call_path`.
 
 There is no MCP `index`, `doctor`, `ready`, `explore`, `drill`, `query`,
 `bookmark`, `serve`, or `cache` tool. Product tools own activation.
@@ -40,6 +40,7 @@ There is no MCP `index`, `doctor`, `ready`, `explore`, `drill`, `query`,
 | `symbols` | | `parent_id`, `limit` | Root symbols, or children of `parent_id`. |
 | `snippet` | `query`, `id`, `paths`, `path`, `file_path`, or `symbol_id` | `line`, `start_line`, `end_line`, `context`, `lines`, `scope`, `function_body`, `choose` | After packet/search/graph selects targets. |
 | `context` | `query`, `id`, or `bookmark` | `include_evidence`, `max_results` | One concrete target, not a broad question. |
+| `prove_call_path` | `source_text`, `clauses`, `spec` | | Exact verification of a complete host-supplied translation. Do not construct or invoke automatically. |
 
 ## Resources and prompts
 

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -4159,13 +4159,8 @@ test("mcp launcher blocks when managed runtime is unavailable", async () => {
       { method: "resources/read", uri: statusUri },
     ]);
     const toolNames = responses[2].result.tools.map((tool) => tool.name);
-    const catalogSource = await readFile(join(repoRoot, "crates", "codestory-cli", "src", "stdio_catalog.rs"), "utf8");
-    const canonicalTools = catalogSource.slice(
-      catalogSource.indexOf("static TOOLS: &[ToolSpec]"),
-      catalogSource.indexOf("static RESOURCES: &[ResourceSpec]"),
-    );
-    const canonicalToolNames = [...canonicalTools.matchAll(/\bname:\s*"([^"]+)"/gu)]
-      .map((match) => match[1]);
+    const canonicalToolNames = generatedCatalog.revisionProfiles[preferredRevision].tools
+      .map((tool) => tool.name);
     assert.deepEqual([...toolNames].sort(), [...canonicalToolNames].sort());
     const coldGroundTool = responses[2].result.tools.find((tool) => tool.name === "ground");
     const groundSafety = coldGroundTool._meta["com.thegreencedar.codestory/safety"];
@@ -5098,8 +5093,9 @@ test("mcp launcher serves diagnostics while managed provisioning runs, then hand
       id: "cold-tools",
       method: "tools/list",
     });
-    assert.equal(coldTools.result.tools.length, 20);
+    assert.equal(coldTools.result.tools.length, 21);
     assert.ok(coldTools.result.tools.some((tool) => tool.name === "ground"));
+    assert.equal(coldTools.result.tools.filter((tool) => tool.name === "prove_call_path").length, 1);
     const coldGround = await request({
       jsonrpc: "2.0",
       id: "cold-ground",


### PR DESCRIPTION
## Context

This is the atomic public activation for the exact call-path verifier prepared on `dev/codestory-0.18`. The proof kernel and language adapters remain unchanged from the Q2-qualified source tree.

## What changed

- registers observational `codestory-cli prove-call-path --project <ROOT> --spec <PATH|->`
- registers MCP `prove_call_path` for all four negotiated protocol revisions
- uses the same bounded request and public response DTO across CLI and MCP
- keeps cold proof reads observational and refuses to activate or build a project
- publishes revision-native discovery, schemas, generated catalog, skill syntax, help, and documentation
- preserves packet, context, search, diagnostics, and navigation contracts

## Review

The trust-boundary change is limited to public admission and projection. Proof execution still requires the Q2-qualified exact-resolution overlay and raw-edge checks. A cold-project matrix covers CLI and MCP together and asserts that neither creates project storage nor a retrieval generation.

Base: `b90c2913658a7f2ef62225ff4f139a5d4ff8d3c3`
Head: `dc4d5cd064481aec5790626beed15a6511ed742a`
Tree: `7a3fc16a54e8d8add1fa8d7649dea22f0e6bd2cc`

## Verification

- format, workspace check, all-target/all-feature clippy: passed
- workspace nextest: 4,108 passed, 34 skipped
- workspace doc tests: passed
- stdio protocol contracts: 66 passed
- CodeStoryDev installer tests: 6 passed
- plugin static tests: 140 passed, 1 platform skip
- generated syntax, documentation links, and diff checks: passed
- frozen Q2 candidate: 96/120 full proofs, all hard gates zero

Installed-host acceptance remains pending on this exact head. This PR makes no release, package, marketplace, or 0.17 claim.

Closes #2066
Refs #2023
Refs #1973
Refs #2064
