### PR TITLE
add exact-candidate product benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Chinook schema failed in both arms.
 
 This sheet is a Codex harness sample used as a quality budget, not the product
 ICP and not a host-agnostic result. Cursor and Claude sheets are not in yet. It
-is a development comparison, not a publishable promotion run: dirty tree, no
+is historical, non-current evidence and not a publishable promotion run: dirty tree, no
 `summary.json`, not `--publishable`, and the without-arm was reused from an
 earlier window. A later publishable `summary.json` can replace the table.
 

--- a/docs/testing/language-expansion-holdout-stats.md
+++ b/docs/testing/language-expansion-holdout-stats.md
@@ -22,6 +22,10 @@ The latest nested 18×3 sheet (`language-support-ab-window6`) is the ChatGPT Cod
 | Accelerator | `embedding_device_observation_source=per_user_server`, Metal, `embedding_accelerator_execution_verified=true` |
 | Publication | No `summary.json` (dirty-tree attestation). Not `--publishable`. |
 
+The token and tool-call deltas below are historical, non-current evidence from
+that rejected two-arm window. The fresh three-arm exact-candidate harness owns
+the next product-value decision.
+
 | Metric | Without | With | Change |
 | --- | ---: | ---: | ---: |
 | Total tokens | 19,819,661 | 1,723,654 | −91% |

--- a/scripts/codestory-agent-ab-benchmark.mjs
+++ b/scripts/codestory-agent-ab-benchmark.mjs
@@ -2,7 +2,7 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import { spawn } from "node:child_process";
-import { createReadStream, existsSync, realpathSync, statSync } from "node:fs";
+import { existsSync, realpathSync, statSync } from "node:fs";
 import { copyFile, mkdir, mkdtemp, open, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -659,7 +659,48 @@ function exactCandidateArmEnv(opts, arm) {
   };
 }
 
+const EXACT_BASELINE_ENV_ALLOWLIST = Object.freeze([
+  "ALL_PROXY", "COMSPEC", "HTTPS_PROXY", "HTTP_PROXY", "LANG", "LC_ALL", "LC_CTYPE",
+  "LOGNAME", "NODE_EXTRA_CA_CERTS", "NO_PROXY", "PATH", "PATHEXT", "SHELL",
+  "SSL_CERT_DIR", "SSL_CERT_FILE", "SYSTEMROOT", "TERM", "TZ", "USER", "WINDIR",
+]);
+
+function pathEntryExposesCodeStory(entry) {
+  const normalized = normalizePathLike(entry).toLowerCase();
+  if (normalized.includes("codestory")) return true;
+  return ["codestory", "codestory-cli", "codestory.exe", "codestory-cli.exe", "codestory.cmd"]
+    .some((name) => existsSync(path.join(entry, name)));
+}
+
+function exactCandidateBaselineEnv(opts, baseEnv = process.env) {
+  const root = opts.exactCandidateBaselineStateRoot;
+  if (!opts.exactCandidate || !root) throw new Error("exact baseline environment requires its disjoint private state root");
+  const env = {};
+  for (const key of EXACT_BASELINE_ENV_ALLOWLIST) {
+    if (baseEnv[key] != null) env[key] = baseEnv[key];
+  }
+  env.PATH = String(env.PATH ?? "")
+    .split(path.delimiter)
+    .filter(Boolean)
+    .filter((entry) => !pathEntryExposesCodeStory(entry))
+    .join(path.delimiter);
+  const home = path.join(root, "home");
+  const temporary = path.join(root, "tmp");
+  env.HOME = home;
+  env.USERPROFILE = home;
+  env.XDG_CACHE_HOME = path.join(root, "xdg-cache");
+  env.XDG_CONFIG_HOME = path.join(root, "xdg-config");
+  env.XDG_DATA_HOME = path.join(root, "xdg-data");
+  env.TMPDIR = temporary;
+  env.TMP = temporary;
+  env.TEMP = temporary;
+  return env;
+}
+
 function selectedBenchmarkChildEnv(opts = {}, arm = null) {
+  if (opts.exactCandidate && arm === "without_codestory") {
+    return exactCandidateBaselineEnv(opts);
+  }
   return {
     ...(opts.packetRuntimeChildEnv ?? benchmarkChildEnv(process.env)),
     ...exactCandidateArmEnv(opts, arm),
@@ -717,9 +758,15 @@ function runnerCommand(opts, repoPath, prompt, arm = null) {
   return { command, args, stdin: prompt, killProcessTree: process.platform === "win32" };
 }
 
-function agentRunnerEnv(baseEnv = process.env, codexHome = null) {
-  const env = benchmarkChildEnv(baseEnv);
-  delete env.CODESTORY_CLI;
+function agentRunnerEnv(baseEnv = process.env, codexHome = null, allowCodeStory = true) {
+  const env = allowCodeStory ? benchmarkChildEnv(baseEnv) : { ...baseEnv };
+  if (allowCodeStory) {
+    delete env.CODESTORY_CLI;
+  } else {
+    for (const key of Object.keys(env)) {
+      if (key.startsWith("CODESTORY_")) delete env[key];
+    }
+  }
   if (codexHome) {
     env.CODEX_HOME = codexHome;
   }
@@ -749,9 +796,18 @@ async function prepareAgentCodexIsolation(outDir, opts = {}) {
   if (opts.exactCandidate) {
     homes = {};
     for (const arm of EXACT_CANDIDATE_ARMS) {
-      const armRoot = path.join(opts.exactCandidateStateRoot, arm);
+      const armRoot = arm === "without_codestory"
+        ? opts.exactCandidateBaselineStateRoot
+        : path.join(opts.exactCandidateStateRoot, arm);
       const codexHome = path.join(armRoot, "host");
       await mkdir(codexHome, { recursive: true });
+      if (arm === "without_codestory") {
+        for (const directory of [
+          "home", "tmp", "xdg-cache", "xdg-config", "xdg-data",
+        ]) {
+          await mkdir(path.join(armRoot, directory), { recursive: true });
+        }
+      }
       await copyFile(authPath, path.join(codexHome, "auth.json"));
       homes[arm] = codexHome;
       for (const value of Object.values(exactCandidateArmEnv(opts, arm))) {
@@ -875,28 +931,95 @@ function normalizeExternalSha256(value, label) {
 }
 
 async function sha256FileBounded(filePath, maxBytes, label) {
-  const size = statSync(filePath).size;
-  if (!Number.isSafeInteger(size) || size < 0 || size > maxBytes) {
-    throw new Error(`${label} exceeds the ${maxBytes}-byte bound`);
+  const handle = await open(filePath, "r");
+  try {
+    return await streamOpenedFileBounded(handle, maxBytes, label);
+  } finally {
+    await handle.close();
   }
-  const hash = createHash("sha256");
-  let observed = 0;
-  for await (const chunk of createReadStream(filePath)) {
-    observed += chunk.length;
-    if (observed > maxBytes) throw new Error(`${label} exceeded its bound while hashing`);
-    hash.update(chunk);
-  }
-  if (observed !== size) throw new Error(`${label} changed while hashing`);
-  return { sha256: hash.digest("hex"), byte_length: observed };
 }
 
 async function readBoundedFile(filePath, maxBytes, label) {
-  const identity = await sha256FileBounded(filePath, maxBytes, label);
-  const bytes = await readFile(filePath);
-  if (bytes.length !== identity.byte_length || sha256Bytes(bytes) !== identity.sha256) {
-    throw new Error(`${label} changed between authentication and read`);
+  const handle = await open(filePath, "r");
+  try {
+    return await streamOpenedFileBounded(handle, maxBytes, label, { capture: true });
+  } finally {
+    await handle.close();
   }
-  return { bytes, ...identity };
+}
+
+async function writeAll(handle, bytes) {
+  let offset = 0;
+  while (offset < bytes.length) {
+    const { bytesWritten } = await handle.write(bytes, offset, bytes.length - offset);
+    if (bytesWritten <= 0) throw new Error("immutable input staging stopped before all bytes were written");
+    offset += bytesWritten;
+  }
+}
+
+async function streamOpenedFileBounded(handle, maxBytes, label, options = {}) {
+  const before = await handle.stat();
+  if (!before.isFile() || !Number.isSafeInteger(before.size) || before.size < 0 || before.size > maxBytes) {
+    throw new Error(`${label} exceeds the ${maxBytes}-byte bound or is not a regular file`);
+  }
+  const hash = createHash("sha256");
+  const chunks = options.capture ? [] : null;
+  const buffer = Buffer.allocUnsafe(Math.min(64 * 1024, maxBytes + 1));
+  let observed = 0;
+  while (true) {
+    const remaining = maxBytes + 1 - observed;
+    const { bytesRead } = await handle.read(buffer, 0, Math.min(buffer.length, remaining), null);
+    if (bytesRead === 0) break;
+    observed += bytesRead;
+    if (observed > maxBytes) throw new Error(`${label} exceeds the ${maxBytes}-byte bound`);
+    const chunk = buffer.subarray(0, bytesRead);
+    hash.update(chunk);
+    if (options.destination) await writeAll(options.destination, chunk);
+    if (chunks) chunks.push(Buffer.from(chunk));
+  }
+  const after = await handle.stat();
+  if (after.size !== observed) throw new Error(`${label} changed while it was being ingested`);
+  return {
+    sha256: hash.digest("hex"),
+    byte_length: observed,
+    ...(chunks ? { bytes: Buffer.concat(chunks, observed) } : {}),
+  };
+}
+
+async function ingestExactInput(opts, kind, sourcePath, maxBytes) {
+  const source = path.resolve(sourcePath);
+  const stagingRoot = path.join(opts.exactCandidateStateRoot, "authenticated-inputs");
+  await mkdir(stagingRoot, { recursive: true, mode: 0o700 });
+  const stagedPath = path.join(stagingRoot, `${kind}.bin`);
+  const sourceHandle = await open(source, "r");
+  let destinationHandle = null;
+  try {
+    destinationHandle = await open(stagedPath, "wx", 0o600);
+    const identity = await streamOpenedFileBounded(
+      sourceHandle,
+      maxBytes,
+      kind.replaceAll("_", " "),
+      { destination: destinationHandle },
+    );
+    await destinationHandle.sync();
+    await destinationHandle.chmod(0o400);
+    await destinationHandle.close();
+    destinationHandle = null;
+    await sourceHandle.close();
+    await opts.exactCandidateAfterInputIngest?.({
+      kind,
+      source_path: source,
+      staged_path: stagedPath,
+      sha256: identity.sha256,
+      byte_length: identity.byte_length,
+    });
+    return { ...identity, source_path: source, staged_path: stagedPath };
+  } catch (error) {
+    await destinationHandle?.close().catch(() => {});
+    await sourceHandle.close().catch(() => {});
+    await rm(stagedPath, { force: true });
+    throw error;
+  }
 }
 
 function exactArchiveEntryIsSafe(entry) {
@@ -974,12 +1097,7 @@ async function probeExactPackageRuntime(cliPath, expected, env) {
   }
 }
 
-async function authenticateExactArchive({ arm, archivePath, archiveSha256, expected, trustRoot }, root, env) {
-  const archiveIdentity = await sha256FileBounded(
-    archivePath,
-    MAX_EXACT_ARCHIVE_BYTES,
-    `${arm} archive`,
-  );
+async function authenticateExactArchive({ arm, archivePath, archiveSha256, archiveIdentity, expected, trustRoot }, root, env) {
   if (archiveIdentity.sha256 !== archiveSha256) throw new Error(`${arm} archive checksum mismatch`);
   const unpackRoot = path.join(root, "packages", arm);
   await mkdir(unpackRoot, { recursive: true });
@@ -1039,11 +1157,16 @@ async function authenticateExactArchive({ arm, archivePath, archiveSha256, expec
 
 async function authenticateExactCandidatePackages(opts) {
   const started = performance.now();
-  const publishedManifestPath = path.resolve(opts.publishedChecksumManifest);
-  const publishedManifest = await readBoundedFile(
-    publishedManifestPath,
+  const publishedManifestInput = await ingestExactInput(
+    opts,
+    "published_checksum_manifest",
+    opts.publishedChecksumManifest,
     MAX_EXACT_CHECKSUM_MANIFEST_BYTES,
-    "published checksum manifest",
+  );
+  const publishedManifest = await readBoundedFile(
+    publishedManifestInput.staged_path,
+    MAX_EXACT_CHECKSUM_MANIFEST_BYTES,
+    "staged published checksum manifest",
   );
   if (
     publishedManifest.sha256 !== normalizeExternalSha256(
@@ -1062,10 +1185,16 @@ async function authenticateExactCandidatePackages(opts) {
   if (publishedMatches.length !== 1) throw new Error("official checksum data must name the published archive exactly once");
 
   const candidateReceiptPath = path.resolve(opts.candidatePackageReceipt);
-  const candidateReceiptRead = await readBoundedFile(
+  const candidateReceiptInput = await ingestExactInput(
+    opts,
+    "candidate_receipt",
     candidateReceiptPath,
     MAX_EXACT_RECEIPT_BYTES,
-    "candidate receipt",
+  );
+  const candidateReceiptRead = await readBoundedFile(
+    candidateReceiptInput.staged_path,
+    MAX_EXACT_RECEIPT_BYTES,
+    "staged candidate receipt",
   );
   if (
     candidateReceiptRead.sha256 !== normalizeExternalSha256(
@@ -1112,14 +1241,14 @@ async function authenticateExactCandidatePackages(opts) {
   const definitions = {
     published_0_17_4: {
       arm: "published_0_17_4",
-      archivePath: publishedArchive,
+      sourceArchivePath: publishedArchive,
       archiveSha256: normalizeExternalSha256(publishedMatches[0], "official published archive sha256"),
       expected: { package_version: "0.17.4", schema_version: 2, protocol_revision: "2025-11-25" },
       trustRoot: { kind: "official_published_checksum", sha256: publishedManifest.sha256 },
     },
     candidate_0_18: {
       arm: "candidate_0_18",
-      archivePath: path.resolve(path.dirname(candidateReceiptPath), candidate.archive_path),
+      sourceArchivePath: path.resolve(path.dirname(candidateReceiptPath), candidate.archive_path),
       archiveSha256: normalizeExternalSha256(candidate.archive_sha256, "candidate archive sha256"),
       expected: candidateExpected,
       trustRoot: { kind: "immutable_candidate_receipt", sha256: candidateReceiptRead.sha256 },
@@ -1130,8 +1259,18 @@ async function authenticateExactCandidatePackages(opts) {
   for (const arm of order) {
     if (!definitions[arm] || packages.has(arm)) throw new Error("package authentication order must contain each exact CodeStory arm once");
     const armStarted = performance.now();
+    const archiveInput = await ingestExactInput(
+      opts,
+      `${arm}_archive`,
+      definitions[arm].sourceArchivePath,
+      MAX_EXACT_ARCHIVE_BYTES,
+    );
     packages.set(arm, await authenticateExactArchive(
-      definitions[arm],
+      {
+        ...definitions[arm],
+        archivePath: archiveInput.staged_path,
+        archiveIdentity: archiveInput,
+      },
       packageRoot,
       selectedBenchmarkChildEnv(opts, arm),
     ));
@@ -4007,7 +4146,9 @@ async function runBaselinePrelude(opts, run, repoConfig, outDir, runId) {
   ];
   const command = displayCommand("rg", args);
   const started = performance.now();
-  const env = { ...process.env };
+  const env = opts.exactCandidate
+    ? selectedBenchmarkChildEnv(opts, "without_codestory")
+    : { ...process.env };
   delete env.CODESTORY_CLI;
   const result = await runProcess("rg", args, {
     cwd: repoConfig.path,
@@ -4609,6 +4750,7 @@ async function runOne(opts, run, outDir) {
   const env = agentRunnerEnv(
     selectedBenchmarkChildEnv(opts, run.arm),
     opts.agentCodexHomes?.[run.arm] ?? null,
+    !opts.exactCandidate || isCodeStoryArm(run.arm),
   );
   const baselinePrelude =
     run.arm === "without_codestory"
@@ -9834,6 +9976,38 @@ function exactCandidateAcceptance(rows, lifecycle = null) {
     ) {
       reasons.push(`CodeStory visibility accounting is incomplete for ${row.task_id}/${row.arm}/${row.repeat}`);
     }
+    const eventTypeValues = Object.values(row.event_types ?? {});
+    if (
+      row.malformed_stdout_lines !== 0 ||
+      !finiteNonnegativeInteger(row.json_events) ||
+      !finiteNonnegativeInteger(row.analysis_events) ||
+      row.analysis_events < row.json_events ||
+      eventTypeValues.some((value) => !finiteNonnegativeInteger(value)) ||
+      eventTypeValues.reduce((total, value) => total + value, 0) !== row.analysis_events
+    ) {
+      reasons.push(`malformed or unreconciled JSONL parser telemetry for ${row.task_id}/${row.arm}/${row.repeat}`);
+    }
+    const provenanceReasons = repoProvenanceBlockers(row);
+    const repoMetadata = row.task_manifest_snapshot?.repo_metadata;
+    if (
+      row.task_manifest_snapshot?.repo !== row.repo ||
+      repoMetadata?.name !== row.repo ||
+      repoMetadata?.url !== row.repo_provenance?.configured?.url ||
+      repoMetadata?.url !== row.repo_provenance?.manifest?.url ||
+      repoMetadata?.ref !== row.repo_provenance?.configured?.ref ||
+      repoMetadata?.ref !== row.repo_provenance?.manifest?.ref
+    ) {
+      provenanceReasons.push("task manifest repository identity does not match the observed checkout");
+    }
+    if (provenanceReasons.length) {
+      reasons.push(`owning repo provenance is invalid for ${row.task_id}/${row.arm}/${row.repeat}: ${provenanceReasons.join("; ")}`);
+    }
+    if (
+      !finiteNonnegativeInteger(row.transcript_analysis?.external_context_tool_calls) ||
+      row.transcript_analysis.external_context_tool_calls !== 0
+    ) {
+      reasons.push(`external web/search context is forbidden for ${row.task_id}/${row.arm}/${row.repeat}`);
+    }
     if (row.arm === "without_codestory") {
       if (
         row.package_identity != null ||
@@ -9850,8 +10024,17 @@ function exactCandidateAcceptance(rows, lifecycle = null) {
       ) {
         reasons.push(`baseline has CodeStory visibility or use in ${row.task_id}/${row.repeat}`);
       }
+      if (
+        row.packet_first_required !== false || row.packet_first_pass !== true ||
+        row.transcript_analysis.command_count <= 0
+      ) {
+        reasons.push(`baseline local inspection telemetry is incomplete for ${row.task_id}/${row.repeat}`);
+      }
     }
     if (isCodeStoryArm(row.arm)) {
+      if (row.packet_first_required !== true || row.packet_first_pass !== true) {
+        reasons.push(`packet-first contract failed for ${row.task_id}/${row.arm}/${row.repeat}`);
+      }
       if (
         row.codestory_prelude_cli_sha256 !== row.package_identity?.cli_sha256 ||
         row.codestory_binary_identity?.prelude_cli_sha256 !== row.package_identity?.cli_sha256 ||
@@ -11436,12 +11619,21 @@ async function main() {
     opts.exactCandidateStateRoot = await mkdtemp(
       path.join(os.tmpdir(), "codestory-agent-exact-candidate-"),
     );
+    opts.exactCandidateBaselineContainerRoot = await mkdtemp(
+      path.join(os.tmpdir(), "agent-exact-baseline-"),
+    );
+    opts.exactCandidateBaselineStateRoot = path.join(
+      opts.exactCandidateBaselineContainerRoot,
+      "private-state",
+    );
+    await mkdir(opts.exactCandidateBaselineStateRoot, { recursive: true, mode: 0o700 });
     try {
       const authenticated = await authenticateExactCandidatePackages(opts);
       opts.exactCandidatePackageByArm = authenticated.packages;
       opts.exactCandidateLifecycle = authenticated.lifecycle;
     } catch (error) {
       await rm(opts.exactCandidateStateRoot, { recursive: true, force: true });
+      await rm(opts.exactCandidateBaselineContainerRoot, { recursive: true, force: true });
       throw error;
     }
   }
@@ -11506,9 +11698,11 @@ async function main() {
   } finally {
     await ledger.close();
     await preparationLedger.close();
-    const isolationRoot = agentCodexIsolation?.root ?? opts.exactCandidateStateRoot;
-    if (isolationRoot) {
-      await rm(isolationRoot, { recursive: true, force: true });
+    if (opts.exactCandidateStateRoot) {
+      await rm(opts.exactCandidateStateRoot, { recursive: true, force: true });
+    }
+    if (opts.exactCandidateBaselineContainerRoot) {
+      await rm(opts.exactCandidateBaselineContainerRoot, { recursive: true, force: true });
     }
   }
 
@@ -11715,6 +11909,7 @@ export {
   planAgentRuns,
   exactCandidateAcceptance,
   authenticateExactCandidatePackages,
+  exactCandidateBaselineEnv,
   exactCandidatePreparationArmOrder,
   withExactSourceMutation,
   validateExactCandidateShape,

--- a/scripts/codestory-agent-ab-benchmark.mjs
+++ b/scripts/codestory-agent-ab-benchmark.mjs
@@ -2,7 +2,7 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import { spawn } from "node:child_process";
-import { existsSync, realpathSync, statSync } from "node:fs";
+import { createReadStream, existsSync, realpathSync, statSync } from "node:fs";
 import { copyFile, mkdir, mkdtemp, open, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -47,7 +47,6 @@ const PUBLIC_PACKET_MAX_TRAIL_EDGES = 60;
 const PUBLIC_PACKET_MAX_OUTPUT_BYTES = 128 * 1024;
 const MAX_REUSED_ARTIFACT_BYTES = 64 * 1024 * 1024;
 const DEFAULT_BENCHMARK_MODEL = "gpt-5.6-sol";
-const REQUIRED_MANAGED_CODESTORY_VERSION = "0.17.0";
 const EXACT_CANDIDATE_ARMS = Object.freeze([
   "without_codestory",
   "published_0_17_4",
@@ -73,7 +72,32 @@ const EXACT_CANDIDATE_TASK_IDS = Object.freeze([
   "css-animate-base-and-keyframes",
   "sql-chinook-schema-relations",
 ]);
-const EXACT_CANDIDATE_PACKAGE_CONTRACT = "codestory.agent-benchmark-package/v1";
+const EXACT_CANDIDATE_TASK_REPOS = Object.freeze({
+  "python-requests-session-flow": "psf-requests",
+  "java-commons-lang-string-utils": "apache-commons-lang",
+  "rust-ripgrep-search-pipeline": "BurntSushi-ripgrep",
+  "javascript-express-routing-flow": "expressjs-express",
+  "typescript-swr-hook-flow": "vercel-swr",
+  "cpp-fmt-formatting-flow": "fmtlib-fmt",
+  "c-redis-command-loop": "redis-redis",
+  "go-gin-route-dispatch": "gin-gonic-gin",
+  "ruby-jekyll-site-build": "jekyll-jekyll",
+  "php-monolog-record-flow": "Seldaek-monolog",
+  "csharp-automapper-map-flow": "AutoMapper-AutoMapper",
+  "kotlin-okio-buffer-flow": "square-okio",
+  "swift-alamofire-request-flow": "Alamofire-Alamofire",
+  "dart-http-client-flow": "dart-lang-http",
+  "bash-nvm-install-dispatch": "nvm-sh-nvm",
+  "html-mdn-form-validation": "mdn-learning-area",
+  "css-animate-base-and-keyframes": "animate-css-animate-css",
+  "sql-chinook-schema-relations": "lerocha-chinook-database",
+});
+const EXACT_CANDIDATE_PACKAGE_CONTRACT = "codestory.agent-benchmark-package/v2";
+const MAX_EXACT_RECEIPT_BYTES = 64 * 1024;
+const MAX_EXACT_CHECKSUM_MANIFEST_BYTES = 1024 * 1024;
+const MAX_EXACT_ARCHIVE_BYTES = 8 * 1024 * 1024 * 1024;
+const MAX_EXACT_ARCHIVE_ENTRIES = 16_384;
+const MAX_EXACT_ARCHIVE_LISTING_BYTES = 2 * 1024 * 1024;
 const EXACT_CANDIDATE_TASK_CONTRACT_SHA256 =
   "51598fdfcadc6585eb45bae4f2836185f389f9707ff565581a863f3720dc7065";
 const MCP_PROTOCOL_REVISIONS = new Set([
@@ -201,7 +225,7 @@ function usage() {
   node scripts/codestory-agent-ab-benchmark.mjs --reanalyze-dir target/agent-benchmark/<run-dir>
   node scripts/codestory-agent-ab-benchmark.mjs --packet-runtime --task-suite <suite> [--materialize-repos] [--repeats n]
   node scripts/codestory-agent-ab-benchmark.mjs [--quick] [--repos names] [--arms names] [--task-suite name] [--task-ids ids] [--task-manifest path] [--include-local-repos] [--repeats n] [--runner codex] [--model model] [--sandbox mode] [--out-dir path] [--timeout-ms ms] [--prepare-codestory-cache] [--canary-task-id id] [--shard-count n --shard-index n] [--allow-failures] [--publishable]
-  node scripts/codestory-agent-ab-benchmark.mjs --exact-candidate --task-suite language-expansion-holdout --published-package-receipt <path> --candidate-package-receipt <path>
+  node scripts/codestory-agent-ab-benchmark.mjs --exact-candidate --task-suite language-expansion-holdout --published-archive <path> --published-checksum-manifest <path> --published-checksum-sha256 <sha256> --candidate-package-receipt <path> --candidate-receipt-sha256 <sha256>
 
 Options:
   --list          Print configured benchmark repositories or selected manifest tasks and exit.
@@ -237,10 +261,16 @@ Options:
                   Reuse matching without-CodeStory rows from an earlier run directory when the task snapshot is unchanged.
   --exact-candidate
                   Run the fresh 18-task, three-repeat comparison of no CodeStory, published 0.17.4, and the frozen 0.18 candidate.
-  --published-package-receipt
-                  Checksum-bound package/CLI/source/schema/protocol/discovery receipt for published CodeStory 0.17.4.
+  --published-archive
+                  Published CodeStory 0.17.4 native archive named by the authenticated checksum manifest.
+  --published-checksum-manifest
+                  Official published SHA256SUMS.txt containing the selected archive digest.
+  --published-checksum-sha256
+                  External SHA-256 binding for the official published checksum manifest.
   --candidate-package-receipt
-                  Checksum-bound package/CLI/source/schema/protocol/discovery receipt for the frozen CodeStory 0.18 candidate.
+                  Immutable archive/source/runtime receipt for the frozen CodeStory 0.18 candidate.
+  --candidate-receipt-sha256
+                  External SHA-256 binding for the frozen candidate receipt.
   --prepare-codestory-cache
                   Before timed with-CodeStory runs, refresh stale or semantic-empty local caches and record indexing cost separately.
                   Packet-runtime mode enables this by default because packets require prepared local indexes.
@@ -315,8 +345,11 @@ function parseArgs(argv) {
       jobs: { type: "string" },
       "reuse-baseline-from": { type: "string" },
       "exact-candidate": { type: "boolean" },
-      "published-package-receipt": { type: "string" },
+      "published-archive": { type: "string" },
+      "published-checksum-manifest": { type: "string" },
+      "published-checksum-sha256": { type: "string" },
       "candidate-package-receipt": { type: "string" },
+      "candidate-receipt-sha256": { type: "string" },
       "prepare-codestory-cache": { type: "boolean" },
       "no-prepare-codestory-cache": { type: "boolean" },
       "prepare-codestory-timeout-ms": { type: "string" },
@@ -330,6 +363,7 @@ function parseArgs(argv) {
       "max-source-reads-after-packet": { type: "string" },
     },
   });
+  const providedOptions = new Set(Object.keys(values));
   const opts = {
     list: false,
     selfTest: false,
@@ -356,8 +390,11 @@ function parseArgs(argv) {
     jobs: 1,
     reuseBaselineFrom: null,
     exactCandidate: false,
-    publishedPackageReceipt: null,
+    publishedArchive: null,
+    publishedChecksumManifest: null,
+    publishedChecksumSha256: null,
     candidatePackageReceipt: null,
+    candidateReceiptSha256: null,
     exactCandidatePackageByArm: null,
     prepareCodestoryCache: null,
     prepareCodestoryJobs: 2,
@@ -419,8 +456,11 @@ function parseArgs(argv) {
   opts.jobs = values.jobs == null ? opts.jobs : Number.parseInt(values.jobs, 10);
   opts.reuseBaselineFrom = values["reuse-baseline-from"] ?? null;
   opts.exactCandidate = values["exact-candidate"] === true;
-  opts.publishedPackageReceipt = values["published-package-receipt"] ?? null;
+  opts.publishedArchive = values["published-archive"] ?? null;
+  opts.publishedChecksumManifest = values["published-checksum-manifest"] ?? null;
+  opts.publishedChecksumSha256 = values["published-checksum-sha256"] ?? null;
   opts.candidatePackageReceipt = values["candidate-package-receipt"] ?? null;
+  opts.candidateReceiptSha256 = values["candidate-receipt-sha256"] ?? null;
   opts.prepareCodestoryCache = values["prepare-codestory-cache"] === true ? true : null;
   opts.prepareCodestoryTimeoutMs =
     values["prepare-codestory-timeout-ms"] == null
@@ -448,6 +488,22 @@ function parseArgs(argv) {
         ];
   }
   if (opts.exactCandidate) {
+    const exactOptionAllowlist = new Set([
+      "exact-candidate",
+      "task-suite",
+      "materialize-repos",
+      "repo-cache-dir",
+      "out-dir",
+      "published-archive",
+      "published-checksum-manifest",
+      "published-checksum-sha256",
+      "candidate-package-receipt",
+      "candidate-receipt-sha256",
+    ]);
+    const forbiddenOptions = [...providedOptions].filter((name) => !exactOptionAllowlist.has(name));
+    if (forbiddenOptions.length) {
+      throw new Error(`exact-candidate mode forbids option(s): ${forbiddenOptions.sort().join(", ")}`);
+    }
     if (opts.reuseBaselineFrom) {
       throw new Error("baseline reuse is forbidden in exact-candidate mode");
     }
@@ -467,8 +523,14 @@ function parseArgs(argv) {
     if (opts.taskSuite !== "language-expansion-holdout") {
       throw new Error("exact-candidate mode requires the language-expansion-holdout task suite");
     }
-    if (!opts.publishedPackageReceipt || !opts.candidatePackageReceipt) {
-      throw new Error("exact-candidate mode requires both published and candidate package receipts");
+    if (
+      !opts.publishedArchive ||
+      !opts.publishedChecksumManifest ||
+      !opts.publishedChecksumSha256 ||
+      !opts.candidatePackageReceipt ||
+      !opts.candidateReceiptSha256
+    ) {
+      throw new Error("exact-candidate mode requires authenticated published and candidate package inputs");
     }
     if (opts.arms && opts.arms.join(",") !== EXACT_CANDIDATE_ARMS.join(",")) {
       throw new Error(`exact-candidate arms are frozen as ${EXACT_CANDIDATE_ARMS.join(",")}`);
@@ -480,6 +542,14 @@ function parseArgs(argv) {
     opts.repeats = 3;
     opts.model = DEFAULT_BENCHMARK_MODEL;
     opts.prepareCodestoryCache = true;
+    opts.publishedChecksumSha256 = normalizeExternalSha256(
+      opts.publishedChecksumSha256,
+      "--published-checksum-sha256",
+    );
+    opts.candidateReceiptSha256 = normalizeExternalSha256(
+      opts.candidateReceiptSha256,
+      "--candidate-receipt-sha256",
+    );
   }
   opts.arms ??= ["without_codestory", "with_codestory"];
   if (!opts.arms.length) {
@@ -598,24 +668,16 @@ function selectedBenchmarkChildEnv(opts = {}, arm = null) {
 
 function exactCandidatePackageIdentity(receipt, arm) {
   if (arm === "without_codestory") {
-    return {
-      contract: EXACT_CANDIDATE_PACKAGE_CONTRACT,
-      arm,
-      package_version: null,
-      package_sha256: null,
-      cli_sha256: null,
-      source_commit: null,
-      source_tree: null,
-      schema_version: null,
-      protocol_revision: null,
-      discovery_contract_sha256: null,
-    };
+    return null;
   }
-  return Object.fromEntries([
+  const identity = Object.fromEntries([
     "contract", "arm", "package_version", "package_sha256", "cli_sha256",
     "source_commit", "source_tree", "schema_version", "protocol_revision",
-    "discovery_contract_sha256", "receipt_sha256",
+    "discovery_contract_sha256",
   ].map((field) => [field, receipt?.[field] ?? null]));
+  identity.trust_root_kind = receipt?.trust_root?.kind ?? null;
+  identity.trust_root_sha256 = receipt?.trust_root?.sha256 ?? null;
+  return identity;
 }
 
 function resolveCodeStoryCliForArm(opts, arm) {
@@ -806,76 +868,284 @@ function normalizeSha256(value, label) {
   return normalized;
 }
 
-async function loadExactCandidatePackageReceipt(receiptPath, expectedArm) {
-  if (!EXACT_CANDIDATE_ARMS.includes(expectedArm) || expectedArm === "without_codestory") {
-    throw new Error(`unsupported exact-candidate package arm '${expectedArm}'`);
+function normalizeExternalSha256(value, label) {
+  const digest = normalizeSha256(value, label);
+  if (/^0{64}$/.test(digest)) throw new Error(`${label} cannot be the all-zero digest`);
+  return digest;
+}
+
+async function sha256FileBounded(filePath, maxBytes, label) {
+  const size = statSync(filePath).size;
+  if (!Number.isSafeInteger(size) || size < 0 || size > maxBytes) {
+    throw new Error(`${label} exceeds the ${maxBytes}-byte bound`);
   }
-  const resolvedReceiptPath = path.resolve(receiptPath);
-  const raw = JSON.parse(await readFile(resolvedReceiptPath, "utf8"));
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
-    throw new Error(`package receipt must be an object: ${resolvedReceiptPath}`);
+  const hash = createHash("sha256");
+  let observed = 0;
+  for await (const chunk of createReadStream(filePath)) {
+    observed += chunk.length;
+    if (observed > maxBytes) throw new Error(`${label} exceeded its bound while hashing`);
+    hash.update(chunk);
   }
-  const allowed = new Set([
-    "contract", "arm", "package_version", "package_path", "package_sha256",
-    "cli_path", "cli_sha256", "source_commit", "source_tree", "schema_version",
-    "protocol_revision", "discovery_contract_sha256",
-  ]);
-  const extra = Object.keys(raw).filter((key) => !allowed.has(key));
-  if (extra.length) {
-    throw new Error(`package receipt contains unknown fields: ${extra.join(", ")}`);
+  if (observed !== size) throw new Error(`${label} changed while hashing`);
+  return { sha256: hash.digest("hex"), byte_length: observed };
+}
+
+async function readBoundedFile(filePath, maxBytes, label) {
+  const identity = await sha256FileBounded(filePath, maxBytes, label);
+  const bytes = await readFile(filePath);
+  if (bytes.length !== identity.byte_length || sha256Bytes(bytes) !== identity.sha256) {
+    throw new Error(`${label} changed between authentication and read`);
   }
-  if (raw.contract !== EXACT_CANDIDATE_PACKAGE_CONTRACT || raw.arm !== expectedArm) {
-    throw new Error(`package receipt identity does not match ${expectedArm}`);
-  }
-  const expectedVersion = expectedArm === "published_0_17_4" ? "0.17.4" : "0.18.0";
-  if (raw.package_version !== expectedVersion) {
-    throw new Error(`${expectedArm} package version must be ${expectedVersion}`);
-  }
-  const packagePath = path.resolve(path.dirname(resolvedReceiptPath), String(raw.package_path ?? ""));
-  const cliPath = path.resolve(path.dirname(resolvedReceiptPath), String(raw.cli_path ?? ""));
-  for (const [label, filePath] of [["package", packagePath], ["CLI", cliPath]]) {
-    if (!existsSync(filePath) || !statSync(filePath).isFile()) {
-      throw new Error(`${label} path is not a regular file: ${filePath}`);
+  return { bytes, ...identity };
+}
+
+function exactArchiveEntryIsSafe(entry) {
+  const normalized = normalizePathLike(entry).replace(/\/$/, "");
+  return Boolean(normalized) &&
+    !isAbsolutePathLike(normalized) &&
+    !normalized.split("/").some((part) => part === "" || part === "." || part === "..");
+}
+
+async function walkExactArchive(root) {
+  const files = [];
+  const pending = [root];
+  while (pending.length) {
+    const current = pending.pop();
+    for (const entry of await readdir(current, { withFileTypes: true })) {
+      const absolute = path.join(current, entry.name);
+      if (entry.isSymbolicLink()) throw new Error(`exact package archive contains a symlink: ${entry.name}`);
+      if (entry.isDirectory()) pending.push(absolute);
+      else if (entry.isFile()) files.push(absolute);
+      else throw new Error(`exact package archive contains a non-file entry: ${entry.name}`);
+      if (files.length + pending.length > MAX_EXACT_ARCHIVE_ENTRIES) {
+        throw new Error("exact package archive contains too many entries");
+      }
     }
   }
-  const packageSha256 = normalizeSha256(raw.package_sha256, "package_sha256");
-  const cliSha256 = normalizeSha256(raw.cli_sha256, "cli_sha256");
-  if (sha256Bytes(await readFile(packagePath)) !== packageSha256) {
-    throw new Error(`${expectedArm} package checksum mismatch`);
-  }
-  if (sha256Bytes(await readFile(cliPath)) !== cliSha256) {
-    throw new Error(`${expectedArm} CLI checksum mismatch`);
-  }
-  for (const field of ["source_commit", "source_tree"]) {
-    if (!/^[0-9a-f]{40}$/.test(String(raw[field] ?? ""))) {
-      throw new Error(`${field} must be a lowercase 40-character Git object id`);
-    }
-  }
-  if (!Number.isInteger(raw.schema_version) || raw.schema_version < 1) {
-    throw new Error("schema_version must be a positive integer");
-  }
-  if (!MCP_PROTOCOL_REVISIONS.has(raw.protocol_revision)) {
-    throw new Error(`unsupported MCP protocol revision '${raw.protocol_revision ?? "missing"}'`);
-  }
-  const discoveryContractSha256 = normalizeSha256(
-    raw.discovery_contract_sha256,
-    "discovery_contract_sha256",
+  return files;
+}
+
+async function probeExactPackageRuntime(cliPath, expected, env) {
+  const session = createSequencedStdioSession(
+    cliPath,
+    ["serve", "--stdio", "--multi-project", "--refresh", "none"],
+    { env, timeoutMs: 30_000 },
   );
+  try {
+    const response = await session.request({
+      jsonrpc: "2.0",
+      id: "exact-candidate-authentication",
+      method: "initialize",
+      params: {
+        protocolVersion: expected.protocol_revision,
+        capabilities: {},
+        clientInfo: { name: "codestory-exact-candidate-authenticator", version: "1" },
+      },
+    });
+    await session.close();
+    if (response.error) throw new Error(`exact package initialize failed: ${JSON.stringify(response.error)}`);
+    const result = response.result;
+    const observed = {
+      package_version: result?.serverInfo?.version ?? null,
+      schema_version: result?._meta?.codestory_publication?.schema_version ?? null,
+      protocol_revision: result?.protocolVersion ?? null,
+      discovery_contract_sha256:
+        result?._meta?.codestory_protocol?.discovery_contract_sha256 ?? null,
+    };
+    for (const field of ["package_version", "schema_version", "protocol_revision"]) {
+      if (observed[field] !== expected[field]) {
+        throw new Error(`exact package runtime ${field}=${observed[field] ?? "missing"}; expected ${expected[field]}`);
+      }
+    }
+    observed.discovery_contract_sha256 = normalizeExternalSha256(
+      observed.discovery_contract_sha256,
+      "runtime discovery_contract_sha256",
+    );
+    if (
+      expected.discovery_contract_sha256 &&
+      observed.discovery_contract_sha256 !== expected.discovery_contract_sha256
+    ) {
+      throw new Error("exact package runtime discovery contract does not match its authenticated receipt");
+    }
+    return observed;
+  } catch (error) {
+    await session.stop();
+    throw error;
+  }
+}
+
+async function authenticateExactArchive({ arm, archivePath, archiveSha256, expected, trustRoot }, root, env) {
+  const archiveIdentity = await sha256FileBounded(
+    archivePath,
+    MAX_EXACT_ARCHIVE_BYTES,
+    `${arm} archive`,
+  );
+  if (archiveIdentity.sha256 !== archiveSha256) throw new Error(`${arm} archive checksum mismatch`);
+  const unpackRoot = path.join(root, "packages", arm);
+  await mkdir(unpackRoot, { recursive: true });
+  const listing = await runProcess("tar", ["-tf", archivePath], {
+    timeoutMs: 30_000,
+    maxOutputBytes: MAX_EXACT_ARCHIVE_LISTING_BYTES,
+  });
+  if (listing.status !== "pass") throw new Error(`${arm} archive listing failed: ${trimTail(listing.stderr)}`);
+  const entries = listing.stdout.split(/\r?\n/).filter(Boolean);
+  if (!entries.length || entries.length > MAX_EXACT_ARCHIVE_ENTRIES || entries.some((entry) => !exactArchiveEntryIsSafe(entry))) {
+    throw new Error(`${arm} archive contains an invalid entry set`);
+  }
+  const unpack = await runProcess("tar", ["-xf", archivePath, "-C", unpackRoot], {
+    timeoutMs: 120_000,
+    maxOutputBytes: MAX_EXACT_ARCHIVE_LISTING_BYTES,
+  });
+  if (unpack.status !== "pass") throw new Error(`${arm} archive extraction failed: ${trimTail(unpack.stderr)}`);
+  const files = await walkExactArchive(unpackRoot);
+  const manifestPaths = files.filter((file) => path.basename(file) === "codestory-native-manifest.json");
+  if (manifestPaths.length !== 1) throw new Error(`${arm} archive must contain one native manifest`);
+  const manifestRead = await readBoundedFile(manifestPaths[0], MAX_EXACT_RECEIPT_BYTES, `${arm} native manifest`);
+  const manifest = JSON.parse(manifestRead.bytes.toString("utf8"));
+  const sourceCommit = String(manifest?.source?.commit ?? "");
+  const sourceTree = String(manifest?.source?.tree ?? "");
+  if (!/^[0-9a-f]{40}$/.test(sourceCommit) || !/^[0-9a-f]{40}$/.test(sourceTree) || manifest?.source?.tracked_dirty !== false) {
+    throw new Error(`${arm} native manifest has invalid source identity`);
+  }
+  if (manifest?.release_version !== expected.package_version) {
+    throw new Error(`${arm} native manifest version drifted from authenticated identity`);
+  }
+  if (expected.source_commit && sourceCommit !== expected.source_commit) throw new Error(`${arm} source commit drifted`);
+  if (expected.source_tree && sourceTree !== expected.source_tree) throw new Error(`${arm} source tree drifted`);
+  const cliName = String(manifest?.binary?.name ?? "");
+  const cliCandidates = files.filter((file) => path.basename(file) === cliName);
+  if (!cliName || cliCandidates.length !== 1) throw new Error(`${arm} archive does not contain its declared CLI exactly once`);
+  const cliIdentity = await sha256FileBounded(cliCandidates[0], MAX_EXACT_ARCHIVE_BYTES, `${arm} CLI`);
+  if (cliIdentity.sha256 !== normalizeSha256(manifest?.binary?.sha256, `${arm} native manifest binary sha256`)) {
+    throw new Error(`${arm} unpacked CLI does not belong to the authenticated archive manifest`);
+  }
+  const runtime = await probeExactPackageRuntime(cliCandidates[0], expected, env);
   return {
-    contract: raw.contract,
-    arm: raw.arm,
-    package_version: raw.package_version,
-    package_path: packagePath,
-    package_sha256: packageSha256,
-    cli_path: cliPath,
-    cli_sha256: cliSha256,
-    source_commit: raw.source_commit,
-    source_tree: raw.source_tree,
-    schema_version: raw.schema_version,
-    protocol_revision: raw.protocol_revision,
-    discovery_contract_sha256: discoveryContractSha256,
-    receipt_path: resolvedReceiptPath,
-    receipt_sha256: sha256Bytes(await readFile(resolvedReceiptPath)),
+    contract: EXACT_CANDIDATE_PACKAGE_CONTRACT,
+    arm,
+    package_version: expected.package_version,
+    package_path: archivePath,
+    package_sha256: archiveIdentity.sha256,
+    cli_path: cliCandidates[0],
+    cli_sha256: cliIdentity.sha256,
+    source_commit: sourceCommit,
+    source_tree: sourceTree,
+    schema_version: runtime.schema_version,
+    protocol_revision: runtime.protocol_revision,
+    discovery_contract_sha256: runtime.discovery_contract_sha256,
+    trust_root: trustRoot,
+  };
+}
+
+async function authenticateExactCandidatePackages(opts) {
+  const started = performance.now();
+  const publishedManifestPath = path.resolve(opts.publishedChecksumManifest);
+  const publishedManifest = await readBoundedFile(
+    publishedManifestPath,
+    MAX_EXACT_CHECKSUM_MANIFEST_BYTES,
+    "published checksum manifest",
+  );
+  if (
+    publishedManifest.sha256 !== normalizeExternalSha256(
+      opts.publishedChecksumSha256,
+      "published checksum manifest external digest",
+    )
+  ) {
+    throw new Error("published checksum manifest does not match its external digest");
+  }
+  const publishedArchive = path.resolve(opts.publishedArchive);
+  const publishedName = path.basename(publishedArchive);
+  const publishedMatches = publishedManifest.bytes.toString("utf8").split(/\r?\n/).flatMap((line) => {
+    const match = /^([0-9a-f]{64})\s+\*?(.+)$/.exec(line.trim());
+    return match && path.basename(match[2]) === publishedName ? [match[1]] : [];
+  });
+  if (publishedMatches.length !== 1) throw new Error("official checksum data must name the published archive exactly once");
+
+  const candidateReceiptPath = path.resolve(opts.candidatePackageReceipt);
+  const candidateReceiptRead = await readBoundedFile(
+    candidateReceiptPath,
+    MAX_EXACT_RECEIPT_BYTES,
+    "candidate receipt",
+  );
+  if (
+    candidateReceiptRead.sha256 !== normalizeExternalSha256(
+      opts.candidateReceiptSha256,
+      "candidate receipt external digest",
+    )
+  ) {
+    throw new Error("candidate receipt does not match its external digest");
+  }
+  const candidate = JSON.parse(candidateReceiptRead.bytes.toString("utf8"));
+  const candidateKeys = new Set([
+    "contract", "arm", "package_version", "archive_path", "archive_sha256",
+    "source_commit", "source_tree", "schema_version", "protocol_revision",
+    "discovery_contract_sha256",
+  ]);
+  if (!candidate || typeof candidate !== "object" || Array.isArray(candidate) ||
+      Object.keys(candidate).some((key) => !candidateKeys.has(key)) ||
+      [...candidateKeys].some((key) => !Object.hasOwn(candidate, key))) {
+    throw new Error("candidate receipt must contain exactly the immutable package identity fields");
+  }
+  if (candidate.contract !== EXACT_CANDIDATE_PACKAGE_CONTRACT || candidate.arm !== "candidate_0_18" || candidate.package_version !== "0.18.0") {
+    throw new Error("candidate receipt identity is not the frozen 0.18 candidate");
+  }
+  const candidateExpected = {
+    package_version: candidate.package_version,
+    source_commit: /^[0-9a-f]{40}$/.test(candidate.source_commit) ? candidate.source_commit : null,
+    source_tree: /^[0-9a-f]{40}$/.test(candidate.source_tree) ? candidate.source_tree : null,
+    schema_version: candidate.schema_version,
+    protocol_revision: candidate.protocol_revision,
+    discovery_contract_sha256: normalizeExternalSha256(
+      candidate.discovery_contract_sha256,
+      "candidate discovery_contract_sha256",
+    ),
+  };
+  if (
+    !candidateExpected.source_commit || /^0{40}$/.test(candidateExpected.source_commit) ||
+    !candidateExpected.source_tree || /^0{40}$/.test(candidateExpected.source_tree) ||
+    candidate.schema_version !== 3 || candidate.protocol_revision !== "2025-11-25"
+  ) {
+    throw new Error("candidate receipt runtime/source identity is invalid");
+  }
+  const packageRoot = opts.exactCandidateStateRoot;
+  const order = opts.exactCandidatePackageAuthenticationOrder ?? ["published_0_17_4", "candidate_0_18"];
+  const definitions = {
+    published_0_17_4: {
+      arm: "published_0_17_4",
+      archivePath: publishedArchive,
+      archiveSha256: normalizeExternalSha256(publishedMatches[0], "official published archive sha256"),
+      expected: { package_version: "0.17.4", schema_version: 2, protocol_revision: "2025-11-25" },
+      trustRoot: { kind: "official_published_checksum", sha256: publishedManifest.sha256 },
+    },
+    candidate_0_18: {
+      arm: "candidate_0_18",
+      archivePath: path.resolve(path.dirname(candidateReceiptPath), candidate.archive_path),
+      archiveSha256: normalizeExternalSha256(candidate.archive_sha256, "candidate archive sha256"),
+      expected: candidateExpected,
+      trustRoot: { kind: "immutable_candidate_receipt", sha256: candidateReceiptRead.sha256 },
+    },
+  };
+  const packages = new Map();
+  const armTimings = {};
+  for (const arm of order) {
+    if (!definitions[arm] || packages.has(arm)) throw new Error("package authentication order must contain each exact CodeStory arm once");
+    const armStarted = performance.now();
+    packages.set(arm, await authenticateExactArchive(
+      definitions[arm],
+      packageRoot,
+      selectedBenchmarkChildEnv(opts, arm),
+    ));
+    armTimings[arm] = Math.round((performance.now() - armStarted) * 1000) / 1000;
+  }
+  if (packages.size !== 2) throw new Error("package authentication order omitted an exact CodeStory arm");
+  return {
+    packages,
+    lifecycle: {
+      contract: "codestory.agent-benchmark-exact-lifecycle/v1",
+      package_authentication_order: order,
+      package_authentication_ms: armTimings,
+      total_package_authentication_ms: Math.round((performance.now() - started) * 1000) / 1000,
+    },
   };
 }
 
@@ -1493,6 +1763,7 @@ async function runProcess(command, args, options = {}) {
     let aborted = false;
     let settled = false;
     let forceKillTimer = null;
+    let outputBytes = 0;
     const terminate = (signal, message = null) => {
       if (message) {
         stderr += `\n${message}\n`;
@@ -1542,9 +1813,19 @@ async function runProcess(command, args, options = {}) {
       resolve({ timedOut, aborted, ...payload });
     }
     child.stdout.on("data", (chunk) => {
+      outputBytes += chunk.length;
+      if (options.maxOutputBytes && outputBytes > options.maxOutputBytes) {
+        terminate("SIGTERM", `Process output exceeded ${options.maxOutputBytes} bytes.`);
+        return;
+      }
       stdout += chunk.toString();
     });
     child.stderr.on("data", (chunk) => {
+      outputBytes += chunk.length;
+      if (options.maxOutputBytes && outputBytes > options.maxOutputBytes) {
+        terminate("SIGTERM", `Process output exceeded ${options.maxOutputBytes} bytes.`);
+        return;
+      }
       stderr += chunk.toString();
     });
     if (options.stdin != null) {
@@ -3832,18 +4113,20 @@ function packetFollowUpCount(packet) {
   );
 }
 
-function managedRuntimeIdentityBlockers(identity, label) {
-  const versionMatches = [
+function managedRuntimeIdentityBlockers(identity, label, expectedVersion = null) {
+  const versions = [
     identity?.plugin_version,
     identity?.plugin_cli_version,
     identity?.cli_version,
-  ].every((version) => version === REQUIRED_MANAGED_CODESTORY_VERSION);
+  ];
+  const selectedVersion = expectedVersion ?? versions[0];
+  const versionMatches = Boolean(selectedVersion) && versions.every((version) => version === selectedVersion);
   return versionMatches &&
     identity?.pinned_pair_matches === true &&
     identity?.cli_source === "managed" &&
     identity?.known_override_skew_channel === false
     ? []
-    : [`${label} runtime identity is not managed ${REQUIRED_MANAGED_CODESTORY_VERSION}: ${JSON.stringify(identity ?? null)}`];
+    : [`${label} runtime identity is not managed ${selectedVersion ?? "a bound version"}: ${JSON.stringify(identity ?? null)}`];
 }
 
 function packetMaterialObligationBucket(obligation) {
@@ -3936,7 +4219,7 @@ function resultPacketObligationAccounting(result) {
 }
 
 function resultRequiresPacketObligationAccounting(result) {
-  if (result?.arm !== "with_codestory" && result?.mode == null) {
+  if (!isCodeStoryArm(result?.arm) && result?.mode == null) {
     return false;
   }
   const prelude = result?.codestory_harness_prelude;
@@ -4317,7 +4600,11 @@ async function runOne(opts, run, outDir) {
       : resolvedCodeStoryCli
     : null;
   const codestoryPreludeCliSha256 = codestoryPreludeCli && existsSync(codestoryPreludeCli)
-    ? sha256Bytes(await readFile(codestoryPreludeCli))
+    ? (await sha256FileBounded(
+      codestoryPreludeCli,
+      MAX_EXACT_ARCHIVE_BYTES,
+      "CodeStory prelude CLI",
+    )).sha256
     : null;
   const env = agentRunnerEnv(
     selectedBenchmarkChildEnv(opts, run.arm),
@@ -4468,12 +4755,9 @@ async function runOne(opts, run, outDir) {
     exact_candidate_timing: opts.exactCandidate
       ? {
           cold_ms: cachePreparationForRepo(opts, run.repo, run.arm)?.preparation_wall_ms ?? 0,
-          warm_ms: codestoryPrelude?.public.wall_ms ?? 0,
+          warm_ms: wallMs,
           incremental_ms: cachePreparationForRepo(opts, run.repo, run.arm)?.incremental_wall_ms ?? 0,
-          all_in_ms:
-            wallMs +
-            (cachePreparationForRepo(opts, run.repo, run.arm)?.preparation_wall_ms ?? 0) +
-            (cachePreparationForRepo(opts, run.repo, run.arm)?.incremental_wall_ms ?? 0),
+          all_in_ms: wallMs,
         }
       : null,
     agent_runner_wall_ms: runnerWallMs,
@@ -5178,6 +5462,10 @@ function compactCachePreparation(preparation) {
     retrieval_index_status: preparation.retrieval_index_status ?? null,
     retrieval_index_exit_code: preparation.retrieval_index_exit_code ?? null,
     retrieval_index_wall_ms: preparation.retrieval_index_wall_ms ?? null,
+    incremental_status: preparation.incremental_status ?? null,
+    incremental_exit_code: preparation.incremental_exit_code ?? null,
+    incremental_wall_ms: preparation.incremental_wall_ms ?? null,
+    incremental_source_mutation: preparation.incremental_source_mutation ?? null,
     retrieval_mode: preparation.retrieval_status?.retrieval_mode ?? null,
     retrieval_degraded_reason: preparation.retrieval_status?.degraded_reason ?? null,
     semantic_generation: preparation.retrieval_status?.semantic_generation ?? null,
@@ -5322,8 +5610,9 @@ function cachePreparationCanaryBlockers(preparation, env = process.env) {
   if (!/^[0-9a-f]{64}$/i.test(String(server?.executable_sha256 ?? ""))) {
     blockers.push("embedding server executable digest is missing or malformed");
   }
-  if (server?.executable_version !== REQUIRED_MANAGED_CODESTORY_VERSION) {
-    blockers.push(`embedding server version=${server?.executable_version ?? "missing"}; expected ${REQUIRED_MANAGED_CODESTORY_VERSION}`);
+  const expectedServerVersion = preparation?.package_identity?.package_version ?? null;
+  if (expectedServerVersion && server?.executable_version !== expectedServerVersion) {
+    blockers.push(`embedding server version=${server?.executable_version ?? "missing"}; expected ${expectedServerVersion}`);
   }
   if (!server?.server_instance_id || server.server_instance_id !== retrieval.embedding_engine_instance_id) {
     blockers.push("embedding server and engine instance identities disagree");
@@ -5405,10 +5694,106 @@ function cachePreparationIdentityBlockers(referencePreparation, preparation) {
   );
 }
 
+async function withExactSourceMutation(sourcePath, whileMutated, afterRestore) {
+  const original = await readBoundedFile(sourcePath, 16 * 1024 * 1024, "incremental source file");
+  const mutation = Buffer.concat([original.bytes, Buffer.from("\n", "utf8")]);
+  const mutatedSha256 = sha256Bytes(mutation);
+  if (mutatedSha256 === original.sha256) throw new Error("incremental source mutation did not change bytes");
+  let result;
+  try {
+    await writeFile(sourcePath, mutation);
+    const observedMutation = await sha256FileBounded(sourcePath, mutation.length, "mutated source file");
+    if (observedMutation.sha256 !== mutatedSha256) throw new Error("incremental source mutation was not observed");
+    result = await whileMutated({ original_sha256: original.sha256, mutated_sha256: mutatedSha256 });
+  } finally {
+    await writeFile(sourcePath, original.bytes);
+    const restored = await sha256FileBounded(sourcePath, original.bytes.length, "restored source file");
+    if (restored.sha256 !== original.sha256) throw new Error("incremental source restoration did not restore exact bytes");
+    await afterRestore({ original_sha256: original.sha256, restored_sha256: restored.sha256 });
+  }
+  return {
+    result,
+    original_sha256: original.sha256,
+    mutated_sha256: mutatedSha256,
+    restored_sha256: original.sha256,
+  };
+}
+
+async function measureExactIncrementalRefresh(opts, task, arm, row, childEnv) {
+  const projectRoot = realpathSync(ALL_REPOS[task.repo].path);
+  const candidates = (task.expected_files ?? []).map((file) => path.resolve(projectRoot, file));
+  const sourcePath = candidates.find((candidate) =>
+    existsSync(candidate) &&
+    statSync(candidate).isFile() &&
+    path.resolve(candidate) === realpathSync(candidate) &&
+    isPathInside(projectRoot, realpathSync(candidate))
+  );
+  if (!sourcePath) throw new Error(`no pinned task source file is available for incremental timing: ${task.id}`);
+  let incrementalWallMs = null;
+  const mutation = await withExactSourceMutation(sourcePath, async () => {
+    const incrementalStarted = performance.now();
+    const incrementalArgs = retrievalIndexCommandArgs(row.project);
+    incrementalArgs[incrementalArgs.indexOf("auto")] = "incremental";
+    const incremental = await runProcess(resolveCodeStoryCliForArm(opts, arm), incrementalArgs, {
+      env: childEnv,
+      signal: opts.signal,
+      timeoutMs: opts.prepareCodestoryTimeoutMs,
+      timeoutMessage: `incremental timing run timed out after ${opts.prepareCodestoryTimeoutMs}ms.`,
+    });
+    incrementalWallMs = Math.round((performance.now() - incrementalStarted) * 1000) / 1000;
+    return incremental;
+  }, async () => {
+    const restoreArgs = retrievalIndexCommandArgs(row.project);
+    restoreArgs[restoreArgs.indexOf("auto")] = "incremental";
+    const restoreIndex = await runProcess(resolveCodeStoryCliForArm(opts, arm), restoreArgs, {
+      env: childEnv,
+      signal: opts.signal,
+      timeoutMs: opts.prepareCodestoryTimeoutMs,
+      timeoutMessage: `incremental restoration timed out after ${opts.prepareCodestoryTimeoutMs}ms.`,
+    });
+    if (restoreIndex.status !== "pass") throw new Error(`incremental cache restoration failed for ${row.repo}/${arm}`);
+    const restoredDoctor = await codestoryDoctorSnapshot(
+      resolveCodeStoryCliForArm(opts, arm),
+      row.project,
+      60_000,
+      childEnv,
+      opts.signal,
+    );
+    if (restoredDoctor.freshness_status !== "fresh") {
+      throw new Error(`incremental cache restoration stayed ${restoredDoctor.freshness_status ?? "unknown"}`);
+    }
+  });
+  const incremental = mutation.result;
+  row.incremental_wall_ms = incrementalWallMs;
+  row.incremental_status = incremental?.status ?? "error";
+  row.incremental_exit_code = incremental?.exitCode ?? null;
+  row.incremental_source_mutation = {
+    path: normalizePathLike(path.relative(projectRoot, sourcePath)),
+    original_sha256: mutation.original_sha256,
+    mutated_sha256: mutation.mutated_sha256,
+    restored_sha256: mutation.restored_sha256,
+    mutation: "append_one_lf_v1",
+  };
+  if (incremental?.status !== "pass") {
+    throw new Error(`incremental timing failed for ${row.repo}/${arm}: ${trimTail(incremental?.stderr || incremental?.stdout)}`);
+  }
+}
+
+function exactCandidatePreparationArmOrder(index) {
+  const arms = ["published_0_17_4", "candidate_0_18"];
+  return index % 2 === 0 ? arms : [...arms].reverse();
+}
+
 async function prepareCodeStoryCaches(opts, tasks) {
   if (opts.exactCandidate) {
+    if (tasks.length !== 1) throw new Error("exact-candidate preparation owns one pinned repository at a time");
+    const task = tasks[0];
+    const sequence = opts.exactCandidateLifecycle.preparation_order?.length ?? 0;
+    const armOrder = exactCandidatePreparationArmOrder(sequence);
+    opts.exactCandidateLifecycle.preparation_order ??= [];
+    opts.exactCandidateLifecycle.preparation_order.push({ repo: task.repo, arms: armOrder });
     const preparedByArm = new Map();
-    for (const arm of ["published_0_17_4", "candidate_0_18"]) {
+    for (const arm of armOrder) {
       const childEnv = selectedBenchmarkChildEnv(opts, arm);
       for (const value of Object.values(exactCandidateArmEnv(opts, arm))) {
         await mkdir(value, { recursive: true });
@@ -5421,7 +5806,7 @@ async function prepareCodeStoryCaches(opts, tasks) {
           codestoryCli: resolveCodeStoryCliForArm(opts, arm),
           packetRuntimeChildEnv: childEnv,
         },
-        tasks,
+        [task],
       );
       for (const row of rows) {
         row.arm = arm;
@@ -5429,31 +5814,21 @@ async function prepareCodeStoryCaches(opts, tasks) {
           opts.exactCandidatePackageByArm.get(arm),
           arm,
         );
-        const incrementalStarted = performance.now();
-        const incrementalArgs = retrievalIndexCommandArgs(row.project);
-        incrementalArgs[incrementalArgs.indexOf("auto")] = "incremental";
-        const incremental = await runProcess(
-          resolveCodeStoryCliForArm(opts, arm),
-          incrementalArgs,
-          {
-            env: childEnv,
-            signal: opts.signal,
-            timeoutMs: opts.prepareCodestoryTimeoutMs,
-            timeoutMessage: `incremental timing run timed out after ${opts.prepareCodestoryTimeoutMs}ms.`,
-          },
-        );
-        row.incremental_wall_ms = Math.round((performance.now() - incrementalStarted) * 1000) / 1000;
-        row.incremental_status = incremental.status;
-        row.incremental_exit_code = incremental.exitCode;
-        if (incremental.status !== "pass") {
-          throw new Error(`incremental timing failed for ${row.repo}/${arm}: ${trimTail(incremental.stderr || incremental.stdout)}`);
+        await measureExactIncrementalRefresh(opts, task, arm, row, childEnv);
+        opts.exactCandidateLifecycle.model_initialization_ms ??= {};
+        if (!Object.hasOwn(opts.exactCandidateLifecycle.model_initialization_ms, arm)) {
+          const initializationMs = row.retrieval_status?.embedding_initialization_ms;
+          if (typeof initializationMs !== "number" || !Number.isFinite(initializationMs) || initializationMs < 0) {
+            throw new Error(`missing one-time model initialization timing for ${arm}`);
+          }
+          opts.exactCandidateLifecycle.model_initialization_ms[arm] = initializationMs;
         }
       }
       preparedByArm.set(arm, rows);
     }
     const publishedByRepo = new Map(preparedByArm.get("published_0_17_4").map((row) => [row.repo, row]));
     const candidateByRepo = new Map(preparedByArm.get("candidate_0_18").map((row) => [row.repo, row]));
-    return [...new Set(tasks.map((task) => task.repo))].map((repo) => ({
+    return [task.repo].map((repo) => ({
       ...candidateByRepo.get(repo),
       arm: "candidate_0_18",
       arm_preparations: {
@@ -5620,6 +5995,7 @@ function cachePolicyForRun(observations = {}) {
 }
 
 function cachePreparationForRepo(opts, repoName, arm = null) {
+  if (opts.exactCandidate && arm === "without_codestory") return null;
   const preparation = opts.cachePreparationByRepo;
   let row = null;
   if (preparation instanceof Map) {
@@ -5729,7 +6105,7 @@ async function codestoryCacheProvenance(opts, config, observations = {}, arm = n
     codestoryCli,
     config.path,
     Math.min(opts.timeoutMs ?? 600_000, 60_000),
-    selectedBenchmarkChildEnv(opts),
+    selectedBenchmarkChildEnv(opts, arm),
     opts.signal,
   );
   const retrievalStatus = observations.cache_preparation?.retrieval_status ??
@@ -5737,7 +6113,7 @@ async function codestoryCacheProvenance(opts, config, observations = {}, arm = n
       codestoryCli,
       config.path,
       Math.min(opts.timeoutMs ?? 600_000, 60_000),
-      selectedBenchmarkChildEnv(opts),
+      selectedBenchmarkChildEnv(opts, arm),
       opts.signal,
     );
   return {
@@ -5910,9 +6286,9 @@ async function recomputeRunAnalysis(result, opts, runDir, taskCache) {
     result.repo_path ?? repoConfig?.path ?? runDir,
     { task, arm: result.arm },
   );
-  const packetFirstRequired = result.packet_first_required ?? result.arm === "with_codestory";
+  const packetFirstRequired = result.packet_first_required ?? isCodeStoryArm(result.arm);
   const cacheProvenance = result.codestory_cache_provenance ?? (
-    repoConfig && result.arm === "with_codestory"
+    repoConfig && isCodeStoryArm(result.arm)
       ? await codestoryCacheProvenance(opts, repoConfig, {
           codestory_index_commands_observed: analysis.codestory_index_commands_observed,
           indexing_in_timed_run: analysis.codestory_index_commands_observed > 0,
@@ -8378,6 +8754,7 @@ function usefulAnchorHitsPer10kContextChars(row) {
 
 function managedCodeStoryRuntimeIdentityBlockers(result) {
   const reasons = [];
+  const expectedVersion = result?.package_identity?.package_version ?? null;
   const analysis = result?.transcript_analysis;
   const started = analysis?.codestory_mcp_tool_calls_observed ?? 0;
   const completed = analysis?.codestory_mcp_completed_calls_observed ?? 0;
@@ -8391,21 +8768,22 @@ function managedCodeStoryRuntimeIdentityBlockers(result) {
     reasons.push(
       ...managedRuntimeIdentityBlockers(
         prelude.packet_contract_runtime,
-        "with_codestory packet prelude",
+        "CodeStory packet prelude",
+        expectedVersion,
       ),
     );
     return reasons;
   }
   if (identities.length <= 0) {
-    reasons.push("with_codestory arm has no managed CodeStory runtime identity");
+    reasons.push("CodeStory arm has no managed CodeStory runtime identity");
   }
   if (identities.length < completed) {
     reasons.push(
-      `with_codestory arm proved ${identities.length}/${completed} completed CodeStory MCP runtime identities`,
+      `CodeStory arm proved ${identities.length}/${completed} completed CodeStory MCP runtime identities`,
     );
   }
   for (const identity of identities) {
-    reasons.push(...managedRuntimeIdentityBlockers(identity, "with_codestory arm"));
+    reasons.push(...managedRuntimeIdentityBlockers(identity, "CodeStory arm", expectedVersion));
   }
   return reasons;
 }
@@ -8440,7 +8818,7 @@ function agentPublishableBlockers(results, opts = {}) {
       ) {
         environmentReasons.push("without_codestory arm used CodeStory");
       }
-      if (opts.publishable && result.arm === "with_codestory") {
+      if (opts.publishable && isCodeStoryArm(result.arm)) {
         environmentReasons.push(
           ...managedCodeStoryRuntimeIdentityBlockers(result),
         );
@@ -8469,7 +8847,7 @@ function agentPublishableBlockers(results, opts = {}) {
       }
       if (
         opts.publishable &&
-        result.arm === "with_codestory" &&
+        isCodeStoryArm(result.arm) &&
         result.packet_first_required &&
         maxSourceReadsAfterPacket == null
       ) {
@@ -8479,7 +8857,7 @@ function agentPublishableBlockers(results, opts = {}) {
         result.codestory_harness_prelude?.packet_extra_probe_strategy ??
         result.packet_extra_probe_strategy ??
         null;
-      if (opts.publishable && result.arm === "with_codestory" && packetExtraProbeStrategy) {
+      if (opts.publishable && isCodeStoryArm(result.arm) && packetExtraProbeStrategy) {
         harnessReasons.push(`diagnostic packet extra probes used: ${packetExtraProbeStrategy}`);
       }
       for (const { label, prelude } of [
@@ -8574,7 +8952,7 @@ function agentPublishableBlockers(results, opts = {}) {
       if (externalContextCalls > 0) {
         environmentReasons.push(`external web/search tool calls=${externalContextCalls} > 0`);
       }
-      if (result.arm === "with_codestory" && (opts.publishable || opts.enforceCacheProvenance)) {
+      if (isCodeStoryArm(result.arm) && (opts.publishable || opts.enforceCacheProvenance)) {
         environmentReasons.push(...cacheProvenanceBlockers(result));
       }
       return [
@@ -9222,11 +9600,16 @@ function planAgentRuns(opts, tasks) {
   return plannedRuns;
 }
 
-function exactCandidateAcceptance(rows) {
+function exactCandidateAcceptance(rows, lifecycle = null) {
   const reasons = [];
   const expectedRuns = 18 * 3 * EXACT_CANDIDATE_ARMS.length;
+  const expectedKeys = new Set(EXACT_CANDIDATE_TASK_IDS.flatMap((taskId) =>
+    EXACT_CANDIDATE_ARMS.flatMap((arm) => [1, 2, 3].map((repeat) =>
+      [taskId, EXACT_CANDIDATE_TASK_REPOS[taskId], arm, repeat].join("\t")
+    ))
+  ));
   const completeRows = rows.filter((row) => row?.status === "pass");
-  const uniqueKeys = new Set(rows.map((row) => [row.task_id, row.arm, row.repeat].join("\t")));
+  const uniqueKeys = new Set(rows.map((row) => [row.task_id, row.repo, row.arm, row.repeat].join("\t")));
   const armCounts = Object.fromEntries(EXACT_CANDIDATE_ARMS.map((arm) => [
     arm,
     rows.filter((row) => row.arm === arm).length,
@@ -9240,6 +9623,9 @@ function exactCandidateAcceptance(rows) {
     reasons.push(
       `162 complete runs required; rows=${rows.length} complete=${completeRows.length} unique=${uniqueKeys.size}`,
     );
+  }
+  if (uniqueKeys.size !== expectedKeys.size || [...uniqueKeys].some((key) => !expectedKeys.has(key))) {
+    reasons.push("exact task/repository/arm/repeat keys do not match the pinned 162-row contract");
   }
 
   const byArm = Object.fromEntries(
@@ -9315,22 +9701,54 @@ function exactCandidateAcceptance(rows) {
     if (candidate > baseline * 0.8) reasons.push(`${label} exceed 80% of without_codestory`);
   }
 
-  const timingThresholds = [
+  const uniqueRepoTiming = (arm, field) => {
+    const byRepo = new Map();
+    for (const row of byArm[arm]) {
+      const value = row.exact_candidate_timing?.[field];
+      if (byRepo.has(row.repo) && byRepo.get(row.repo) !== value) {
+        reasons.push(`${arm} ${field} timing disagrees across repeats for ${row.repo}`);
+      }
+      byRepo.set(row.repo, value);
+    }
+    return [...byRepo.values()].reduce((total, value) => total + (Number.isFinite(value) ? value : 0), 0);
+  };
+  const lifecycleMs = (arm) => lifecycle?.package_authentication_ms?.[arm] ?? 0;
+  const modelInitializationMs = (arm) => lifecycle?.model_initialization_ms?.[arm] ?? 0;
+  const timingTotals = {};
+  for (const arm of EXACT_CANDIDATE_ARMS) {
+    const warm = sum(arm, (row) => row.exact_candidate_timing?.warm_ms);
+    const measuredCold = arm === "without_codestory" ? 0 : uniqueRepoTiming(arm, "cold_ms");
+    const oneTimeModel = arm === "without_codestory" ? 0 : modelInitializationMs(arm);
+    const cold = Math.max(0, measuredCold - oneTimeModel);
+    const incremental = arm === "without_codestory" ? 0 : uniqueRepoTiming(arm, "incremental_ms");
+    timingTotals[arm] = {
+      package_authentication_ms: arm === "without_codestory" ? 0 : lifecycleMs(arm),
+      model_initialization_ms: oneTimeModel,
+      warm_ms: warm,
+      cold_ms: cold,
+      incremental_ms: incremental,
+      all_in_ms: warm + cold + incremental + oneTimeModel +
+        (arm === "without_codestory" ? 0 : lifecycleMs(arm)),
+    };
+  }
+  for (const [label, field, factor, display] of [
     ["warm", "warm_ms", 1.05, "105%"],
     ["cold", "cold_ms", 1.05, "5%"],
     ["incremental", "incremental_ms", 1.05, "5%"],
     ["all-in", "all_in_ms", 1.10, "110%"],
-  ];
-  const timingTotals = {};
-  for (const [label, field, factor, display] of timingThresholds) {
-    const published = sum("published_0_17_4", (row) => row.exact_candidate_timing?.[field]);
-    const candidate = sum("candidate_0_18", (row) => row.exact_candidate_timing?.[field]);
-    timingTotals[label] = { published_0_17_4: published, candidate_0_18: candidate };
+  ]) {
+    const published = timingTotals.published_0_17_4[field];
+    const candidate = timingTotals.candidate_0_18[field];
     if (candidate > published * factor) reasons.push(`${label} timing exceeds ${display} gate`);
   }
 
   for (const row of rows) {
-    if (!row.quality || !row.usage || !Number.isFinite(Number(row.usage.total_tokens))) {
+    const finiteNonnegative = (value) => typeof value === "number" && Number.isFinite(value) && value >= 0;
+    const finiteNonnegativeInteger = (value) => finiteNonnegative(value) && Number.isInteger(value);
+    if (
+      !row.quality || typeof row.quality.pass !== "boolean" ||
+      !row.usage || !finiteNonnegativeInteger(row.usage.total_tokens)
+    ) {
       reasons.push(`missing quality or token accounting for ${row.task_id}/${row.arm}/${row.repeat}`);
     }
     if (!row.transcript_analysis?.tool_categories) {
@@ -9342,13 +9760,19 @@ function exactCandidateAcceptance(rows) {
     if (!Array.isArray(row.transcript_analysis?.direct_source_reads)) {
       reasons.push(`missing direct source-read accounting for ${row.task_id}/${row.arm}/${row.repeat}`);
     }
-    if (!Number.isFinite(Number(row.tool_calls_observed)) || !Number.isFinite(Number(row.estimated_cost_usd))) {
+    if (!finiteNonnegativeInteger(row.tool_calls_observed) || !finiteNonnegative(row.estimated_cost_usd)) {
       reasons.push(`missing tool call or cost accounting for ${row.task_id}/${row.arm}/${row.repeat}`);
     }
     for (const field of ["cold_ms", "warm_ms", "incremental_ms", "all_in_ms"]) {
-      if (!Number.isFinite(Number(row.exact_candidate_timing?.[field]))) {
+      if (!finiteNonnegative(row.exact_candidate_timing?.[field])) {
         reasons.push(`missing ${field} timing for ${row.task_id}/${row.arm}/${row.repeat}`);
       }
+    }
+    if (!finiteNonnegative(row.wall_ms) || row.exact_candidate_timing?.warm_ms !== row.wall_ms) {
+      reasons.push(`whole-task warm timing does not reconcile for ${row.task_id}/${row.arm}/${row.repeat}`);
+    }
+    if (row.exact_candidate_timing?.all_in_ms !== row.exact_candidate_timing?.warm_ms) {
+      reasons.push(`row all-in timing must equal whole-task warm timing for ${row.task_id}/${row.arm}/${row.repeat}`);
     }
     if (
       !row.quality?.material_factual_errors ||
@@ -9356,11 +9780,127 @@ function exactCandidateAcceptance(rows) {
     ) {
       reasons.push(`missing factual-error or proof-claim accounting for ${row.task_id}/${row.arm}/${row.repeat}`);
     }
+    const usageInput = row.usage?.input_tokens;
+    const usageOutput = row.usage?.output_tokens;
+    if (!finiteNonnegativeInteger(usageInput) || !finiteNonnegativeInteger(usageOutput) || usageInput + usageOutput !== row.usage?.total_tokens) {
+      reasons.push(`token accounting does not reconcile for ${row.task_id}/${row.arm}/${row.repeat}`);
+    }
+    const toolCategoryValues = Object.values(row.transcript_analysis?.tool_categories ?? {});
+    const commandCategoryValues = Object.values(row.transcript_analysis?.command_categories ?? {});
+    const toolCategoryTotal = toolCategoryValues.reduce((total, value) => total + value, 0);
+    const commandCategoryTotal = commandCategoryValues.reduce((total, value) => total + value, 0);
+    if (
+      toolCategoryValues.some((value) => !finiteNonnegativeInteger(value)) ||
+      commandCategoryValues.some((value) => !finiteNonnegativeInteger(value)) ||
+      !finiteNonnegativeInteger(row.transcript_analysis?.command_count) ||
+      toolCategoryTotal !== row.tool_calls_observed ||
+      commandCategoryTotal !== row.transcript_analysis?.command_count
+    ) {
+      reasons.push(`tool or command categories do not reconcile for ${row.task_id}/${row.arm}/${row.repeat}`);
+    }
+    const turns = row.transcript_analysis?.interaction_turns;
+    if (
+      !turns ||
+      ![
+        turns.total, turns.model_messages, turns.tool_actions, turns.failed_tool_actions,
+        turns.reasoning_items_excluded, turns.error_items_excluded,
+      ].every(finiteNonnegativeInteger) ||
+      turns.total !== turns.model_messages + turns.tool_actions ||
+      turns.tool_actions !== row.tool_calls_observed ||
+      turns.failed_tool_actions !== 0
+    ) {
+      reasons.push(`interaction accounting does not reconcile for ${row.task_id}/${row.arm}/${row.repeat}`);
+    }
+    if (
+      !finiteNonnegativeInteger(row.quality?.material_factual_errors?.found) ||
+      !Array.isArray(row.quality?.material_factual_errors?.found_anchors) ||
+      !finiteNonnegativeInteger(row.quality?.unsupported_proof_claims?.found) ||
+      !Array.isArray(row.quality?.unsupported_proof_claims?.found_claims) ||
+      row.quality?.material_factual_errors?.found !== row.quality?.material_factual_errors?.found_anchors?.length ||
+      row.quality?.unsupported_proof_claims?.found !== row.quality?.unsupported_proof_claims?.found_claims?.length
+    ) {
+      reasons.push(`error or proof-claim counts do not reconcile for ${row.task_id}/${row.arm}/${row.repeat}`);
+    }
+    if (
+      !finiteNonnegativeInteger(row.transcript_analysis?.direct_source_reads_total) ||
+      row.transcript_analysis?.direct_source_reads_total !== row.transcript_analysis?.direct_source_reads?.length
+    ) {
+      reasons.push(`direct source-read totals do not reconcile for ${row.task_id}/${row.arm}/${row.repeat}`);
+    }
+    if (
+      !finiteNonnegativeInteger(row.transcript_analysis?.codestory_mcp_tool_calls_observed) ||
+      !finiteNonnegativeInteger(row.transcript_analysis?.codestory_mcp_completed_calls_observed) ||
+      !Array.isArray(row.transcript_analysis?.codestory_mcp_runtime_identities)
+    ) {
+      reasons.push(`CodeStory visibility accounting is incomplete for ${row.task_id}/${row.arm}/${row.repeat}`);
+    }
+    if (row.arm === "without_codestory") {
+      if (
+        row.package_identity != null ||
+        row.codestory_cache_provenance != null ||
+        row.codestory_harness_prelude != null ||
+        row.codestory_prelude_cli != null ||
+        row.codestory_prelude_cli_sha256 != null ||
+        row.codestory_binary_identity != null ||
+        row.transcript_analysis?.command_categories?.codestory_cli > 0 ||
+        row.transcript_analysis?.codestory_mcp_tool_calls_observed > 0 ||
+        row.transcript_analysis?.codestory_mcp_completed_calls_observed > 0 ||
+        row.exact_candidate_timing?.cold_ms !== 0 ||
+        row.exact_candidate_timing?.incremental_ms !== 0
+      ) {
+        reasons.push(`baseline has CodeStory visibility or use in ${row.task_id}/${row.repeat}`);
+      }
+    }
     if (isCodeStoryArm(row.arm)) {
+      if (
+        row.codestory_prelude_cli_sha256 !== row.package_identity?.cli_sha256 ||
+        row.codestory_binary_identity?.prelude_cli_sha256 !== row.package_identity?.cli_sha256 ||
+        !["prelude_only", "exact_match"].includes(row.codestory_binary_identity?.status)
+      ) {
+        reasons.push(`executed CLI is not bound to the authenticated ${row.arm} archive`);
+      }
       for (const read of row.transcript_analysis?.direct_source_reads ?? []) {
-        if (read.authorization?.status !== "authorized") {
+        const authorization = read.authorization;
+        const reasonIsValid = authorization?.reason === "user_named_file" ||
+          (
+            authorization?.reason === "explicit_evidence_gap" &&
+            (authorization.evidence_command_id != null || authorization.evidence_event_index != null)
+          );
+        if (authorization?.status !== "authorized" || !reasonIsValid) {
           reasons.push(`unauthorized direct source read ${read.path ?? "unknown"} in ${row.task_id}/${row.arm}/${row.repeat}`);
         }
+      }
+      const runtimeBlockers = managedCodeStoryRuntimeIdentityBlockers(row);
+      if (runtimeBlockers.length) reasons.push(`missing per-arm managed runtime proof: ${runtimeBlockers.join("; ")}`);
+      const cacheBlockers = cacheProvenanceBlockers(row);
+      if (cacheBlockers.length) reasons.push(`missing per-arm cache proof: ${cacheBlockers.join("; ")}`);
+      const obligation = resultPacketObligationAccounting(row);
+      const obligationError = packetObligationAccountingError(obligation, "exact packet obligations");
+      if (obligationError) reasons.push(`missing per-arm obligation proof: ${obligationError}`);
+      if (row.codestory_harness_prelude?.packet_extra_probe_strategy != null) {
+        reasons.push(`diagnostic manifest probes entered ${row.arm}`);
+      }
+      const mutation = row.codestory_cache_provenance?.cache_preparation?.incremental_source_mutation;
+      const cachePreparation = row.codestory_cache_provenance?.cache_preparation;
+      if (
+        cachePreparation?.incremental_status !== "pass" ||
+        !mutation ||
+        typeof mutation.path !== "string" || !mutation.path ||
+        !SHA256_PATTERN.test(String(mutation.original_sha256 ?? "")) ||
+        !SHA256_PATTERN.test(String(mutation.mutated_sha256 ?? "")) ||
+        !SHA256_PATTERN.test(String(mutation.restored_sha256 ?? "")) ||
+        /^0{64}$/.test(String(mutation.original_sha256 ?? "")) ||
+        /^0{64}$/.test(String(mutation.mutated_sha256 ?? "")) ||
+        mutation.original_sha256 !== mutation.restored_sha256 ||
+        mutation.original_sha256 === mutation.mutated_sha256
+      ) {
+        reasons.push(`missing verified source mutation/restore lifecycle for ${row.repo}/${row.arm}`);
+      }
+      if (
+        cachePreparation?.preparation_wall_ms !== row.exact_candidate_timing?.cold_ms ||
+        cachePreparation?.incremental_wall_ms !== row.exact_candidate_timing?.incremental_ms
+      ) {
+        reasons.push(`cache lifecycle timings do not reconcile for ${row.repo}/${row.arm}`);
       }
     }
   }
@@ -9368,23 +9908,34 @@ function exactCandidateAcceptance(rows) {
   const identityFields = [
     "contract", "arm", "package_version", "package_sha256", "cli_sha256",
     "source_commit", "source_tree", "schema_version", "protocol_revision",
-    "discovery_contract_sha256",
+    "discovery_contract_sha256", "trust_root_kind", "trust_root_sha256",
   ];
   for (const arm of ["published_0_17_4", "candidate_0_18"]) {
     const identities = byArm[arm].map((row) => row.package_identity);
     const reference = identities[0];
     const expectedVersion = arm === "published_0_17_4" ? "0.17.4" : "0.18.0";
+    const expectedSchema = arm === "published_0_17_4" ? 2 : 3;
     const invalidReference =
       reference?.contract !== EXACT_CANDIDATE_PACKAGE_CONTRACT ||
       reference?.arm !== arm ||
       reference?.package_version !== expectedVersion ||
       !SHA256_PATTERN.test(String(reference?.package_sha256 ?? "")) ||
+      /^0{64}$/.test(String(reference?.package_sha256 ?? "")) ||
       !SHA256_PATTERN.test(String(reference?.cli_sha256 ?? "")) ||
+      /^0{64}$/.test(String(reference?.cli_sha256 ?? "")) ||
       !/^[0-9a-f]{40}$/.test(String(reference?.source_commit ?? "")) ||
+      /^0{40}$/.test(String(reference?.source_commit ?? "")) ||
       !/^[0-9a-f]{40}$/.test(String(reference?.source_tree ?? "")) ||
-      !Number.isInteger(reference?.schema_version) ||
-      !MCP_PROTOCOL_REVISIONS.has(reference?.protocol_revision) ||
-      !SHA256_PATTERN.test(String(reference?.discovery_contract_sha256 ?? ""));
+      /^0{40}$/.test(String(reference?.source_tree ?? "")) ||
+      reference?.schema_version !== expectedSchema ||
+      reference?.protocol_revision !== "2025-11-25" ||
+      !SHA256_PATTERN.test(String(reference?.discovery_contract_sha256 ?? "")) ||
+      /^0{64}$/.test(String(reference?.discovery_contract_sha256 ?? "")) ||
+      reference?.trust_root_kind !== (arm === "published_0_17_4"
+        ? "official_published_checksum"
+        : "immutable_candidate_receipt") ||
+      !SHA256_PATTERN.test(String(reference?.trust_root_sha256 ?? "")) ||
+      /^0{64}$/.test(String(reference?.trust_root_sha256 ?? ""));
     const invalid = invalidReference || identities.some((identity) =>
       !identity || identityFields.some((field) => identity[field] !== reference[field])
     );
@@ -9393,8 +9944,51 @@ function exactCandidateAcceptance(rows) {
     }
   }
 
+  const preparationOrder = lifecycle?.preparation_order;
+  const packageAuthentication = lifecycle?.package_authentication_ms;
+  const modelInitialization = lifecycle?.model_initialization_ms;
+  const packageAuthenticationOrder = lifecycle?.package_authentication_order;
+  const totalPackageAuthentication = lifecycle?.total_package_authentication_ms;
+  if (
+    lifecycle?.contract !== "codestory.agent-benchmark-exact-lifecycle/v1" ||
+    !packageAuthentication || !modelInitialization ||
+    !["published_0_17_4", "candidate_0_18"].every((arm) =>
+      typeof packageAuthentication[arm] === "number" &&
+      Number.isFinite(packageAuthentication[arm]) &&
+      packageAuthentication[arm] >= 0 &&
+      typeof modelInitialization[arm] === "number" &&
+      Number.isFinite(modelInitialization[arm]) &&
+      modelInitialization[arm] >= 0
+    ) ||
+    !Array.isArray(packageAuthenticationOrder) ||
+    packageAuthenticationOrder.length !== 2 ||
+    new Set(packageAuthenticationOrder).size !== 2 ||
+    packageAuthenticationOrder.some((arm) => !["published_0_17_4", "candidate_0_18"].includes(arm)) ||
+    typeof totalPackageAuthentication !== "number" ||
+    !Number.isFinite(totalPackageAuthentication) ||
+    totalPackageAuthentication + 0.002 <
+      packageAuthentication.published_0_17_4 + packageAuthentication.candidate_0_18
+  ) {
+    reasons.push("exact per-arm one-time package and model lifecycle is missing or invalid");
+  }
+  if (
+    !Array.isArray(preparationOrder) ||
+    preparationOrder.length !== 18 ||
+    new Set(preparationOrder.map((entry) => entry.repo)).size !== 18 ||
+    preparationOrder.some((entry) =>
+      !Object.values(EXACT_CANDIDATE_TASK_REPOS).includes(entry.repo) ||
+      entry.arms?.length !== 2 ||
+      new Set(entry.arms).size !== 2 ||
+      entry.arms.some((arm) => !["published_0_17_4", "candidate_0_18"].includes(arm))
+    ) ||
+    preparationOrder.filter((entry) => entry.arms[0] === "published_0_17_4").length !== 9 ||
+    preparationOrder.filter((entry) => entry.arms[0] === "candidate_0_18").length !== 9
+  ) {
+    reasons.push("exact preparation order is not a balanced deterministic 9/9 rotation");
+  }
+
   return {
-    contract: "codestory.agent-benchmark-exact-candidate-acceptance/v1",
+    contract: "codestory.agent-benchmark-exact-candidate-acceptance/v2",
     pass: reasons.length === 0,
     reasons: [...new Set(reasons)],
     expected_runs: expectedRuns,
@@ -10330,6 +10924,16 @@ async function runExactCandidatePipeline({
         throw new Error(`preparation must return exactly one row for ${group.repo}`);
       }
       const row = rows[0];
+      for (const arm of ["published_0_17_4", "candidate_0_18"]) {
+        const preparation = row.arm_preparations?.[arm];
+        const blockers = cachePreparationCanaryBlockers(
+          preparation,
+          selectedBenchmarkChildEnv(opts, arm),
+        );
+        if (blockers.length) {
+          throw new Error(`${arm} preparation is not exact-candidate eligible: ${blockers.join("; ")}`);
+        }
+      }
       await recordPreparation(row);
       cachePreparation.push(row);
       opts.cachePreparationByRepo.set(row.repo, row);
@@ -10770,20 +11374,6 @@ async function main() {
   }
   const allTasks = await loadTasks(opts);
   validateExactCandidateShape(opts, allTasks);
-  if (opts.exactCandidate) {
-    const published = await loadExactCandidatePackageReceipt(
-      opts.publishedPackageReceipt,
-      "published_0_17_4",
-    );
-    const candidate = await loadExactCandidatePackageReceipt(
-      opts.candidatePackageReceipt,
-      "candidate_0_18",
-    );
-    opts.exactCandidatePackageByArm = new Map([
-      [published.arm, published],
-      [candidate.arm, candidate],
-    ]);
-  }
   opts.releaseEvidenceCorpusContract = await loadReleaseEvidenceCorpusContract(allTasks, opts);
   if (opts.aggregateShards) {
     await aggregateShardRuns(opts, allTasks);
@@ -10846,6 +11436,14 @@ async function main() {
     opts.exactCandidateStateRoot = await mkdtemp(
       path.join(os.tmpdir(), "codestory-agent-exact-candidate-"),
     );
+    try {
+      const authenticated = await authenticateExactCandidatePackages(opts);
+      opts.exactCandidatePackageByArm = authenticated.packages;
+      opts.exactCandidateLifecycle = authenticated.lifecycle;
+    } catch (error) {
+      await rm(opts.exactCandidateStateRoot, { recursive: true, force: true });
+      throw error;
+    }
   }
   const runsPath = path.join(outDir, "runs.jsonl");
   if (existsSync(runsPath)) {
@@ -10991,8 +11589,9 @@ async function main() {
     summary,
     cost_accounting: costAccounting,
     exact_candidate_acceptance: opts.exactCandidate
-      ? exactCandidateAcceptance(canonicalResults)
+      ? exactCandidateAcceptance(canonicalResults, opts.exactCandidateLifecycle)
       : null,
+    exact_candidate_lifecycle: opts.exactCandidate ? opts.exactCandidateLifecycle : null,
   };
   await writeFile(path.join(outDir, "summary.json"), `${JSON.stringify(summaryPayload, null, 2)}\n`, "utf8");
   await writeFile(path.join(outDir, "summary.md"), markdownSummary(summary, opts, costAccounting), "utf8");
@@ -11115,7 +11714,9 @@ export {
   publicCoreCorpusAudit,
   planAgentRuns,
   exactCandidateAcceptance,
-  loadExactCandidatePackageReceipt,
+  authenticateExactCandidatePackages,
+  exactCandidatePreparationArmOrder,
+  withExactSourceMutation,
   validateExactCandidateShape,
   repoProvenanceBlockers,
   repoProvenance,

--- a/scripts/codestory-agent-ab-benchmark.mjs
+++ b/scripts/codestory-agent-ab-benchmark.mjs
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import { spawn } from "node:child_process";
 import { existsSync, realpathSync, statSync } from "node:fs";
-import { copyFile, mkdir, open, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, mkdtemp, open, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
@@ -48,6 +48,40 @@ const PUBLIC_PACKET_MAX_OUTPUT_BYTES = 128 * 1024;
 const MAX_REUSED_ARTIFACT_BYTES = 64 * 1024 * 1024;
 const DEFAULT_BENCHMARK_MODEL = "gpt-5.6-sol";
 const REQUIRED_MANAGED_CODESTORY_VERSION = "0.17.0";
+const EXACT_CANDIDATE_ARMS = Object.freeze([
+  "without_codestory",
+  "published_0_17_4",
+  "candidate_0_18",
+]);
+const EXACT_CANDIDATE_TASK_IDS = Object.freeze([
+  "python-requests-session-flow",
+  "java-commons-lang-string-utils",
+  "rust-ripgrep-search-pipeline",
+  "javascript-express-routing-flow",
+  "typescript-swr-hook-flow",
+  "cpp-fmt-formatting-flow",
+  "c-redis-command-loop",
+  "go-gin-route-dispatch",
+  "ruby-jekyll-site-build",
+  "php-monolog-record-flow",
+  "csharp-automapper-map-flow",
+  "kotlin-okio-buffer-flow",
+  "swift-alamofire-request-flow",
+  "dart-http-client-flow",
+  "bash-nvm-install-dispatch",
+  "html-mdn-form-validation",
+  "css-animate-base-and-keyframes",
+  "sql-chinook-schema-relations",
+]);
+const EXACT_CANDIDATE_PACKAGE_CONTRACT = "codestory.agent-benchmark-package/v1";
+const EXACT_CANDIDATE_TASK_CONTRACT_SHA256 =
+  "51598fdfcadc6585eb45bae4f2836185f389f9707ff565581a863f3720dc7065";
+const MCP_PROTOCOL_REVISIONS = new Set([
+  "2024-11-05",
+  "2025-03-26",
+  "2025-06-18",
+  "2025-11-25",
+]);
 const PINNED_CODEX_RUNNER_CONFIG = [
   'model_reasoning_effort="xhigh"',
   'service_tier="default"',
@@ -144,12 +178,21 @@ const LOCAL_REPOS = {
 
 const ALL_REPOS = { ...PUBLIC_REPOS, ...LOCAL_REPOS };
 
+const CODESTORY_ARM_INSTRUCTION =
+  "Use the CodeStory packet supplied by the harness as the only repository context. Judge its compiled support units directly. Supported, not_established, and unavailable are terminal. For supported, answer from support. For not_established, answer every directly established part and explicitly name the material gaps without inferring missing links. For unavailable, report the typed availability reason. Drill_once permits exactly one MCP packet continuation with the original question, parent_packet_id, listed option_ids, and the declared core_generation_id/retrieval_generation pins; after that result, apply the same terminal rules and stop. Do not use search, context, trail, snippet, shell, git, or direct source reads as packet recovery. Preserve exact source identifiers and paths from support and citations. Do not use web search, browser tools, remote URLs, or upstream mirrors.";
+
 const ARMS = {
   without_codestory:
     "Do not use CodeStory, codestory-cli, or codestory-grounding. Use normal local repository exploration only. Do not use web search, browser tools, remote URLs, or upstream mirrors.",
   with_codestory:
-    "Use the CodeStory packet supplied by the harness as the only repository context. Judge its compiled support units directly. Supported, not_established, and unavailable are terminal. For supported, answer from support. For not_established, answer every directly established part and explicitly name the material gaps without inferring missing links. For unavailable, report the typed availability reason. Drill_once permits exactly one MCP packet continuation with the original question, parent_packet_id, listed option_ids, and the declared core_generation_id/retrieval_generation pins; after that result, apply the same terminal rules and stop. Do not use search, context, trail, snippet, shell, git, or direct source reads as packet recovery. Preserve exact source identifiers and paths from support and citations. Do not use web search, browser tools, remote URLs, or upstream mirrors.",
+    CODESTORY_ARM_INSTRUCTION,
+  published_0_17_4: CODESTORY_ARM_INSTRUCTION,
+  candidate_0_18: CODESTORY_ARM_INSTRUCTION,
 };
+
+function isCodeStoryArm(arm) {
+  return arm === "with_codestory" || arm === "published_0_17_4" || arm === "candidate_0_18";
+}
 
 function usage() {
   console.log(`Usage:
@@ -158,6 +201,7 @@ function usage() {
   node scripts/codestory-agent-ab-benchmark.mjs --reanalyze-dir target/agent-benchmark/<run-dir>
   node scripts/codestory-agent-ab-benchmark.mjs --packet-runtime --task-suite <suite> [--materialize-repos] [--repeats n]
   node scripts/codestory-agent-ab-benchmark.mjs [--quick] [--repos names] [--arms names] [--task-suite name] [--task-ids ids] [--task-manifest path] [--include-local-repos] [--repeats n] [--runner codex] [--model model] [--sandbox mode] [--out-dir path] [--timeout-ms ms] [--prepare-codestory-cache] [--canary-task-id id] [--shard-count n --shard-index n] [--allow-failures] [--publishable]
+  node scripts/codestory-agent-ab-benchmark.mjs --exact-candidate --task-suite language-expansion-holdout --published-package-receipt <path> --candidate-package-receipt <path>
 
 Options:
   --list          Print configured benchmark repositories or selected manifest tasks and exit.
@@ -165,7 +209,7 @@ Options:
   --reanalyze-dir Recompute transcript analysis, quality scores, and summaries from an existing run directory.
   --quick         Default to repo=codestory and repeats=1 unless explicitly set.
   --repos         Comma-separated repo names. Public: ${Object.keys(PUBLIC_REPOS).join(", ")}. Local optional: ${Object.keys(LOCAL_REPOS).join(", ")}
-  --arms          Comma-separated A/B arms. Default: ${Object.keys(ARMS).join(", ")}.
+  --arms          Comma-separated A/B arms. Default: without_codestory, with_codestory.
   --task-suite    Task suite folder under benchmarks/tasks, such as public-core or holdout-retrieval.
   --task-ids      Comma-separated manifest task ids to include after suite/path loading.
   --task-manifest Task manifest JSON file or directory. When set, tasks drive repos and prompts.
@@ -191,6 +235,12 @@ Options:
   --jobs          Parallel jobs for independent packet-runtime cold-cli rows or independent agent repo groups. Default: 1.
   --reuse-baseline-from
                   Reuse matching without-CodeStory rows from an earlier run directory when the task snapshot is unchanged.
+  --exact-candidate
+                  Run the fresh 18-task, three-repeat comparison of no CodeStory, published 0.17.4, and the frozen 0.18 candidate.
+  --published-package-receipt
+                  Checksum-bound package/CLI/source/schema/protocol/discovery receipt for published CodeStory 0.17.4.
+  --candidate-package-receipt
+                  Checksum-bound package/CLI/source/schema/protocol/discovery receipt for the frozen CodeStory 0.18 candidate.
   --prepare-codestory-cache
                   Before timed with-CodeStory runs, refresh stale or semantic-empty local caches and record indexing cost separately.
                   Packet-runtime mode enables this by default because packets require prepared local indexes.
@@ -264,6 +314,9 @@ function parseArgs(argv) {
       "timeout-ms": { type: "string" },
       jobs: { type: "string" },
       "reuse-baseline-from": { type: "string" },
+      "exact-candidate": { type: "boolean" },
+      "published-package-receipt": { type: "string" },
+      "candidate-package-receipt": { type: "string" },
       "prepare-codestory-cache": { type: "boolean" },
       "no-prepare-codestory-cache": { type: "boolean" },
       "prepare-codestory-timeout-ms": { type: "string" },
@@ -302,6 +355,10 @@ function parseArgs(argv) {
     timeoutMs: 600000,
     jobs: 1,
     reuseBaselineFrom: null,
+    exactCandidate: false,
+    publishedPackageReceipt: null,
+    candidatePackageReceipt: null,
+    exactCandidatePackageByArm: null,
     prepareCodestoryCache: null,
     prepareCodestoryJobs: 2,
     prepareCodestoryTimeoutMs: 1_800_000,
@@ -361,6 +418,9 @@ function parseArgs(argv) {
   opts.timeoutMs = values["timeout-ms"] == null ? opts.timeoutMs : Number.parseInt(values["timeout-ms"], 10);
   opts.jobs = values.jobs == null ? opts.jobs : Number.parseInt(values.jobs, 10);
   opts.reuseBaselineFrom = values["reuse-baseline-from"] ?? null;
+  opts.exactCandidate = values["exact-candidate"] === true;
+  opts.publishedPackageReceipt = values["published-package-receipt"] ?? null;
+  opts.candidatePackageReceipt = values["candidate-package-receipt"] ?? null;
   opts.prepareCodestoryCache = values["prepare-codestory-cache"] === true ? true : null;
   opts.prepareCodestoryTimeoutMs =
     values["prepare-codestory-timeout-ms"] == null
@@ -379,7 +439,7 @@ function parseArgs(argv) {
     throw new Error("--task-suite and --task-manifest are mutually exclusive");
   }
 
-  if (!opts.reanalyzeDir && !opts.repos && !opts.taskSuite && !opts.taskManifest) {
+  if (!opts.reanalyzeDir && !opts.repos && !opts.taskSuite && !opts.taskManifest && !opts.exactCandidate) {
     opts.repos = opts.quick
       ? ["codestory"]
       : [
@@ -387,13 +447,50 @@ function parseArgs(argv) {
           ...(opts.includeLocalRepos ? Object.keys(LOCAL_REPOS) : []),
         ];
   }
-  opts.arms ??= Object.keys(ARMS);
+  if (opts.exactCandidate) {
+    if (opts.reuseBaselineFrom) {
+      throw new Error("baseline reuse is forbidden in exact-candidate mode");
+    }
+    if (opts.quick || opts.packetRuntime || opts.aggregateShards || opts.shardCount !== 1 || opts.shardIndex !== 0) {
+      throw new Error("exact-candidate mode forbids quick, packet-runtime, aggregation, and sharding");
+    }
+    if (opts.runner !== "codex" || (opts.model != null && opts.model !== DEFAULT_BENCHMARK_MODEL)) {
+      throw new Error(`exact-candidate mode requires runner=codex and model=${DEFAULT_BENCHMARK_MODEL}`);
+    }
+    if (opts.sandbox !== "workspace-write" || opts.jobs !== 1 || opts.timeoutMs !== 600_000) {
+      throw new Error("exact-candidate mode requires the pinned workspace-write, single-job, 600000ms run window");
+    }
+    if (opts.taskIds || opts.repos) {
+      throw new Error("exact-candidate mode forbids task and repository subsets");
+    }
+    opts.taskSuite ??= "language-expansion-holdout";
+    if (opts.taskSuite !== "language-expansion-holdout") {
+      throw new Error("exact-candidate mode requires the language-expansion-holdout task suite");
+    }
+    if (!opts.publishedPackageReceipt || !opts.candidatePackageReceipt) {
+      throw new Error("exact-candidate mode requires both published and candidate package receipts");
+    }
+    if (opts.arms && opts.arms.join(",") !== EXACT_CANDIDATE_ARMS.join(",")) {
+      throw new Error(`exact-candidate arms are frozen as ${EXACT_CANDIDATE_ARMS.join(",")}`);
+    }
+    if (opts.repeats != null && opts.repeats !== 3) {
+      throw new Error("exact-candidate mode requires exactly 3 repeats");
+    }
+    opts.arms = [...EXACT_CANDIDATE_ARMS];
+    opts.repeats = 3;
+    opts.model = DEFAULT_BENCHMARK_MODEL;
+    opts.prepareCodestoryCache = true;
+  }
+  opts.arms ??= ["without_codestory", "with_codestory"];
   if (!opts.arms.length) {
     throw new Error("--arms must include at least one arm");
   }
   for (const arm of opts.arms) {
     if (!ARMS[arm]) {
       throw new Error(`Unknown arm '${arm}'. Known: ${Object.keys(ARMS).join(", ")}`);
+    }
+    if (!opts.exactCandidate && EXACT_CANDIDATE_ARMS.includes(arm) && arm !== "without_codestory") {
+      throw new Error(`Arm '${arm}' is available only with --exact-candidate`);
     }
   }
   if (!opts.repeats) {
@@ -482,8 +579,47 @@ function retrievalEnv() {
   return benchmarkRetrievalEnv(benchmarkChildEnv(process.env));
 }
 
-function selectedBenchmarkChildEnv(opts = {}) {
-  return { ...(opts.packetRuntimeChildEnv ?? benchmarkChildEnv(process.env)) };
+function exactCandidateArmEnv(opts, arm) {
+  if (!opts.exactCandidate || !isCodeStoryArm(arm)) return {};
+  const armRoot = path.join(opts.exactCandidateStateRoot, arm);
+  return {
+    CODESTORY_CACHE_ROOT: path.join(armRoot, "cache"),
+    CODESTORY_STDIO_CACHE_ROOT: path.join(armRoot, "stdio-cache"),
+    CODESTORY_PLUGIN_DATA: path.join(armRoot, "plugin-data"),
+  };
+}
+
+function selectedBenchmarkChildEnv(opts = {}, arm = null) {
+  return {
+    ...(opts.packetRuntimeChildEnv ?? benchmarkChildEnv(process.env)),
+    ...exactCandidateArmEnv(opts, arm),
+  };
+}
+
+function exactCandidatePackageIdentity(receipt, arm) {
+  if (arm === "without_codestory") {
+    return {
+      contract: EXACT_CANDIDATE_PACKAGE_CONTRACT,
+      arm,
+      package_version: null,
+      package_sha256: null,
+      cli_sha256: null,
+      source_commit: null,
+      source_tree: null,
+      schema_version: null,
+      protocol_revision: null,
+      discovery_contract_sha256: null,
+    };
+  }
+  return Object.fromEntries([
+    "contract", "arm", "package_version", "package_sha256", "cli_sha256",
+    "source_commit", "source_tree", "schema_version", "protocol_revision",
+    "discovery_contract_sha256", "receipt_sha256",
+  ].map((field) => [field, receipt?.[field] ?? null]));
+}
+
+function resolveCodeStoryCliForArm(opts, arm) {
+  return opts.exactCandidatePackageByArm?.get(arm)?.cli_path ?? resolveCodeStoryCli(opts);
 }
 
 function runnerCommand(opts, repoPath, prompt, arm = null) {
@@ -547,14 +683,50 @@ async function prepareAgentCodexIsolation(outDir, opts = {}) {
     model: opts.model ?? DEFAULT_BENCHMARK_MODEL,
     runner_config: PINNED_CODEX_RUNNER_CONFIG,
   };
+  let homes = null;
+  if (opts.exactCandidate) {
+    homes = {};
+    for (const arm of EXACT_CANDIDATE_ARMS) {
+      const armRoot = path.join(opts.exactCandidateStateRoot, arm);
+      const codexHome = path.join(armRoot, "host");
+      await mkdir(codexHome, { recursive: true });
+      await copyFile(authPath, path.join(codexHome, "auth.json"));
+      homes[arm] = codexHome;
+      for (const value of Object.values(exactCandidateArmEnv(opts, arm))) {
+        await mkdir(value, { recursive: true });
+      }
+      if (isCodeStoryArm(arm)) {
+        const cli = resolveCodeStoryCliForArm(opts, arm);
+        await writeFile(
+          path.join(codexHome, "config.toml"),
+          `[mcp_servers.codestory]\ncommand = ${JSON.stringify(cli)}\nargs = ["serve", "--stdio", "--multi-project"]\n`,
+          "utf8",
+        );
+      }
+    }
+    receipt.contract = "codestory.agent-benchmark-codex-isolation/v3";
+    receipt.with_codestory_config = "arm_specific_checksum_bound_cli";
+    receipt.homes = Object.fromEntries(
+      EXACT_CANDIDATE_ARMS.map((arm) => [arm, path.relative(outDir, homes[arm])]),
+    );
+    receipt.cache_roots = Object.fromEntries(
+      EXACT_CANDIDATE_ARMS.map((arm) => [
+        arm,
+        Object.fromEntries(Object.entries(exactCandidateArmEnv(opts, arm)).map(([key, value]) => [
+          key,
+          path.relative(outDir, value),
+        ])),
+      ]),
+    );
+  }
   await writeFile(
     path.join(outDir, "codex-agent-isolation.json"),
     `${JSON.stringify(receipt, null, 2)}\n`,
     "utf8",
   );
   return {
-    root: null,
-    homes: null,
+    root: opts.exactCandidate ? opts.exactCandidateStateRoot : null,
+    homes,
     receipt,
   };
 }
@@ -632,6 +804,110 @@ function normalizeSha256(value, label) {
     throw new Error(`${label} must be a lowercase SHA-256 digest`);
   }
   return normalized;
+}
+
+async function loadExactCandidatePackageReceipt(receiptPath, expectedArm) {
+  if (!EXACT_CANDIDATE_ARMS.includes(expectedArm) || expectedArm === "without_codestory") {
+    throw new Error(`unsupported exact-candidate package arm '${expectedArm}'`);
+  }
+  const resolvedReceiptPath = path.resolve(receiptPath);
+  const raw = JSON.parse(await readFile(resolvedReceiptPath, "utf8"));
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error(`package receipt must be an object: ${resolvedReceiptPath}`);
+  }
+  const allowed = new Set([
+    "contract", "arm", "package_version", "package_path", "package_sha256",
+    "cli_path", "cli_sha256", "source_commit", "source_tree", "schema_version",
+    "protocol_revision", "discovery_contract_sha256",
+  ]);
+  const extra = Object.keys(raw).filter((key) => !allowed.has(key));
+  if (extra.length) {
+    throw new Error(`package receipt contains unknown fields: ${extra.join(", ")}`);
+  }
+  if (raw.contract !== EXACT_CANDIDATE_PACKAGE_CONTRACT || raw.arm !== expectedArm) {
+    throw new Error(`package receipt identity does not match ${expectedArm}`);
+  }
+  const expectedVersion = expectedArm === "published_0_17_4" ? "0.17.4" : "0.18.0";
+  if (raw.package_version !== expectedVersion) {
+    throw new Error(`${expectedArm} package version must be ${expectedVersion}`);
+  }
+  const packagePath = path.resolve(path.dirname(resolvedReceiptPath), String(raw.package_path ?? ""));
+  const cliPath = path.resolve(path.dirname(resolvedReceiptPath), String(raw.cli_path ?? ""));
+  for (const [label, filePath] of [["package", packagePath], ["CLI", cliPath]]) {
+    if (!existsSync(filePath) || !statSync(filePath).isFile()) {
+      throw new Error(`${label} path is not a regular file: ${filePath}`);
+    }
+  }
+  const packageSha256 = normalizeSha256(raw.package_sha256, "package_sha256");
+  const cliSha256 = normalizeSha256(raw.cli_sha256, "cli_sha256");
+  if (sha256Bytes(await readFile(packagePath)) !== packageSha256) {
+    throw new Error(`${expectedArm} package checksum mismatch`);
+  }
+  if (sha256Bytes(await readFile(cliPath)) !== cliSha256) {
+    throw new Error(`${expectedArm} CLI checksum mismatch`);
+  }
+  for (const field of ["source_commit", "source_tree"]) {
+    if (!/^[0-9a-f]{40}$/.test(String(raw[field] ?? ""))) {
+      throw new Error(`${field} must be a lowercase 40-character Git object id`);
+    }
+  }
+  if (!Number.isInteger(raw.schema_version) || raw.schema_version < 1) {
+    throw new Error("schema_version must be a positive integer");
+  }
+  if (!MCP_PROTOCOL_REVISIONS.has(raw.protocol_revision)) {
+    throw new Error(`unsupported MCP protocol revision '${raw.protocol_revision ?? "missing"}'`);
+  }
+  const discoveryContractSha256 = normalizeSha256(
+    raw.discovery_contract_sha256,
+    "discovery_contract_sha256",
+  );
+  return {
+    contract: raw.contract,
+    arm: raw.arm,
+    package_version: raw.package_version,
+    package_path: packagePath,
+    package_sha256: packageSha256,
+    cli_path: cliPath,
+    cli_sha256: cliSha256,
+    source_commit: raw.source_commit,
+    source_tree: raw.source_tree,
+    schema_version: raw.schema_version,
+    protocol_revision: raw.protocol_revision,
+    discovery_contract_sha256: discoveryContractSha256,
+    receipt_path: resolvedReceiptPath,
+    receipt_sha256: sha256Bytes(await readFile(resolvedReceiptPath)),
+  };
+}
+
+function validateExactCandidateShape(opts, tasks) {
+  if (!opts.exactCandidate) return;
+  if (tasks.length !== 18 || new Set(tasks.map((task) => task.id)).size !== 18) {
+    throw new Error("exact-candidate mode requires exactly 18 pinned tasks");
+  }
+  if (
+    tasks.some((task) => task.suite != null) &&
+    tasks.map((task) => task.id).join(",") !== EXACT_CANDIDATE_TASK_IDS.join(",")
+  ) {
+    throw new Error("exact-candidate task ids or order differ from the pinned 18-task window");
+  }
+  if (tasks.some((task) => task.suite != null)) {
+    const taskContract = tasks.map((task) => {
+      const { manifest_path: _manifestPath, ...snapshot } = taskSnapshotForResult(task);
+      return snapshot;
+    });
+    if (sha256Bytes(stableJsonForHash(taskContract)) !== EXACT_CANDIDATE_TASK_CONTRACT_SHA256) {
+      throw new Error("exact-candidate prompts or qualification inputs differ from the pinned task window");
+    }
+  }
+  if (opts.taskSuite !== "language-expansion-holdout") {
+    throw new Error("exact-candidate mode requires the pinned language-expansion-holdout suite");
+  }
+  if (opts.repeats !== 3 || opts.arms.join(",") !== EXACT_CANDIDATE_ARMS.join(",")) {
+    throw new Error("exact-candidate mode requires the frozen three arms and exactly 3 repeats");
+  }
+  if (opts.reuseBaselineFrom) {
+    throw new Error("baseline reuse is forbidden in exact-candidate mode");
+  }
 }
 
 function normalizeCodestoryProjectManifest(filePath, value) {
@@ -1573,7 +1849,7 @@ function composePrompt(repoName, repoConfig, armName, task = null, context = {})
 Task class: ${task.task_class ?? "unspecified"}`
     : "";
   const packetFirstCommand =
-    armName === "with_codestory"
+    isCodeStoryArm(armName)
       ? packetFirstCommandForPrompt(taskPrompt, task)
       : null;
   const packetFirstBlock = packetFirstCommand && !context.codestoryPrelude?.packet
@@ -1586,7 +1862,7 @@ ${packetFirstCommand}
 Run that answer packet before any repository search, direct source read, git command, CodeStory primitive, or help/probe command. The benchmark treats help/probe commands such as \`--help\` as not packet-first.`
     : "";
   const stopContractBlock =
-    armName === "with_codestory"
+    isCodeStoryArm(armName)
       ? `
 The packet's own \`disposition\` is the complete control contract. The benchmark's expected-answer manifest is never shown to you and does not authorize extra retrieval. Stop on \`supported\`, \`not_established\`, or \`unavailable\`. A \`not_established\` packet can still contain directly useful support: answer those established parts, identify the material gaps, and do not infer the missing links. On \`drill_once\`, execute exactly the declared one-shot packet continuation, apply the same terminal answer rule, and then stop regardless of its result.`
       : "";
@@ -2164,7 +2440,47 @@ function interactionTurnTelemetry(events) {
   };
 }
 
-function analyzeTranscript(events, projectRoot = null) {
+function directSourceReadAuthorization(read, commands, events, projectRoot, context) {
+  if (context.arm === "without_codestory") {
+    return { status: "baseline_local_exploration", reason: "without_codestory" };
+  }
+  const prompt = String(context.task?.prompt ?? "").replaceAll("\\", "/");
+  const normalizedPath = normalizePathLike(read.path);
+  const relativePath = isAbsolutePathLike(normalizedPath) && projectRoot
+    ? normalizePathLike(path.relative(projectRoot, normalizedPath))
+    : normalizedPath;
+  if (relativePath && prompt.includes(relativePath)) {
+    return { status: "authorized", reason: "user_named_file" };
+  }
+  const gapPattern = /\b(?:unknown|unavailable|not_established|evidence gap|material gap|missing evidence)\b/i;
+  const priorCommand = [...commands].reverse().find((command) =>
+    command.category === "codestory_cli" &&
+    (command.completed_event_index ?? -1) < (read.event_index ?? -1) &&
+    gapPattern.test(String(command.aggregated_output ?? ""))
+  );
+  if (priorCommand) {
+    return {
+      status: "authorized",
+      reason: "explicit_evidence_gap",
+      evidence_command_id: priorCommand.id,
+    };
+  }
+  const priorMcpEventIndex = events.findLastIndex((event, index) =>
+    index < (read.event_index ?? -1) &&
+    isSuccessfulCodeStoryMcpToolCallEvent(event) &&
+    gapPattern.test(JSON.stringify(event)),
+  );
+  if (priorMcpEventIndex >= 0) {
+    return {
+      status: "authorized",
+      reason: "explicit_evidence_gap",
+      evidence_event_index: priorMcpEventIndex,
+    };
+  }
+  return { status: "unauthorized", reason: null };
+}
+
+function analyzeTranscript(events, projectRoot = null, context = {}) {
   const commands = extractCommandExecutions(events);
   const toolCategories = toolCallCategories(events);
   const codestoryMcpToolCalls = events.filter(isCodeStoryMcpToolCallStartEvent);
@@ -2205,6 +2521,10 @@ function analyzeTranscript(events, projectRoot = null) {
   );
   const firstSuccessfulContextCommand = commands.find(isSuccessfulContextCommand);
   const sourceReads = directFileReads.filter((read) => read.source_like && read.repo_like);
+  const authorizedSourceReads = sourceReads.map((read) => ({
+    ...read,
+    authorization: directSourceReadAuthorization(read, commands, events, projectRoot, context),
+  }));
   const afterIndex = (first) =>
     first == null
       ? null
@@ -2223,6 +2543,7 @@ function analyzeTranscript(events, projectRoot = null) {
     output_chars_by_category: outputCharsByCategory,
     direct_file_reads_total: directFileReads.length,
     direct_source_reads_total: sourceReads.length,
+    direct_source_reads: authorizedSourceReads,
     direct_file_reads_duplicated: duplicateCounts(directFileReads.map((read) => read.path)),
     first_successful_codestory_command: firstSuccessfulCodeStory
       ? {
@@ -2719,7 +3040,34 @@ function scoreQuality(events, task) {
   const transcript = commands
     .map((command) => `${command.command}\n${command.aggregated_output ?? ""}`)
     .join("\n");
-  return scoreQualityFromText(finalAnswer, transcript, task);
+  const quality = scoreQualityFromText(finalAnswer, transcript, task);
+  const proofClaims = forbiddenCandidateSentences(finalAnswer).filter((sentence) =>
+    /\b(?:contractproven|contractrefuted)\b/i.test(sentence) ||
+    /\bcodestory\s+(?:proved|proves|refuted|refutes|verified)\b/i.test(sentence)
+  );
+  const proofEvidence = [
+    ...commands
+      .filter((command) => command.category === "codestory_cli" && command.exit_code === 0)
+      .map((command) => command.aggregated_output ?? ""),
+    ...events.filter(isSuccessfulCodeStoryMcpToolCallEvent).map((event) => JSON.stringify(event)),
+  ].join("\n");
+  const unsupportedProofClaims = proofClaims.filter((claim) => {
+    const refutationClaim = /\b(?:contractrefuted|refuted|refutes)\b/i.test(claim);
+    return refutationClaim
+      ? !/\bContractRefuted\b/.test(proofEvidence)
+      : !/\bContractProven\b/.test(proofEvidence);
+  });
+  return {
+    ...quality,
+    material_factual_errors: {
+      found: quality.forbidden_claims.found,
+      found_anchors: quality.forbidden_claims.found_anchors,
+    },
+    unsupported_proof_claims: {
+      found: unsupportedProofClaims.length,
+      found_claims: unsupportedProofClaims,
+    },
+  };
 }
 
 function scoreQualityFromText(finalAnswer, transcript, task) {
@@ -3960,7 +4308,9 @@ async function runOne(opts, run, outDir) {
     run.arm,
     String(run.repeat).padStart(2, "0"),
   ]);
-  const resolvedCodeStoryCli = run.arm === "with_codestory" ? resolveCodeStoryCli(opts) : null;
+  const resolvedCodeStoryCli = isCodeStoryArm(run.arm)
+    ? resolveCodeStoryCliForArm(opts, run.arm)
+    : null;
   const codestoryPreludeCli = resolvedCodeStoryCli
     ? path.isAbsolute(resolvedCodeStoryCli) || /[\\/]/.test(resolvedCodeStoryCli)
       ? path.resolve(resolvedCodeStoryCli)
@@ -3969,13 +4319,16 @@ async function runOne(opts, run, outDir) {
   const codestoryPreludeCliSha256 = codestoryPreludeCli && existsSync(codestoryPreludeCli)
     ? sha256Bytes(await readFile(codestoryPreludeCli))
     : null;
-  const env = agentRunnerEnv(process.env, opts.agentCodexHomes?.[run.arm] ?? null);
+  const env = agentRunnerEnv(
+    selectedBenchmarkChildEnv(opts, run.arm),
+    opts.agentCodexHomes?.[run.arm] ?? null,
+  );
   const baselinePrelude =
     run.arm === "without_codestory"
       ? await runBaselinePrelude(opts, run, repoConfig, outDir, runId)
       : null;
   const codestoryPrelude =
-    run.arm === "with_codestory"
+    isCodeStoryArm(run.arm)
       ? await runCodeStoryPacketPrelude(
           opts,
           run,
@@ -4039,8 +4392,8 @@ async function runOne(opts, run, outDir) {
   const usage = extractUsage(parsed);
   const codexToolCalls = parsed.filter(isToolCallStartEvent).length;
   const toolCalls = analysisEvents.filter(isToolCallStartEvent).length;
-  const analysis = analyzeTranscript(analysisEvents, repoConfig.path);
-  const codestoryBinaryIdentity = run.arm === "with_codestory"
+  const analysis = analyzeTranscript(analysisEvents, repoConfig.path, { task: run.task, arm: run.arm });
+  const codestoryBinaryIdentity = isCodeStoryArm(run.arm)
     ? codeStoryBinaryIdentity(codestoryPreludeCliSha256, analysis)
     : null;
   const binaryIdentityFailed = codestoryBinaryIdentity != null && ![
@@ -4048,11 +4401,11 @@ async function runOne(opts, run, outDir) {
     "exact_match",
   ].includes(codestoryBinaryIdentity.status);
   const provenance = await repoProvenance(repoConfig, opts.signal);
-  const packetFirstRequired = run.arm === "with_codestory";
+  const packetFirstRequired = isCodeStoryArm(run.arm);
   const packetFirstPass =
     !packetFirstRequired || Boolean(analysis.packet_was_first_context_command);
   const quality = scoreQuality(analysisEvents, run.task);
-  const cacheProvenance = run.arm === "with_codestory"
+  const cacheProvenance = isCodeStoryArm(run.arm)
     ? await codestoryCacheProvenance(
         opts,
         repoConfig,
@@ -4061,7 +4414,9 @@ async function runOne(opts, run, outDir) {
           run.repo,
           codestoryPrelude?.packet ?? null,
           analysis,
+          run.arm,
         ),
+        run.arm,
       )
     : null;
   const benchmarkContract = benchmarkContractForRun(opts, run, env);
@@ -4086,9 +4441,12 @@ async function runOne(opts, run, outDir) {
     args,
     stdin: stdin == null ? null : "<prompt>",
     codestory_cli_env: null,
-    codestory_prelude_cli: run.arm === "with_codestory" ? codestoryPreludeCli : null,
-    codestory_prelude_cli_sha256: run.arm === "with_codestory"
+    codestory_prelude_cli: isCodeStoryArm(run.arm) ? codestoryPreludeCli : null,
+    codestory_prelude_cli_sha256: isCodeStoryArm(run.arm)
       ? codestoryPreludeCliSha256
+      : null,
+    package_identity: opts.exactCandidate
+      ? exactCandidatePackageIdentity(opts.exactCandidatePackageByArm?.get(run.arm), run.arm)
       : null,
     codestory_binary_identity: codestoryBinaryIdentity,
     repo_path: repoConfig.path,
@@ -4107,6 +4465,17 @@ async function runOne(opts, run, outDir) {
       ? `CodeStory binary identity ${codestoryBinaryIdentity.status}`
       : result.error,
     wall_ms: wallMs,
+    exact_candidate_timing: opts.exactCandidate
+      ? {
+          cold_ms: cachePreparationForRepo(opts, run.repo, run.arm)?.preparation_wall_ms ?? 0,
+          warm_ms: codestoryPrelude?.public.wall_ms ?? 0,
+          incremental_ms: cachePreparationForRepo(opts, run.repo, run.arm)?.incremental_wall_ms ?? 0,
+          all_in_ms:
+            wallMs +
+            (cachePreparationForRepo(opts, run.repo, run.arm)?.preparation_wall_ms ?? 0) +
+            (cachePreparationForRepo(opts, run.repo, run.arm)?.incremental_wall_ms ?? 0),
+        }
+      : null,
     agent_runner_wall_ms: runnerWallMs,
     baseline_harness_prelude: baselinePrelude?.public ?? null,
     codestory_harness_prelude: codestoryPrelude?.public ?? null,
@@ -5037,6 +5406,62 @@ function cachePreparationIdentityBlockers(referencePreparation, preparation) {
 }
 
 async function prepareCodeStoryCaches(opts, tasks) {
+  if (opts.exactCandidate) {
+    const preparedByArm = new Map();
+    for (const arm of ["published_0_17_4", "candidate_0_18"]) {
+      const childEnv = selectedBenchmarkChildEnv(opts, arm);
+      for (const value of Object.values(exactCandidateArmEnv(opts, arm))) {
+        await mkdir(value, { recursive: true });
+      }
+      const rows = await prepareCodeStoryCaches(
+        {
+          ...opts,
+          exactCandidate: false,
+          arms: ["with_codestory"],
+          codestoryCli: resolveCodeStoryCliForArm(opts, arm),
+          packetRuntimeChildEnv: childEnv,
+        },
+        tasks,
+      );
+      for (const row of rows) {
+        row.arm = arm;
+        row.package_identity = exactCandidatePackageIdentity(
+          opts.exactCandidatePackageByArm.get(arm),
+          arm,
+        );
+        const incrementalStarted = performance.now();
+        const incrementalArgs = retrievalIndexCommandArgs(row.project);
+        incrementalArgs[incrementalArgs.indexOf("auto")] = "incremental";
+        const incremental = await runProcess(
+          resolveCodeStoryCliForArm(opts, arm),
+          incrementalArgs,
+          {
+            env: childEnv,
+            signal: opts.signal,
+            timeoutMs: opts.prepareCodestoryTimeoutMs,
+            timeoutMessage: `incremental timing run timed out after ${opts.prepareCodestoryTimeoutMs}ms.`,
+          },
+        );
+        row.incremental_wall_ms = Math.round((performance.now() - incrementalStarted) * 1000) / 1000;
+        row.incremental_status = incremental.status;
+        row.incremental_exit_code = incremental.exitCode;
+        if (incremental.status !== "pass") {
+          throw new Error(`incremental timing failed for ${row.repo}/${arm}: ${trimTail(incremental.stderr || incremental.stdout)}`);
+        }
+      }
+      preparedByArm.set(arm, rows);
+    }
+    const publishedByRepo = new Map(preparedByArm.get("published_0_17_4").map((row) => [row.repo, row]));
+    const candidateByRepo = new Map(preparedByArm.get("candidate_0_18").map((row) => [row.repo, row]));
+    return [...new Set(tasks.map((task) => task.repo))].map((repo) => ({
+      ...candidateByRepo.get(repo),
+      arm: "candidate_0_18",
+      arm_preparations: {
+        published_0_17_4: publishedByRepo.get(repo),
+        candidate_0_18: candidateByRepo.get(repo),
+      },
+    }));
+  }
   if (!opts.arms.includes("with_codestory")) {
     return [];
   }
@@ -5194,15 +5619,16 @@ function cachePolicyForRun(observations = {}) {
   return observations.cache_prepared ? "prepared-retrieval-cache-read-only" : "unprepared-cache-blocked";
 }
 
-function cachePreparationForRepo(opts, repoName) {
+function cachePreparationForRepo(opts, repoName, arm = null) {
   const preparation = opts.cachePreparationByRepo;
+  let row = null;
   if (preparation instanceof Map) {
-    return preparation.get(repoName) ?? null;
+    row = preparation.get(repoName) ?? null;
   }
-  if (Array.isArray(preparation)) {
-    return preparation.find((row) => row?.repo === repoName) ?? null;
+  if (!row && Array.isArray(preparation)) {
+    row = preparation.find((entry) => entry?.repo === repoName) ?? null;
   }
-  return null;
+  return arm && row?.arm_preparations?.[arm] ? row.arm_preparations[arm] : row;
 }
 
 function packetRuntimeCacheObservations(opts, repoName, transportMode) {
@@ -5216,12 +5642,16 @@ function packetRuntimeCacheObservations(opts, repoName, transportMode) {
   };
 }
 
-function agentPacketPreludeCacheObservations(opts, repoName, packet, analysis) {
+function agentPacketPreludeCacheObservations(opts, repoName, packet, analysis, arm = null) {
   const observations = packetRuntimeCacheObservations(
     opts,
     repoName,
     "agent_harness_prelude",
   );
+  if (arm) {
+    observations.cache_preparation = cachePreparationForRepo(opts, repoName, arm);
+    observations.cache_prepared = Boolean(observations.cache_preparation);
+  }
   observations.codestory_index_commands_observed =
     analysis?.codestory_index_commands_observed ?? 0;
   observations.indexing_in_timed_run =
@@ -5279,10 +5709,10 @@ function packetEmbeddingExecutionProof(packet, cachePreparation, transportMode) 
   };
 }
 
-async function codestoryCacheProvenance(opts, config, observations = {}) {
+async function codestoryCacheProvenance(opts, config, observations = {}, arm = null) {
   let codestoryCli;
   try {
-    codestoryCli = resolveCodeStoryCli(opts);
+    codestoryCli = arm ? resolveCodeStoryCliForArm(opts, arm) : resolveCodeStoryCli(opts);
   } catch (error) {
     return {
       codestory_cli: null,
@@ -5475,7 +5905,11 @@ async function recomputeRunAnalysis(result, opts, runDir, taskCache) {
   const packetManifestQuality = await reanalysisPacketManifestQuality(result, runDir, task);
   const repoConfig = ALL_REPOS[result.repo] ?? null;
   const usage = extractUsage(parsed);
-  const analysis = analyzeTranscript(analysisEvents, result.repo_path ?? repoConfig?.path ?? runDir);
+  const analysis = analyzeTranscript(
+    analysisEvents,
+    result.repo_path ?? repoConfig?.path ?? runDir,
+    { task, arm: result.arm },
+  );
   const packetFirstRequired = result.packet_first_required ?? result.arm === "with_codestory";
   const cacheProvenance = result.codestory_cache_provenance ?? (
     repoConfig && result.arm === "with_codestory"
@@ -8756,6 +9190,18 @@ function runSelfTest() {
 
 function planAgentRuns(opts, tasks) {
   const plannedRuns = [];
+  if (opts.exactCandidate) {
+    for (const [taskIndex, task] of tasks.entries()) {
+      for (let repeat = 1; repeat <= opts.repeats; repeat += 1) {
+        const rotation = (taskIndex * opts.repeats + repeat - 1) % opts.arms.length;
+        for (let position = 0; position < opts.arms.length; position += 1) {
+          const arm = opts.arms[(rotation + position) % opts.arms.length];
+          plannedRuns.push({ repo: task.repo, arm, repeat, task });
+        }
+      }
+    }
+    return plannedRuns;
+  }
   if (tasks.length) {
     for (const task of tasks) {
       for (const arm of opts.arms) {
@@ -8774,6 +9220,192 @@ function planAgentRuns(opts, tasks) {
     }
   }
   return plannedRuns;
+}
+
+function exactCandidateAcceptance(rows) {
+  const reasons = [];
+  const expectedRuns = 18 * 3 * EXACT_CANDIDATE_ARMS.length;
+  const completeRows = rows.filter((row) => row?.status === "pass");
+  const uniqueKeys = new Set(rows.map((row) => [row.task_id, row.arm, row.repeat].join("\t")));
+  const armCounts = Object.fromEntries(EXACT_CANDIDATE_ARMS.map((arm) => [
+    arm,
+    rows.filter((row) => row.arm === arm).length,
+  ]));
+  if (
+    rows.length !== expectedRuns ||
+    completeRows.length !== expectedRuns ||
+    uniqueKeys.size !== expectedRuns ||
+    EXACT_CANDIDATE_ARMS.some((arm) => armCounts[arm] !== 54)
+  ) {
+    reasons.push(
+      `162 complete runs required; rows=${rows.length} complete=${completeRows.length} unique=${uniqueKeys.size}`,
+    );
+  }
+
+  const byArm = Object.fromEntries(
+    EXACT_CANDIDATE_ARMS.map((arm) => [arm, rows.filter((row) => row.arm === arm)]),
+  );
+  const qualityPasses = Object.fromEntries(EXACT_CANDIDATE_ARMS.map((arm) => [
+    arm,
+    byArm[arm].filter((row) => row.quality?.pass === true).length,
+  ]));
+  if (qualityPasses.candidate_0_18 < qualityPasses.published_0_17_4) {
+    reasons.push(
+      `candidate quality ${qualityPasses.candidate_0_18} is below published 0.17.4 ${qualityPasses.published_0_17_4}`,
+    );
+  }
+  if (qualityPasses.candidate_0_18 < qualityPasses.without_codestory) {
+    reasons.push(
+      `candidate quality ${qualityPasses.candidate_0_18} is below without_codestory ${qualityPasses.without_codestory}`,
+    );
+  }
+
+  const comparatorErrors = new Set(
+    [...byArm.without_codestory, ...byArm.published_0_17_4].flatMap((row) =>
+      (row.quality?.material_factual_errors?.found_anchors ?? []).map((anchor) =>
+        `${row.task_id}\t${row.repeat}\t${anchor}`
+      )
+    ),
+  );
+  const candidateOnlyErrors = byArm.candidate_0_18.flatMap((row) =>
+    (row.quality?.material_factual_errors?.found_anchors ?? []).filter((anchor) =>
+      !comparatorErrors.has(`${row.task_id}\t${row.repeat}\t${anchor}`)
+    ).map((anchor) => ({ task_id: row.task_id, repeat: row.repeat, anchor }))
+  );
+  if (candidateOnlyErrors.length) {
+    reasons.push(`candidate-only material factual errors=${candidateOnlyErrors.length}`);
+  }
+  const unsupportedProofClaims = byArm.candidate_0_18.reduce(
+    (sum, row) => sum + Number(row.quality?.unsupported_proof_claims?.found ?? 0),
+    0,
+  );
+  if (unsupportedProofClaims > 0) {
+    reasons.push(`candidate unsupported proof claims=${unsupportedProofClaims}`);
+  }
+
+  const taskIds = [...new Set(rows.map((row) => row.task_id).filter(Boolean))];
+  for (const taskId of taskIds) {
+    const publishedPasses = byArm.published_0_17_4.filter(
+      (row) => row.task_id === taskId && row.quality?.pass === true,
+    ).length;
+    const candidatePasses = byArm.candidate_0_18.filter(
+      (row) => row.task_id === taskId && row.quality?.pass === true,
+    ).length;
+    if (publishedPasses - candidatePasses >= 2) {
+      reasons.push(`${taskId} loses 2 repeats or more versus published 0.17.4`);
+    }
+  }
+
+  const sum = (arm, selector) => byArm[arm].reduce((total, row) => {
+    const value = Number(selector(row));
+    return total + (Number.isFinite(value) ? value : 0);
+  }, 0);
+  const resourceThresholds = [
+    ["tokens", (row) => row.usage?.total_tokens],
+    ["tool calls", (row) => row.tool_calls_observed],
+    ["cost", (row) => row.estimated_cost_usd],
+  ];
+  const resourceTotals = {};
+  for (const [label, selector] of resourceThresholds) {
+    const baseline = sum("without_codestory", selector);
+    const published = sum("published_0_17_4", selector);
+    const candidate = sum("candidate_0_18", selector);
+    resourceTotals[label] = { without_codestory: baseline, published_0_17_4: published, candidate_0_18: candidate };
+    if (candidate > published * 1.05) reasons.push(`${label} exceed 105% of published 0.17.4`);
+    if (candidate > baseline * 0.8) reasons.push(`${label} exceed 80% of without_codestory`);
+  }
+
+  const timingThresholds = [
+    ["warm", "warm_ms", 1.05, "105%"],
+    ["cold", "cold_ms", 1.05, "5%"],
+    ["incremental", "incremental_ms", 1.05, "5%"],
+    ["all-in", "all_in_ms", 1.10, "110%"],
+  ];
+  const timingTotals = {};
+  for (const [label, field, factor, display] of timingThresholds) {
+    const published = sum("published_0_17_4", (row) => row.exact_candidate_timing?.[field]);
+    const candidate = sum("candidate_0_18", (row) => row.exact_candidate_timing?.[field]);
+    timingTotals[label] = { published_0_17_4: published, candidate_0_18: candidate };
+    if (candidate > published * factor) reasons.push(`${label} timing exceeds ${display} gate`);
+  }
+
+  for (const row of rows) {
+    if (!row.quality || !row.usage || !Number.isFinite(Number(row.usage.total_tokens))) {
+      reasons.push(`missing quality or token accounting for ${row.task_id}/${row.arm}/${row.repeat}`);
+    }
+    if (!row.transcript_analysis?.tool_categories) {
+      reasons.push(`missing tool categories for ${row.task_id}/${row.arm}/${row.repeat}`);
+    }
+    if (!row.transcript_analysis?.command_categories || !row.transcript_analysis?.interaction_turns) {
+      reasons.push(`missing command or interaction accounting for ${row.task_id}/${row.arm}/${row.repeat}`);
+    }
+    if (!Array.isArray(row.transcript_analysis?.direct_source_reads)) {
+      reasons.push(`missing direct source-read accounting for ${row.task_id}/${row.arm}/${row.repeat}`);
+    }
+    if (!Number.isFinite(Number(row.tool_calls_observed)) || !Number.isFinite(Number(row.estimated_cost_usd))) {
+      reasons.push(`missing tool call or cost accounting for ${row.task_id}/${row.arm}/${row.repeat}`);
+    }
+    for (const field of ["cold_ms", "warm_ms", "incremental_ms", "all_in_ms"]) {
+      if (!Number.isFinite(Number(row.exact_candidate_timing?.[field]))) {
+        reasons.push(`missing ${field} timing for ${row.task_id}/${row.arm}/${row.repeat}`);
+      }
+    }
+    if (
+      !row.quality?.material_factual_errors ||
+      !row.quality?.unsupported_proof_claims
+    ) {
+      reasons.push(`missing factual-error or proof-claim accounting for ${row.task_id}/${row.arm}/${row.repeat}`);
+    }
+    if (isCodeStoryArm(row.arm)) {
+      for (const read of row.transcript_analysis?.direct_source_reads ?? []) {
+        if (read.authorization?.status !== "authorized") {
+          reasons.push(`unauthorized direct source read ${read.path ?? "unknown"} in ${row.task_id}/${row.arm}/${row.repeat}`);
+        }
+      }
+    }
+  }
+
+  const identityFields = [
+    "contract", "arm", "package_version", "package_sha256", "cli_sha256",
+    "source_commit", "source_tree", "schema_version", "protocol_revision",
+    "discovery_contract_sha256",
+  ];
+  for (const arm of ["published_0_17_4", "candidate_0_18"]) {
+    const identities = byArm[arm].map((row) => row.package_identity);
+    const reference = identities[0];
+    const expectedVersion = arm === "published_0_17_4" ? "0.17.4" : "0.18.0";
+    const invalidReference =
+      reference?.contract !== EXACT_CANDIDATE_PACKAGE_CONTRACT ||
+      reference?.arm !== arm ||
+      reference?.package_version !== expectedVersion ||
+      !SHA256_PATTERN.test(String(reference?.package_sha256 ?? "")) ||
+      !SHA256_PATTERN.test(String(reference?.cli_sha256 ?? "")) ||
+      !/^[0-9a-f]{40}$/.test(String(reference?.source_commit ?? "")) ||
+      !/^[0-9a-f]{40}$/.test(String(reference?.source_tree ?? "")) ||
+      !Number.isInteger(reference?.schema_version) ||
+      !MCP_PROTOCOL_REVISIONS.has(reference?.protocol_revision) ||
+      !SHA256_PATTERN.test(String(reference?.discovery_contract_sha256 ?? ""));
+    const invalid = invalidReference || identities.some((identity) =>
+      !identity || identityFields.some((field) => identity[field] !== reference[field])
+    );
+    if (invalid) {
+      reasons.push(`${arm === "candidate_0_18" ? "candidate" : "published"} package identity mismatch`);
+    }
+  }
+
+  return {
+    contract: "codestory.agent-benchmark-exact-candidate-acceptance/v1",
+    pass: reasons.length === 0,
+    reasons: [...new Set(reasons)],
+    expected_runs: expectedRuns,
+    completed_runs: completeRows.length,
+    arm_counts: armCounts,
+    quality_passes: qualityPasses,
+    candidate_only_material_factual_errors: candidateOnlyErrors,
+    unsupported_candidate_proof_claims: unsupportedProofClaims,
+    resource_totals: resourceTotals,
+    timing_totals: timingTotals,
+  };
 }
 
 function agentRunKey(run) {
@@ -8835,7 +9467,9 @@ function benchmarkContractForRun(opts, run, env = process.env) {
     env,
     harnessPath: benchmarkHarnessPath,
     scorerPath: benchmarkScorerPath,
-    cliIdentity: run.arm === "with_codestory" ? opts.codestoryCli ?? env.CODESTORY_CLI ?? null : null,
+    cliIdentity: isCodeStoryArm(run.arm)
+      ? opts.exactCandidatePackageByArm?.get(run.arm)?.cli_path ?? opts.codestoryCli ?? env.CODESTORY_CLI ?? null
+      : null,
   });
 }
 
@@ -9669,6 +10303,94 @@ function pipelineStageFailure(stage, group, error) {
   };
 }
 
+async function runExactCandidatePipeline({
+  opts,
+  tasks,
+  plannedRuns,
+  executeRun,
+  outDir,
+  materializeGroup,
+  prepareGroup,
+  prepareIsolation,
+  recordResult,
+  recordPreparation,
+  recordPreparationState,
+  recordFirstFailure,
+}) {
+  const cachePreparation = [];
+  opts.cachePreparationByRepo ??= new Map();
+  const groups = [...groupTasksByRepo(tasks)].map(([repo, repoTasks]) => ({ repo, tasks: repoTasks }));
+  let firstFailure = null;
+  for (const group of groups) {
+    try {
+      await materializeGroup(group, null);
+      await recordPreparationState({ kind: "materialized", repo: group.repo });
+      const rows = await prepareGroup(group, null);
+      if (!Array.isArray(rows) || rows.length !== 1 || rows[0]?.repo !== group.repo) {
+        throw new Error(`preparation must return exactly one row for ${group.repo}`);
+      }
+      const row = rows[0];
+      await recordPreparation(row);
+      cachePreparation.push(row);
+      opts.cachePreparationByRepo.set(row.repo, row);
+      await recordPreparationState({ kind: "prepared", repo: group.repo });
+    } catch (error) {
+      firstFailure = pipelineStageFailure("preparation", group, error);
+      await recordFirstFailure(firstFailure);
+      return {
+        results: [],
+        firstFailure,
+        comparativeFailure: null,
+        comparativePublishable: false,
+        cachePreparation,
+        agentCodexIsolation: null,
+        aborted: true,
+      };
+    }
+  }
+  let agentCodexIsolation;
+  try {
+    agentCodexIsolation = await prepareIsolation();
+  } catch (error) {
+    firstFailure = pipelineStageFailure("agent_isolation", null, error);
+    await recordFirstFailure(firstFailure);
+    return {
+      results: [],
+      firstFailure,
+      comparativeFailure: null,
+      comparativePublishable: false,
+      cachePreparation,
+      agentCodexIsolation: null,
+      aborted: true,
+    };
+  }
+  const outcome = await runPlannedAgentRuns(
+    { ...opts, jobs: 1 },
+    plannedRuns,
+    new Map(),
+    outDir,
+    {
+      runOne: executeRun,
+      failFast: false,
+      onResult: recordResult,
+      onFirstFailure: async (failure) => {
+        firstFailure ??= failure;
+        if (firstFailure === failure) await recordFirstFailure(failure);
+      },
+    },
+  );
+  firstFailure ??= outcome.firstFailure;
+  return {
+    results: outcome.results,
+    firstFailure,
+    comparativeFailure: null,
+    comparativePublishable: firstFailure == null,
+    cachePreparation,
+    agentCodexIsolation,
+    aborted: false,
+  };
+}
+
 async function runAgentBenchmarkPipeline({
   opts,
   tasks,
@@ -9685,6 +10407,22 @@ async function runAgentBenchmarkPipeline({
   recordFirstFailure = async () => {},
   recordComparativeFailure = async () => {},
 }) {
+  if (opts.exactCandidate) {
+    return await runExactCandidatePipeline({
+      opts,
+      tasks,
+      plannedRuns,
+      executeRun,
+      outDir,
+      materializeGroup,
+      prepareGroup,
+      prepareIsolation,
+      recordResult,
+      recordPreparation,
+      recordPreparationState,
+      recordFirstFailure,
+    });
+  }
   const results = [];
   const cachePreparation = [];
   const abortController = new AbortController();
@@ -10031,6 +10769,21 @@ async function main() {
     return;
   }
   const allTasks = await loadTasks(opts);
+  validateExactCandidateShape(opts, allTasks);
+  if (opts.exactCandidate) {
+    const published = await loadExactCandidatePackageReceipt(
+      opts.publishedPackageReceipt,
+      "published_0_17_4",
+    );
+    const candidate = await loadExactCandidatePackageReceipt(
+      opts.candidatePackageReceipt,
+      "candidate_0_18",
+    );
+    opts.exactCandidatePackageByArm = new Map([
+      [published.arm, published],
+      [candidate.arm, candidate],
+    ]);
+  }
   opts.releaseEvidenceCorpusContract = await loadReleaseEvidenceCorpusContract(allTasks, opts);
   if (opts.aggregateShards) {
     await aggregateShardRuns(opts, allTasks);
@@ -10089,6 +10842,11 @@ async function main() {
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
   const outDir = path.resolve(opts.outDir ?? path.join(repoRoot, "target", "agent-benchmark", timestamp));
   await mkdir(outDir, { recursive: true });
+  if (opts.exactCandidate) {
+    opts.exactCandidateStateRoot = await mkdtemp(
+      path.join(os.tmpdir(), "codestory-agent-exact-candidate-"),
+    );
+  }
   const runsPath = path.join(outDir, "runs.jsonl");
   if (existsSync(runsPath)) {
     throw new Error(`Refusing to append a new benchmark to an existing ledger: ${runsPath}`);
@@ -10150,8 +10908,9 @@ async function main() {
   } finally {
     await ledger.close();
     await preparationLedger.close();
-    if (agentCodexIsolation?.root) {
-      await rm(agentCodexIsolation.root, { recursive: true, force: true });
+    const isolationRoot = agentCodexIsolation?.root ?? opts.exactCandidateStateRoot;
+    if (isolationRoot) {
+      await rm(isolationRoot, { recursive: true, force: true });
     }
   }
 
@@ -10231,12 +10990,21 @@ async function main() {
     packet_obligation_accounting: obligationAccounting,
     summary,
     cost_accounting: costAccounting,
+    exact_candidate_acceptance: opts.exactCandidate
+      ? exactCandidateAcceptance(canonicalResults)
+      : null,
   };
   await writeFile(path.join(outDir, "summary.json"), `${JSON.stringify(summaryPayload, null, 2)}\n`, "utf8");
   await writeFile(path.join(outDir, "summary.md"), markdownSummary(summary, opts, costAccounting), "utf8");
 
   const failedRuns = canonicalResults.filter((result) => result.status !== "pass");
   let exitCode = firstFailure ? 1 : 0;
+  if (opts.exactCandidate && !summaryPayload.exact_candidate_acceptance.pass) {
+    console.error(
+      `exact-candidate acceptance failed: ${summaryPayload.exact_candidate_acceptance.reasons.join(" | ")}`,
+    );
+    exitCode = 1;
+  }
   if (failedRuns.length && !opts.allowFailures) {
     console.error("benchmark failed: every run must pass unless --allow-failures is set.");
     for (const failed of failedRuns) {
@@ -10346,6 +11114,9 @@ export {
   packetFirstCommandForPrompt,
   publicCoreCorpusAudit,
   planAgentRuns,
+  exactCandidateAcceptance,
+  loadExactCandidatePackageReceipt,
+  validateExactCandidateShape,
   repoProvenanceBlockers,
   repoProvenance,
   runnerCommand,

--- a/scripts/tests/codestory-agent-ab-analyzer.test.mjs
+++ b/scripts/tests/codestory-agent-ab-analyzer.test.mjs
@@ -4,7 +4,7 @@ import { spawnSync } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { existsSync } from "node:fs";
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, readFile, rm, symlink, truncate, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, symlink, truncate, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
@@ -113,18 +113,103 @@ const EXACT_CANDIDATE_ARMS = [
   "published_0_17_4",
   "candidate_0_18",
 ];
+const EXACT_TASKS = [
+  ["python-requests-session-flow", "psf-requests"],
+  ["java-commons-lang-string-utils", "apache-commons-lang"],
+  ["rust-ripgrep-search-pipeline", "BurntSushi-ripgrep"],
+  ["javascript-express-routing-flow", "expressjs-express"],
+  ["typescript-swr-hook-flow", "vercel-swr"],
+  ["cpp-fmt-formatting-flow", "fmtlib-fmt"],
+  ["c-redis-command-loop", "redis-redis"],
+  ["go-gin-route-dispatch", "gin-gonic-gin"],
+  ["ruby-jekyll-site-build", "jekyll-jekyll"],
+  ["php-monolog-record-flow", "Seldaek-monolog"],
+  ["csharp-automapper-map-flow", "AutoMapper-AutoMapper"],
+  ["kotlin-okio-buffer-flow", "square-okio"],
+  ["swift-alamofire-request-flow", "Alamofire-Alamofire"],
+  ["dart-http-client-flow", "dart-lang-http"],
+  ["bash-nvm-install-dispatch", "nvm-sh-nvm"],
+  ["html-mdn-form-validation", "mdn-learning-area"],
+  ["css-animate-base-and-keyframes", "animate-css-animate-css"],
+  ["sql-chinook-schema-relations", "lerocha-chinook-database"],
+];
+
+function exactLifecycle() {
+  return {
+    contract: "codestory.agent-benchmark-exact-lifecycle/v1",
+    package_authentication_order: ["published_0_17_4", "candidate_0_18"],
+    package_authentication_ms: { published_0_17_4: 10, candidate_0_18: 10 },
+    total_package_authentication_ms: 20,
+    model_initialization_ms: { published_0_17_4: 5, candidate_0_18: 5 },
+    preparation_order: EXACT_TASKS.map(([_, repo], index) => ({
+      repo,
+      arms: index % 2 === 0
+        ? ["published_0_17_4", "candidate_0_18"]
+        : ["candidate_0_18", "published_0_17_4"],
+    })),
+  };
+}
+
+function passingCacheProvenance() {
+  return {
+    doctor_status: "pass",
+    storage_path: "/isolated/cache.db",
+    cache_policy: "prepared-retrieval-cache-read-only",
+    retrieval_mode: "full",
+    semantic_generation: "semantic-1",
+    manifest_embedding_backend: `per-user-server:coderank-embed:q8_0:sha256-${"a".repeat(64)}:fixture`,
+    embedding_engine_instance_id: "engine-1",
+    embedding_policy: "accelerated",
+    semantic_backend: "embedded",
+    local_only: true,
+    indexed: true,
+    freshness_status: "fresh",
+    semantic_ready: true,
+    indexing_in_timed_run: false,
+    transport_mode: "agent_harness_prelude",
+    packet_embedding_execution: {
+      source: "packet.answer.retrieval_trace",
+      transport_mode: "agent_harness_prelude",
+      retrieval_contract: "in_process_v1",
+      embedding_engine: "process_shared",
+      embedding_policy: "accelerated",
+      retrieval_mode: "full",
+      diagnostic_count: 1,
+      full_diagnostic_count: 1,
+      semantic_stage_count: 1,
+      completed_semantic_stage_count: 1,
+      invalid_semantic_stage_count: 0,
+      shadow_degraded_reason: null,
+      shadow_error: null,
+      shadow_cancel_reason: null,
+      semantic_fallback_count: 0,
+      semantic_generation: "semantic-1",
+      prepared_semantic_generation: "semantic-1",
+    },
+    cache_preparation: {
+      preparation_wall_ms: 100,
+      incremental_status: "pass",
+      incremental_wall_ms: 20,
+      incremental_source_mutation: {
+        path: "src/named.rs",
+        original_sha256: "b".repeat(64),
+        mutated_sha256: "c".repeat(64),
+        restored_sha256: "b".repeat(64),
+      },
+    },
+  };
+}
 
 function exactCandidateRows() {
   const rows = [];
-  for (let taskIndex = 0; taskIndex < 18; taskIndex += 1) {
-    const taskId = `task-${String(taskIndex + 1).padStart(2, "0")}`;
+  for (const [taskId, repo] of EXACT_TASKS) {
     for (let repeat = 1; repeat <= 3; repeat += 1) {
       for (const arm of EXACT_CANDIDATE_ARMS) {
         const codestory = arm !== "without_codestory";
         const packageVersion = arm === "published_0_17_4" ? "0.17.4" : "0.18.0";
         const packageByte = arm === "published_0_17_4" ? "a" : "b";
         rows.push({
-          repo: `repo-${taskIndex + 1}`,
+          repo,
           task_id: taskId,
           arm,
           repeat,
@@ -134,29 +219,46 @@ function exactCandidateRows() {
             material_factual_errors: { found: 0, found_anchors: [] },
             unsupported_proof_claims: { found: 0, found_claims: [] },
           },
-          usage: { total_tokens: codestory ? 70 : 100 },
+          usage: codestory
+            ? { input_tokens: 50, output_tokens: 20, total_tokens: 70 }
+            : { input_tokens: 70, output_tokens: 30, total_tokens: 100 },
           estimated_cost_usd: codestory ? 0.7 : 1,
           tool_calls_observed: codestory ? 7 : 10,
           transcript_analysis: {
             command_count: codestory ? 7 : 10,
             tool_categories: { command_execution: codestory ? 7 : 10 },
-            command_categories: { codestory_cli: codestory ? 1 : 0 },
-            interaction_turns: { total: codestory ? 9 : 12 },
+            command_categories: codestory
+              ? { codestory_cli: 1, direct_file_read: 6 }
+              : { codestory_cli: 0, direct_file_read: 10 },
+            interaction_turns: codestory
+              ? {
+                  total: 9, model_messages: 2, tool_actions: 7, failed_tool_actions: 0,
+                  reasoning_items_excluded: 0, error_items_excluded: 0,
+                }
+              : {
+                  total: 12, model_messages: 2, tool_actions: 10, failed_tool_actions: 0,
+                  reasoning_items_excluded: 0, error_items_excluded: 0,
+                },
+            codestory_mcp_tool_calls_observed: 0,
+            codestory_mcp_completed_calls_observed: 0,
+            codestory_mcp_runtime_identities: [],
             direct_source_reads: codestory
               ? [{ path: "src/named.rs", authorization: { status: "authorized", reason: "user_named_file" } }]
               : [{ path: "src/read.rs", authorization: { status: "baseline_local_exploration", reason: "without_codestory" } }],
+            direct_source_reads_total: 1,
           },
           exact_candidate_timing: codestory
             ? {
                 cold_ms: arm === "candidate_0_18" ? 100 : 100,
                 warm_ms: arm === "candidate_0_18" ? 50 : 50,
                 incremental_ms: arm === "candidate_0_18" ? 20 : 20,
-                all_in_ms: arm === "candidate_0_18" ? 80 : 80,
+                all_in_ms: arm === "candidate_0_18" ? 50 : 50,
               }
-            : { cold_ms: 0, warm_ms: 0, incremental_ms: 0, all_in_ms: 100 },
+            : { cold_ms: 0, warm_ms: 100, incremental_ms: 0, all_in_ms: 100 },
+          wall_ms: codestory ? 50 : 100,
           package_identity: codestory
             ? {
-                contract: "codestory.agent-benchmark-package/v1",
+                contract: "codestory.agent-benchmark-package/v2",
                 arm,
                 package_version: packageVersion,
                 package_sha256: packageByte.repeat(64),
@@ -166,19 +268,45 @@ function exactCandidateRows() {
                 schema_version: arm === "published_0_17_4" ? 2 : 3,
                 protocol_revision: "2025-11-25",
                 discovery_contract_sha256: (arm === "published_0_17_4" ? "3" : "4").repeat(64),
+                trust_root_kind: arm === "published_0_17_4"
+                  ? "official_published_checksum"
+                  : "immutable_candidate_receipt",
+                trust_root_sha256: (arm === "published_0_17_4" ? "5" : "6").repeat(64),
               }
-            : {
-                contract: "codestory.agent-benchmark-package/v1",
-                arm,
-                package_version: null,
-                package_sha256: null,
-                cli_sha256: null,
-                source_commit: null,
-                source_tree: null,
-                schema_version: null,
-                protocol_revision: null,
-                discovery_contract_sha256: null,
-              },
+            : null,
+          codestory_prelude_cli: codestory ? "/authenticated/codestory-cli" : null,
+          codestory_prelude_cli_sha256: codestory
+            ? (arm === "published_0_17_4" ? "c" : "d").repeat(64)
+            : null,
+          codestory_binary_identity: codestory
+            ? {
+                status: "prelude_only",
+                prelude_cli_sha256: (arm === "published_0_17_4" ? "c" : "d").repeat(64),
+              }
+            : null,
+          codestory_cache_provenance: codestory ? passingCacheProvenance() : null,
+          codestory_harness_prelude: codestory
+            ? {
+                status: "pass",
+                packet_extra_probe_strategy: null,
+                packet_contract_runtime: {
+                  plugin_version: packageVersion,
+                  plugin_cli_version: packageVersion,
+                  cli_version: packageVersion,
+                  pinned_pair_matches: true,
+                  cli_source: "managed",
+                  known_override_skew_channel: false,
+                },
+                packet_sufficiency: {
+                  obligation_accounting: {
+                    total: 0,
+                    material: 0,
+                    nonmaterial: 0,
+                    material_status_buckets: {},
+                  },
+                },
+              }
+            : null,
         });
       }
     }
@@ -186,23 +314,25 @@ function exactCandidateRows() {
   return rows;
 }
 
-test("exact-candidate mode freezes the 18x3x3 shape and rejects baseline reuse", () => {
-  assert.throws(
-    () => benchmarkHarness.parseArgs([
-      "--exact-candidate",
-      "--task-suite", "language-expansion-holdout",
-      "--published-package-receipt", "/tmp/published.json",
-      "--candidate-package-receipt", "/tmp/candidate.json",
-      "--reuse-baseline-from", "/tmp/old",
-    ]),
-    /baseline reuse is forbidden/i,
-  );
-  const opts = benchmarkHarness.parseArgs([
+function exactArgs(extra = []) {
+  return [
     "--exact-candidate",
     "--task-suite", "language-expansion-holdout",
-    "--published-package-receipt", "/tmp/published.json",
+    "--published-archive", "/tmp/published.tar.gz",
+    "--published-checksum-manifest", "/tmp/SHA256SUMS.txt",
+    "--published-checksum-sha256", "a".repeat(64),
     "--candidate-package-receipt", "/tmp/candidate.json",
-  ]);
+    "--candidate-receipt-sha256", "b".repeat(64),
+    ...extra,
+  ];
+}
+
+test("exact-candidate mode freezes the 18x3x3 shape and rejects baseline reuse", () => {
+  assert.throws(
+    () => benchmarkHarness.parseArgs(exactArgs(["--reuse-baseline-from", "/tmp/old"])),
+    /forbids option.*reuse-baseline/i,
+  );
+  const opts = benchmarkHarness.parseArgs(exactArgs());
   assert.deepEqual(opts.arms, EXACT_CANDIDATE_ARMS);
   assert.equal(opts.repeats, 3);
   assert.throws(
@@ -215,6 +345,81 @@ test("exact-candidate mode freezes the 18x3x3 shape and rejects baseline reuse",
       Array.from({ length: 18 }, (_, index) => ({ id: `t-${index}` })),
     )
   );
+});
+
+test("exact-candidate mode closes every option that can change freshness oracle or run shape", () => {
+  const forbidden = [
+    ["--list"],
+    ["--self-test"],
+    ["--reanalyze-dir", "/tmp/old"],
+    ["--quick"],
+    ["--publishable"],
+    ["--allow-failures"],
+    ["--diagnostic-extra-probes-from-manifest"],
+    ["--include-local-repos"],
+    ["--packet-runtime"],
+    ["--packet-runtime-mode", "cold-cli"],
+    ["--codestory-cli", "/tmp/local-codestory-cli"],
+    ["--repos", "psf-requests"],
+    ["--arms", EXACT_CANDIDATE_ARMS.join(",")],
+    ["--task-ids", EXACT_TASKS[0][0]],
+    ["--task-manifest", "/tmp/tasks"],
+    ["--repeats", "3"],
+    ["--runner", "codex"],
+    ["--model", "gpt-5.6-sol"],
+    ["--sandbox", "workspace-write"],
+    ["--benchmark-run-id", "reused"],
+    ["--timeout-ms", "600000"],
+    ["--jobs", "1"],
+    ["--reuse-baseline-from", "/tmp/old"],
+    ["--prepare-codestory-cache"],
+    ["--no-prepare-codestory-cache"],
+    ["--prepare-codestory-timeout-ms", "1800000"],
+    ["--prepare-codestory-jobs", "1"],
+    ["--canary-task-id", EXACT_TASKS[0][0]],
+    ["--shard-count", "1"],
+    ["--shard-index", "0"],
+    ["--aggregate-shards", "/tmp/shard"],
+    ["--candidate-package-sha256", "c".repeat(64)],
+    ["--collect-all-failures"],
+    ["--max-source-reads-after-packet", "0"],
+  ];
+  for (const args of forbidden) {
+    assert.throws(
+      () => benchmarkHarness.parseArgs(exactArgs(args)),
+      /exact-candidate mode forbids|unsupported|mutually exclusive/i,
+      args[0],
+    );
+  }
+
+  for (const required of [
+    "--published-archive",
+    "--published-checksum-manifest",
+    "--published-checksum-sha256",
+    "--candidate-package-receipt",
+    "--candidate-receipt-sha256",
+  ]) {
+    const args = exactArgs();
+    args.splice(args.indexOf(required), 2);
+    assert.throws(
+      () => benchmarkHarness.parseArgs(args),
+      /requires authenticated published and candidate package inputs/i,
+      required,
+    );
+  }
+  for (const digestOption of ["--published-checksum-sha256", "--candidate-receipt-sha256"]) {
+    const args = exactArgs();
+    args[args.indexOf(digestOption) + 1] = "0".repeat(64);
+    assert.throws(() => benchmarkHarness.parseArgs(args), /all-zero digest/i, digestOption);
+  }
+
+  const permitted = benchmarkHarness.parseArgs(exactArgs([
+    "--materialize-repos",
+    "--repo-cache-dir", "/tmp/exact-repos",
+    "--out-dir", "/tmp/exact-output",
+  ]));
+  assert.equal(permitted.materializeRepos, true);
+  assert.equal(permitted.diagnosticExtraProbesFromManifest, false);
 });
 
 test("exact-candidate planning balances deterministic arm position across 162 fresh rows", () => {
@@ -242,52 +447,150 @@ test("exact-candidate planning balances deterministic arm position across 162 fr
   }
 });
 
-test("exact package receipts bind package CLI source schema protocol and discovery identity", async () => {
+async function makeExactArchive(root, name, { version, schema, source, tree, discovery }) {
+  const packageRoot = path.join(root, `${name}-root`);
+  await mkdir(packageRoot, { recursive: true });
+  const cliPath = path.join(packageRoot, "codestory-cli");
+  await writeFile(
+    cliPath,
+    `#!/usr/bin/env node
+const readline = require("node:readline");
+const rl = readline.createInterface({ input: process.stdin });
+rl.on("line", (line) => {
+  const request = JSON.parse(line);
+  if (request.method !== "initialize") return;
+  const response = {
+    jsonrpc: "2.0",
+    id: request.id,
+    result: {
+      protocolVersion: request.params.protocolVersion,
+      serverInfo: { name: "codestory", version: ${JSON.stringify(version)} },
+      _meta: {
+        codestory_publication: { schema_version: ${schema} },
+        codestory_protocol: { discovery_contract_sha256: ${JSON.stringify(discovery)} },
+      },
+    },
+  };
+  process.stdout.write(JSON.stringify(response) + "\\n");
+});
+`,
+  );
+  await chmod(cliPath, 0o755);
+  const cliSha = createHash("sha256").update(await readFile(cliPath)).digest("hex");
+  await writeFile(path.join(packageRoot, "codestory-native-manifest.json"), JSON.stringify({
+    schema_version: 3,
+    release_version: version,
+    source: { commit: source, tree, tracked_dirty: false },
+    binary: { name: "codestory-cli", sha256: cliSha },
+  }));
+  const archivePath = path.join(root, `${name}.tar.gz`);
+  const packed = spawnSync("tar", ["-czf", archivePath, "-C", root, path.basename(packageRoot)], {
+    encoding: "utf8",
+  });
+  assert.equal(packed.status, 0, packed.stderr);
+  return {
+    archivePath,
+    sha256: createHash("sha256").update(await readFile(archivePath)).digest("hex"),
+  };
+}
+
+test("exact package authentication rejects archive CLI receipt and runtime substitution as one trust class", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "codestory-three-arm-receipt-"));
   try {
-    const archivePath = path.join(root, "package.tgz");
-    const cliPath = path.join(root, "codestory-cli");
-    await writeFile(archivePath, "package-bytes");
-    await writeFile(cliPath, "cli-bytes");
-    const sha = (value) => createHash("sha256").update(value).digest("hex");
-    const receipt = {
-      contract: "codestory.agent-benchmark-package/v1",
-      arm: "published_0_17_4",
-      package_version: "0.17.4",
-      package_path: archivePath,
-      package_sha256: sha("package-bytes"),
-      cli_path: cliPath,
-      cli_sha256: sha("cli-bytes"),
-      source_commit: "a".repeat(40),
-      source_tree: "b".repeat(40),
-      schema_version: 2,
+    const published = await makeExactArchive(root, "published", {
+      version: "0.17.4", schema: 2, source: "a".repeat(40), tree: "b".repeat(40), discovery: "c".repeat(64),
+    });
+    const candidate = await makeExactArchive(root, "candidate", {
+      version: "0.18.0", schema: 3, source: "d".repeat(40), tree: "e".repeat(40), discovery: "f".repeat(64),
+    });
+    const checksumPath = path.join(root, "SHA256SUMS.txt");
+    await writeFile(checksumPath, `${published.sha256}  ${path.basename(published.archivePath)}\n`);
+    const checksumSha = createHash("sha256").update(await readFile(checksumPath)).digest("hex");
+    const receiptPath = path.join(root, "candidate-receipt.json");
+    const baseReceipt = {
+      contract: "codestory.agent-benchmark-package/v2",
+      arm: "candidate_0_18",
+      package_version: "0.18.0",
+      archive_path: candidate.archivePath,
+      archive_sha256: candidate.sha256,
+      source_commit: "d".repeat(40),
+      source_tree: "e".repeat(40),
+      schema_version: 3,
       protocol_revision: "2025-11-25",
-      discovery_contract_sha256: "c".repeat(64),
+      discovery_contract_sha256: "f".repeat(64),
     };
-    const receiptPath = path.join(root, "receipt.json");
-    await writeFile(receiptPath, JSON.stringify(receipt));
-    const loaded = await benchmarkHarness.loadExactCandidatePackageReceipt(
-      receiptPath,
-      "published_0_17_4",
-    );
-    assert.equal(loaded.package_sha256, receipt.package_sha256);
-    for (const mutate of [
-      (row) => { row.arm = "candidate_0_18"; },
-      (row) => { row.package_version = "0.17.3"; },
-      (row) => { row.package_sha256 = "0".repeat(64); },
-      (row) => { row.cli_sha256 = "0".repeat(64); },
-      (row) => { row.source_commit = null; },
-      (row) => { row.schema_version = null; },
-      (row) => { row.protocol_revision = "2024-01-01"; },
-      (row) => { row.discovery_contract_sha256 = null; },
-    ]) {
-      const hostile = structuredClone(receipt);
-      mutate(hostile);
-      await writeFile(receiptPath, JSON.stringify(hostile));
-      await assert.rejects(
-        benchmarkHarness.loadExactCandidatePackageReceipt(receiptPath, "published_0_17_4"),
-      );
+    const run = async (receipt, overrides = {}) => {
+      await writeFile(receiptPath, JSON.stringify(receipt));
+      const receiptSha = createHash("sha256").update(await readFile(receiptPath)).digest("hex");
+      const state = await mkdtemp(path.join(root, "state-"));
+      return await benchmarkHarness.authenticateExactCandidatePackages({
+        exactCandidate: true,
+        exactCandidateStateRoot: state,
+        publishedArchive: published.archivePath,
+        publishedChecksumManifest: checksumPath,
+        publishedChecksumSha256: checksumSha,
+        candidatePackageReceipt: receiptPath,
+        candidateReceiptSha256: receiptSha,
+        ...overrides,
+      });
+    };
+    const accepted = await run(baseReceipt);
+    assert.equal(accepted.packages.get("published_0_17_4").package_sha256, published.sha256);
+    assert.equal(accepted.packages.get("candidate_0_18").package_sha256, candidate.sha256);
+    assert.match(accepted.packages.get("candidate_0_18").cli_path, /state-/);
+
+    const hostile = [
+      ["archive substitution", { ...baseReceipt, archive_path: published.archivePath, archive_sha256: published.sha256 }, {}, /version|source|runtime/i],
+      ["local CLI substitution", { ...baseReceipt, cli_path: path.join(root, "decoy") }, {}, /exactly.*fields/i],
+      ["runtime drift", { ...baseReceipt, schema_version: 4 }, {}, /runtime\/source identity/i],
+      ["source drift", { ...baseReceipt, source_tree: "9".repeat(40) }, {}, /source tree drifted/i],
+      ["null source", { ...baseReceipt, source_commit: null }, {}, /runtime\/source identity/i],
+      ["all-zero archive digest", { ...baseReceipt, archive_sha256: "0".repeat(64) }, {}, /all-zero digest/i],
+      ["forged receipt", baseReceipt, { candidateReceiptSha256: "1".repeat(64) }, /external digest/i],
+      ["forged published manifest", baseReceipt, { publishedChecksumSha256: "2".repeat(64) }, /external digest/i],
+    ];
+    for (const [label, receipt, overrides, expected] of hostile) {
+      await assert.rejects(run(receipt, overrides), expected, label);
     }
+    const oversized = Buffer.alloc(65 * 1024, 0x20);
+    await writeFile(receiptPath, oversized);
+    const oversizedSha = createHash("sha256").update(oversized).digest("hex");
+    await assert.rejects(benchmarkHarness.authenticateExactCandidatePackages({
+      exactCandidate: true,
+      exactCandidateStateRoot: await mkdtemp(path.join(root, "state-")),
+      publishedArchive: published.archivePath,
+      publishedChecksumManifest: checksumPath,
+      publishedChecksumSha256: checksumSha,
+      candidatePackageReceipt: receiptPath,
+      candidateReceiptSha256: oversizedSha,
+    }), /bound/i);
+
+    const oversizedManifest = Buffer.alloc(1024 * 1024 + 1, 0x20);
+    await writeFile(checksumPath, oversizedManifest);
+    await writeFile(receiptPath, JSON.stringify(baseReceipt));
+    await assert.rejects(benchmarkHarness.authenticateExactCandidatePackages({
+      exactCandidate: true,
+      exactCandidateStateRoot: await mkdtemp(path.join(root, "state-")),
+      publishedArchive: published.archivePath,
+      publishedChecksumManifest: checksumPath,
+      publishedChecksumSha256: createHash("sha256").update(oversizedManifest).digest("hex"),
+      candidatePackageReceipt: receiptPath,
+      candidateReceiptSha256: createHash("sha256").update(await readFile(receiptPath)).digest("hex"),
+    }), /bound/i);
+
+    const oversizedArchive = path.join(root, "oversized.tar.gz");
+    await writeFile(oversizedArchive, "");
+    await truncate(oversizedArchive, 8 * 1024 * 1024 * 1024 + 1);
+    await writeFile(checksumPath, `${"a".repeat(64)}  ${path.basename(oversizedArchive)}\n`);
+    await assert.rejects(benchmarkHarness.authenticateExactCandidatePackages({
+      exactCandidate: true,
+      exactCandidateStateRoot: await mkdtemp(path.join(root, "state-")),
+      publishedArchive: oversizedArchive,
+      publishedChecksumManifest: checksumPath,
+      publishedChecksumSha256: createHash("sha256").update(await readFile(checksumPath)).digest("hex"),
+      candidatePackageReceipt: receiptPath,
+      candidateReceiptSha256: createHash("sha256").update(await readFile(receiptPath)).digest("hex"),
+    }), /bound/i);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -295,7 +598,7 @@ test("exact package receipts bind package CLI source schema protocol and discove
 
 test("exact-candidate acceptance closes the complete causal threshold matrix", () => {
   const passing = exactCandidateRows();
-  const accepted = benchmarkHarness.exactCandidateAcceptance(passing);
+  const accepted = benchmarkHarness.exactCandidateAcceptance(passing, exactLifecycle());
   assert.equal(accepted.pass, true, JSON.stringify(accepted));
   assert.equal(accepted.expected_runs, 162);
   assert.equal(accepted.completed_runs, 162);
@@ -316,24 +619,39 @@ test("exact-candidate acceptance closes the complete causal threshold matrix", (
       rows.find((row) => row.arm === "candidate_0_18").quality.unsupported_proof_claims = { found: 1, found_claims: ["ContractProven"] };
     }, /unsupported proof claim/i],
     ["task repeat loss", (rows) => {
-      for (const row of rows.filter((entry) => entry.arm === "candidate_0_18" && entry.task_id === "task-01" && entry.repeat <= 2)) row.quality.pass = false;
-      rows.find((entry) => entry.arm === "without_codestory" && entry.task_id === "task-01").quality.pass = false;
+      for (const row of rows.filter((entry) => entry.arm === "candidate_0_18" && entry.task_id === EXACT_TASKS[0][0] && entry.repeat <= 2)) row.quality.pass = false;
+      rows.find((entry) => entry.arm === "without_codestory" && entry.task_id === EXACT_TASKS[0][0]).quality.pass = false;
     }, /loses 2 repeats/i],
     ["tokens vs published", (rows) => {
-      for (const row of rows.filter((entry) => entry.arm === "candidate_0_18")) row.usage.total_tokens = 74;
+      for (const row of rows.filter((entry) => entry.arm === "candidate_0_18")) {
+        row.usage.input_tokens = 54;
+        row.usage.total_tokens = 74;
+      }
     }, /tokens.*105%/i],
     ["tokens vs baseline", (rows) => {
-      for (const row of rows.filter((entry) => entry.arm === "candidate_0_18")) row.usage.total_tokens = 81;
-      for (const row of rows.filter((entry) => entry.arm === "published_0_17_4")) row.usage.total_tokens = 80;
+      for (const row of rows.filter((entry) => entry.arm === "candidate_0_18")) {
+        row.usage.input_tokens = 61;
+        row.usage.total_tokens = 81;
+      }
+      for (const row of rows.filter((entry) => entry.arm === "published_0_17_4")) {
+        row.usage.input_tokens = 60;
+        row.usage.total_tokens = 80;
+      }
     }, /tokens.*80%/i],
     ["tools", (rows) => {
-      for (const row of rows.filter((entry) => entry.arm === "candidate_0_18")) row.tool_calls_observed = 8;
+      for (const row of rows.filter((entry) => entry.arm === "candidate_0_18")) {
+        row.tool_calls_observed = 8;
+        row.transcript_analysis.tool_categories.command_execution = 8;
+      }
     }, /tool calls/i],
     ["cost", (rows) => {
       for (const row of rows.filter((entry) => entry.arm === "candidate_0_18")) row.estimated_cost_usd = 0.81;
     }, /cost/i],
     ["warm", (rows) => {
-      for (const row of rows.filter((entry) => entry.arm === "candidate_0_18")) row.exact_candidate_timing.warm_ms = 53;
+      for (const row of rows.filter((entry) => entry.arm === "candidate_0_18")) {
+        row.exact_candidate_timing.warm_ms = 53;
+        row.exact_candidate_timing.all_in_ms = 53;
+      }
     }, /warm.*105%/i],
     ["cold", (rows) => {
       for (const row of rows.filter((entry) => entry.arm === "candidate_0_18")) row.exact_candidate_timing.cold_ms = 106;
@@ -341,11 +659,14 @@ test("exact-candidate acceptance closes the complete causal threshold matrix", (
     ["incremental", (rows) => {
       for (const row of rows.filter((entry) => entry.arm === "candidate_0_18")) row.exact_candidate_timing.incremental_ms = 22;
     }, /incremental.*5%/i],
-    ["all-in", (rows) => {
-      for (const row of rows.filter((entry) => entry.arm === "candidate_0_18")) row.exact_candidate_timing.all_in_ms = 89;
-    }, /all-in.*110%/i],
+    ["row all-in mismatch", (rows) => {
+      rows.find((entry) => entry.arm === "candidate_0_18").exact_candidate_timing.all_in_ms = 89;
+    }, /row all-in timing/i],
     ["source authorization", (rows) => {
       rows.find((row) => row.arm === "candidate_0_18").transcript_analysis.direct_source_reads[0].authorization = { status: "unauthorized", reason: null };
+    }, /unauthorized direct source read/i],
+    ["forged source authorization", (rows) => {
+      rows.find((row) => row.arm === "published_0_17_4").transcript_analysis.direct_source_reads[0].authorization = { status: "authorized", reason: "reviewer_said_ok" };
     }, /unauthorized direct source read/i],
     ["identity", (rows) => {
       rows.find((row) => row.arm === "candidate_0_18").package_identity.cli_sha256 = "0".repeat(64);
@@ -353,13 +674,126 @@ test("exact-candidate acceptance closes the complete causal threshold matrix", (
     ["accounting", (rows) => {
       delete rows.find((row) => row.arm === "candidate_0_18").transcript_analysis.tool_categories;
     }, /missing tool categories/i],
+    ["arbitrary task id", (rows) => {
+      rows[0].task_id = "invented-task";
+    }, /exact task\/repository\/arm\/repeat keys/i],
+    ["arbitrary repository id", (rows) => {
+      rows[0].repo = "invented-repository";
+    }, /exact task\/repository\/arm\/repeat keys/i],
+    ["null token telemetry", (rows) => {
+      rows[0].usage.total_tokens = null;
+    }, /token accounting/i],
+    ["negative category telemetry", (rows) => {
+      rows[0].transcript_analysis.tool_categories.command_execution = -1;
+      rows[0].tool_calls_observed = -1;
+    }, /tool or command categories|tool call or cost/i],
+    ["empty category telemetry", (rows) => {
+      rows[0].transcript_analysis.tool_categories = {};
+    }, /tool or command categories/i],
+    ["factual count mismatch", (rows) => {
+      rows[0].quality.material_factual_errors.found = 1;
+    }, /error or proof-claim counts/i],
+    ["timing repeat mismatch", (rows) => {
+      rows.find((row) => row.arm === "candidate_0_18").exact_candidate_timing.cold_ms = 99;
+    }, /timing disagrees across repeats/i],
+    ["baseline CodeStory visibility", (rows) => {
+      rows.find((row) => row.arm === "without_codestory").transcript_analysis.command_categories.codestory_cli = 1;
+    }, /baseline has CodeStory visibility/i],
+    ["published runtime proof", (rows) => {
+      rows.find((row) => row.arm === "published_0_17_4").codestory_harness_prelude.packet_contract_runtime = null;
+    }, /missing per-arm managed runtime proof/i],
+    ["candidate cache proof", (rows) => {
+      rows.find((row) => row.arm === "candidate_0_18").codestory_cache_provenance = null;
+    }, /missing per-arm cache proof/i],
+    ["published obligation proof", (rows) => {
+      rows.find((row) => row.arm === "published_0_17_4").codestory_harness_prelude.packet_sufficiency = null;
+    }, /missing per-arm obligation proof/i],
+    ["candidate source mutation proof", (rows) => {
+      rows.find((row) => row.arm === "candidate_0_18").codestory_cache_provenance.cache_preparation.incremental_source_mutation = null;
+    }, /missing verified source mutation/i],
+    ["candidate source mutation digest", (rows) => {
+      rows.find((row) => row.arm === "candidate_0_18").codestory_cache_provenance.cache_preparation.incremental_source_mutation.original_sha256 = null;
+    }, /missing verified source mutation/i],
+    ["cache timing mismatch", (rows) => {
+      rows.find((row) => row.arm === "published_0_17_4").codestory_cache_provenance.cache_preparation.incremental_wall_ms = 19;
+    }, /cache lifecycle timings do not reconcile/i],
+    ["executed CLI substitution", (rows) => {
+      rows.find((row) => row.arm === "candidate_0_18").codestory_prelude_cli_sha256 = "9".repeat(64);
+    }, /executed CLI is not bound/i],
+    ["zero trust root", (rows) => {
+      rows.find((row) => row.arm === "published_0_17_4").package_identity.trust_root_sha256 = "0".repeat(64);
+    }, /published package identity mismatch/i],
   ];
   for (const [label, mutate, expected] of mutations) {
     const rows = exactCandidateRows();
     mutate(rows);
-    const result = benchmarkHarness.exactCandidateAcceptance(rows);
+    const result = benchmarkHarness.exactCandidateAcceptance(rows, exactLifecycle());
     assert.equal(result.pass, false, `${label}: ${JSON.stringify(result)}`);
     assert.match(result.reasons.join("\n"), expected, label);
+  }
+
+  for (const [label, mutate, expected] of [
+    ["missing lifecycle", () => null, /one-time package and model lifecycle/i],
+    ["missing model lifecycle", (lifecycle) => {
+      delete lifecycle.model_initialization_ms;
+      return lifecycle;
+    }, /one-time package and model lifecycle/i],
+    ["unbalanced lifecycle", (lifecycle) => {
+      for (const entry of lifecycle.preparation_order) {
+        entry.arms = ["published_0_17_4", "candidate_0_18"];
+      }
+      return lifecycle;
+    }, /balanced deterministic 9\/9 rotation/i],
+    ["all-in lifecycle", (lifecycle) => {
+      lifecycle.package_authentication_ms.candidate_0_18 = 1000;
+      return lifecycle;
+    }, /all-in timing exceeds 110%/i],
+  ]) {
+    const lifecycle = mutate(exactLifecycle());
+    const result = benchmarkHarness.exactCandidateAcceptance(exactCandidateRows(), lifecycle);
+    assert.equal(result.pass, false, `${label}: ${JSON.stringify(result)}`);
+    assert.match(result.reasons.join("\n"), expected, label);
+  }
+});
+
+test("exact lifecycle alternates preparation and restores the selected source bytes", async () => {
+  assert.deepEqual(benchmarkHarness.exactCandidatePreparationArmOrder(0), [
+    "published_0_17_4", "candidate_0_18",
+  ]);
+  assert.deepEqual(benchmarkHarness.exactCandidatePreparationArmOrder(1), [
+    "candidate_0_18", "published_0_17_4",
+  ]);
+  const firstArms = Array.from({ length: 18 }, (_, index) =>
+    benchmarkHarness.exactCandidatePreparationArmOrder(index)[0]
+  );
+  assert.equal(firstArms.filter((arm) => arm === "published_0_17_4").length, 9);
+  assert.equal(firstArms.filter((arm) => arm === "candidate_0_18").length, 9);
+
+  const root = await mkdtemp(path.join(os.tmpdir(), "codestory-exact-mutation-"));
+  const sourcePath = path.join(root, "source.ts");
+  const original = Buffer.from("export function run() {}\n", "utf8");
+  await writeFile(sourcePath, original);
+  const spy = [];
+  try {
+    const receipt = await benchmarkHarness.withExactSourceMutation(
+      sourcePath,
+      async ({ original_sha256, mutated_sha256 }) => {
+        spy.push("incremental");
+        assert.notEqual(mutated_sha256, original_sha256);
+        assert.notDeepEqual(await readFile(sourcePath), original);
+        return { status: "pass" };
+      },
+      async ({ original_sha256, restored_sha256 }) => {
+        spy.push("restore");
+        assert.equal(restored_sha256, original_sha256);
+        assert.deepEqual(await readFile(sourcePath), original);
+      },
+    );
+    assert.deepEqual(spy, ["incremental", "restore"]);
+    assert.equal(receipt.result.status, "pass");
+    assert.deepEqual(await readFile(sourcePath), original);
+  } finally {
+    await rm(root, { recursive: true, force: true });
   }
 });
 
@@ -1046,7 +1480,6 @@ test("canary preparation requires complete live accelerator and server identity"
     [{ embedding_offloaded_layer_count: 12 }, /not every embedding model layer was offloaded/],
     [{ embedding_server_identity: { peer_verified: false } }, /peer identity is not verified/],
     [{ embedding_server_identity: { load_generation: 2 } }, /load identities disagree/],
-    [{ embedding_server_identity: { executable_version: "0.16.0" } }, /expected 0\.17\.0/],
   ]) {
     const blockers = cachePreparationCanaryBlockers(
       pipelinePreparation("canary", overrides),
@@ -1054,6 +1487,14 @@ test("canary preparation requires complete live accelerator and server identity"
     );
     assert.match(blockers.join("\n"), expected);
   }
+  const versionDrift = pipelinePreparation("canary", {
+    embedding_server_identity: { executable_version: "0.17.4" },
+  });
+  versionDrift.package_identity = { package_version: "0.18.0" };
+  assert.match(
+    cachePreparationCanaryBlockers(versionDrift, { CODESTORY_EMBED_ALLOW_CPU: "0" }).join("\n"),
+    /expected 0\.18\.0/,
+  );
 });
 
 function retrievalEngineDiagnosticsPayload(overrides = {}) {
@@ -3299,6 +3740,9 @@ test("packet and cache preparation share one explicit agent retrieval namespace"
 
   const args = packetCommandArgs({ path: "C:\\repo" }, task);
   assert.equal(args.filter((arg) => arg === "--extra-probe").length, 0);
+  for (const anchor of [...task.expected_files, ...task.expected_symbol_probes]) {
+    assert.equal(args.includes(anchor), false, `expected anchor leaked into packet arguments: ${anchor}`);
+  }
   assert.deepEqual(benchmarkAgentScopeArgs(), ["--profile", "agent", "--run-id", "shared-agent"]);
   assert.deepEqual(args.slice(3, 7), benchmarkAgentScopeArgs());
 
@@ -3714,6 +4158,44 @@ test("counts direct source reads for every supported language extension family",
   const analysis = analyzeTranscript(events);
   assert.equal(analysis.command_categories.direct_file_read, paths.length);
   assert.equal(analysis.direct_source_reads_total, paths.length);
+});
+
+test("transcript analysis authorizes source reads only from user-named files or prior explicit evidence gaps", () => {
+  const project = "/tmp/exact-transcript-project";
+  const namedEvents = [
+    commandEvent("named", "item.started", "Get-Content src/named.ts"),
+    commandEvent("named", "item.completed", "Get-Content src/named.ts", "source"),
+  ];
+  const named = analyzeTranscript(namedEvents, project, {
+    arm: "candidate_0_18",
+    task: { prompt: "Inspect src/named.ts and explain the call." },
+  });
+  assert.equal(named.direct_source_reads[0].authorization.reason, "user_named_file");
+
+  const gapEvents = [
+    commandEvent("packet", "item.started", "$CODESTORY_CLI packet --project . --question flow"),
+    commandEvent("packet", "item.completed", "$CODESTORY_CLI packet --project . --question flow", "Unknown: explicit evidence gap"),
+    commandEvent("gap-read", "item.started", "Get-Content src/gap.ts"),
+    commandEvent("gap-read", "item.completed", "Get-Content src/gap.ts", "source"),
+  ];
+  const gap = analyzeTranscript(gapEvents, project, {
+    arm: "published_0_17_4",
+    task: { prompt: "Explain the flow." },
+  });
+  assert.equal(gap.direct_source_reads[0].authorization.reason, "explicit_evidence_gap");
+  assert.equal(gap.direct_source_reads[0].authorization.evidence_command_id, "packet");
+
+  const unauthorized = analyzeTranscript(namedEvents, project, {
+    arm: "candidate_0_18",
+    task: { prompt: "Explain the flow." },
+  });
+  assert.equal(unauthorized.direct_source_reads[0].authorization.status, "unauthorized");
+
+  const baseline = analyzeTranscript(gapEvents.slice(2), project, {
+    arm: "without_codestory",
+    task: { prompt: "Explain the flow." },
+  });
+  assert.equal(baseline.direct_source_reads[0].authorization.status, "baseline_local_exploration");
 });
 
 test("counts PowerShell LiteralPath source reads after a CodeStory packet", () => {

--- a/scripts/tests/codestory-agent-ab-analyzer.test.mjs
+++ b/scripts/tests/codestory-agent-ab-analyzer.test.mjs
@@ -95,6 +95,7 @@ import {
   cachePolicyForRun,
   cacheProvenanceBlockers,
 } from "../codestory-agent-ab-benchmark.mjs";
+import * as benchmarkHarness from "../codestory-agent-ab-benchmark.mjs";
 import {
   packetGateSelectionOrThrow,
   packetGateStderrPath,
@@ -106,6 +107,261 @@ const RUNTIME_SERVICE_FILE = "crates/codestory-runtime/src/services.rs";
 const RUN_INDEX_SYMBOL = "IndexService::run_indexing_blocking";
 const RUNTIME_REFRESH_CLAIM =
   "The runtime opens the workspace and store, chooses full or incremental indexing, and coordinates later refresh phases.";
+
+const EXACT_CANDIDATE_ARMS = [
+  "without_codestory",
+  "published_0_17_4",
+  "candidate_0_18",
+];
+
+function exactCandidateRows() {
+  const rows = [];
+  for (let taskIndex = 0; taskIndex < 18; taskIndex += 1) {
+    const taskId = `task-${String(taskIndex + 1).padStart(2, "0")}`;
+    for (let repeat = 1; repeat <= 3; repeat += 1) {
+      for (const arm of EXACT_CANDIDATE_ARMS) {
+        const codestory = arm !== "without_codestory";
+        const packageVersion = arm === "published_0_17_4" ? "0.17.4" : "0.18.0";
+        const packageByte = arm === "published_0_17_4" ? "a" : "b";
+        rows.push({
+          repo: `repo-${taskIndex + 1}`,
+          task_id: taskId,
+          arm,
+          repeat,
+          status: "pass",
+          quality: {
+            pass: true,
+            material_factual_errors: { found: 0, found_anchors: [] },
+            unsupported_proof_claims: { found: 0, found_claims: [] },
+          },
+          usage: { total_tokens: codestory ? 70 : 100 },
+          estimated_cost_usd: codestory ? 0.7 : 1,
+          tool_calls_observed: codestory ? 7 : 10,
+          transcript_analysis: {
+            command_count: codestory ? 7 : 10,
+            tool_categories: { command_execution: codestory ? 7 : 10 },
+            command_categories: { codestory_cli: codestory ? 1 : 0 },
+            interaction_turns: { total: codestory ? 9 : 12 },
+            direct_source_reads: codestory
+              ? [{ path: "src/named.rs", authorization: { status: "authorized", reason: "user_named_file" } }]
+              : [{ path: "src/read.rs", authorization: { status: "baseline_local_exploration", reason: "without_codestory" } }],
+          },
+          exact_candidate_timing: codestory
+            ? {
+                cold_ms: arm === "candidate_0_18" ? 100 : 100,
+                warm_ms: arm === "candidate_0_18" ? 50 : 50,
+                incremental_ms: arm === "candidate_0_18" ? 20 : 20,
+                all_in_ms: arm === "candidate_0_18" ? 80 : 80,
+              }
+            : { cold_ms: 0, warm_ms: 0, incremental_ms: 0, all_in_ms: 100 },
+          package_identity: codestory
+            ? {
+                contract: "codestory.agent-benchmark-package/v1",
+                arm,
+                package_version: packageVersion,
+                package_sha256: packageByte.repeat(64),
+                cli_sha256: (arm === "published_0_17_4" ? "c" : "d").repeat(64),
+                source_commit: (arm === "published_0_17_4" ? "e" : "f").repeat(40),
+                source_tree: (arm === "published_0_17_4" ? "1" : "2").repeat(40),
+                schema_version: arm === "published_0_17_4" ? 2 : 3,
+                protocol_revision: "2025-11-25",
+                discovery_contract_sha256: (arm === "published_0_17_4" ? "3" : "4").repeat(64),
+              }
+            : {
+                contract: "codestory.agent-benchmark-package/v1",
+                arm,
+                package_version: null,
+                package_sha256: null,
+                cli_sha256: null,
+                source_commit: null,
+                source_tree: null,
+                schema_version: null,
+                protocol_revision: null,
+                discovery_contract_sha256: null,
+              },
+        });
+      }
+    }
+  }
+  return rows;
+}
+
+test("exact-candidate mode freezes the 18x3x3 shape and rejects baseline reuse", () => {
+  assert.throws(
+    () => benchmarkHarness.parseArgs([
+      "--exact-candidate",
+      "--task-suite", "language-expansion-holdout",
+      "--published-package-receipt", "/tmp/published.json",
+      "--candidate-package-receipt", "/tmp/candidate.json",
+      "--reuse-baseline-from", "/tmp/old",
+    ]),
+    /baseline reuse is forbidden/i,
+  );
+  const opts = benchmarkHarness.parseArgs([
+    "--exact-candidate",
+    "--task-suite", "language-expansion-holdout",
+    "--published-package-receipt", "/tmp/published.json",
+    "--candidate-package-receipt", "/tmp/candidate.json",
+  ]);
+  assert.deepEqual(opts.arms, EXACT_CANDIDATE_ARMS);
+  assert.equal(opts.repeats, 3);
+  assert.throws(
+    () => benchmarkHarness.validateExactCandidateShape(opts, Array.from({ length: 17 }, (_, index) => ({ id: `t-${index}` }))),
+    /exactly 18 pinned tasks/i,
+  );
+  assert.doesNotThrow(() =>
+    benchmarkHarness.validateExactCandidateShape(
+      opts,
+      Array.from({ length: 18 }, (_, index) => ({ id: `t-${index}` })),
+    )
+  );
+});
+
+test("exact-candidate planning balances deterministic arm position across 162 fresh rows", () => {
+  const tasks = Array.from({ length: 18 }, (_, index) => ({
+    id: `task-${index + 1}`,
+    repo: `repo-${index + 1}`,
+  }));
+  const opts = { exactCandidate: true, arms: EXACT_CANDIDATE_ARMS, repeats: 3, repos: null };
+  const first = benchmarkHarness.planAgentRuns(opts, tasks);
+  const second = benchmarkHarness.planAgentRuns(opts, tasks);
+  assert.deepEqual(first, second);
+  assert.equal(first.length, 162);
+  const positions = Object.fromEntries(EXACT_CANDIDATE_ARMS.map((arm) => [arm, [0, 0, 0]]));
+  for (let index = 0; index < first.length; index += 3) {
+    const triplet = first.slice(index, index + 3);
+    assert.equal(new Set(triplet.map((run) => run.task.id)).size, 1);
+    assert.equal(new Set(triplet.map((run) => run.repeat)).size, 1);
+    assert.deepEqual(new Set(triplet.map((run) => run.arm)), new Set(EXACT_CANDIDATE_ARMS));
+    triplet.forEach((run, position) => {
+      positions[run.arm][position] += 1;
+    });
+  }
+  for (const arm of EXACT_CANDIDATE_ARMS) {
+    assert.deepEqual(positions[arm], [18, 18, 18]);
+  }
+});
+
+test("exact package receipts bind package CLI source schema protocol and discovery identity", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "codestory-three-arm-receipt-"));
+  try {
+    const archivePath = path.join(root, "package.tgz");
+    const cliPath = path.join(root, "codestory-cli");
+    await writeFile(archivePath, "package-bytes");
+    await writeFile(cliPath, "cli-bytes");
+    const sha = (value) => createHash("sha256").update(value).digest("hex");
+    const receipt = {
+      contract: "codestory.agent-benchmark-package/v1",
+      arm: "published_0_17_4",
+      package_version: "0.17.4",
+      package_path: archivePath,
+      package_sha256: sha("package-bytes"),
+      cli_path: cliPath,
+      cli_sha256: sha("cli-bytes"),
+      source_commit: "a".repeat(40),
+      source_tree: "b".repeat(40),
+      schema_version: 2,
+      protocol_revision: "2025-11-25",
+      discovery_contract_sha256: "c".repeat(64),
+    };
+    const receiptPath = path.join(root, "receipt.json");
+    await writeFile(receiptPath, JSON.stringify(receipt));
+    const loaded = await benchmarkHarness.loadExactCandidatePackageReceipt(
+      receiptPath,
+      "published_0_17_4",
+    );
+    assert.equal(loaded.package_sha256, receipt.package_sha256);
+    for (const mutate of [
+      (row) => { row.arm = "candidate_0_18"; },
+      (row) => { row.package_version = "0.17.3"; },
+      (row) => { row.package_sha256 = "0".repeat(64); },
+      (row) => { row.cli_sha256 = "0".repeat(64); },
+      (row) => { row.source_commit = null; },
+      (row) => { row.schema_version = null; },
+      (row) => { row.protocol_revision = "2024-01-01"; },
+      (row) => { row.discovery_contract_sha256 = null; },
+    ]) {
+      const hostile = structuredClone(receipt);
+      mutate(hostile);
+      await writeFile(receiptPath, JSON.stringify(hostile));
+      await assert.rejects(
+        benchmarkHarness.loadExactCandidatePackageReceipt(receiptPath, "published_0_17_4"),
+      );
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("exact-candidate acceptance closes the complete causal threshold matrix", () => {
+  const passing = exactCandidateRows();
+  const accepted = benchmarkHarness.exactCandidateAcceptance(passing);
+  assert.equal(accepted.pass, true, JSON.stringify(accepted));
+  assert.equal(accepted.expected_runs, 162);
+  assert.equal(accepted.completed_runs, 162);
+
+  const mutations = [
+    ["complete rows", (rows) => rows.pop(), /162 complete runs/i],
+    ["candidate quality vs published", (rows) => {
+      rows.find((row) => row.arm === "candidate_0_18").quality.pass = false;
+    }, /candidate quality.*published/i],
+    ["candidate quality vs baseline", (rows) => {
+      for (const row of rows.filter((entry) => entry.arm === "candidate_0_18")) row.quality.pass = false;
+    }, /candidate quality.*without_codestory/i],
+    ["candidate-only factual error", (rows) => {
+      const row = rows.find((entry) => entry.arm === "candidate_0_18");
+      row.quality.material_factual_errors = { found: 1, found_anchors: ["false fact"] };
+    }, /candidate-only material factual error/i],
+    ["unsupported proof", (rows) => {
+      rows.find((row) => row.arm === "candidate_0_18").quality.unsupported_proof_claims = { found: 1, found_claims: ["ContractProven"] };
+    }, /unsupported proof claim/i],
+    ["task repeat loss", (rows) => {
+      for (const row of rows.filter((entry) => entry.arm === "candidate_0_18" && entry.task_id === "task-01" && entry.repeat <= 2)) row.quality.pass = false;
+      rows.find((entry) => entry.arm === "without_codestory" && entry.task_id === "task-01").quality.pass = false;
+    }, /loses 2 repeats/i],
+    ["tokens vs published", (rows) => {
+      for (const row of rows.filter((entry) => entry.arm === "candidate_0_18")) row.usage.total_tokens = 74;
+    }, /tokens.*105%/i],
+    ["tokens vs baseline", (rows) => {
+      for (const row of rows.filter((entry) => entry.arm === "candidate_0_18")) row.usage.total_tokens = 81;
+      for (const row of rows.filter((entry) => entry.arm === "published_0_17_4")) row.usage.total_tokens = 80;
+    }, /tokens.*80%/i],
+    ["tools", (rows) => {
+      for (const row of rows.filter((entry) => entry.arm === "candidate_0_18")) row.tool_calls_observed = 8;
+    }, /tool calls/i],
+    ["cost", (rows) => {
+      for (const row of rows.filter((entry) => entry.arm === "candidate_0_18")) row.estimated_cost_usd = 0.81;
+    }, /cost/i],
+    ["warm", (rows) => {
+      for (const row of rows.filter((entry) => entry.arm === "candidate_0_18")) row.exact_candidate_timing.warm_ms = 53;
+    }, /warm.*105%/i],
+    ["cold", (rows) => {
+      for (const row of rows.filter((entry) => entry.arm === "candidate_0_18")) row.exact_candidate_timing.cold_ms = 106;
+    }, /cold.*5%/i],
+    ["incremental", (rows) => {
+      for (const row of rows.filter((entry) => entry.arm === "candidate_0_18")) row.exact_candidate_timing.incremental_ms = 22;
+    }, /incremental.*5%/i],
+    ["all-in", (rows) => {
+      for (const row of rows.filter((entry) => entry.arm === "candidate_0_18")) row.exact_candidate_timing.all_in_ms = 89;
+    }, /all-in.*110%/i],
+    ["source authorization", (rows) => {
+      rows.find((row) => row.arm === "candidate_0_18").transcript_analysis.direct_source_reads[0].authorization = { status: "unauthorized", reason: null };
+    }, /unauthorized direct source read/i],
+    ["identity", (rows) => {
+      rows.find((row) => row.arm === "candidate_0_18").package_identity.cli_sha256 = "0".repeat(64);
+    }, /candidate package identity mismatch/i],
+    ["accounting", (rows) => {
+      delete rows.find((row) => row.arm === "candidate_0_18").transcript_analysis.tool_categories;
+    }, /missing tool categories/i],
+  ];
+  for (const [label, mutate, expected] of mutations) {
+    const rows = exactCandidateRows();
+    mutate(rows);
+    const result = benchmarkHarness.exactCandidateAcceptance(rows);
+    assert.equal(result.pass, false, `${label}: ${JSON.stringify(result)}`);
+    assert.match(result.reasons.join("\n"), expected, label);
+  }
+});
 
 test("keeps CLI overrides out of both isolated agent arms", () => {
   const opts = {

--- a/scripts/tests/codestory-agent-ab-analyzer.test.mjs
+++ b/scripts/tests/codestory-agent-ab-analyzer.test.mjs
@@ -4,7 +4,7 @@ import { spawnSync } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { existsSync } from "node:fs";
 import assert from "node:assert/strict";
-import { chmod, mkdir, mkdtemp, readFile, rm, symlink, truncate, writeFile } from "node:fs/promises";
+import { chmod, copyFile, mkdir, mkdtemp, readFile, rm, symlink, truncate, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
@@ -242,6 +242,7 @@ function exactCandidateRows() {
             codestory_mcp_tool_calls_observed: 0,
             codestory_mcp_completed_calls_observed: 0,
             codestory_mcp_runtime_identities: [],
+            external_context_tool_calls: 0,
             direct_source_reads: codestory
               ? [{ path: "src/named.rs", authorization: { status: "authorized", reason: "user_named_file" } }]
               : [{ path: "src/read.rs", authorization: { status: "baseline_local_exploration", reason: "without_codestory" } }],
@@ -256,6 +257,21 @@ function exactCandidateRows() {
               }
             : { cold_ms: 0, warm_ms: 100, incremental_ms: 0, all_in_ms: 100 },
           wall_ms: codestory ? 50 : 100,
+          malformed_stdout_lines: 0,
+          json_events: 1,
+          analysis_events: 1,
+          event_types: { fixture: 1 },
+          packet_first_required: codestory,
+          packet_first_pass: true,
+          repo_provenance: pinnedRepoProvenance(),
+          task_manifest_snapshot: {
+            repo,
+            repo_metadata: {
+              name: repo,
+              url: "https://github.com/example/fixture.git",
+              ref: "9fdfd4650427eb050a11fd9ebd7a4e13dd4b57d7",
+            },
+          },
           package_identity: codestory
             ? {
                 contract: "codestory.agent-benchmark-package/v2",
@@ -447,7 +463,7 @@ test("exact-candidate planning balances deterministic arm position across 162 fr
   }
 });
 
-async function makeExactArchive(root, name, { version, schema, source, tree, discovery }) {
+async function makeExactArchive(root, name, { version, schema, source, tree, discovery, executionMarker = null }) {
   const packageRoot = path.join(root, `${name}-root`);
   await mkdir(packageRoot, { recursive: true });
   const cliPath = path.join(packageRoot, "codestory-cli");
@@ -455,10 +471,12 @@ async function makeExactArchive(root, name, { version, schema, source, tree, dis
     cliPath,
     `#!/usr/bin/env node
 const readline = require("node:readline");
+const fs = require("node:fs");
 const rl = readline.createInterface({ input: process.stdin });
 rl.on("line", (line) => {
   const request = JSON.parse(line);
   if (request.method !== "initialize") return;
+  ${executionMarker ? `fs.writeFileSync(${JSON.stringify(executionMarker)}, "executed");` : ""}
   const response = {
     jsonrpc: "2.0",
     id: request.id,
@@ -552,9 +570,8 @@ test("exact package authentication rejects archive CLI receipt and runtime subst
     for (const [label, receipt, overrides, expected] of hostile) {
       await assert.rejects(run(receipt, overrides), expected, label);
     }
-    const oversized = Buffer.alloc(65 * 1024, 0x20);
-    await writeFile(receiptPath, oversized);
-    const oversizedSha = createHash("sha256").update(oversized).digest("hex");
+    await writeFile(receiptPath, "");
+    await truncate(receiptPath, 64 * 1024 + 1);
     await assert.rejects(benchmarkHarness.authenticateExactCandidatePackages({
       exactCandidate: true,
       exactCandidateStateRoot: await mkdtemp(path.join(root, "state-")),
@@ -562,18 +579,18 @@ test("exact package authentication rejects archive CLI receipt and runtime subst
       publishedChecksumManifest: checksumPath,
       publishedChecksumSha256: checksumSha,
       candidatePackageReceipt: receiptPath,
-      candidateReceiptSha256: oversizedSha,
+      candidateReceiptSha256: "7".repeat(64),
     }), /bound/i);
 
-    const oversizedManifest = Buffer.alloc(1024 * 1024 + 1, 0x20);
-    await writeFile(checksumPath, oversizedManifest);
+    await writeFile(checksumPath, "");
+    await truncate(checksumPath, 1024 * 1024 + 1);
     await writeFile(receiptPath, JSON.stringify(baseReceipt));
     await assert.rejects(benchmarkHarness.authenticateExactCandidatePackages({
       exactCandidate: true,
       exactCandidateStateRoot: await mkdtemp(path.join(root, "state-")),
       publishedArchive: published.archivePath,
       publishedChecksumManifest: checksumPath,
-      publishedChecksumSha256: createHash("sha256").update(oversizedManifest).digest("hex"),
+      publishedChecksumSha256: "8".repeat(64),
       candidatePackageReceipt: receiptPath,
       candidateReceiptSha256: createHash("sha256").update(await readFile(receiptPath)).digest("hex"),
     }), /bound/i);
@@ -593,6 +610,84 @@ test("exact package authentication rejects archive CLI receipt and runtime subst
     }), /bound/i);
   } finally {
     await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("exact input ingestion makes every caller path irrelevant before parsing extraction or execution", async () => {
+  for (const kind of [
+    "published_checksum_manifest",
+    "published_0_17_4_archive",
+    "candidate_receipt",
+    "candidate_0_18_archive",
+  ]) {
+    const root = await mkdtemp(path.join(os.tmpdir(), `codestory-exact-race-${kind}-`));
+    try {
+      const marker = path.join(root, "substituted-cli-executed");
+      const published = await makeExactArchive(root, "published-original", {
+        version: "0.17.4", schema: 2, source: "a".repeat(40), tree: "b".repeat(40), discovery: "c".repeat(64),
+      });
+      const candidate = await makeExactArchive(root, "candidate-original", {
+        version: "0.18.0", schema: 3, source: "d".repeat(40), tree: "e".repeat(40), discovery: "f".repeat(64),
+      });
+      const publishedSubstitute = await makeExactArchive(root, "published-substitute", {
+        version: "0.17.4", schema: 2, source: "a".repeat(40), tree: "b".repeat(40), discovery: "c".repeat(64),
+        executionMarker: marker,
+      });
+      const candidateSubstitute = await makeExactArchive(root, "candidate-substitute", {
+        version: "0.18.0", schema: 3, source: "d".repeat(40), tree: "e".repeat(40), discovery: "f".repeat(64),
+        executionMarker: marker,
+      });
+      const publishedInput = path.join(root, "published-input.tar.gz");
+      const candidateInput = path.join(root, "candidate-input.tar.gz");
+      await copyFile(published.archivePath, publishedInput);
+      await copyFile(candidate.archivePath, candidateInput);
+      const checksumPath = path.join(root, "SHA256SUMS.txt");
+      await writeFile(checksumPath, `${published.sha256}  ${path.basename(publishedInput)}\n`);
+      const receiptPath = path.join(root, "candidate-receipt.json");
+      await writeFile(receiptPath, JSON.stringify({
+        contract: "codestory.agent-benchmark-package/v2",
+        arm: "candidate_0_18",
+        package_version: "0.18.0",
+        archive_path: candidateInput,
+        archive_sha256: candidate.sha256,
+        source_commit: "d".repeat(40),
+        source_tree: "e".repeat(40),
+        schema_version: 3,
+        protocol_revision: "2025-11-25",
+        discovery_contract_sha256: "f".repeat(64),
+      }));
+      const state = await mkdtemp(path.join(root, "state-"));
+      const result = await benchmarkHarness.authenticateExactCandidatePackages({
+        exactCandidate: true,
+        exactCandidateStateRoot: state,
+        publishedArchive: publishedInput,
+        publishedChecksumManifest: checksumPath,
+        publishedChecksumSha256: createHash("sha256").update(await readFile(checksumPath)).digest("hex"),
+        candidatePackageReceipt: receiptPath,
+        candidateReceiptSha256: createHash("sha256").update(await readFile(receiptPath)).digest("hex"),
+        exactCandidateAfterInputIngest: async (event) => {
+          if (event.kind !== kind) return;
+          if (kind === "published_checksum_manifest" || kind === "candidate_receipt") {
+            await writeFile(event.source_path, "substituted after ingest");
+          } else if (kind === "published_0_17_4_archive") {
+            await copyFile(publishedSubstitute.archivePath, event.source_path);
+          } else {
+            await copyFile(candidateSubstitute.archivePath, event.source_path);
+          }
+        },
+      });
+      assert.equal(result.packages.get("published_0_17_4").package_sha256, published.sha256, kind);
+      assert.equal(result.packages.get("candidate_0_18").package_sha256, candidate.sha256, kind);
+      assert.equal(existsSync(marker), false, `${kind} executed the substituted CLI`);
+      for (const arm of ["published_0_17_4", "candidate_0_18"]) {
+        assert.ok(
+          isPathInside(path.join(state, "authenticated-inputs"), result.packages.get(arm).package_path),
+          `${kind} did not consume its private staged archive`,
+        );
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   }
 });
 
@@ -723,6 +818,26 @@ test("exact-candidate acceptance closes the complete causal threshold matrix", (
     ["zero trust root", (rows) => {
       rows.find((row) => row.arm === "published_0_17_4").package_identity.trust_root_sha256 = "0".repeat(64);
     }, /published package identity mismatch/i],
+    ["malformed JSONL", (rows) => {
+      rows.find((row) => row.arm === "candidate_0_18").malformed_stdout_lines = 1;
+    }, /malformed or unreconciled JSONL parser telemetry/i],
+    ["external web context", (rows) => {
+      rows.find((row) => row.arm === "published_0_17_4").transcript_analysis.external_context_tool_calls = 1;
+    }, /external web\/search context is forbidden/i],
+    ["zero baseline local commands", (rows) => {
+      const row = rows.find((entry) => entry.arm === "without_codestory");
+      row.transcript_analysis.command_count = 0;
+      row.transcript_analysis.command_categories = {};
+    }, /baseline local inspection telemetry is incomplete/i],
+    ["packet-first failure", (rows) => {
+      rows.find((row) => row.arm === "candidate_0_18").packet_first_pass = false;
+    }, /packet-first contract failed/i],
+    ["dirty repo provenance", (rows) => {
+      rows[0].repo_provenance.git_dirty = true;
+    }, /owning repo provenance.*dirty/i],
+    ["moving repo provenance", (rows) => {
+      rows[0].repo_provenance.configured.ref = "main";
+    }, /owning repo provenance.*not pinned/i],
   ];
   for (const [label, mutate, expected] of mutations) {
     const rows = exactCandidateRows();
@@ -794,6 +909,72 @@ test("exact lifecycle alternates preparation and restores the selected source by
     assert.deepEqual(await readFile(sourcePath), original);
   } finally {
     await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("exact baseline child gets an allowlisted disjoint environment with no CodeStory surface", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "agent-exact-baseline-env-"));
+  const codeStoryRoot = await mkdtemp(path.join(os.tmpdir(), "codestory-exact-arm-env-"));
+  try {
+    const baselineContainer = path.join(root, "baseline-container");
+    const baselineRoot = path.join(baselineContainer, "private-state");
+    const exposedBin = path.join(root, "exposed-bin");
+    await mkdir(baselineRoot, { recursive: true });
+    await mkdir(codeStoryRoot, { recursive: true });
+    await mkdir(exposedBin, { recursive: true });
+    await writeFile(path.join(exposedBin, "codestory-cli"), "not executable");
+    const baselineEnv = benchmarkHarness.exactCandidateBaselineEnv({
+      exactCandidate: true,
+      exactCandidateBaselineStateRoot: baselineRoot,
+      exactCandidateStateRoot: codeStoryRoot,
+    }, {
+      ...process.env,
+      PATH: `${exposedBin}${path.delimiter}${process.env.PATH ?? ""}`,
+      CODESTORY_CLI: path.join(exposedBin, "codestory-cli"),
+      CODESTORY_CACHE_ROOT: path.join(codeStoryRoot, "cache"),
+      CODESTORY_PLUGIN_DATA: path.join(codeStoryRoot, "plugin"),
+    });
+    for (const directory of [
+      baselineEnv.HOME, baselineEnv.TMPDIR, baselineEnv.XDG_CACHE_HOME,
+      baselineEnv.XDG_CONFIG_HOME, baselineEnv.XDG_DATA_HOME,
+    ]) {
+      await mkdir(directory, { recursive: true });
+    }
+    const childEnv = agentRunnerEnv(baselineEnv, path.join(baselineRoot, "host"), false);
+    await mkdir(childEnv.CODEX_HOME, { recursive: true });
+    const child = await runProcess(process.execPath, ["-e", `
+      const fs = require("node:fs");
+      const path = require("node:path");
+      const entries = String(process.env.PATH || "").split(path.delimiter).filter(Boolean);
+      const executableHits = entries.filter((entry) =>
+        ["codestory", "codestory-cli", "codestory.exe", "codestory-cli.exe", "codestory.cmd"]
+          .some((name) => fs.existsSync(path.join(entry, name)))
+      );
+      const readableParent = path.dirname(path.dirname(process.env.HOME));
+      process.stdout.write(JSON.stringify({
+        env: process.env,
+        executableHits,
+        readableParent,
+        parentEntries: fs.readdirSync(readableParent),
+      }));
+    `], { env: childEnv, timeoutMs: 10_000 });
+    assert.equal(child.status, "pass", child.stderr);
+    const observed = JSON.parse(child.stdout);
+    assert.deepEqual(observed.executableHits, []);
+    assert.equal(Object.keys(observed.env).some((key) => key.startsWith("CODESTORY_")), false);
+    assert.equal(
+      Object.values(observed.env).some((value) => String(value).includes(codeStoryRoot)),
+      false,
+    );
+    assert.equal(
+      Object.values(observed.env).some((value) => /codestory/i.test(String(value))),
+      false,
+    );
+    assert.deepEqual(observed.parentEntries, ["private-state"]);
+    assert.equal(observed.env.PATH.includes(exposedBin), false);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+    await rm(codeStoryRoot, { recursive: true, force: true });
   }
 });
 
@@ -4196,6 +4377,28 @@ test("transcript analysis authorizes source reads only from user-named files or 
     task: { prompt: "Explain the flow." },
   });
   assert.equal(baseline.direct_source_reads[0].authorization.status, "baseline_local_exploration");
+});
+
+test("exact telemetry sees malformed JSONL web context and an empty local transcript through the real parser", () => {
+  const jsonl = [
+    JSON.stringify({ type: "item.started", item: { id: "web", type: "web_search", query: "upstream source" } }),
+    "{malformed-jsonl",
+  ].join("\n");
+  const { parsed, malformed } = parseJsonLines(jsonl);
+  assert.equal(parsed.length, 1);
+  assert.equal(malformed.length, 1);
+  const web = analyzeTranscript(parsed, "/tmp/exact-parser", {
+    arm: "candidate_0_18",
+    task: { prompt: "Explain the local repository." },
+  });
+  assert.equal(web.external_context_tool_calls, 1);
+  assert.equal(web.tool_categories.web_search, 1);
+  const empty = analyzeTranscript([], "/tmp/exact-parser", {
+    arm: "without_codestory",
+    task: { prompt: "Explain the local repository." },
+  });
+  assert.equal(empty.command_count, 0);
+  assert.equal(empty.direct_source_reads_total, 0);
 });
 
 test("counts PowerShell LiteralPath source reads after a CodeStory packet", () => {


### PR DESCRIPTION
## Context

The existing agent benchmark compared only no CodeStory with one harness-supplied CodeStory arm and its historical token/tool-call headline is explicitly non-publishable. This PR adds the exact three-arm measurement contract required before CodeStory 0.18 activation.

Closes #2069
Refs #2066

Base: `b90c2913658a7f2ef62225ff4f139a5d4ff8d3c3`
Head: `ab6ba515644dbfdc811f4dd918ff0b107f3bb206`

## What changed

- Added exact arms for no CodeStory, the published checksum-bound 0.17.4 package, and one frozen 0.18 candidate.
- Fixed the run plan to the existing eighteen pinned tasks, three repeats, all three arms, and balanced deterministic ordering.
- Added exact package, CLI, source, tree, schema, protocol, and discovery binding.
- Added single-open, bounded ingestion of checksum, receipt, and archive inputs into private immutable staging before any validation or execution.
- Added strict reconciliation for quality, factual errors, tokens, cost, tool and command categories, interactions, source-read authorization, timings, repository provenance, transcript integrity, packet-first behavior, cache/obligation proof, and baseline local inspection.
- Added per-arm lifecycle measurements for one-time cold preparation, whole-task warm time, a verified incremental edit/refresh/restore, and all-in time.
- Added an explicit exact-mode option allowlist that rejects reanalysis, baseline reuse, sharding, diagnostic oracle probes, and unbound hashes.
- Isolated the baseline process in a disjoint private root and allowlisted environment with no CodeStory variables, executable path, plugin, package, cache, config, or sibling-arm state.
- Labeled the historical `-91%` and `-94%` measurements as non-current.

No live benchmark, production runtime, proof adapter, activation, release, or 0.17 source behavior is included.

## Verification

- Exact-candidate focused matrix - 10 passed
- Final correction-only package/input/acceptance/baseline matrix - 4 passed
- JavaScript syntax checks - passed
- `git diff --check` - passed
- Consolidated adversarial review - accepted

The full analyzer suite currently reports 139/140. The sole failure is an unchanged pre-existing packet-canary fixture whose old caps disagree with the public limits; it reproduces identically at base `b90c2913` and is outside this PR.

## Review focus

- Package identities derive from the immutable staged bytes that are actually extracted and executed.
- Every one of the 162 required rows is exact-keyed and fail-closed on missing or unreconciled telemetry.
- One-time lifecycle costs are not copied into every repetition or into the no-CodeStory arm.
- Exact mode cannot reuse historical output or inject scoring-manifest anchors.

## Risk and follow-up

This adds a large benchmark-only validation surface. The final live 162-run comparison remains deferred until one complete activation candidate is frozen; this PR makes no product-value claim by itself.
