### PR TITLE
add dark agent routing conformance

### DIFF
--- a/scripts/codestory-agent-routing-conformance.mjs
+++ b/scripts/codestory-agent-routing-conformance.mjs
@@ -1,0 +1,913 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SHA256 = /^[0-9a-f]{64}$/u;
+const PROOF_DISPOSITIONS = new Set([
+  "contract_proven",
+  "contract_refuted",
+  "unknown",
+  "unavailable",
+]);
+const ROUTING_ACTIONS = Object.freeze([
+  "source_read",
+  "search",
+  "context",
+  "packet",
+  "prove_call_path",
+  "tool_search",
+]);
+
+export const INSTALLED_IDENTITY_FIELDS = Object.freeze([
+  "package.name",
+  "package.version",
+  "package.sha256",
+  "launcher.relative_path",
+  "launcher.sha256",
+  "cli.version",
+  "cli.sha256",
+  "cli.source",
+  "publication.schema_version",
+  "protocol.revision",
+  "protocol.discovery_contract_sha256",
+]);
+
+const IDENTITY_REQUIREMENTS = Object.freeze({
+  mode: "exact",
+  fields: INSTALLED_IDENTITY_FIELDS,
+});
+
+function deepFreeze(value) {
+  if (value && typeof value === "object" && !Object.isFrozen(value)) {
+    for (const child of Object.values(value)) deepFreeze(child);
+    Object.freeze(value);
+  }
+  return value;
+}
+
+function scenario({
+  id,
+  first,
+  followups = [],
+  source = "none",
+  required = [],
+  forbidden = [],
+  disposition = null,
+  typedContract = "none",
+}) {
+  const allowed = new Set([first, ...followups].filter((item) => item !== "none"));
+  return {
+    id,
+    expected_first_tool: first,
+    permitted_followups: followups,
+    forbidden_tools: ROUTING_ACTIONS.filter((item) => !allowed.has(item)),
+    source_read_authorization: { kind: source },
+    final_claim_constraints: {
+      required_terms: required,
+      forbidden_terms: forbidden,
+      proof_disposition: disposition,
+    },
+    typed_contract: typedContract,
+    identity_requirements: IDENTITY_REQUIREMENTS,
+  };
+}
+
+const NO_PROOF_CLAIMS = ["ContractProven", "ContractRefuted"];
+
+export const ROUTING_SCENARIOS = deepFreeze([
+  scenario({
+    id: "named_file_direct_read",
+    first: "source_read",
+    source: "user_named_file",
+    forbidden: NO_PROOF_CLAIMS,
+  }),
+  scenario({
+    id: "exact_symbol_search",
+    first: "search",
+    required: ["not a proof claim"],
+    forbidden: NO_PROOF_CLAIMS,
+  }),
+  scenario({
+    id: "ambiguous_symbol_then_context",
+    first: "search",
+    followups: ["context"],
+    required: ["selector_ambiguous", "selected target"],
+    forbidden: NO_PROOF_CLAIMS,
+  }),
+  scenario({
+    id: "selected_target_context",
+    first: "context",
+    required: ["selected target", "only"],
+    forbidden: NO_PROOF_CLAIMS,
+  }),
+  scenario({
+    id: "broad_packet",
+    first: "packet",
+    required: ["packet", "not proof"],
+    forbidden: NO_PROOF_CLAIMS,
+  }),
+  scenario({
+    id: "packet_single_continuation",
+    first: "packet",
+    followups: ["packet"],
+    required: ["one bounded continuation", "gap-1"],
+    forbidden: NO_PROOF_CLAIMS,
+  }),
+  scenario({
+    id: "packet_gap_to_focused_source",
+    first: "packet",
+    followups: ["source_read"],
+    source: "packet_evidence_gap",
+    required: ["gap-1", "source"],
+    forbidden: NO_PROOF_CLAIMS,
+  }),
+  scenario({
+    id: "packet_unavailable_to_source",
+    first: "packet",
+    followups: ["source_read"],
+    source: "packet_unavailable",
+    required: ["retrieval_unavailable", "source"],
+    forbidden: NO_PROOF_CLAIMS,
+  }),
+  scenario({
+    id: "typed_proof_contract_proven",
+    first: "prove_call_path",
+    required: ["ContractProven", "indexed source"],
+    disposition: "contract_proven",
+    typedContract: "valid",
+  }),
+  scenario({
+    id: "typed_proof_contract_refuted",
+    first: "prove_call_path",
+    required: ["ContractRefuted", "positive_contradiction"],
+    disposition: "contract_refuted",
+    typedContract: "valid",
+  }),
+  scenario({
+    id: "typed_proof_unknown",
+    first: "prove_call_path",
+    required: ["Unknown", "selector_missing", "does not establish absence"],
+    disposition: "unknown",
+    typedContract: "valid",
+  }),
+  scenario({
+    id: "typed_proof_unavailable",
+    first: "prove_call_path",
+    required: ["Unavailable", "proof_semantic_projection_unavailable"],
+    disposition: "unavailable",
+    typedContract: "valid",
+  }),
+  scenario({
+    id: "malformed_proof_contract",
+    first: "prove_call_path",
+    required: ["invalid_proof_interpretation", "no proof disposition"],
+    forbidden: NO_PROOF_CLAIMS,
+    typedContract: "malformed",
+  }),
+  scenario({
+    id: "refuse_free_english_proof",
+    first: "none",
+    required: ["cannot construct", "typed contract"],
+    forbidden: [...NO_PROOF_CLAIMS, "verified"],
+    typedContract: "forbidden",
+  }),
+  scenario({
+    id: "proof_observational",
+    first: "prove_call_path",
+    required: ["Unknown", "edge_not_proof_authoritative", "did not activate semantic retrieval"],
+    disposition: "unknown",
+    typedContract: "valid",
+  }),
+  scenario({
+    id: "hidden_proof_tool_discovery",
+    first: "tool_search",
+    followups: ["prove_call_path"],
+    required: ["only prove_call_path", "ContractProven"],
+    disposition: "contract_proven",
+    typedContract: "valid",
+  }),
+]);
+
+const SCENARIOS_BY_ID = new Map(ROUTING_SCENARIOS.map((entry) => [entry.id, entry]));
+
+export const STATIC_PARITY_HOSTS = deepFreeze({
+  claude_code: {
+    metadata: ".claude-plugin/plugin.json",
+    hook: "hooks/claude-codex-hooks.json",
+    rule: "skills/codestory-grounding/SKILL.md",
+  },
+  copilot_cli: {
+    metadata: ".github/plugin/plugin.json",
+    hook: "hooks/copilot-hooks.json",
+    rule: "skills/codestory-grounding/SKILL.md",
+  },
+  copilot_editor: {
+    metadata: ".github/plugin/plugin.json",
+    hook: "hooks/copilot-hooks.json",
+    rule: "skills/codestory-grounding/SKILL.md",
+  },
+});
+
+class ConformanceError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "ConformanceError";
+  }
+}
+
+function fail(message) {
+  throw new ConformanceError(message);
+}
+
+function plainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function parseJsonLines(text, host) {
+  if (typeof text !== "string") fail(`${host} transcript must be JSONL text`);
+  const events = [];
+  let lineNumber = 0;
+  for (const line of text.split(/\r?\n/u)) {
+    lineNumber += 1;
+    if (!line.trim()) continue;
+    try {
+      const event = JSON.parse(line);
+      if (!plainObject(event)) fail(`${host} transcript line ${lineNumber} must be an object`);
+      events.push(event);
+    } catch (error) {
+      if (error instanceof ConformanceError) throw error;
+      fail(`${host} transcript has malformed JSONL at line ${lineNumber}`);
+    }
+  }
+  if (events.length === 0) fail(`${host} transcript is empty`);
+  return events;
+}
+
+function canonical(value) {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
+  if (plainObject(value)) {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonical(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function equalJson(left, right) {
+  return canonical(left) === canonical(right);
+}
+
+function normalizeToolName(name, server = "") {
+  const raw = String(name ?? "").trim();
+  const lower = raw.toLowerCase();
+  if (lower.startsWith("mcp__codestory__")) return lower.slice("mcp__codestory__".length);
+  const cursorMcp = lower.match(/^mcp[_-]codestory[_-](.+)$/u);
+  if (cursorMcp) return cursorMcp[1];
+  if (String(server).toLowerCase() === "codestory") return lower;
+  if (lower === "tool_search" || lower.endsWith("__tool_search")) return "tool_search";
+  return null;
+}
+
+function normalizePath(path) {
+  const normalized = String(path ?? "").trim().replace(/^['"]+|['"]+$/gu, "").replaceAll("\\", "/");
+  if (!normalized || normalized.startsWith("/") || /^[a-z]:\//iu.test(normalized)) {
+    fail(`source read path must be project-relative: ${JSON.stringify(path)}`);
+  }
+  const parts = normalized.split("/");
+  if (parts.some((part) => !part || part === "." || part === ".." || part.includes("\0"))) {
+    fail(`source read path is invalid: ${JSON.stringify(path)}`);
+  }
+  return parts.join("/");
+}
+
+function sourceReadPath(command) {
+  const text = String(command ?? "").trim();
+  const patterns = [
+    /^sed\s+-n\s+['"][^'"]+['"]\s+['"]([^'"]+)['"]\s*$/u,
+    /^(?:cat|type|nl)(?:\s+-[A-Za-z]+)*\s+['"]([^'"]+)['"]\s*$/u,
+    /^Get-Content(?:\s+-(?:LiteralPath|Path))?\s+['"]([^'"]+)['"]\s*$/iu,
+  ];
+  for (const pattern of patterns) {
+    const match = text.match(pattern);
+    if (match) return normalizePath(match[1]);
+  }
+  return null;
+}
+
+function beginAction(state, id, action) {
+  if (!id || state.open.has(id) || state.completed.has(id)) fail(`duplicate or missing tool call id ${JSON.stringify(id)}`);
+  if (state.open.size > 0) {
+    fail(`tool call ${JSON.stringify(id)} started before ${JSON.stringify([...state.open.keys()][0])} completed`);
+  }
+  state.open.set(id, action);
+  state.actions.push(action);
+}
+
+function completeAction(state, id, result, error = false) {
+  const action = state.open.get(id);
+  if (!action) fail(`unmatched tool call result ${JSON.stringify(id)}`);
+  state.open.delete(id);
+  state.completed.add(id);
+  action.result = result;
+  action.error = error;
+  action.completed = true;
+}
+
+function parseCodex(events) {
+  const state = { actions: [], open: new Map(), completed: new Set(), final: "" };
+  for (const event of events) {
+    const type = String(event.type ?? "");
+    if (["thread.started", "turn.started", "turn.completed"].includes(type)) continue;
+    if (type !== "item.started" && type !== "item.completed") {
+      fail(`unsupported Codex event ${JSON.stringify(type)}`);
+    }
+    const item = event.item;
+    if (!plainObject(item)) fail("Codex item event is missing item");
+    const itemType = String(item.type ?? "");
+    if (type === "item.completed" && itemType === "agent_message") {
+      if (typeof item.text !== "string") fail("Codex agent message is missing text");
+      state.final = item.text;
+      continue;
+    }
+    if (["reasoning", "error"].includes(itemType)) continue;
+    if (type === "item.started") {
+      if (itemType === "mcp_tool_call") {
+        const tool = normalizeToolName(item.tool ?? item.name, item.server);
+        beginAction(state, String(item.id ?? ""), {
+          kind: tool ?? "external_tool",
+          tool: tool ?? String(item.tool ?? item.name ?? "unknown"),
+          args: item.arguments ?? item.args ?? {},
+          server: String(item.server ?? ""),
+        });
+      } else if (itemType === "command_execution") {
+        const path = sourceReadPath(item.command);
+        beginAction(state, String(item.id ?? ""), {
+          kind: path ? "source_read" : "shell",
+          tool: path ? "source_read" : "shell",
+          path,
+          command: String(item.command ?? ""),
+        });
+      } else {
+        beginAction(state, String(item.id ?? ""), {
+          kind: "external_tool",
+          tool: itemType || "unknown",
+          args: item.arguments ?? {},
+        });
+      }
+      continue;
+    }
+    completeAction(
+      state,
+      String(item.id ?? ""),
+      item.result ?? item.aggregated_output ?? null,
+      item.error != null || String(item.status ?? "completed").toLowerCase() === "failed" || item.exit_code > 0,
+    );
+  }
+  return finishParsedState("Codex", state);
+}
+
+function cursorBlocks(event) {
+  return Array.isArray(event?.message?.content) ? event.message.content : null;
+}
+
+function parseCursor(events) {
+  const state = { actions: [], open: new Map(), completed: new Set(), final: "" };
+  for (const event of events) {
+    if (event.type === "system" && event.subtype === "init") continue;
+    const blocks = cursorBlocks(event);
+    if (!blocks || !["assistant", "user"].includes(event.type)) {
+      fail(`unsupported Cursor event ${JSON.stringify(event.type ?? null)}`);
+    }
+    for (const block of blocks) {
+      if (!plainObject(block)) fail("Cursor content block must be an object");
+      if (event.type === "assistant" && block.type === "text") {
+        if (typeof block.text !== "string") fail("Cursor text block is missing text");
+        state.final = block.text;
+      } else if (event.type === "assistant" && block.type === "tool_use") {
+        const tool = normalizeToolName(block.name);
+        const shell = ["shell", "bash", "exec_command"].includes(String(block.name ?? "").toLowerCase());
+        const path = shell ? sourceReadPath(block.input?.command) : null;
+        beginAction(state, String(block.id ?? ""), {
+          kind: path ? "source_read" : tool ?? (shell ? "shell" : "external_tool"),
+          tool: path ? "source_read" : tool ?? String(block.name ?? "unknown"),
+          args: block.input ?? {},
+          path,
+          command: shell ? String(block.input?.command ?? "") : null,
+        });
+      } else if (event.type === "user" && block.type === "tool_result") {
+        completeAction(state, String(block.tool_use_id ?? ""), block.content ?? null, block.is_error === true);
+      } else {
+        fail(`unsupported Cursor content block ${JSON.stringify(block.type ?? null)}`);
+      }
+    }
+  }
+  return finishParsedState("Cursor", state);
+}
+
+function finishParsedState(host, state) {
+  if (state.open.size > 0) fail(`${host} transcript has unmatched tool call ${JSON.stringify([...state.open.keys()][0])}`);
+  if (!state.final) fail(`${host} transcript is missing a final agent message`);
+  return { actions: state.actions, final: state.final };
+}
+
+export function parseInstalledTranscript(host, transcript) {
+  const normalized = String(host ?? "").toLowerCase();
+  const events = parseJsonLines(transcript, normalized || "unknown");
+  if (normalized === "codex") return parseCodex(events);
+  if (normalized === "cursor") return parseCursor(events);
+  fail(`unsupported host ${JSON.stringify(host)}`);
+}
+
+function valueAt(object, dotted) {
+  return dotted.split(".").reduce((value, key) => value?.[key], object);
+}
+
+function validateIdentityShape(identity, label) {
+  if (!plainObject(identity)) fail(`${label} must be an object`);
+  for (const field of INSTALLED_IDENTITY_FIELDS) {
+    const value = valueAt(identity, field);
+    if (value === undefined || value === null || value === "") fail(`${label}.${field} is required`);
+  }
+  for (const field of ["package.sha256", "launcher.sha256", "cli.sha256", "protocol.discovery_contract_sha256"]) {
+    const value = valueAt(identity, field);
+    if (!SHA256.test(String(value)) || /^0{64}$/u.test(String(value))) fail(`${label}.${field} must be a nonzero lowercase SHA-256`);
+  }
+  if (identity.package.name !== "codestory") fail(`${label}.package.name must be codestory`);
+  if (identity.launcher.relative_path !== "scripts/codestory-mcp.cjs") {
+    fail(`${label}.launcher.relative_path must be scripts/codestory-mcp.cjs`);
+  }
+  if (identity.cli.source !== "managed") fail(`${label}.cli.source must be managed`);
+  if (!Number.isInteger(identity.publication.schema_version) || identity.publication.schema_version < 1) {
+    fail(`${label}.publication.schema_version must be a positive integer`);
+  }
+}
+
+function validateExactIdentity(installed, expected) {
+  validateIdentityShape(expected, "expected identity");
+  validateIdentityShape(installed, "installed identity");
+  for (const field of INSTALLED_IDENTITY_FIELDS) {
+    if (valueAt(installed, field) !== valueAt(expected, field)) {
+      fail(`installed identity ${field} does not match the exact expected identity`);
+    }
+  }
+}
+
+function parseJsonText(value) {
+  if (typeof value !== "string") return null;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+function decodeResultEnvelope(value, depth = 0) {
+  if (depth > 4) fail("tool result nesting exceeds the installed transcript contract");
+  if (typeof value === "string") {
+    const parsed = parseJsonText(value);
+    return parsed === null ? value : decodeResultEnvelope(parsed, depth + 1);
+  }
+  if (Array.isArray(value) && value.length === 1 && value[0]?.type === "text") {
+    return decodeResultEnvelope(value[0].text, depth + 1);
+  }
+  return value;
+}
+
+function normalizedResult(action) {
+  const raw = decodeResultEnvelope(action.result);
+  if (!plainObject(raw)) return { raw, body: parseJsonText(raw), meta: null, isError: action.error };
+  const structured = plainObject(raw.structuredContent) ? raw.structuredContent : null;
+  const textBlock = Array.isArray(raw.content)
+    ? raw.content.find((entry) => entry?.type === "text" && typeof entry.text === "string")
+    : null;
+  const textBody = parseJsonText(textBlock?.text);
+  if (structured && textBlock && (!textBody || !equalJson(structured, textBody))) {
+    fail(`${action.tool} structured and text results differ`);
+  }
+  return {
+    raw,
+    body: structured ?? textBody ?? (plainObject(raw) ? raw : null),
+    meta: plainObject(raw._meta) ? raw._meta : null,
+    isError: action.error || raw.isError === true,
+  };
+}
+
+function validateResultIdentity(action, expected) {
+  const normalized = normalizedResult(action);
+  const publication = normalized.meta?.codestory_publication;
+  const protocol = normalized.meta?.codestory_protocol;
+  const runtime = publication?.contract_runtime;
+  const mismatches = [
+    ["package.version", runtime?.plugin_version, expected.package.version],
+    ["cli.pinned_version", runtime?.plugin_cli_version, expected.cli.version],
+    ["cli.version", runtime?.cli_version, expected.cli.version],
+    ["cli.sha256", runtime?.cli_sha256, expected.cli.sha256],
+    ["cli.source", runtime?.cli_source, expected.cli.source],
+    ["publication.schema_version", publication?.schema_version, expected.publication.schema_version],
+    ["protocol.revision", protocol?.negotiated, expected.protocol.revision],
+    ["protocol.discovery_contract_sha256", protocol?.discovery_contract_sha256, expected.protocol.discovery_contract_sha256],
+  ];
+  for (const [field, observed, wanted] of mismatches) {
+    if (observed !== wanted) fail(`${action.tool} result identity ${field} does not match installed identity`);
+  }
+  if (runtime?.pinned_pair_matches !== true || runtime?.known_override_skew_channel !== false) {
+    fail(`${action.tool} result identity does not prove one pinned managed runtime`);
+  }
+  return normalized;
+}
+
+function actionName(action) {
+  return action.kind;
+}
+
+function validateActionOrder(scenarioContract, actions) {
+  if (scenarioContract.expected_first_tool === "none") {
+    if (actions.length > 0) fail(`${scenarioContract.id} expected no tool but observed ${actionName(actions[0])}`);
+    return;
+  }
+  if (actions.length === 0) fail(`${scenarioContract.id} expected first tool ${scenarioContract.expected_first_tool} but observed none`);
+  if (actionName(actions[0]) !== scenarioContract.expected_first_tool) {
+    fail(`${scenarioContract.id} expected first tool ${scenarioContract.expected_first_tool} but observed ${actionName(actions[0])}`);
+  }
+  for (const action of actions.slice(1)) {
+    if (!scenarioContract.permitted_followups.includes(actionName(action))) {
+      fail(`${scenarioContract.id} follow-up ${actionName(action)} is not permitted`);
+    }
+  }
+  for (const action of actions) {
+    if (scenarioContract.forbidden_tools.includes(actionName(action)) || !ROUTING_ACTIONS.includes(actionName(action))) {
+      fail(`${scenarioContract.id} used forbidden tool ${actionName(action)}`);
+    }
+  }
+}
+
+function validateSourceReads(scenarioContract, request, actions, results) {
+  const reads = actions.filter((action) => action.kind === "source_read");
+  const kind = scenarioContract.source_read_authorization.kind;
+  if (kind === "none") {
+    if (reads.length > 0) fail(`${scenarioContract.id} source read is not authorized`);
+    return;
+  }
+  if (reads.length === 0) fail(`${scenarioContract.id} requires one authorized source read`);
+  if (kind === "user_named_file") {
+    const named = new Set((request.named_files ?? []).map(normalizePath));
+    for (const read of reads) {
+      if (!named.has(read.path)) fail(`${scenarioContract.id} source read is not authorized by a user-named file`);
+    }
+    return;
+  }
+  const packet = actions.find((action) => action.kind === "packet");
+  const body = packet ? results.get(packet)?.body : null;
+  if (kind === "packet_evidence_gap") {
+    if (body?.status !== "no_useful_evidence") fail(`${scenarioContract.id} source read lacks a terminal packet evidence gap`);
+    const allowed = new Set(
+      (body?.gaps ?? []).flatMap((gap) => gap?.authorized_source_paths ?? []).map(normalizePath),
+    );
+    for (const read of reads) {
+      if (!allowed.has(read.path)) fail(`${scenarioContract.id} source read is not authorized by the packet evidence gap`);
+    }
+    return;
+  }
+  if (kind === "packet_unavailable") {
+    if (body?.status !== "unavailable") fail(`${scenarioContract.id} source read requires packet Unavailable`);
+    return;
+  }
+  fail(`${scenarioContract.id} has unsupported source-read authorization ${kind}`);
+}
+
+function stripProject(args) {
+  if (!plainObject(args)) return args;
+  const { project: _project, ...contract } = args;
+  return contract;
+}
+
+function validTypedContract(contract) {
+  return plainObject(contract)
+    && typeof contract.source_text === "string"
+    && contract.source_text.length > 0
+    && Array.isArray(contract.clauses)
+    && contract.clauses.length > 0
+    && plainObject(contract.spec);
+}
+
+function validateProofCalls(scenarioContract, request, actions, results) {
+  const proofCalls = actions.filter((action) => action.kind === "prove_call_path");
+  if (proofCalls.length > 1) fail(`${scenarioContract.id} proof may be called only once; selector relaxation and retries are forbidden`);
+  if (proofCalls.length === 0) {
+    if (["valid", "malformed"].includes(scenarioContract.typed_contract)) {
+      fail(`${scenarioContract.id} did not call the typed verifier`);
+    }
+    return;
+  }
+  if (!plainObject(request.proof_contract)) {
+    fail(`${scenarioContract.id} proof requires a host-supplied typed contract; free-English construction is forbidden`);
+  }
+  if (!equalJson(stripProject(proofCalls[0].args), request.proof_contract)) {
+    fail(`${scenarioContract.id} proof request must preserve the host-supplied typed contract exactly`);
+  }
+  const isValid = validTypedContract(request.proof_contract);
+  if (scenarioContract.typed_contract === "valid" && !isValid) fail(`${scenarioContract.id} requires a complete typed contract`);
+  if (scenarioContract.typed_contract === "malformed" && isValid) fail(`${scenarioContract.id} requires the malformed-contract boundary`);
+
+  const projection = results.get(proofCalls[0]);
+  const activated = projection?.meta?.codestory_execution?.semantic_retrieval_activated;
+  if (activated !== false) fail(`${scenarioContract.id} proof activated semantic retrieval or omitted observational evidence`);
+  if (scenarioContract.typed_contract === "malformed") {
+    if (!projection?.isError || projection.raw?.structuredContent !== undefined) {
+      fail(`${scenarioContract.id} malformed semantic contract must return isError without structured content`);
+    }
+    return;
+  }
+  if (projection?.isError) fail(`${scenarioContract.id} typed proof unexpectedly returned a tool error`);
+}
+
+function validatePacketContinuation(scenarioContract, actions, results) {
+  const packets = actions.filter((action) => action.kind === "packet");
+  if (packets.length > 2) fail(`${scenarioContract.id} allows at most one packet continuation`);
+  if (packets.length < 2) return;
+  const first = results.get(packets[0])?.body;
+  if (first?.status !== "continuation_available") fail(`${scenarioContract.id} repeated packet without a continuation offer`);
+  const expected = {
+    project: packets[0].args.project,
+    question: packets[0].args.question,
+    parent_packet_id: first?.continuation?.continuation_id,
+    option_ids: first?.continuation?.gap_ids,
+    core_generation_id: first?.publication?.core_generation_id,
+    retrieval_generation_id: first?.publication?.retrieval_generation_id,
+  };
+  if (!equalJson(packets[1].args, expected)) fail(`${scenarioContract.id} packet continuation arguments do not match the pinned offer`);
+}
+
+function validateSelectedContext(scenarioContract, request, actions) {
+  const contexts = actions.filter((action) => action.kind === "context");
+  if (contexts.length === 0) return;
+  if (typeof request.selected_target !== "string" || !request.selected_target) {
+    fail(`${scenarioContract.id} context requires one host-selected target`);
+  }
+  for (const action of contexts) {
+    if (action.args?.selector?.canonical_id !== request.selected_target) {
+      fail(`${scenarioContract.id} context selector does not match the selected target`);
+    }
+  }
+}
+
+function validateHiddenDiscovery(scenarioContract, actions, results) {
+  const searches = actions.filter((action) => action.kind === "tool_search");
+  if (scenarioContract.id !== "hidden_proof_tool_discovery") {
+    if (searches.length > 0) fail(`${scenarioContract.id} hidden-tool discovery is forbidden`);
+    return;
+  }
+  if (searches.length !== 1) fail(`${scenarioContract.id} requires exactly one hidden-tool discovery`);
+  const search = searches[0];
+  if (search.args?.query !== "codestory mcp prove_call_path") {
+    fail(`${scenarioContract.id} hidden-tool discovery must name only prove_call_path`);
+  }
+  const searchBody = results.get(search)?.body;
+  const tools = plainObject(searchBody) && Array.isArray(searchBody.tools) ? searchBody.tools : [];
+  if (!equalJson(tools, ["mcp__codestory__prove_call_path"])) {
+    fail(`${scenarioContract.id} hidden-tool discovery returned tools outside prove_call_path`);
+  }
+}
+
+function proofDisposition(actions, results) {
+  const proof = actions.find((action) => action.kind === "prove_call_path");
+  if (!proof) return null;
+  const kind = results.get(proof)?.body?.disposition?.kind;
+  return typeof kind === "string" ? kind : null;
+}
+
+function materialGaps(actions, results) {
+  const gaps = [];
+  for (const action of actions) {
+    if (!["search", "context", "packet", "prove_call_path"].includes(action.kind)) continue;
+    const body = results.get(action)?.body;
+    const collections = [body?.gaps, body?.disposition?.gaps];
+    for (const entries of collections) {
+      if (!Array.isArray(entries)) continue;
+      for (const gap of entries) {
+        const id = gap?.gap_id ?? gap?.code;
+        if (typeof id === "string" && id) gaps.push(id);
+      }
+    }
+  }
+  return [...new Set(gaps)];
+}
+
+function validateFinalClaims(scenarioContract, final, actions, results) {
+  const lower = final.toLowerCase();
+  for (const term of scenarioContract.final_claim_constraints.required_terms) {
+    if (!lower.includes(term.toLowerCase())) fail(`${scenarioContract.id} missing required final claim ${term}`);
+  }
+  for (const term of scenarioContract.final_claim_constraints.forbidden_terms) {
+    if (lower.includes(term.toLowerCase())) fail(`${scenarioContract.id} final claim violates forbidden term ${term}`);
+  }
+  if (/execut(?:e|ed|es|ion) at runtime|runtime reach(?:es|able)|will execute/iu.test(final)) {
+    fail(`${scenarioContract.id} final claim violates the no-runtime-claim boundary`);
+  }
+  for (const gap of materialGaps(actions, results)) {
+    if (!lower.includes(gap.toLowerCase())) fail(`${scenarioContract.id} missing required final claim for material gap ${gap}`);
+  }
+  const observed = proofDisposition(actions, results);
+  const expected = scenarioContract.final_claim_constraints.proof_disposition;
+  if (observed === null && /\b(?:verified|certified|definitively|proven|refuted)\b/iu.test(final)) {
+    fail(`${scenarioContract.id} final claim violates retrieval/proof authority separation`);
+  }
+  if (expected !== null && observed !== expected) {
+    fail(`${scenarioContract.id} expected proof disposition ${expected} but observed ${observed ?? "none"}`);
+  }
+  if (observed !== null && !PROOF_DISPOSITIONS.has(observed)) fail(`${scenarioContract.id} observed unknown proof disposition ${observed}`);
+  if (observed === "unknown" && /\b(absent|does not exist|never happens|cannot call)\b/iu.test(final)) {
+    if (!lower.includes("does not establish absence")) fail(`${scenarioContract.id} Unknown must not become absence`);
+  }
+}
+
+export function validateInstalledSession({
+  host,
+  scenarioId,
+  request,
+  installedIdentity,
+  expectedIdentity,
+  transcript,
+}) {
+  const scenarioContract = SCENARIOS_BY_ID.get(scenarioId);
+  if (!scenarioContract) fail(`unknown routing scenario ${JSON.stringify(scenarioId)}`);
+  if (!plainObject(request)) fail(`${scenarioId} request must be an object`);
+  validateExactIdentity(installedIdentity, expectedIdentity);
+  const parsed = parseInstalledTranscript(host, transcript);
+  validateActionOrder(scenarioContract, parsed.actions);
+
+  const results = new Map();
+  for (const action of parsed.actions) {
+    if (!action.completed) fail(`${scenarioId} has an incomplete ${action.tool} action`);
+    if (["search", "context", "packet", "prove_call_path"].includes(action.kind)) {
+      results.set(action, validateResultIdentity(action, expectedIdentity));
+    } else {
+      results.set(action, normalizedResult(action));
+    }
+    const expectedSemanticError = scenarioContract.typed_contract === "malformed"
+      && action.kind === "prove_call_path";
+    if (results.get(action).isError && !expectedSemanticError) {
+      fail(`${scenarioId} has an unexpected failed ${action.tool} action`);
+    }
+  }
+
+  validateSourceReads(scenarioContract, request, parsed.actions, results);
+  validateProofCalls(scenarioContract, request, parsed.actions, results);
+  validatePacketContinuation(scenarioContract, parsed.actions, results);
+  validateSelectedContext(scenarioContract, request, parsed.actions);
+  validateHiddenDiscovery(scenarioContract, parsed.actions, results);
+  validateFinalClaims(scenarioContract, parsed.final, parsed.actions, results);
+
+  return {
+    schema_version: 1,
+    status: "pass",
+    host: String(host).toLowerCase(),
+    scenario_id: scenarioId,
+    identity_binding: "exact",
+    actions: parsed.actions.map(actionName),
+    proof_disposition: proofDisposition(parsed.actions, results),
+  };
+}
+
+async function fileSha256(path) {
+  return createHash("sha256").update(await readFile(path)).digest("hex");
+}
+
+async function readJson(path, label) {
+  let value;
+  try {
+    value = JSON.parse(await readFile(path, "utf8"));
+  } catch (error) {
+    fail(`${label} is not readable canonical JSON: ${error.message}`);
+  }
+  if (!plainObject(value)) fail(`${label} must be a JSON object`);
+  return value;
+}
+
+export async function validateStaticHostParity(pluginRoot, expectedIdentity) {
+  validateIdentityShape(expectedIdentity, "expected identity");
+  const root = resolve(pluginRoot);
+  const portable = await readJson(resolve(root, "plugin.json"), "portable plugin manifest");
+  const pin = await readJson(resolve(root, "cli-version.json"), "CLI version pin");
+  const catalog = await readJson(resolve(root, "generated-mcp-catalog.json"), "generated MCP catalog");
+  const mcp = await readJson(resolve(root, "mcp.json"), "portable MCP manifest");
+  const launcherPath = resolve(root, expectedIdentity.launcher.relative_path);
+  const launcherSha256 = await fileSha256(launcherPath);
+
+  if (portable.name !== expectedIdentity.package.name || portable.version !== expectedIdentity.package.version) {
+    fail("portable package metadata does not match expected package identity");
+  }
+  if (pin.cli_version !== expectedIdentity.cli.version) fail("CLI pin does not match expected CLI identity");
+  if (launcherSha256 !== expectedIdentity.launcher.sha256) fail("launcher bytes do not match expected launcher identity");
+  if (catalog.wireContract?.publicationStampSchemaVersion !== expectedIdentity.publication.schema_version) {
+    fail("catalog schema does not match expected publication identity");
+  }
+  if (catalog.wireContract?.preferredMcpProtocolVersion !== expectedIdentity.protocol.revision) {
+    fail("catalog revision does not match expected protocol identity");
+  }
+  if (catalog.wireContract?.discoveryContracts?.[expectedIdentity.protocol.revision]
+      !== expectedIdentity.protocol.discovery_contract_sha256) {
+    fail("catalog discovery digest does not match expected discovery identity");
+  }
+  const server = mcp.mcpServers?.codestory;
+  if (server?.command !== "node"
+      || !Array.isArray(server.args)
+      || server.args.length !== 1
+      || server.args[0] !== "${PLUGIN_ROOT}/scripts/codestory-mcp.cjs") {
+    fail("portable MCP metadata does not bind the canonical launcher");
+  }
+
+  const hosts = [];
+  for (const [host, inputs] of Object.entries(STATIC_PARITY_HOSTS)) {
+    const metadataPath = resolve(root, inputs.metadata);
+    const hookPath = resolve(root, inputs.hook);
+    const rulePath = resolve(root, inputs.rule);
+    const metadata = await readJson(metadataPath, `${host} metadata`);
+    const hookText = await readFile(hookPath, "utf8");
+    const ruleText = await readFile(rulePath, "utf8");
+    if (metadata.name !== "codestory" || metadata.version !== portable.version) {
+      fail(`${host} metadata does not match the portable package`);
+    }
+    const expectedHook = host === "claude_code" ? `./${inputs.hook}` : inputs.hook;
+    if (metadata.hooks !== expectedHook) fail(`${host} metadata does not bind its declared hook`);
+    if (host.startsWith("copilot") && metadata.skills !== "skills/") {
+      fail(`${host} metadata does not bind the canonical rule/skill directory`);
+    }
+    if (!hookText.includes("codestory-activate.cjs")) fail(`${host} hook does not bind the canonical activation hook`);
+    if (!ruleText.includes("# CodeStory Grounding")) fail(`${host} rule input is not the canonical grounding skill`);
+    hosts.push({
+      host,
+      package_version: portable.version,
+      package_sha256: expectedIdentity.package.sha256,
+      launcher_sha256: launcherSha256,
+      metadata_sha256: await fileSha256(metadataPath),
+      hook_sha256: createHash("sha256").update(hookText).digest("hex"),
+      rule_sha256: createHash("sha256").update(ruleText).digest("hex"),
+      model_routing_evaluated: false,
+    });
+  }
+  return { schema_version: 1, status: "pass", hosts };
+}
+
+function parseOptions(argv) {
+  const allowed = new Set([
+    "--host",
+    "--scenario",
+    "--request",
+    "--transcript",
+    "--installed-identity",
+    "--expected-identity",
+    "--plugin-root",
+    "--static-parity",
+  ]);
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = argv[index];
+    if (!allowed.has(key)) fail(`unknown option ${key}`);
+    if (key === "--static-parity") {
+      options.staticParity = true;
+      continue;
+    }
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) fail(`${key} requires a value`);
+    options[key.slice(2).replaceAll("-", "_")] = value;
+    index += 1;
+  }
+  return options;
+}
+
+async function readInputJson(path, label) {
+  return readJson(resolve(path), label);
+}
+
+async function main(argv) {
+  const options = parseOptions(argv);
+  if (!options.expected_identity) fail("--expected-identity is required");
+  const expectedIdentity = await readInputJson(options.expected_identity, "expected identity");
+  let report;
+  if (options.staticParity) {
+    if (!options.plugin_root) fail("--plugin-root is required with --static-parity");
+    report = await validateStaticHostParity(options.plugin_root, expectedIdentity);
+  } else {
+    for (const required of ["host", "scenario", "request", "transcript", "installed_identity"]) {
+      if (!options[required]) fail(`--${required.replaceAll("_", "-")} is required`);
+    }
+    report = validateInstalledSession({
+      host: options.host,
+      scenarioId: options.scenario,
+      request: await readInputJson(options.request, "request"),
+      transcript: await readFile(resolve(options.transcript), "utf8"),
+      installedIdentity: await readInputJson(options.installed_identity, "installed identity"),
+      expectedIdentity,
+    });
+  }
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main(process.argv.slice(2)).catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/codestory-agent-routing-conformance.mjs
+++ b/scripts/codestory-agent-routing-conformance.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 
 import { createHash } from "node:crypto";
+import { lstatSync, readFileSync, realpathSync } from "node:fs";
 import { readFile } from "node:fs/promises";
-import { resolve } from "node:path";
+import { relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const SHA256 = /^[0-9a-f]{64}$/u;
@@ -22,12 +23,17 @@ const ROUTING_ACTIONS = Object.freeze([
 ]);
 
 export const INSTALLED_IDENTITY_FIELDS = Object.freeze([
+  "installation.root",
+  "receipt.relative_path",
+  "receipt.sha256",
   "package.name",
   "package.version",
+  "package.archive_relative_path",
   "package.sha256",
   "launcher.relative_path",
   "launcher.sha256",
   "cli.version",
+  "cli.relative_path",
   "cli.sha256",
   "cli.source",
   "publication.schema_version",
@@ -59,17 +65,32 @@ function scenario({
   typedContract = "none",
 }) {
   const allowed = new Set([first, ...followups].filter((item) => item !== "none"));
+  const finalConstraints = {
+    named_file_direct_read: { authority: "source", outcome: "supported" },
+    exact_symbol_search: { authority: "search_lead", outcome: "discovery_only" },
+    ambiguous_symbol_then_context: { authority: "context_evidence", outcome: "supported" },
+    selected_target_context: { authority: "context_evidence", outcome: "supported" },
+    broad_packet: { authority: "packet_evidence", outcome: "supported" },
+    packet_single_continuation: { authority: "packet_evidence", outcome: "supported" },
+    packet_gap_to_focused_source: { authority: "source", outcome: "supported" },
+    packet_unavailable_to_source: { authority: "source", outcome: "unavailable" },
+    typed_proof_contract_proven: { authority: "typed_proof", outcome: "supported", proof_disposition: "contract_proven" },
+    typed_proof_contract_refuted: { authority: "typed_proof", outcome: "refuted", proof_disposition: "contract_refuted" },
+    typed_proof_unknown: { authority: "typed_proof", outcome: "unknown", proof_disposition: "unknown" },
+    typed_proof_unavailable: { authority: "typed_proof", outcome: "unavailable", proof_disposition: "unavailable" },
+    malformed_proof_contract: { authority: "none", outcome: "invalid_contract" },
+    refuse_free_english_proof: { authority: "none", outcome: "refused" },
+    proof_observational: { authority: "typed_proof", outcome: "unknown", proof_disposition: "unknown" },
+    hidden_proof_tool_discovery: { authority: "typed_proof", outcome: "supported", proof_disposition: "contract_proven" },
+  }[id];
   return {
     id,
     expected_first_tool: first,
+    required_action_sequence: first === "none" ? [] : [first, ...followups],
     permitted_followups: followups,
     forbidden_tools: ROUTING_ACTIONS.filter((item) => !allowed.has(item)),
     source_read_authorization: { kind: source },
-    final_claim_constraints: {
-      required_terms: required,
-      forbidden_terms: forbidden,
-      proof_disposition: disposition,
-    },
+    final_claim_constraints: finalConstraints,
     typed_contract: typedContract,
     identity_requirements: IDENTITY_REQUIREMENTS,
   };
@@ -210,6 +231,19 @@ export const STATIC_PARITY_HOSTS = deepFreeze({
     rule: "skills/codestory-grounding/SKILL.md",
   },
 });
+
+const STATIC_ROSTER_PATHS = Object.freeze([
+  "plugin.json",
+  "cli-version.json",
+  "generated-mcp-catalog.json",
+  "mcp.json",
+  "scripts/codestory-mcp.cjs",
+  ".claude-plugin/plugin.json",
+  ".github/plugin/plugin.json",
+  "hooks/claude-codex-hooks.json",
+  "hooks/copilot-hooks.json",
+  "skills/codestory-grounding/SKILL.md",
+]);
 
 class ConformanceError extends Error {
   constructor(message) {
@@ -367,42 +401,132 @@ function parseCodex(events) {
   return finishParsedState("Codex", state);
 }
 
-function cursorBlocks(event) {
-  return Array.isArray(event?.message?.content) ? event.message.content : null;
+function cursorText(event, role) {
+  if (event?.message?.role !== role || !Array.isArray(event?.message?.content)) {
+    fail(`Cursor ${role} event has invalid message content`);
+  }
+  let text = "";
+  for (const block of event.message.content) {
+    if (!plainObject(block) || block.type !== "text" || typeof block.text !== "string") {
+      fail(`Cursor ${role} event contains a non-text block`);
+    }
+    text += block.text;
+  }
+  return text;
+}
+
+function unwrapCursorToolCall(event) {
+  if (!plainObject(event.tool_call)) fail("Cursor tool_call event is missing tool_call");
+  const keys = Object.keys(event.tool_call);
+  if (keys.length !== 1 || !/^[A-Za-z][A-Za-z0-9]*ToolCall$/u.test(keys[0])) {
+    fail("Cursor tool_call must contain exactly one *ToolCall payload");
+  }
+  const wrapper = event.tool_call[keys[0]];
+  if (!plainObject(wrapper) || !plainObject(wrapper.args)) fail("Cursor tool_call payload is missing args");
+  return { key: keys[0], wrapper };
+}
+
+function cursorStartedAction(callId, key, args) {
+  if (key === "readToolCall") {
+    return { kind: "source_read", tool: "source_read", path: normalizePath(args.path), args, cursor_key: key };
+  }
+  if (key === "mcpToolCall") {
+    if (args.toolCallId !== callId || typeof args.providerIdentifier !== "string"
+        || typeof args.toolName !== "string" || !plainObject(args.args)) {
+      fail("Cursor mcpToolCall args are incomplete or do not match call_id");
+    }
+    const tool = normalizeToolName(args.toolName, args.providerIdentifier);
+    return {
+      kind: tool ?? "external_tool",
+      tool: tool ?? args.toolName,
+      args: args.args,
+      server: args.providerIdentifier,
+      cursor_key: key,
+      cursor_args: args,
+    };
+  }
+  if (key === "toolSearchToolCall") {
+    if (typeof args.query !== "string" || !args.query) fail("Cursor toolSearchToolCall is missing query");
+    return { kind: "tool_search", tool: "tool_search", args, cursor_key: key, cursor_args: args };
+  }
+  return { kind: "external_tool", tool: key, args, cursor_key: key, cursor_args: args };
 }
 
 function parseCursor(events) {
   const state = { actions: [], open: new Map(), completed: new Set(), final: "" };
-  for (const event of events) {
-    if (event.type === "system" && event.subtype === "init") continue;
-    const blocks = cursorBlocks(event);
-    if (!blocks || !["assistant", "user"].includes(event.type)) {
-      fail(`unsupported Cursor event ${JSON.stringify(event.type ?? null)}`);
+  let initSeen = false;
+  let userSeen = false;
+  let terminalSeen = false;
+  let sessionId = null;
+  let assistantDeltas = "";
+  let userText = "";
+  events.forEach((event, index) => {
+    if (terminalSeen) fail("Cursor terminal result must be the final stream event");
+    if (typeof event.session_id !== "string" || !event.session_id) fail("Cursor event is missing session_id");
+    if (sessionId === null) sessionId = event.session_id;
+    if (event.session_id !== sessionId) fail("Cursor session_id changed within one transcript");
+
+    if (event.type === "system") {
+      if (index !== 0 || initSeen || event.subtype !== "init") fail("Cursor stream must begin with one system init event");
+      initSeen = true;
+      return;
     }
-    for (const block of blocks) {
-      if (!plainObject(block)) fail("Cursor content block must be an object");
-      if (event.type === "assistant" && block.type === "text") {
-        if (typeof block.text !== "string") fail("Cursor text block is missing text");
-        state.final = block.text;
-      } else if (event.type === "assistant" && block.type === "tool_use") {
-        const tool = normalizeToolName(block.name);
-        const shell = ["shell", "bash", "exec_command"].includes(String(block.name ?? "").toLowerCase());
-        const path = shell ? sourceReadPath(block.input?.command) : null;
-        beginAction(state, String(block.id ?? ""), {
-          kind: path ? "source_read" : tool ?? (shell ? "shell" : "external_tool"),
-          tool: path ? "source_read" : tool ?? String(block.name ?? "unknown"),
-          args: block.input ?? {},
-          path,
-          command: shell ? String(block.input?.command ?? "") : null,
-        });
-      } else if (event.type === "user" && block.type === "tool_result") {
-        completeAction(state, String(block.tool_use_id ?? ""), block.content ?? null, block.is_error === true);
-      } else {
-        fail(`unsupported Cursor content block ${JSON.stringify(block.type ?? null)}`);
+    if (!initSeen) fail("Cursor stream is missing system init");
+    if (event.type === "user") {
+      if (userSeen || state.actions.length > 0) fail("Cursor stream has duplicate or late user input");
+      userText = cursorText(event, "user");
+      if (!userText) fail("Cursor user input is empty");
+      userSeen = true;
+      return;
+    }
+    if (!userSeen) fail("Cursor stream is missing user input before agent activity");
+    if (event.type === "assistant") {
+      assistantDeltas += cursorText(event, "assistant");
+      return;
+    }
+    if (event.type === "tool_call") {
+      const callId = String(event.call_id ?? "");
+      const { key, wrapper } = unwrapCursorToolCall(event);
+      if (event.subtype === "started") {
+        if (Object.hasOwn(wrapper, "result")) fail("Cursor started tool call must not contain a result");
+        beginAction(state, callId, cursorStartedAction(callId, key, wrapper.args));
+        return;
       }
+      if (event.subtype !== "completed") fail(`unsupported Cursor tool_call subtype ${JSON.stringify(event.subtype)}`);
+      const action = state.open.get(callId);
+      if (!action) fail(`unmatched tool call result ${JSON.stringify(callId)}`);
+      if (action.cursor_key !== key || !equalJson(action.cursor_args ?? action.args, wrapper.args)) {
+        fail(`Cursor completed tool call ${JSON.stringify(callId)} does not match its start`);
+      }
+      if (!plainObject(wrapper.result) || Object.keys(wrapper.result).length !== 1
+          || !Object.hasOwn(wrapper.result, "success")) {
+        fail(`Cursor completed tool call ${JSON.stringify(callId)} must contain exactly one success result`);
+      }
+      if (event.truncated != null || wrapper.result.truncated != null) {
+        fail(`Cursor completed tool call ${JSON.stringify(callId)} is partial`);
+      }
+      const success = wrapper.result.success;
+      if (key === "readToolCall" && (!plainObject(success) || success.exceededLimit !== false)) {
+        fail(`Cursor completed tool call ${JSON.stringify(callId)} contains a partial read`);
+      }
+      completeAction(state, callId, success, false);
+      return;
     }
-  }
-  return finishParsedState("Cursor", state);
+    if (event.type === "result") {
+      terminalSeen = true;
+      if (event.subtype !== "success" || event.is_error !== false || typeof event.result !== "string") {
+        fail("Cursor terminal result must have subtype success and is_error false");
+      }
+      if (state.open.size > 0) fail(`Cursor terminal result has unmatched tool call ${JSON.stringify([...state.open.keys()][0])}`);
+      if (assistantDeltas !== event.result) fail("Cursor assistant deltas do not match terminal result");
+      state.final = event.result;
+      return;
+    }
+    fail(`unsupported Cursor event ${JSON.stringify(event.type ?? null)}`);
+  });
+  if (!terminalSeen) fail("Cursor transcript is missing a terminal result");
+  const parsed = finishParsedState("Cursor", state);
+  return { ...parsed, user_text: userText };
 }
 
 function finishParsedState(host, state) {
@@ -429,7 +553,7 @@ function validateIdentityShape(identity, label) {
     const value = valueAt(identity, field);
     if (value === undefined || value === null || value === "") fail(`${label}.${field} is required`);
   }
-  for (const field of ["package.sha256", "launcher.sha256", "cli.sha256", "protocol.discovery_contract_sha256"]) {
+  for (const field of ["receipt.sha256", "package.sha256", "launcher.sha256", "cli.sha256", "protocol.discovery_contract_sha256"]) {
     const value = valueAt(identity, field);
     if (!SHA256.test(String(value)) || /^0{64}$/u.test(String(value))) fail(`${label}.${field} must be a nonzero lowercase SHA-256`);
   }
@@ -438,6 +562,9 @@ function validateIdentityShape(identity, label) {
     fail(`${label}.launcher.relative_path must be scripts/codestory-mcp.cjs`);
   }
   if (identity.cli.source !== "managed") fail(`${label}.cli.source must be managed`);
+  for (const field of ["receipt.relative_path", "package.archive_relative_path", "launcher.relative_path", "cli.relative_path"]) {
+    normalizePath(valueAt(identity, field));
+  }
   if (!Number.isInteger(identity.publication.schema_version) || identity.publication.schema_version < 1) {
     fail(`${label}.publication.schema_version must be a positive integer`);
   }
@@ -451,6 +578,66 @@ function validateExactIdentity(installed, expected) {
       fail(`installed identity ${field} does not match the exact expected identity`);
     }
   }
+}
+
+function sha256Bytes(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function fileInsideInstalledRoot(root, relativePath, label) {
+  const normalized = normalizePath(relativePath);
+  const lexical = resolve(root, normalized);
+  let actual;
+  try {
+    if (!lstatSync(lexical).isFile()) fail(`${label} must be a regular file`);
+    actual = realpathSync(lexical);
+  } catch (error) {
+    if (error instanceof ConformanceError) throw error;
+    fail(`${label} is not readable: ${error.message}`);
+  }
+  const escaped = relative(root, actual);
+  if (!escaped || escaped === ".." || escaped.startsWith(`..${sep}`) || resolve(root, escaped) !== actual) {
+    fail(`${label} escapes the authenticated installed root`);
+  }
+  return actual;
+}
+
+function authenticateInstalledIdentity(installedRoot, installedReceipt, expected) {
+  validateIdentityShape(expected, "expected identity");
+  let root;
+  try {
+    root = realpathSync(installedRoot);
+  } catch (error) {
+    fail(`installed root is not readable: ${error.message}`);
+  }
+  if (root !== expected.installation.root) fail("installed identity installation.root does not match the authenticated root");
+  const receiptPath = fileInsideInstalledRoot(root, expected.receipt.relative_path, "installed receipt");
+  if (realpathSync(installedReceipt) !== receiptPath) fail("installed receipt path does not match the expected installed receipt");
+  const receiptBytes = readFileSync(receiptPath);
+  if (sha256Bytes(receiptBytes) !== expected.receipt.sha256) fail("installed identity receipt.sha256 does not match receipt bytes");
+  let receipt;
+  try {
+    receipt = JSON.parse(receiptBytes.toString("utf8"));
+  } catch {
+    fail("installed receipt is invalid JSON");
+  }
+  if (!plainObject(receipt) || receipt.schema_version !== 1 || !plainObject(receipt.identity)) {
+    fail("installed receipt must use schema_version 1 and contain identity");
+  }
+  const installed = { ...receipt.identity, receipt: expected.receipt };
+  validateExactIdentity(installed, expected);
+  const artifacts = [
+    ["package", installed.package.archive_relative_path, installed.package.sha256],
+    ["launcher", installed.launcher.relative_path, installed.launcher.sha256],
+    ["cli", installed.cli.relative_path, installed.cli.sha256],
+  ];
+  for (const [label, path, digest] of artifacts) {
+    const bytes = readFileSync(fileInsideInstalledRoot(root, path, `installed ${label}`));
+    if (sha256Bytes(bytes) !== digest || digest !== valueAt(expected, `${label}.sha256`)) {
+      fail(`installed identity ${label}.sha256 does not match authenticated ${label} bytes`);
+    }
+  }
+  return installed;
 }
 
 function parseJsonText(value) {
@@ -522,6 +709,10 @@ function actionName(action) {
 }
 
 function validateActionOrder(scenarioContract, actions) {
+  const observedSequence = actions.map(actionName);
+  if (!equalJson(observedSequence, scenarioContract.required_action_sequence)) {
+    fail(`${scenarioContract.id} required action sequence ${JSON.stringify(scenarioContract.required_action_sequence)} but observed ${JSON.stringify(observedSequence)}`);
+  }
   if (scenarioContract.expected_first_tool === "none") {
     if (actions.length > 0) fail(`${scenarioContract.id} expected no tool but observed ${actionName(actions[0])}`);
     return;
@@ -582,13 +773,491 @@ function stripProject(args) {
   return contract;
 }
 
+function requireExactKeys(value, keys, label) {
+  if (!plainObject(value) || !equalJson(Object.keys(value).sort(), [...keys].sort())) {
+    fail(`${label} does not match its required schema`);
+  }
+}
+
+function nonemptyString(value) {
+  return typeof value === "string" && value.length > 0;
+}
+
+function validateSelector(selector, label) {
+  if (!plainObject(selector) || !nonemptyString(selector.kind)) fail(`${label} is invalid`);
+  if (selector.kind === "canonical_id") {
+    requireExactKeys(selector, ["kind", "canonical_id"], label);
+    if (!nonemptyString(selector.canonical_id)) fail(`${label}.canonical_id is required`);
+    return;
+  }
+  if (selector.kind === "qualified_name") {
+    requireExactKeys(selector, ["kind", "qualified_name", "project_file_components"], label);
+    if (!nonemptyString(selector.qualified_name)
+        || !(selector.project_file_components === null || (Array.isArray(selector.project_file_components)
+          && selector.project_file_components.length > 0))) fail(`${label} is invalid`);
+    return;
+  }
+  if (selector.kind === "pinned_node") {
+    requireExactKeys(selector, ["kind", "project_id", "core_generation_id", "core_run_id", "node_id"], label);
+    if (![selector.project_id, selector.core_generation_id, selector.core_run_id, selector.node_id].every(nonemptyString)) {
+      fail(`${label} is invalid`);
+    }
+    return;
+  }
+  fail(`${label} uses an unsupported selector kind`);
+}
+
+function validateScopeSelectorList(selectors, label) {
+  selectors.forEach((selector, index) => validateSelector(selector, `${label} ${index}`));
+}
+
+function proofContractFieldKey(field, stepCount, prohibitionCount, exclusionCount, label) {
+  if (!plainObject(field) || !nonemptyString(field.kind)) fail(`${label} is invalid`);
+  if (field.kind === "start") {
+    requireExactKeys(field, ["kind"], label);
+    return "start";
+  }
+  if (["step_target", "directness", "ordering", "relation"].includes(field.kind)) {
+    requireExactKeys(field, ["kind", "step"], label);
+    if (!Number.isInteger(field.step) || field.step < 0 || field.step >= stepCount) fail(`${label}.step is invalid`);
+    return `${field.kind}:${field.step}`;
+  }
+  if (["traversal_prohibition", "projection_exclusion"].includes(field.kind)) {
+    requireExactKeys(field, ["kind", "index"], label);
+    const limit = field.kind === "traversal_prohibition" ? prohibitionCount : exclusionCount;
+    if (!Number.isInteger(field.index) || field.index < 0 || field.index >= limit) fail(`${label}.index is invalid`);
+    return `${field.kind}:${field.index}`;
+  }
+  fail(`${label} uses an unsupported proof contract field`);
+}
+
 function validTypedContract(contract) {
-  return plainObject(contract)
-    && typeof contract.source_text === "string"
-    && contract.source_text.length > 0
-    && Array.isArray(contract.clauses)
-    && contract.clauses.length > 0
-    && plainObject(contract.spec);
+  try {
+    requireExactKeys(contract, ["source_text", "clauses", "spec"], "typed proof contract");
+    if (!nonemptyString(contract.source_text) || !Array.isArray(contract.clauses) || contract.clauses.length === 0) {
+      fail("typed proof contract source_text and clauses are required");
+    }
+    requireExactKeys(contract.spec, ["start", "steps", "prohibit_traversal_through", "exclude_from_projection"], "typed proof spec");
+    validateSelector(contract.spec.start, "typed proof start selector");
+    if (!Array.isArray(contract.spec.steps) || contract.spec.steps.length < 1 || contract.spec.steps.length > 6
+        || !Array.isArray(contract.spec.prohibit_traversal_through)
+        || !Array.isArray(contract.spec.exclude_from_projection)) fail("typed proof spec arrays are invalid");
+    contract.spec.steps.forEach((step, index) => {
+      requireExactKeys(step, ["relation", "target"], `typed proof step ${index}`);
+      if (step.relation !== "direct_outgoing_call") fail(`typed proof step ${index} relation is invalid`);
+      validateSelector(step.target, `typed proof step ${index} target`);
+    });
+    validateScopeSelectorList(contract.spec.prohibit_traversal_through, "typed proof traversal prohibition");
+    validateScopeSelectorList(contract.spec.exclude_from_projection, "typed proof projection exclusion");
+
+    const sourceBytes = Buffer.from(contract.source_text);
+    const covered = new Uint8Array(sourceBytes.length);
+    const resolvedFields = new Set();
+    for (const [index, clause] of contract.clauses.entries()) {
+      requireExactKeys(
+        clause,
+        ["start", "end", "clause_id", "quote", "classification", "fields", "reason", "non_material_kind"],
+        `typed proof contract clause ${index}`,
+      );
+      if (!Number.isInteger(clause.start) || !Number.isInteger(clause.end) || clause.start < 0
+          || clause.end <= clause.start || !nonemptyString(clause.clause_id) || typeof clause.quote !== "string"
+          || !["resolved_material", "unresolved_material", "non_material"].includes(clause.classification)
+          || !Array.isArray(clause.fields) || clause.end > sourceBytes.length) fail(`typed proof contract clause ${index} is invalid`);
+      if (sourceBytes.subarray(clause.start, clause.end).toString("utf8") !== clause.quote) {
+        fail(`typed proof contract clause ${index} quote does not match source bytes`);
+      }
+      covered.fill(1, clause.start, clause.end);
+      const fields = clause.fields.map((field, fieldIndex) => proofContractFieldKey(
+        field,
+        contract.spec.steps.length,
+        contract.spec.prohibit_traversal_through.length,
+        contract.spec.exclude_from_projection.length,
+        `typed proof contract clause ${index} field ${fieldIndex}`,
+      ));
+      if (new Set(fields).size !== fields.length) fail(`typed proof contract clause ${index} repeats a field`);
+      if (clause.classification === "resolved_material") {
+        if (fields.length === 0 || clause.reason !== null || clause.non_material_kind !== null) {
+          fail(`typed proof contract clause ${index} resolved classification is invalid`);
+        }
+        fields.forEach((field) => resolvedFields.add(field));
+      } else if (clause.classification === "unresolved_material") {
+        if (fields.length !== 0 || !["missing_selector_resolution", "ambiguous_selector_resolution", "unsupported_interpretation"].includes(clause.reason)
+            || clause.non_material_kind !== null) fail(`typed proof contract clause ${index} unresolved classification is invalid`);
+      } else if (fields.length !== 0 || clause.reason !== null
+          || !["whitespace", "punctuation", "connector", "commentary"].includes(clause.non_material_kind)) {
+        fail(`typed proof contract clause ${index} non-material classification is invalid`);
+      }
+    }
+    let byteOffset = 0;
+    for (const character of contract.source_text) {
+      const width = Buffer.byteLength(character);
+      if (!/^\s$/u.test(character)) {
+        for (let index = byteOffset; index < byteOffset + width; index += 1) {
+          if (covered[index] !== 1) fail("typed proof contract leaves source text unclassified");
+        }
+      }
+      byteOffset += width;
+    }
+    const requiredFields = ["start"];
+    contract.spec.steps.forEach((_, index) => requiredFields.push(
+      `step_target:${index}`, `directness:${index}`, `ordering:${index}`, `relation:${index}`,
+    ));
+    contract.spec.prohibit_traversal_through.forEach((_, index) => requiredFields.push(`traversal_prohibition:${index}`));
+    contract.spec.exclude_from_projection.forEach((_, index) => requiredFields.push(`projection_exclusion:${index}`));
+    if (requiredFields.some((field) => !resolvedFields.has(field))) fail("typed proof contract is missing required resolved fields");
+    return true;
+  } catch (error) {
+    if (error instanceof ConformanceError) return false;
+    throw error;
+  }
+}
+
+function validatePublication(value, label) {
+  requireExactKeys(value, ["core_generation_id", "retrieval_generation_id"], label);
+  if (!nonemptyString(value.core_generation_id) || !nonemptyString(value.retrieval_generation_id)) fail(`${label} is invalid`);
+}
+
+function validateSearchResult(body) {
+  requireExactKeys(body, ["kind", "publication", "leads", "gaps"], "search result");
+  if (body.kind !== "complete" || !Array.isArray(body.leads) || body.leads.length === 0 || !Array.isArray(body.gaps)) {
+    fail("search result is incomplete");
+  }
+  validatePublication(body.publication, "search result publication");
+  body.leads.forEach((lead, index) => {
+    requireExactKeys(lead, ["lead_id", "canonical_id"], `search result lead ${index}`);
+    if (!nonemptyString(lead.lead_id) || !nonemptyString(lead.canonical_id)) fail(`search result lead ${index} is invalid`);
+  });
+  body.gaps.forEach((gap, index) => {
+    requireExactKeys(gap, ["code"], `search result gap ${index}`);
+    if (!nonemptyString(gap.code)) fail(`search result gap ${index} is invalid`);
+  });
+}
+
+function validateContextResult(body) {
+  requireExactKeys(body, ["kind", "publication", "target", "evidence", "gaps"], "context result");
+  if (body.kind !== "complete" || !plainObject(body.target) || !nonemptyString(body.target.canonical_id)
+      || !Array.isArray(body.evidence) || body.evidence.length === 0 || !Array.isArray(body.gaps)) {
+    fail("context result is incomplete");
+  }
+  validatePublication(body.publication, "context result publication");
+  requireExactKeys(body.target, ["canonical_id"], "context result target");
+  body.evidence.forEach((entry, index) => {
+    requireExactKeys(entry, ["evidence_id", "path"], `context result evidence ${index}`);
+    if (!nonemptyString(entry.evidence_id) || !nonemptyString(entry.path)) fail(`context result evidence ${index} is invalid`);
+  });
+  body.gaps.forEach((gap, index) => {
+    requireExactKeys(gap, ["code"], `context result gap ${index}`);
+    if (!nonemptyString(gap.code)) fail(`context result gap ${index} is invalid`);
+  });
+}
+
+function validatePacketResult(body) {
+  const keys = ["kind", "packet_id", "status", "publication", "evidence", "gaps"];
+  if (body?.status === "continuation_available") keys.push("continuation");
+  if (body?.status === "unavailable") keys.splice(1, 1, "reason");
+  requireExactKeys(body, keys, "packet result");
+  if (!["complete", "budget_exceeded"].includes(body.kind)
+      || !["complete", "continuation_available", "no_useful_evidence", "unavailable"].includes(body.status)
+      || !Array.isArray(body.evidence) || !Array.isArray(body.gaps)) fail("packet result is incomplete");
+  validatePublication(body.publication, "packet result publication");
+  if (body.status !== "unavailable" && !nonemptyString(body.packet_id)) fail("packet result packet_id is required");
+  if (body.status === "unavailable" && !nonemptyString(body.reason)) fail("packet result reason is required");
+  body.evidence.forEach((entry, index) => {
+    requireExactKeys(entry, ["evidence_id", "path"], `packet result evidence ${index}`);
+    if (!nonemptyString(entry.evidence_id) || !nonemptyString(entry.path)) fail(`packet result evidence ${index} is invalid`);
+  });
+  body.gaps.forEach((gap, index) => {
+    const gapKeys = Array.isArray(gap?.authorized_source_paths) ? ["gap_id", "authorized_source_paths"] : ["gap_id"];
+    requireExactKeys(gap, gapKeys, `packet result gap ${index}`);
+    if (!nonemptyString(gap.gap_id)
+        || (gapKeys.length === 2 && (!gap.authorized_source_paths.every(nonemptyString)
+          || gap.authorized_source_paths.length === 0))) fail(`packet result gap ${index} is invalid`);
+  });
+  if (body.status === "continuation_available") {
+    requireExactKeys(body.continuation, ["continuation_id", "gap_ids"], "packet result continuation");
+    if (!nonemptyString(body.continuation.continuation_id) || !Array.isArray(body.continuation.gap_ids)
+        || body.continuation.gap_ids.length === 0) fail("packet result continuation is invalid");
+  }
+}
+
+function proofIndex(value, length, label) {
+  if (!Number.isInteger(value) || value < 0 || value >= length) fail(`${label} is out of range`);
+  return value;
+}
+
+function validateProjectedProofSelector(selector, identities, label) {
+  if (!plainObject(selector) || !nonemptyString(selector.kind)) fail(`${label} is invalid`);
+  if (["pinned_node", "canonical_id", "qualified_name"].includes(selector.kind)) {
+    validateSelector(selector, label);
+    return;
+  }
+  if (["pinned_node_ref", "canonical_id_ref"].includes(selector.kind)) {
+    requireExactKeys(selector, ["kind", "symbol"], label);
+  } else if (selector.kind === "qualified_name_ref") {
+    requireExactKeys(selector, ["kind", "symbol", "path_binding"], label);
+    if (!["none", "exact_file"].includes(selector.path_binding)) fail(`${label}.path_binding is invalid`);
+  } else {
+    fail(`${label} uses an unsupported projected selector kind`);
+  }
+  proofIndex(selector.symbol, identities.symbols.length, `${label}.symbol`);
+}
+
+function validateProofClauseSchema(clause, index) {
+  requireExactKeys(
+    clause,
+    ["start", "end", "clause_id", "quote", "classification", "fields", "reason", "non_material_kind"],
+    `proof result clause ${index}`,
+  );
+  if (!Number.isInteger(clause.start) || clause.start < 0 || !Number.isInteger(clause.end) || clause.end <= clause.start
+      || !nonemptyString(clause.clause_id) || typeof clause.quote !== "string" || !Array.isArray(clause.fields)
+      || !["resolved_material", "unresolved_material", "non_material"].includes(clause.classification)) {
+    fail(`proof result clause ${index} is invalid`);
+  }
+  clause.fields.forEach((field, fieldIndex) => proofContractFieldKey(
+    field, 6, 256, 256, `proof result clause ${index} field ${fieldIndex}`,
+  ));
+}
+
+function validateProofGap(gap, index) {
+  const selectorKinds = ["selector_missing", "selector_ambiguous", "non_callable_selector"];
+  const stepKinds = [
+    "direct_call_missing", "recursive_call_not_representable", "source_window_too_large", "invalid_utf8",
+    "source_line_out_of_range", "edge_containment_unproven", "missing_direct_call_receipt",
+    "receipt_or_edge_already_used", "projection_exclusion_conflicts_with_required_receipt",
+  ];
+  if (selectorKinds.includes(gap?.kind)) {
+    requireExactKeys(gap, ["kind", "selector_index"], `proof result gap ${index}`);
+    if (!Number.isInteger(gap.selector_index) || gap.selector_index < 0 || gap.selector_index > 6) fail(`proof result gap ${index} is invalid`);
+    return;
+  }
+  if (stepKinds.includes(gap?.kind)) {
+    requireExactKeys(gap, ["kind", "step_index"], `proof result gap ${index}`);
+    if (!Number.isInteger(gap.step_index) || gap.step_index < 0 || gap.step_index > 5) fail(`proof result gap ${index} is invalid`);
+    return;
+  }
+  fail(`proof result gap ${index} has an unsupported kind`);
+}
+
+function validateProofReceipt(receipt, index, identities) {
+  requireExactKeys(receipt, [
+    "receipt_id", "edge_id", "source", "target", "evidence", "exact_callsite_start_byte",
+    "callsite_identity", "column_or_ordinal", "containment", "line_window",
+  ], `proof result receipt ${index}`);
+  if (!nonemptyString(receipt.receipt_id) || !nonemptyString(receipt.edge_id)
+      || !Number.isInteger(receipt.exact_callsite_start_byte) || receipt.exact_callsite_start_byte < 0
+      || !nonemptyString(receipt.callsite_identity) || !Number.isInteger(receipt.column_or_ordinal)
+      || receipt.column_or_ordinal < 0) {
+    fail(`proof result receipt ${index} is invalid`);
+  }
+  proofIndex(receipt.source, identities.symbols.length, `proof result receipt ${index} source`);
+  proofIndex(receipt.target, identities.symbols.length, `proof result receipt ${index} target`);
+  proofIndex(receipt.evidence, identities.evidence.length, `proof result receipt ${index} evidence`);
+  requireExactKeys(receipt.containment, ["file", "owner", "start_line", "end_line"], `proof result receipt ${index} containment`);
+  requireExactKeys(receipt.line_window, ["kind", "file", "anchor_line", "byte_start", "byte_end", "text"], `proof result receipt ${index} line_window`);
+  proofIndex(receipt.containment.file, identities.files.length, `proof result receipt ${index} containment.file`);
+  proofIndex(receipt.containment.owner, identities.symbols.length, `proof result receipt ${index} containment.owner`);
+  proofIndex(receipt.line_window.file, identities.files.length, `proof result receipt ${index} line_window.file`);
+  if (receipt.line_window.kind !== "indexed_line_v1" || !Number.isInteger(receipt.line_window.anchor_line)
+      || receipt.line_window.anchor_line < 1 || !Number.isInteger(receipt.line_window.byte_start)
+      || receipt.line_window.byte_start < 0 || !Number.isInteger(receipt.line_window.byte_end)
+      || receipt.line_window.byte_end < receipt.line_window.byte_start || typeof receipt.line_window.text !== "string") {
+    fail(`proof result receipt ${index} line_window is invalid`);
+  }
+  if (receipt.line_window.byte_end - receipt.line_window.byte_start !== Buffer.byteLength(receipt.line_window.text)
+      || receipt.containment.file !== receipt.line_window.file || receipt.containment.owner !== receipt.source
+      || !Number.isInteger(receipt.containment.start_line) || receipt.containment.start_line < 1
+      || !Number.isInteger(receipt.containment.end_line) || receipt.containment.end_line < receipt.containment.start_line) {
+    fail(`proof result receipt ${index} containment or source window is inconsistent`);
+  }
+  const evidence = identities.evidence[receipt.evidence];
+  if (evidence.caller !== receipt.source || evidence.target !== receipt.target || evidence.edge_id !== receipt.edge_id
+      || evidence.callsite_identity !== receipt.callsite_identity) fail(`proof result receipt ${index} does not match exact-resolution evidence`);
+}
+
+function validateProofResult(body) {
+  requireExactKeys(body, [
+    "kind", "schema_version", "domain", "contract_interpretation", "guard_version",
+    "source_text_sha256", "contract_digest", "core_publication", "identities", "spec",
+    "clauses", "disposition", "steps", "receipts",
+  ], "proof result");
+  if (body.kind !== "complete" || body.schema_version !== 1 || body.domain !== "indexed_source_call_path_v1"
+      || body.contract_interpretation !== "host_supplied" || body.guard_version !== "clause_guard_v1"
+      || !SHA256.test(body.source_text_sha256) || !SHA256.test(body.contract_digest)
+      || !plainObject(body.core_publication) || !plainObject(body.identities) || !plainObject(body.spec)
+      || !Array.isArray(body.clauses) || body.clauses.length === 0 || !Array.isArray(body.steps) || !Array.isArray(body.receipts)
+      || !plainObject(body.disposition)) fail("proof result is incomplete");
+  requireExactKeys(body.core_publication, ["project_id", "generation_id", "run_id"], "proof result core_publication");
+  if (![body.core_publication.project_id, body.core_publication.generation_id, body.core_publication.run_id].every(nonemptyString)) {
+    fail("proof result core_publication is invalid");
+  }
+  requireExactKeys(body.identities, ["files", "symbols", "provenance_profiles", "evidence"], "proof result identities");
+  if (![body.identities.files, body.identities.symbols, body.identities.provenance_profiles, body.identities.evidence].every(Array.isArray)) {
+    fail("proof result identities are invalid");
+  }
+  body.identities.files.forEach((file, index) => {
+    requireExactKeys(file, ["file_node_id", "project_file_components", "indexed_sha256", "observed_sha256"], `proof result file ${index}`);
+    if (!(file.file_node_id === null || nonemptyString(file.file_node_id))
+        || !(file.project_file_components === null || (Array.isArray(file.project_file_components)
+          && file.project_file_components.every(nonemptyString)))
+        || !(file.indexed_sha256 === null || SHA256.test(file.indexed_sha256))
+        || !(file.observed_sha256 === null || SHA256.test(file.observed_sha256))) fail(`proof result file ${index} is invalid`);
+  });
+  body.identities.symbols.forEach((symbol, index) => {
+    requireExactKeys(symbol, ["node_id", "canonical_id", "qualified_name", "file"], `proof result symbol ${index}`);
+    if (!nonemptyString(symbol.node_id) || !(symbol.canonical_id === null || nonemptyString(symbol.canonical_id))
+        || !(symbol.qualified_name === null || nonemptyString(symbol.qualified_name))) fail(`proof result symbol ${index} is invalid`);
+    if (symbol.file !== null) proofIndex(symbol.file, body.identities.files.length, `proof result symbol ${index}.file`);
+  });
+  body.identities.provenance_profiles.forEach((profile, index) => {
+    requireExactKeys(profile, ["producer", "fact_schema_version", "algorithm", "language_adapter", "language_adapter_version", "parser_fingerprint"], `proof result provenance profile ${index}`);
+    if (profile.producer !== "codestory-internal" || profile.fact_schema_version !== 1
+        || profile.algorithm !== "exact-call-resolution-v1" || !nonemptyString(profile.language_adapter)
+        || !nonemptyString(profile.language_adapter_version) || !SHA256.test(profile.parser_fingerprint)) {
+      fail(`proof result provenance profile ${index} is invalid`);
+    }
+  });
+  body.identities.evidence.forEach((evidence, index) => {
+    requireExactKeys(evidence, ["fact_id", "caller", "target", "edge_id", "callsite_identity", "chain", "provenance"], `proof result evidence ${index}`);
+    if (!SHA256.test(evidence.fact_id) || !nonemptyString(evidence.edge_id) || !nonemptyString(evidence.callsite_identity)
+        || !Array.isArray(evidence.chain) || !plainObject(evidence.provenance)) fail(`proof result evidence ${index} is invalid`);
+    proofIndex(evidence.caller, body.identities.symbols.length, `proof result evidence ${index}.caller`);
+    proofIndex(evidence.target, body.identities.symbols.length, `proof result evidence ${index}.target`);
+    evidence.chain.forEach((entry, chainIndex) => {
+      requireExactKeys(entry, ["kind", "symbols"], `proof result evidence ${index} chain ${chainIndex}`);
+      if (!nonemptyString(entry.kind) || !Array.isArray(entry.symbols)) fail(`proof result evidence ${index} chain ${chainIndex} is invalid`);
+      entry.symbols.forEach((symbol) => proofIndex(symbol, body.identities.symbols.length, `proof result evidence ${index} chain ${chainIndex} symbol`));
+    });
+    requireExactKeys(evidence.provenance, ["profile", "dependency_files", "evidence_sha256"], `proof result evidence ${index} provenance`);
+    proofIndex(evidence.provenance.profile, body.identities.provenance_profiles.length, `proof result evidence ${index} provenance.profile`);
+    if (!Array.isArray(evidence.provenance.dependency_files) || !SHA256.test(evidence.provenance.evidence_sha256)) {
+      fail(`proof result evidence ${index} provenance is invalid`);
+    }
+    evidence.provenance.dependency_files.forEach((file) => proofIndex(file, body.identities.files.length, `proof result evidence ${index} dependency file`));
+  });
+  requireExactKeys(body.spec, ["start", "steps", "prohibit_traversal_through", "exclude_from_projection"], "proof result spec");
+  validateProjectedProofSelector(body.spec.start, body.identities, "proof result start selector");
+  if (!Array.isArray(body.spec.steps) || body.spec.steps.length < 1 || body.spec.steps.length > 6
+      || !Array.isArray(body.spec.prohibit_traversal_through) || !Array.isArray(body.spec.exclude_from_projection)) {
+    fail("proof result spec is invalid");
+  }
+  body.spec.steps.forEach((step, index) => {
+    requireExactKeys(step, ["relation", "target"], `proof result spec step ${index}`);
+    if (step.relation !== "direct_outgoing_call") fail(`proof result spec step ${index} is invalid`);
+    validateProjectedProofSelector(step.target, body.identities, `proof result spec step ${index} target`);
+  });
+  validateScopeSelectorList(body.spec.prohibit_traversal_through, "proof result traversal prohibition");
+  validateScopeSelectorList(body.spec.exclude_from_projection, "proof result projection exclusion");
+  body.clauses.forEach(validateProofClauseSchema);
+  if (body.disposition.contract_digest !== body.contract_digest || !PROOF_DISPOSITIONS.has(body.disposition.kind)) {
+    fail("proof result disposition is invalid");
+  }
+  const disposition = body.disposition;
+  if (disposition.kind === "contract_proven") {
+    requireExactKeys(disposition, ["kind", "contract_digest", "receipts"], "proof result ContractProven disposition");
+    if (!Array.isArray(disposition.receipts) || disposition.receipts.length === 0 || new Set(disposition.receipts).size !== disposition.receipts.length) {
+      fail("proof result ContractProven receipts are missing");
+    }
+  } else if (disposition.kind === "contract_refuted") {
+    requireExactKeys(disposition, ["kind", "contract_digest", "refutation"], "proof result ContractRefuted disposition");
+    const refutation = disposition.refutation;
+    if (refutation?.kind === "prohibited_scope_traversal") {
+      requireExactKeys(refutation, ["kind", "step_index", "prohibition_index", "connected_receipts"], "proof result refutation basis");
+      if (!Number.isInteger(refutation.prohibition_index) || refutation.prohibition_index < 0
+          || refutation.prohibition_index >= body.spec.prohibit_traversal_through.length) fail("proof result refutation basis is invalid");
+    } else if (refutation?.kind === "certified_absence") {
+      requireExactKeys(refutation, ["kind", "step_index", "extractor_capability_receipt_id", "untruncated_enumeration_receipt_id", "connected_receipts"], "proof result refutation basis");
+      if (!nonemptyString(refutation.extractor_capability_receipt_id)
+          || !nonemptyString(refutation.untruncated_enumeration_receipt_id)) fail("proof result refutation basis is invalid");
+    } else {
+      fail("proof result refutation basis is missing");
+    }
+    if (!Number.isInteger(refutation.step_index) || refutation.step_index < 0 || refutation.step_index >= body.spec.steps.length
+        || !Array.isArray(refutation.connected_receipts)) fail("proof result refutation basis is invalid");
+  } else if (disposition.kind === "unknown") {
+    requireExactKeys(disposition, ["kind", "contract_digest", "gaps", "connected_receipts"], "proof result Unknown disposition");
+    if (!Array.isArray(disposition.gaps) || disposition.gaps.length === 0 || !Array.isArray(disposition.connected_receipts)) {
+      fail("proof result Unknown gaps are missing");
+    }
+    disposition.gaps.forEach(validateProofGap);
+  } else {
+    requireExactKeys(disposition, ["kind", "contract_digest", "reasons"], "proof result Unavailable disposition");
+    if (!Array.isArray(disposition.reasons) || disposition.reasons.length === 0 || !disposition.reasons.every(nonemptyString)) {
+      fail("proof result Unavailable reasons are missing");
+    }
+  }
+  body.receipts.forEach((receipt, index) => validateProofReceipt(receipt, index, body.identities));
+  const receiptReferences = disposition.kind === "contract_proven"
+    ? disposition.receipts
+    : disposition.kind === "contract_refuted" ? disposition.refutation.connected_receipts
+      : disposition.kind === "unknown" ? disposition.connected_receipts : [];
+  receiptReferences.forEach((receipt) => proofIndex(receipt, body.receipts.length, "proof result disposition receipt"));
+  if (body.steps.length !== body.spec.steps?.length) fail("proof result steps do not match spec");
+  body.steps.forEach((step, index) => {
+    requireExactKeys(step, ["step_index", "status", "receipt"], `proof result step ${index}`);
+    if (step.step_index !== index || !["proven", "positive_contradiction", "certified_absence", "unavailable", "unknown"].includes(step.status)
+        || !(step.receipt === null || Number.isInteger(step.receipt))) fail(`proof result step ${index} is invalid`);
+    if (step.receipt !== null) proofIndex(step.receipt, body.receipts.length, `proof result step ${index}.receipt`);
+  });
+}
+
+function validateToolResultSchema(action, projection) {
+  if (!plainObject(projection.body)) fail(`${action.tool} result is not a JSON object`);
+  if (action.kind === "search") validateSearchResult(projection.body);
+  if (action.kind === "context") validateContextResult(projection.body);
+  if (action.kind === "packet") validatePacketResult(projection.body);
+  if (action.kind === "prove_call_path" && !projection.isError) validateProofResult(projection.body);
+}
+
+function projectedSelectorValue(selector, result, label) {
+  if (["pinned_node", "canonical_id", "qualified_name"].includes(selector.kind)) return selector;
+  const symbol = result.identities.symbols[selector.symbol];
+  if (selector.kind === "canonical_id_ref") {
+    if (!nonemptyString(symbol.canonical_id)) fail(`${label} canonical identity is unavailable`);
+    return { kind: "canonical_id", canonical_id: symbol.canonical_id };
+  }
+  if (selector.kind === "pinned_node_ref") {
+    return {
+      kind: "pinned_node",
+      project_id: result.core_publication.project_id,
+      core_generation_id: result.core_publication.generation_id,
+      core_run_id: result.core_publication.run_id,
+      node_id: symbol.node_id,
+    };
+  }
+  if (!nonemptyString(symbol.qualified_name)) fail(`${label} qualified identity is unavailable`);
+  let projectFileComponents = null;
+  if (selector.path_binding === "exact_file") {
+    if (symbol.file === null) fail(`${label} exact file binding is unavailable`);
+    projectFileComponents = result.identities.files[symbol.file].project_file_components;
+    if (!Array.isArray(projectFileComponents)) fail(`${label} exact file binding is invalid`);
+  }
+  return {
+    kind: "qualified_name",
+    qualified_name: symbol.qualified_name,
+    project_file_components: projectFileComponents,
+  };
+}
+
+function validateProofResultAgainstRequest(result, contract) {
+  if (result.source_text_sha256 !== sha256Bytes(Buffer.from(contract.source_text))) {
+    fail("proof result source_text_sha256 does not match the host-supplied contract");
+  }
+  if (!equalJson(result.clauses, contract.clauses)) fail("proof result clauses do not match the host-supplied contract");
+  if (!equalJson(projectedSelectorValue(result.spec.start, result, "proof result start selector"), contract.spec.start)) {
+    fail("proof result start selector does not match the host-supplied contract");
+  }
+  if (result.spec.steps.length !== contract.spec.steps.length) fail("proof result steps do not match the host-supplied contract");
+  result.spec.steps.forEach((step, index) => {
+    const projected = {
+      relation: step.relation,
+      target: projectedSelectorValue(step.target, result, `proof result step ${index} target`),
+    };
+    if (!equalJson(projected, contract.spec.steps[index])) fail(`proof result step ${index} does not match the host-supplied contract`);
+  });
+  if (!equalJson(result.spec.prohibit_traversal_through, contract.spec.prohibit_traversal_through)
+      || !equalJson(result.spec.exclude_from_projection, contract.spec.exclude_from_projection)) {
+    fail("proof result scope selectors do not match the host-supplied contract");
+  }
 }
 
 function validateProofCalls(scenarioContract, request, actions, results) {
@@ -620,6 +1289,7 @@ function validateProofCalls(scenarioContract, request, actions, results) {
     return;
   }
   if (projection?.isError) fail(`${scenarioContract.id} typed proof unexpectedly returned a tool error`);
+  validateProofResultAgainstRequest(projection.body, request.proof_contract);
 }
 
 function validatePacketContinuation(scenarioContract, actions, results) {
@@ -639,7 +1309,7 @@ function validatePacketContinuation(scenarioContract, actions, results) {
   if (!equalJson(packets[1].args, expected)) fail(`${scenarioContract.id} packet continuation arguments do not match the pinned offer`);
 }
 
-function validateSelectedContext(scenarioContract, request, actions) {
+function validateSelectedContext(scenarioContract, request, actions, results) {
   const contexts = actions.filter((action) => action.kind === "context");
   if (contexts.length === 0) return;
   if (typeof request.selected_target !== "string" || !request.selected_target) {
@@ -648,6 +1318,9 @@ function validateSelectedContext(scenarioContract, request, actions) {
   for (const action of contexts) {
     if (action.args?.selector?.canonical_id !== request.selected_target) {
       fail(`${scenarioContract.id} context selector does not match the selected target`);
+    }
+    if (results.get(action)?.body?.target?.canonical_id !== request.selected_target) {
+      fail(`${scenarioContract.id} context result does not match the selected target`);
     }
   }
 }
@@ -677,64 +1350,138 @@ function proofDisposition(actions, results) {
   return typeof kind === "string" ? kind : null;
 }
 
-function materialGaps(actions, results) {
-  const gaps = [];
-  for (const action of actions) {
-    if (!["search", "context", "packet", "prove_call_path"].includes(action.kind)) continue;
-    const body = results.get(action)?.body;
-    const collections = [body?.gaps, body?.disposition?.gaps];
-    for (const entries of collections) {
-      if (!Array.isArray(entries)) continue;
-      for (const gap of entries) {
-        const id = gap?.gap_id ?? gap?.code;
-        if (typeof id === "string" && id) gaps.push(id);
-      }
+const FINAL_CLAIM_KEYS = Object.freeze([
+  "authority",
+  "outcome",
+  "target_id",
+  "evidence_ids",
+  "gap_ids",
+  "reason_codes",
+  "proof_disposition",
+  "refutation_basis",
+  "runtime_execution_claim",
+  "absence_claim",
+  "material_omissions",
+]);
+
+function uniqueStrings(values, label) {
+  if (!Array.isArray(values) || !values.every(nonemptyString) || new Set(values).size !== values.length) {
+    fail(`${label} must be unique nonempty strings`);
+  }
+  return values;
+}
+
+function parseFinalClaim(final, scenarioId) {
+  const claim = parseJsonText(final);
+  requireExactKeys(claim, FINAL_CLAIM_KEYS, `${scenarioId} final claim`);
+  if (!nonemptyString(claim.authority) || !nonemptyString(claim.outcome)
+      || !(claim.target_id === null || nonemptyString(claim.target_id))
+      || !(claim.proof_disposition === null || PROOF_DISPOSITIONS.has(claim.proof_disposition))
+      || !(claim.refutation_basis === null || nonemptyString(claim.refutation_basis))
+      || typeof claim.runtime_execution_claim !== "boolean" || typeof claim.absence_claim !== "boolean") {
+    fail(`${scenarioId} final claim has invalid typed fields`);
+  }
+  uniqueStrings(claim.evidence_ids, `${scenarioId} final claim evidence_ids`);
+  uniqueStrings(claim.gap_ids, `${scenarioId} final claim gap_ids`);
+  uniqueStrings(claim.reason_codes, `${scenarioId} final claim reason_codes`);
+  if (!Array.isArray(claim.material_omissions)) fail(`${scenarioId} final claim material_omissions must be an array`);
+  return claim;
+}
+
+function expectedFinalClaim(scenarioContract, actions, results) {
+  const expected = {
+    ...scenarioContract.final_claim_constraints,
+    target_id: null,
+    evidence_ids: [],
+    gap_ids: [],
+    reason_codes: [],
+    proof_disposition: scenarioContract.final_claim_constraints.proof_disposition ?? null,
+    refutation_basis: null,
+    runtime_execution_claim: false,
+    absence_claim: false,
+    material_omissions: [],
+  };
+  const contexts = actions.filter((action) => action.kind === "context");
+  const packets = actions.filter((action) => action.kind === "packet");
+  const searches = actions.filter((action) => action.kind === "search");
+  const proof = actions.find((action) => action.kind === "prove_call_path");
+  const reads = actions.filter((action) => action.kind === "source_read");
+
+  if (contexts.length > 0) {
+    const body = results.get(contexts.at(-1)).body;
+    expected.target_id = body.target.canonical_id;
+    expected.evidence_ids = body.evidence.map(({ evidence_id }) => evidence_id);
+  } else if (searches.length > 0) {
+    const body = results.get(searches.at(-1)).body;
+    if (body.leads.length === 1) expected.target_id = body.leads[0].canonical_id;
+    expected.evidence_ids = body.leads.map(({ lead_id }) => lead_id);
+  } else if (packets.length > 0) {
+    expected.evidence_ids = packets.flatMap((action) => results.get(action).body.evidence.map(({ evidence_id }) => evidence_id));
+  }
+  if (reads.length > 0) expected.evidence_ids = reads.map(({ path }) => `source:${path}`);
+  if (proof) {
+    const disposition = results.get(proof).body?.disposition;
+    if (disposition?.kind === "contract_proven") {
+      const receipts = results.get(proof).body.receipts;
+      expected.evidence_ids = disposition.receipts.map((index) => receipts[index]?.receipt_id);
+    } else {
+      expected.evidence_ids = [];
+    }
+    if (disposition?.kind === "contract_refuted") expected.refutation_basis = disposition.refutation.kind;
+  }
+
+  for (const action of [...searches, ...packets]) {
+    expected.gap_ids.push(...results.get(action).body.gaps.map((gap) => gap.gap_id ?? gap.code));
+  }
+  if (proof) {
+    const disposition = results.get(proof).body?.disposition;
+    if (Array.isArray(disposition?.gaps)) expected.gap_ids.push(...disposition.gaps.map(({ kind }) => kind));
+    if (Array.isArray(disposition?.reasons)) expected.reason_codes.push(...disposition.reasons);
+    if (results.get(proof).isError && nonemptyString(results.get(proof).body?.code)) {
+      expected.reason_codes.push(results.get(proof).body.code);
     }
   }
-  return [...new Set(gaps)];
+  for (const action of packets) {
+    const reason = results.get(action).body.reason;
+    if (nonemptyString(reason)) expected.reason_codes.push(reason);
+  }
+  if (scenarioContract.id === "refuse_free_english_proof") expected.reason_codes.push("typed_contract_required");
+  expected.evidence_ids = [...new Set(expected.evidence_ids)];
+  expected.gap_ids = [...new Set(expected.gap_ids.filter(nonemptyString))];
+  expected.reason_codes = [...new Set(expected.reason_codes)];
+  return expected;
 }
 
 function validateFinalClaims(scenarioContract, final, actions, results) {
-  const lower = final.toLowerCase();
-  for (const term of scenarioContract.final_claim_constraints.required_terms) {
-    if (!lower.includes(term.toLowerCase())) fail(`${scenarioContract.id} missing required final claim ${term}`);
+  const claim = parseFinalClaim(final, scenarioContract.id);
+  const expected = expectedFinalClaim(scenarioContract, actions, results);
+  for (const key of FINAL_CLAIM_KEYS) {
+    if (!equalJson(claim[key], expected[key])) {
+      fail(`${scenarioContract.id} final claim ${key} does not match result-bound evidence`);
+    }
   }
-  for (const term of scenarioContract.final_claim_constraints.forbidden_terms) {
-    if (lower.includes(term.toLowerCase())) fail(`${scenarioContract.id} final claim violates forbidden term ${term}`);
-  }
-  if (/execut(?:e|ed|es|ion) at runtime|runtime reach(?:es|able)|will execute/iu.test(final)) {
-    fail(`${scenarioContract.id} final claim violates the no-runtime-claim boundary`);
-  }
-  for (const gap of materialGaps(actions, results)) {
-    if (!lower.includes(gap.toLowerCase())) fail(`${scenarioContract.id} missing required final claim for material gap ${gap}`);
-  }
-  const observed = proofDisposition(actions, results);
-  const expected = scenarioContract.final_claim_constraints.proof_disposition;
-  if (observed === null && /\b(?:verified|certified|definitively|proven|refuted)\b/iu.test(final)) {
-    fail(`${scenarioContract.id} final claim violates retrieval/proof authority separation`);
-  }
-  if (expected !== null && observed !== expected) {
-    fail(`${scenarioContract.id} expected proof disposition ${expected} but observed ${observed ?? "none"}`);
-  }
-  if (observed !== null && !PROOF_DISPOSITIONS.has(observed)) fail(`${scenarioContract.id} observed unknown proof disposition ${observed}`);
-  if (observed === "unknown" && /\b(absent|does not exist|never happens|cannot call)\b/iu.test(final)) {
-    if (!lower.includes("does not establish absence")) fail(`${scenarioContract.id} Unknown must not become absence`);
-  }
+  if (claim.runtime_execution_claim) fail(`${scenarioContract.id} final claim makes a runtime execution claim`);
+  if (claim.absence_claim) fail(`${scenarioContract.id} final claim absence_claim contradicts Unknown or retrieval authority`);
+  if (claim.material_omissions.length > 0) fail(`${scenarioContract.id} final claim contains material omissions`);
 }
 
 export function validateInstalledSession({
   host,
   scenarioId,
   request,
-  installedIdentity,
+  installedRoot,
+  installedReceipt,
   expectedIdentity,
   transcript,
 }) {
   const scenarioContract = SCENARIOS_BY_ID.get(scenarioId);
   if (!scenarioContract) fail(`unknown routing scenario ${JSON.stringify(scenarioId)}`);
   if (!plainObject(request)) fail(`${scenarioId} request must be an object`);
-  validateExactIdentity(installedIdentity, expectedIdentity);
+  authenticateInstalledIdentity(installedRoot, installedReceipt, expectedIdentity);
   const parsed = parseInstalledTranscript(host, transcript);
+  if (String(host).toLowerCase() === "cursor" && parsed.user_text !== request.text) {
+    fail(`${scenarioId} Cursor user text does not match the declared request`);
+  }
   validateActionOrder(scenarioContract, parsed.actions);
 
   const results = new Map();
@@ -750,12 +1497,15 @@ export function validateInstalledSession({
     if (results.get(action).isError && !expectedSemanticError) {
       fail(`${scenarioId} has an unexpected failed ${action.tool} action`);
     }
+    if (!expectedSemanticError && ["search", "context", "packet", "prove_call_path"].includes(action.kind)) {
+      validateToolResultSchema(action, results.get(action));
+    }
   }
 
   validateSourceReads(scenarioContract, request, parsed.actions, results);
   validateProofCalls(scenarioContract, request, parsed.actions, results);
   validatePacketContinuation(scenarioContract, parsed.actions, results);
-  validateSelectedContext(scenarioContract, request, parsed.actions);
+  validateSelectedContext(scenarioContract, request, parsed.actions, results);
   validateHiddenDiscovery(scenarioContract, parsed.actions, results);
   validateFinalClaims(scenarioContract, parsed.final, parsed.actions, results);
 
@@ -788,6 +1538,12 @@ async function readJson(path, label) {
 export async function validateStaticHostParity(pluginRoot, expectedIdentity) {
   validateIdentityShape(expectedIdentity, "expected identity");
   const root = resolve(pluginRoot);
+  requireExactKeys(expectedIdentity.static_roster, STATIC_ROSTER_PATHS, "expected static digest roster");
+  for (const path of STATIC_ROSTER_PATHS) {
+    const digest = expectedIdentity.static_roster[path];
+    if (!SHA256.test(digest) || /^0{64}$/u.test(digest)) fail(`expected static digest roster ${path} is invalid`);
+    if (await fileSha256(resolve(root, path)) !== digest) fail(`static digest roster ${path} does not match package bytes`);
+  }
   const portable = await readJson(resolve(root, "plugin.json"), "portable plugin manifest");
   const pin = await readJson(resolve(root, "cli-version.json"), "CLI version pin");
   const catalog = await readJson(resolve(root, "generated-mcp-catalog.json"), "generated MCP catalog");
@@ -824,6 +1580,7 @@ export async function validateStaticHostParity(pluginRoot, expectedIdentity) {
     const hookPath = resolve(root, inputs.hook);
     const rulePath = resolve(root, inputs.rule);
     const metadata = await readJson(metadataPath, `${host} metadata`);
+    const hook = await readJson(hookPath, `${host} hook`);
     const hookText = await readFile(hookPath, "utf8");
     const ruleText = await readFile(rulePath, "utf8");
     if (metadata.name !== "codestory" || metadata.version !== portable.version) {
@@ -834,8 +1591,38 @@ export async function validateStaticHostParity(pluginRoot, expectedIdentity) {
     if (host.startsWith("copilot") && metadata.skills !== "skills/") {
       fail(`${host} metadata does not bind the canonical rule/skill directory`);
     }
-    if (!hookText.includes("codestory-activate.cjs")) fail(`${host} hook does not bind the canonical activation hook`);
-    if (!ruleText.includes("# CodeStory Grounding")) fail(`${host} rule input is not the canonical grounding skill`);
+    if (host === "claude_code") {
+      const sessionStart = hook.hooks?.SessionStart;
+      if (!Array.isArray(sessionStart) || sessionStart.length !== 1
+          || sessionStart[0].matcher !== "startup|resume|clear|compact"
+          || !Array.isArray(sessionStart[0].hooks) || sessionStart[0].hooks.length !== 1) {
+        fail("claude_code hook structure is invalid");
+      }
+      const command = sessionStart[0].hooks[0];
+      requireExactKeys(command, ["type", "command", "commandWindows", "timeout", "statusMessage"], "claude_code hook command");
+      if (command.type !== "command"
+          || command.command !== "command -v node >/dev/null 2>&1 && node \"${CLAUDE_PLUGIN_ROOT}/hooks/codestory-activate.cjs\" || exit 0"
+          || command.commandWindows !== "if (Get-Command node -ErrorAction SilentlyContinue) { node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\codestory-activate.cjs\" }"
+          || command.timeout !== 300) fail("claude_code hook command is not the canonical launcher");
+    } else {
+      if (hook.version !== 1 || !Array.isArray(hook.hooks?.sessionStart) || hook.hooks.sessionStart.length !== 1) {
+        fail(`${host} hook structure is invalid`);
+      }
+      const command = hook.hooks.sessionStart[0];
+      requireExactKeys(command, ["type", "bash", "powershell", "timeoutSec"], `${host} hook command`);
+      if (command.type !== "command"
+          || command.bash !== "node \"${PLUGIN_ROOT}/hooks/codestory-activate.cjs\""
+          || command.powershell !== "node \"${PLUGIN_ROOT}\\hooks\\codestory-activate.cjs\""
+          || command.timeoutSec !== 300) fail(`${host} hook command is not the canonical launcher`);
+    }
+    if (!/^---\nname: codestory-grounding\n/iu.test(ruleText)
+        || !ruleText.includes("## Direct Tool Loop")
+        || !ruleText.includes("## Task Router")
+        || !ruleText.includes("## Evidence Rules")
+        || !ruleText.includes("`packet`")
+        || !ruleText.includes("`context`")) {
+      fail(`${host} rule input is not the complete canonical grounding contract`);
+    }
     hosts.push({
       host,
       package_version: portable.version,
@@ -856,7 +1643,8 @@ function parseOptions(argv) {
     "--scenario",
     "--request",
     "--transcript",
-    "--installed-identity",
+    "--installed-root",
+    "--installed-receipt",
     "--expected-identity",
     "--plugin-root",
     "--static-parity",
@@ -890,7 +1678,7 @@ async function main(argv) {
     if (!options.plugin_root) fail("--plugin-root is required with --static-parity");
     report = await validateStaticHostParity(options.plugin_root, expectedIdentity);
   } else {
-    for (const required of ["host", "scenario", "request", "transcript", "installed_identity"]) {
+    for (const required of ["host", "scenario", "request", "transcript", "installed_root", "installed_receipt"]) {
       if (!options[required]) fail(`--${required.replaceAll("_", "-")} is required`);
     }
     report = validateInstalledSession({
@@ -898,7 +1686,8 @@ async function main(argv) {
       scenarioId: options.scenario,
       request: await readInputJson(options.request, "request"),
       transcript: await readFile(resolve(options.transcript), "utf8"),
-      installedIdentity: await readInputJson(options.installed_identity, "installed identity"),
+      installedRoot: resolve(options.installed_root),
+      installedReceipt: resolve(options.installed_receipt),
       expectedIdentity,
     });
   }

--- a/scripts/codestory-agent-routing-conformance.mjs
+++ b/scripts/codestory-agent-routing-conformance.mjs
@@ -7,6 +7,8 @@ import { relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const SHA256 = /^[0-9a-f]{64}$/u;
+const PROOF_CONTRACT_DIGEST_DOMAIN = Buffer.from("codestory.proof-contract.digest.v1\0", "utf8");
+const PROOF_FACT_ID_DOMAIN = Buffer.from("codestory-proof-resolution-fact-id-v1\0", "utf8");
 const PROOF_DISPOSITIONS = new Set([
   "contract_proven",
   "contract_refuted",
@@ -290,6 +292,10 @@ function canonical(value) {
 
 function equalJson(left, right) {
   return canonical(left) === canonical(right);
+}
+
+function compareUtf8(left, right) {
+  return Buffer.compare(Buffer.from(left), Buffer.from(right));
 }
 
 function normalizeToolName(name, server = "") {
@@ -582,6 +588,12 @@ function validateExactIdentity(installed, expected) {
 
 function sha256Bytes(bytes) {
   return createHash("sha256").update(bytes).digest("hex");
+}
+
+function proofFactId(evidenceSha256) {
+  const length = Buffer.alloc(8);
+  length.writeBigUInt64BE(BigInt(Buffer.byteLength(evidenceSha256)));
+  return sha256Bytes(Buffer.concat([PROOF_FACT_ID_DOMAIN, length, Buffer.from(evidenceSha256)]));
 }
 
 function fileInsideInstalledRoot(root, relativePath, label) {
@@ -912,6 +924,123 @@ function validTypedContract(contract) {
   }
 }
 
+const PROOF_FIELD_RANK = Object.freeze({
+  start: 0,
+  step_target: 1,
+  directness: 2,
+  ordering: 3,
+  relation: 4,
+  traversal_prohibition: 5,
+  projection_exclusion: 6,
+});
+const UNRESOLVED_REASON_RANK = Object.freeze({
+  missing_selector_resolution: 0,
+  ambiguous_selector_resolution: 1,
+  unsupported_interpretation: 2,
+});
+const NON_MATERIAL_RANK = Object.freeze({ whitespace: 0, punctuation: 1, connector: 2, commentary: 3 });
+
+function normalizedFieldOrder(field) {
+  return [PROOF_FIELD_RANK[field.kind], field.step ?? field.index ?? -1];
+}
+
+function normalizedClassificationOrder(row) {
+  if (row.classification === "resolved_material") return [0, 0];
+  if (row.classification === "unresolved_material") return [1, UNRESOLVED_REASON_RANK[row.reason]];
+  return [2, NON_MATERIAL_RANK[row.non_material_kind]];
+}
+
+function compareTuples(left, right) {
+  for (let index = 0; index < Math.max(left.length, right.length); index += 1) {
+    if (left[index] === right[index]) continue;
+    return left[index] < right[index] ? -1 : 1;
+  }
+  return 0;
+}
+
+function normalizedContractClauses(contract) {
+  const rows = [];
+  for (const clause of contract.clauses) {
+    if (clause.classification === "resolved_material") {
+      const fields = [...clause.fields].sort((left, right) => compareTuples(normalizedFieldOrder(left), normalizedFieldOrder(right)));
+      for (const field of fields) {
+        rows.push({
+          start: clause.start,
+          end: clause.end,
+          clause_id: clause.clause_id,
+          quote: clause.quote,
+          classification: clause.classification,
+          field,
+          reason: null,
+          non_material_kind: null,
+        });
+      }
+    } else {
+      rows.push({
+        start: clause.start,
+        end: clause.end,
+        clause_id: clause.clause_id,
+        quote: clause.quote,
+        classification: clause.classification,
+        field: null,
+        reason: clause.reason,
+        non_material_kind: clause.non_material_kind,
+      });
+    }
+  }
+  rows.sort((left, right) => left.start - right.start
+    || left.end - right.end
+    || compareUtf8(left.clause_id, right.clause_id)
+    || compareTuples(normalizedClassificationOrder(left), normalizedClassificationOrder(right))
+    || compareTuples(left.field === null ? [-1, -1] : normalizedFieldOrder(left.field), right.field === null ? [-1, -1] : normalizedFieldOrder(right.field))
+    || compareUtf8(left.quote, right.quote));
+  return rows.filter((row, index) => index === 0 || !equalJson(row, rows[index - 1]));
+}
+
+function groupedContractClauses(contract) {
+  const grouped = [];
+  for (const row of normalizedContractClauses(contract)) {
+    const prior = grouped.at(-1);
+    const sameGroup = prior !== undefined
+      && prior.start === row.start
+      && prior.end === row.end
+      && prior.clause_id === row.clause_id
+      && prior.quote === row.quote
+      && prior.classification === row.classification
+      && prior.reason === row.reason
+      && prior.non_material_kind === row.non_material_kind;
+    if (sameGroup) {
+      prior.fields.push(row.field);
+    } else {
+      grouped.push({
+        start: row.start,
+        end: row.end,
+        clause_id: row.clause_id,
+        quote: row.quote,
+        classification: row.classification,
+        fields: row.field === null ? [] : [row.field],
+        reason: row.reason,
+        non_material_kind: row.non_material_kind,
+      });
+    }
+  }
+  return grouped;
+}
+
+export function canonicalRequestContractDigest(contract) {
+  if (!validTypedContract(contract)) fail("typed proof contract is not canonicalizable");
+  const sourceTextSha256 = sha256Bytes(Buffer.from(contract.source_text));
+  const document = {
+    schema_version: 1,
+    proof_domain: "indexed_source_call_path_v1",
+    guard_version: "clause_guard_v1",
+    source_text_sha256: sourceTextSha256,
+    clauses: normalizedContractClauses(contract),
+    spec: contract.spec,
+  };
+  return sha256Bytes(Buffer.concat([PROOF_CONTRACT_DIGEST_DOMAIN, Buffer.from(canonical(document))]));
+}
+
 function validatePublication(value, label) {
   requireExactKeys(value, ["core_generation_id", "retrieval_generation_id"], label);
   if (!nonemptyString(value.core_generation_id) || !nonemptyString(value.retrieval_generation_id)) fail(`${label} is invalid`);
@@ -1018,22 +1147,33 @@ function validateProofClauseSchema(clause, index) {
   ));
 }
 
-function validateProofGap(gap, index) {
-  const selectorKinds = ["selector_missing", "selector_ambiguous", "non_callable_selector"];
-  const stepKinds = [
-    "direct_call_missing", "recursive_call_not_representable", "source_window_too_large", "invalid_utf8",
-    "source_line_out_of_range", "edge_containment_unproven", "missing_direct_call_receipt",
-    "receipt_or_edge_already_used", "projection_exclusion_conflicts_with_required_receipt",
-  ];
-  if (selectorKinds.includes(gap?.kind)) {
+const SELECTOR_PROOF_GAP_RANKS = Object.freeze({ selector_missing: 0, selector_ambiguous: 1, non_callable_selector: 2 });
+const STEP_PROOF_GAP_RANKS = Object.freeze({
+  direct_call_missing: 3,
+  recursive_call_not_representable: 4,
+  source_window_too_large: 5,
+  invalid_utf8: 6,
+  source_line_out_of_range: 7,
+  edge_containment_unproven: 8,
+  missing_direct_call_receipt: 9,
+  receipt_or_edge_already_used: 10,
+  projection_exclusion_conflicts_with_required_receipt: 11,
+});
+
+function canonicalProofGapKey(gap, index, stepCount) {
+  if (Object.hasOwn(SELECTOR_PROOF_GAP_RANKS, gap?.kind)) {
     requireExactKeys(gap, ["kind", "selector_index"], `proof result gap ${index}`);
-    if (!Number.isInteger(gap.selector_index) || gap.selector_index < 0 || gap.selector_index > 6) fail(`proof result gap ${index} is invalid`);
-    return;
+    if (!Number.isInteger(gap.selector_index) || gap.selector_index < 0 || gap.selector_index > stepCount) {
+      proofSemanticFail(`gap index ${gap.selector_index} exceeds selector boundary ${stepCount}`);
+    }
+    return [SELECTOR_PROOF_GAP_RANKS[gap.kind], gap.selector_index];
   }
-  if (stepKinds.includes(gap?.kind)) {
+  if (Object.hasOwn(STEP_PROOF_GAP_RANKS, gap?.kind)) {
     requireExactKeys(gap, ["kind", "step_index"], `proof result gap ${index}`);
-    if (!Number.isInteger(gap.step_index) || gap.step_index < 0 || gap.step_index > 5) fail(`proof result gap ${index} is invalid`);
-    return;
+    if (!Number.isInteger(gap.step_index) || gap.step_index < 0 || gap.step_index >= stepCount) {
+      proofSemanticFail(`gap index ${gap.step_index} exceeds step boundary ${stepCount - 1}`);
+    }
+    return [STEP_PROOF_GAP_RANKS[gap.kind], gap.step_index];
   }
   fail(`proof result gap ${index} has an unsupported kind`);
 }
@@ -1178,7 +1318,6 @@ function validateProofResult(body) {
     if (!Array.isArray(disposition.gaps) || disposition.gaps.length === 0 || !Array.isArray(disposition.connected_receipts)) {
       fail("proof result Unknown gaps are missing");
     }
-    disposition.gaps.forEach(validateProofGap);
   } else {
     requireExactKeys(disposition, ["kind", "contract_digest", "reasons"], "proof result Unavailable disposition");
     if (!Array.isArray(disposition.reasons) || disposition.reasons.length === 0 || !disposition.reasons.every(nonemptyString)) {
@@ -1205,7 +1344,6 @@ function validateToolResultSchema(action, projection) {
   if (action.kind === "search") validateSearchResult(projection.body);
   if (action.kind === "context") validateContextResult(projection.body);
   if (action.kind === "packet") validatePacketResult(projection.body);
-  if (action.kind === "prove_call_path" && !projection.isError) validateProofResult(projection.body);
 }
 
 function projectedSelectorValue(selector, result, label) {
@@ -1238,25 +1376,286 @@ function projectedSelectorValue(selector, result, label) {
   };
 }
 
-function validateProofResultAgainstRequest(result, contract) {
+function proofSemanticFail(reason) {
+  fail(`proof result semantic invariant failed: ${reason}`);
+}
+
+function semanticReceiptSequence(values, receiptCount, label) {
+  if (!Array.isArray(values) || new Set(values).size !== values.length) proofSemanticFail(`${label} is not edge-distinct`);
+  values.forEach((receipt) => {
+    if (!Number.isInteger(receipt) || receipt < 0 || receipt >= receiptCount) proofSemanticFail(`${label} contains an invalid receipt reference`);
+  });
+  return values;
+}
+
+function validateSemanticPrefix(steps, sequence, trailingStatus, terminal = null) {
+  const terminalIndex = terminal?.index ?? sequence.length;
+  if (sequence.length > steps.length || terminalIndex >= steps.length) proofSemanticFail("receipt prefix exceeds the proof steps");
+  for (let index = 0; index < terminalIndex; index += 1) {
+    if (steps[index].status !== "proven" || steps[index].receipt !== sequence[index]) {
+      proofSemanticFail("ordered proven prefix does not match its receipt sequence");
+    }
+  }
+  if (terminal) {
+    const expectedReceipt = terminal.status === "certified_absence" ? null : sequence.at(-1);
+    if (steps[terminal.index].status !== terminal.status || steps[terminal.index].receipt !== expectedReceipt) {
+      proofSemanticFail("refutation step contradicts its disposition");
+    }
+  }
+  const suffixStart = terminal ? terminal.index + 1 : sequence.length;
+  for (const step of steps.slice(suffixStart)) {
+    if (step.status !== trailingStatus || step.receipt !== null) proofSemanticFail("proof suffix contradicts its disposition");
+  }
+}
+
+function dispositionReceiptSequence(result, stepCount) {
+  const { disposition, receipts, steps } = result;
+  if (disposition.kind === "contract_proven") {
+    const sequence = semanticReceiptSequence(disposition.receipts, receipts.length, "ContractProven receipt sequence");
+    if (sequence.length !== steps.length) proofSemanticFail("ContractProven must authorize one receipt per step");
+    steps.forEach((step, index) => {
+      if (step.status !== "proven" || step.receipt !== sequence[index]) proofSemanticFail("ContractProven step contradicts its receipt");
+    });
+    return sequence;
+  }
+  if (disposition.kind === "unknown") {
+    const sequence = semanticReceiptSequence(disposition.connected_receipts, receipts.length, "Unknown connected receipt sequence");
+    let priorGap = null;
+    for (const [index, gap] of disposition.gaps.entries()) {
+      const key = canonicalProofGapKey(gap, index, stepCount);
+      if (priorGap !== null && compareTuples(priorGap, key) >= 0) proofSemanticFail("Unknown gaps are not canonical and edge-distinct");
+      priorGap = key;
+    }
+    validateSemanticPrefix(steps, sequence, "unknown");
+    return sequence;
+  }
+  if (disposition.kind === "contract_refuted") {
+    const refutation = disposition.refutation;
+    const sequence = semanticReceiptSequence(refutation.connected_receipts, receipts.length, "ContractRefuted connected receipt sequence");
+    if (refutation.kind === "prohibited_scope_traversal") {
+      if (sequence.length !== refutation.step_index + 1) proofSemanticFail("positive contradiction receipt sequence has the wrong length");
+      validateSemanticPrefix(steps, sequence, "unknown", { index: refutation.step_index, status: "positive_contradiction" });
+    } else {
+      if (sequence.length !== refutation.step_index) proofSemanticFail("certified absence receipt sequence has the wrong length");
+      validateSemanticPrefix(steps, sequence, "unknown", { index: refutation.step_index, status: "certified_absence" });
+    }
+    return sequence;
+  }
+  if (steps.some((step) => step.status !== "unavailable" || step.receipt !== null)) {
+    proofSemanticFail("Unavailable disposition contains a non-Unavailable step or receipt");
+  }
+  const reasonOrder = [
+    "validated_contract_hash_mismatch",
+    "publication_pin_mismatch",
+    "source_not_bound_to_publication",
+    "proof_facts_unavailable",
+    "proof_semantic_projection_unavailable",
+  ];
+  const ranks = disposition.reasons.map((reason) => reasonOrder.indexOf(reason));
+  if (ranks.some((rank) => rank < 0) || ranks.some((rank, index) => index > 0 && ranks[index - 1] >= rank)) {
+    proofSemanticFail("Unavailable reasons are not canonical");
+  }
+  return [];
+}
+
+function parseProofCallsiteIdentity(identity) {
+  const separator = identity.indexOf("|");
+  const prefix = separator === -1 ? identity : identity.slice(0, separator);
+  const marker = separator === -1 ? null : identity.slice(separator + 1);
+  if (marker === "") return null;
+  const fields = prefix.split(":");
+  if (fields.length !== 4 || !/^-?[0-9]+$/u.test(fields[0]) || !/^[0-9]+$/u.test(fields[1])
+      || !/^[0-9]+$/u.test(fields[2]) || !/^-?[0-9]+$/u.test(fields[3])) return null;
+  const [fileId, rawLine, rawColumn, rawTarget] = fields;
+  const line = Number(rawLine);
+  const column = Number(rawColumn);
+  if (!Number.isSafeInteger(line) || line < 1 || line > 0xffff_ffff
+      || !Number.isSafeInteger(column) || column < 1 || column > 0xffff_ffff) return null;
+  try {
+    const normalized = `${BigInt(fileId)}:${line}:${column}:${BigInt(rawTarget)}`;
+    if (normalized !== prefix || BigInt(fileId) === 0n || BigInt(rawTarget) === 0n) return null;
+  } catch {
+    return null;
+  }
+  return { fileId, line, column, rawTarget };
+}
+
+function canonicalNonzeroInteger(value) {
+  if (typeof value !== "string" || !/^-?[0-9]+$/u.test(value)) return null;
+  try {
+    const parsed = BigInt(value);
+    return parsed !== 0n && parsed.toString() === value ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function validateSemanticReceiptTable(result, sequence) {
+  if (sequence.length !== result.receipts.length || sequence.some((receipt, index) => receipt !== index)) {
+    proofSemanticFail("disposition does not exhaust receipts in canonical order");
+  }
+  const fileIds = new Set();
+  const filePaths = new Set();
+  result.identities.files.forEach((file, index) => {
+    const fileId = canonicalNonzeroInteger(file.file_node_id);
+    if (fileId === null || fileIds.has(file.file_node_id) || !SHA256.test(file.indexed_sha256)
+        || !(file.observed_sha256 === null || file.observed_sha256 === file.indexed_sha256)) {
+      proofSemanticFail(`file identity ${index} is not canonical and hash-bound`);
+    }
+    fileIds.add(file.file_node_id);
+    if (file.project_file_components !== null) {
+      if (file.project_file_components.length === 0) proofSemanticFail(`file identity ${index} has an empty path`);
+      const path = canonical(file.project_file_components);
+      if (filePaths.has(path)) proofSemanticFail(`file identity ${index} repeats a project path`);
+      filePaths.add(path);
+    }
+  });
+  const symbolIds = new Set();
+  result.identities.symbols.forEach((symbol, index) => {
+    if (symbolIds.has(symbol.node_id)) proofSemanticFail(`symbol identity ${index} is duplicated`);
+    symbolIds.add(symbol.node_id);
+  });
+  const profiles = new Set();
+  result.identities.provenance_profiles.forEach((profile, index) => {
+    const key = canonical(profile);
+    if (profiles.has(key)) proofSemanticFail(`provenance profile ${index} is duplicated`);
+    profiles.add(key);
+  });
+  const factIds = new Set();
+  const referencedProfiles = new Set();
+  let nextProfile = 0;
+  result.identities.evidence.forEach((evidence, index) => {
+    if (factIds.has(evidence.fact_id) || proofFactId(evidence.provenance.evidence_sha256) !== evidence.fact_id) {
+      proofSemanticFail(`exact-resolution evidence ${index} has an invalid fact identity`);
+    }
+    factIds.add(evidence.fact_id);
+    const caller = result.identities.symbols[evidence.caller];
+    const target = result.identities.symbols[evidence.target];
+    if (!nonemptyString(caller.canonical_id) || !nonemptyString(caller.qualified_name) || caller.file === null
+        || !nonemptyString(target.canonical_id) || !nonemptyString(target.qualified_name) || target.file === null) {
+      proofSemanticFail(`exact-resolution evidence ${index} does not bind complete symbols`);
+    }
+    const chainArities = {
+      same_file_declaration: 1,
+      same_package_declaration: 1,
+      static_import_binding: 2,
+      qualified_path: null,
+      explicit_receiver_type: 1,
+      constructor_binding: 1,
+      implicit_receiver: 1,
+    };
+    for (const entry of evidence.chain) {
+      if (!Object.hasOwn(chainArities, entry.kind)
+          || (chainArities[entry.kind] === null ? entry.symbols.length === 0 : entry.symbols.length !== chainArities[entry.kind])) {
+        proofSemanticFail(`exact-resolution evidence ${index} has an invalid evidence chain`);
+      }
+    }
+    const profile = evidence.provenance.profile;
+    if (!referencedProfiles.has(profile)) {
+      if (profile !== nextProfile) proofSemanticFail("provenance profiles are not referenced in canonical order");
+      referencedProfiles.add(profile);
+      nextProfile += 1;
+    }
+    if (evidence.provenance.dependency_files.length === 0) proofSemanticFail(`exact-resolution evidence ${index} has no dependency files`);
+    let priorFileId = null;
+    for (const fileIndex of evidence.provenance.dependency_files) {
+      const fileId = canonicalNonzeroInteger(result.identities.files[fileIndex].file_node_id);
+      if (fileId === null || (priorFileId !== null && priorFileId >= fileId)) {
+        proofSemanticFail(`exact-resolution evidence ${index} dependency files are not canonical`);
+      }
+      priorFileId = fileId;
+    }
+  });
+  if (referencedProfiles.size !== result.identities.provenance_profiles.length) {
+    proofSemanticFail("a provenance profile is unreferenced");
+  }
+  const receiptIds = new Set();
+  const edgeIds = new Set();
+  const evidenceIndices = new Set();
+  const sourceFiles = new Set();
+  for (const [index, receipt] of result.receipts.entries()) {
+    if (receiptIds.has(receipt.receipt_id) || edgeIds.has(receipt.edge_id) || evidenceIndices.has(receipt.evidence)) {
+      proofSemanticFail("receipt identities, edges, and exact-resolution evidence must be edge-distinct");
+    }
+    receiptIds.add(receipt.receipt_id);
+    edgeIds.add(receipt.edge_id);
+    evidenceIndices.add(receipt.evidence);
+    const source = result.identities.symbols[receipt.source];
+    const target = result.identities.symbols[receipt.target];
+    if (!nonemptyString(source.canonical_id) || !nonemptyString(source.qualified_name) || source.file === null
+        || !nonemptyString(target.canonical_id) || !nonemptyString(target.qualified_name) || target.file === null) {
+      proofSemanticFail(`receipt ${index} source and target must be complete symbols`);
+    }
+    if (source.file !== receipt.containment.file || receipt.containment.file !== receipt.line_window.file) {
+      proofSemanticFail(`receipt ${index} source, containment, and line-window files disagree`);
+    }
+    const file = result.identities.files[source.file];
+    if (!nonemptyString(file.file_node_id) || !SHA256.test(file.indexed_sha256)
+        || file.observed_sha256 !== file.indexed_sha256) proofSemanticFail(`receipt ${index} line window is not hash-bound`);
+    const callsite = parseProofCallsiteIdentity(receipt.callsite_identity);
+    if (callsite === null || callsite.fileId !== file.file_node_id || callsite.rawTarget !== target.node_id
+        || callsite.line !== receipt.line_window.anchor_line || callsite.column !== receipt.column_or_ordinal
+        || receipt.line_window.anchor_line < receipt.containment.start_line
+        || receipt.line_window.anchor_line > receipt.containment.end_line
+        || receipt.exact_callsite_start_byte < receipt.line_window.byte_start
+        || receipt.exact_callsite_start_byte >= receipt.line_window.byte_end) {
+      proofSemanticFail(`receipt ${index} callsite is outside its hash-bound source window`);
+    }
+    const evidence = result.identities.evidence[receipt.evidence];
+    sourceFiles.add(source.file);
+  }
+  if (evidenceIndices.size !== result.identities.evidence.length) proofSemanticFail("exact-resolution evidence is unreferenced");
+  result.identities.files.forEach((file, index) => {
+    if (file.observed_sha256 !== null && !sourceFiles.has(index)) proofSemanticFail("observed source hash belongs to a non-callsite file");
+  });
+  for (let index = 1; index < sequence.length; index += 1) {
+    if (result.receipts[sequence[index - 1]].target !== result.receipts[sequence[index]].source) {
+      proofSemanticFail("receipt trail is disconnected");
+    }
+  }
+}
+
+function validateSelectorReceiptBinding(selector, expectedSymbol, label) {
+  const isReference = ["pinned_node_ref", "canonical_id_ref", "qualified_name_ref"].includes(selector.kind);
+  if (expectedSymbol === null) {
+    if (isReference) proofSemanticFail(`${label} is a disconnected compact reference`);
+  } else if (!isReference || selector.symbol !== expectedSymbol) {
+    proofSemanticFail(`${label} does not match the authorized receipt endpoint`);
+  }
+}
+
+function validateCanonicalProofResult(result, contract) {
+  validateProofResult(result);
+  const sequence = dispositionReceiptSequence(result, result.spec.steps.length);
+  validateSemanticReceiptTable(result, sequence);
   if (result.source_text_sha256 !== sha256Bytes(Buffer.from(contract.source_text))) {
-    fail("proof result source_text_sha256 does not match the host-supplied contract");
+    proofSemanticFail("source_text_sha256 does not match the unchanged typed request");
   }
-  if (!equalJson(result.clauses, contract.clauses)) fail("proof result clauses do not match the host-supplied contract");
+  const expectedDigest = canonicalRequestContractDigest(contract);
+  if (result.contract_digest !== expectedDigest || result.disposition.contract_digest !== expectedDigest) {
+    proofSemanticFail("contract digest is not derived from the unchanged typed request");
+  }
+  if (!equalJson(result.clauses, groupedContractClauses(contract))) {
+    proofSemanticFail("clauses do not match the canonical unchanged typed request");
+  }
+  const firstSource = sequence.length === 0 ? null : result.receipts[sequence[0]].source;
+  validateSelectorReceiptBinding(result.spec.start, firstSource, "proof start selector");
   if (!equalJson(projectedSelectorValue(result.spec.start, result, "proof result start selector"), contract.spec.start)) {
-    fail("proof result start selector does not match the host-supplied contract");
+    proofSemanticFail("start selector does not match the unchanged typed request");
   }
-  if (result.spec.steps.length !== contract.spec.steps.length) fail("proof result steps do not match the host-supplied contract");
+  if (result.spec.steps.length !== contract.spec.steps.length) proofSemanticFail("steps do not match the unchanged typed request");
   result.spec.steps.forEach((step, index) => {
+    const expectedTarget = index < sequence.length ? result.receipts[sequence[index]].target : null;
+    validateSelectorReceiptBinding(step.target, expectedTarget, `proof step ${index} target`);
     const projected = {
       relation: step.relation,
       target: projectedSelectorValue(step.target, result, `proof result step ${index} target`),
     };
-    if (!equalJson(projected, contract.spec.steps[index])) fail(`proof result step ${index} does not match the host-supplied contract`);
+    if (!equalJson(projected, contract.spec.steps[index])) proofSemanticFail(`step ${index} does not match the unchanged typed request`);
   });
   if (!equalJson(result.spec.prohibit_traversal_through, contract.spec.prohibit_traversal_through)
       || !equalJson(result.spec.exclude_from_projection, contract.spec.exclude_from_projection)) {
-    fail("proof result scope selectors do not match the host-supplied contract");
+    proofSemanticFail("scope selectors do not match the unchanged typed request");
   }
 }
 
@@ -1289,7 +1688,7 @@ function validateProofCalls(scenarioContract, request, actions, results) {
     return;
   }
   if (projection?.isError) fail(`${scenarioContract.id} typed proof unexpectedly returned a tool error`);
-  validateProofResultAgainstRequest(projection.body, request.proof_contract);
+  validateCanonicalProofResult(projection.body, request.proof_contract);
 }
 
 function validatePacketContinuation(scenarioContract, actions, results) {
@@ -1424,6 +1823,9 @@ function expectedFinalClaim(scenarioContract, actions, results) {
     if (disposition?.kind === "contract_proven") {
       const receipts = results.get(proof).body.receipts;
       expected.evidence_ids = disposition.receipts.map((index) => receipts[index]?.receipt_id);
+    } else if (disposition?.kind === "contract_refuted") {
+      const receipts = results.get(proof).body.receipts;
+      expected.evidence_ids = disposition.refutation.connected_receipts.map((index) => receipts[index]?.receipt_id);
     } else {
       expected.evidence_ids = [];
     }

--- a/scripts/tests/codestory-agent-routing-conformance.test.mjs
+++ b/scripts/tests/codestory-agent-routing-conformance.test.mjs
@@ -1,9 +1,20 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
+import {
+  copyFileSync,
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import test from "node:test";
+import test, { after } from "node:test";
 
 import {
   INSTALLED_IDENTITY_FIELDS,
@@ -17,21 +28,63 @@ import {
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(here, "..", "..");
 const pluginRoot = join(repoRoot, "plugins", "codestory");
-const SHA_A = "a".repeat(64);
-const SHA_B = "b".repeat(64);
-const SHA_C = "c".repeat(64);
 const SHA_D = "d".repeat(64);
 
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+const installedRoot = realpathSync(mkdtempSync(join(tmpdir(), "codestory-routing-installed-")));
+mkdirSync(join(installedRoot, "archives"), { recursive: true });
+mkdirSync(join(installedRoot, "scripts"), { recursive: true });
+mkdirSync(join(installedRoot, "managed"), { recursive: true });
+writeFileSync(join(installedRoot, "archives", "codestory-0.18.tgz"), "authenticated package fixture\n");
+copyFileSync(
+  join(pluginRoot, "scripts", "codestory-mcp.cjs"),
+  join(installedRoot, "scripts", "codestory-mcp.cjs"),
+);
+writeFileSync(join(installedRoot, "managed", "codestory-cli"), "authenticated managed CLI fixture\n");
+
+const installedIdentity = {
+  installation: { root: installedRoot },
+  package: {
+    name: "codestory",
+    version: "0.18.0-candidate.7",
+    archive_relative_path: "archives/codestory-0.18.tgz",
+    sha256: sha256(readFileSync(join(installedRoot, "archives", "codestory-0.18.tgz"))),
+  },
+  launcher: {
+    relative_path: "scripts/codestory-mcp.cjs",
+    sha256: sha256(readFileSync(join(installedRoot, "scripts", "codestory-mcp.cjs"))),
+  },
+  cli: {
+    relative_path: "managed/codestory-cli",
+    version: "0.18.0-candidate.7",
+    sha256: sha256(readFileSync(join(installedRoot, "managed", "codestory-cli"))),
+    source: "managed",
+  },
+  publication: { schema_version: 3 },
+  protocol: { revision: "2025-11-25", discovery_contract_sha256: SHA_D },
+};
+const installedReceipt = join(installedRoot, "installed-receipt.json");
+writeFileSync(installedReceipt, `${JSON.stringify({ schema_version: 1, identity: installedIdentity }, null, 2)}\n`);
 const EXPECTED_IDENTITY = Object.freeze({
-  package: Object.freeze({ name: "codestory", version: "0.18.0-candidate.7", sha256: SHA_A }),
-  launcher: Object.freeze({ relative_path: "scripts/codestory-mcp.cjs", sha256: SHA_B }),
-  cli: Object.freeze({ version: "0.18.0-candidate.7", sha256: SHA_C, source: "managed" }),
-  publication: Object.freeze({ schema_version: 3 }),
-  protocol: Object.freeze({
-    revision: "2025-11-25",
-    discovery_contract_sha256: SHA_D,
+  ...cloneForFreeze(installedIdentity),
+  receipt: Object.freeze({
+    relative_path: "installed-receipt.json",
+    sha256: sha256(readFileSync(installedReceipt)),
   }),
 });
+
+function cloneForFreeze(value) {
+  if (Array.isArray(value)) return Object.freeze(value.map(cloneForFreeze));
+  if (value && typeof value === "object") {
+    return Object.freeze(Object.fromEntries(Object.entries(value).map(([key, child]) => [key, cloneForFreeze(child)])));
+  }
+  return value;
+}
+
+after(() => rmSync(installedRoot, { recursive: true, force: true }));
 
 const SCENARIO_IDS = [
   "named_file_direct_read",
@@ -56,32 +109,39 @@ function clone(value) {
   return structuredClone(value);
 }
 
-function proofContract() {
+function proofContract({ prohibited = false } = {}) {
+  const sourceText = "`crate::start` directly calls `crate::finish`.";
+  const fields = [
+    { kind: "start" },
+    { kind: "step_target", step: 0 },
+    { kind: "directness", step: 0 },
+    { kind: "ordering", step: 0 },
+    { kind: "relation", step: 0 },
+    ...(prohibited ? [{ kind: "traversal_prohibition", index: 0 }] : []),
+  ];
   return {
-    source_text: "`crate::start` directly calls `crate::finish`.",
+    source_text: sourceText,
     clauses: [
       {
-        clause_id: "start",
-        start_byte: 0,
-        end_byte_exclusive: 14,
-        quote: "`crate::start`",
-        classification: { kind: "resolved_material", fields: [{ kind: "start" }] },
-      },
-      {
-        clause_id: "target",
-        start_byte: 30,
-        end_byte_exclusive: 45,
-        quote: "`crate::finish`",
-        classification: {
-          kind: "resolved_material",
-          fields: [{ kind: "step_target", step: 1 }, { kind: "directness", step: 1 }],
-        },
+        clause_id: "contract",
+        start: 0,
+        end: Buffer.byteLength(sourceText),
+        quote: sourceText,
+        classification: "resolved_material",
+        fields,
+        reason: null,
+        non_material_kind: null,
       },
     ],
     spec: {
       start: { kind: "canonical_id", canonical_id: "rust:crate::start" },
-      steps: [{ target: { kind: "canonical_id", canonical_id: "rust:crate::finish" } }],
-      prohibit_traversal_through: [],
+      steps: [{
+        relation: "direct_outgoing_call",
+        target: { kind: "canonical_id", canonical_id: "rust:crate::finish" },
+      }],
+      prohibit_traversal_through: prohibited
+        ? [{ kind: "canonical_id", canonical_id: "rust:crate::blocked" }]
+        : [],
       exclude_from_projection: [],
     },
   };
@@ -118,13 +178,123 @@ function result(body, { isError = false, meta = runtimeMeta() } = {}) {
   };
 }
 
-function proofBody(disposition, detail = {}) {
+function proofBody(disposition, contract, detail = {}) {
+  const contractDigest = "f".repeat(64);
+  const common = { kind: disposition, contract_digest: contractDigest };
+  let projectedDisposition;
+  let stepStatus;
+  let receipts = [];
+  if (disposition === "contract_proven") {
+    projectedDisposition = { ...common, receipts: [0] };
+    stepStatus = "proven";
+    receipts = [{
+      receipt_id: "receipt-1",
+      edge_id: "edge-1",
+      source: 0,
+      target: 1,
+      evidence: 0,
+      exact_callsite_start_byte: 0,
+      callsite_identity: "file-1:1:1:finish|rust",
+      column_or_ordinal: 1,
+      containment: { file: 0, owner: 0, start_line: 1, end_line: 1 },
+      line_window: {
+        kind: "indexed_line_v1",
+        file: 0,
+        anchor_line: 1,
+        byte_start: 0,
+        byte_end: 10,
+        text: "finish();\n",
+      },
+    }];
+  } else if (disposition === "contract_refuted") {
+    projectedDisposition = {
+      ...common,
+      refutation: {
+        kind: detail.basis?.kind ?? "prohibited_scope_traversal",
+        step_index: 0,
+        prohibition_index: 0,
+        connected_receipts: [],
+      },
+    };
+    stepStatus = "positive_contradiction";
+  } else if (disposition === "unknown") {
+    projectedDisposition = {
+      ...common,
+      gaps: (detail.gaps ?? []).map(({ code }) => code.startsWith("selector_")
+        ? { kind: code, selector_index: 0 }
+        : { kind: code, step_index: 0 }),
+      connected_receipts: [],
+    };
+    stepStatus = "unknown";
+  } else {
+    projectedDisposition = { ...common, reasons: detail.reasons ?? [detail.reason] };
+    stepStatus = "unavailable";
+  }
   return {
     kind: "complete",
-    proof_contract_schema_version: 1,
-    proof_domain: "indexed_source_call_path_v1",
-    clause_guard_version: "clause_guard_v1",
-    disposition: { kind: disposition, ...detail },
+    schema_version: 1,
+    domain: "indexed_source_call_path_v1",
+    contract_interpretation: "host_supplied",
+    guard_version: "clause_guard_v1",
+    source_text_sha256: sha256(Buffer.from(contract.source_text)),
+    contract_digest: contractDigest,
+    core_publication: { project_id: "project-1", generation_id: "core-1", run_id: "run-1" },
+    identities: {
+      files: [{
+        file_node_id: "file-1",
+        project_file_components: ["src", "lib.rs"],
+        indexed_sha256: "a".repeat(64),
+        observed_sha256: "a".repeat(64),
+      }],
+      symbols: [
+        { node_id: "node-1", canonical_id: "rust:crate::start", qualified_name: "crate::start", file: 0 },
+        { node_id: "node-2", canonical_id: "rust:crate::finish", qualified_name: "crate::finish", file: 0 },
+      ],
+      provenance_profiles: [{
+        producer: "codestory-internal",
+        fact_schema_version: 1,
+        algorithm: "exact-call-resolution-v1",
+        language_adapter: "rust",
+        language_adapter_version: "fixture-v1",
+        parser_fingerprint: "b".repeat(64),
+      }],
+      evidence: [{
+        fact_id: "c".repeat(64),
+        caller: 0,
+        target: 1,
+        edge_id: "edge-1",
+        callsite_identity: "file-1:1:1:finish|rust",
+        chain: [{ kind: "same_file_declaration", symbols: [1] }],
+        provenance: { profile: 0, dependency_files: [0], evidence_sha256: "d".repeat(64) },
+      }],
+    },
+    spec: {
+      start: { kind: "canonical_id_ref", symbol: 0 },
+      steps: [{ relation: "direct_outgoing_call", target: { kind: "canonical_id_ref", symbol: 1 } }],
+      prohibit_traversal_through: clone(contract.spec.prohibit_traversal_through),
+      exclude_from_projection: clone(contract.spec.exclude_from_projection),
+    },
+    clauses: clone(contract.clauses),
+    disposition: projectedDisposition,
+    steps: [{ step_index: 0, status: stepStatus, receipt: receipts.length ? 0 : null }],
+    receipts,
+  };
+}
+
+function finalClaim(overrides = {}) {
+  return {
+    authority: "none",
+    outcome: "supported",
+    target_id: null,
+    evidence_ids: [],
+    gap_ids: [],
+    reason_codes: [],
+    proof_disposition: null,
+    refutation_basis: null,
+    runtime_execution_claim: false,
+    absence_claim: false,
+    material_omissions: [],
+    ...overrides,
   };
 }
 
@@ -138,9 +308,8 @@ function baseRun(scenarioId) {
       selected_target: null,
       proof_contract: null,
     },
-    installed_identity: clone(EXPECTED_IDENTITY),
     steps: [],
-    final: "Completed from the permitted evidence.",
+    final: finalClaim(),
   };
 
   const mcp = (tool, args, body, options) => ({ kind: "mcp", tool, args, result: result(body, options) });
@@ -150,51 +319,80 @@ function baseRun(scenarioId) {
     case "named_file_direct_read":
       run.request.named_files = ["src/named.rs"];
       run.steps = [read("src/named.rs")];
-      run.final = "The named file src/named.rs contains the requested definition.";
+      run.final = finalClaim({ authority: "source", evidence_ids: ["source:src/named.rs"] });
       break;
     case "exact_symbol_search":
       run.steps = [mcp("search", { project: "/workspace/repo", query: "ExactThing" }, {
         kind: "complete",
-        leads: [{ canonical_id: "rust:crate::ExactThing" }],
+        publication: { core_generation_id: "core-1", retrieval_generation_id: "retrieval-1" },
+        leads: [{ lead_id: "lead-1", canonical_id: "rust:crate::ExactThing" }],
         gaps: [],
       })];
-      run.final = "Search found the discovery lead rust:crate::ExactThing; this is not a proof claim.";
+      run.final = finalClaim({
+        authority: "search_lead",
+        outcome: "discovery_only",
+        target_id: "rust:crate::ExactThing",
+        evidence_ids: ["lead-1"],
+      });
       break;
     case "ambiguous_symbol_then_context":
       run.request.selected_target = "rust:crate::one::Thing";
       run.steps = [
         mcp("search", { project: "/workspace/repo", query: "Thing" }, {
           kind: "complete",
+          publication: { core_generation_id: "core-1", retrieval_generation_id: "retrieval-1" },
           leads: [
-            { canonical_id: "rust:crate::one::Thing" },
-            { canonical_id: "rust:crate::two::Thing" },
+            { lead_id: "lead-1", canonical_id: "rust:crate::one::Thing" },
+            { lead_id: "lead-2", canonical_id: "rust:crate::two::Thing" },
           ],
           gaps: [{ code: "selector_ambiguous" }],
         }),
         mcp("context", {
           project: "/workspace/repo",
           selector: { canonical_id: "rust:crate::one::Thing" },
-        }, { kind: "complete", target: "rust:crate::one::Thing", evidence: ["src/one.rs:1"] }),
+        }, {
+          kind: "complete",
+          publication: { core_generation_id: "core-1", retrieval_generation_id: "retrieval-1" },
+          target: { canonical_id: "rust:crate::one::Thing" },
+          evidence: [{ evidence_id: "context-1", path: "src/one.rs" }],
+          gaps: [],
+        }),
       ];
-      run.final = "The search was selector_ambiguous. Context covers selected target rust:crate::one::Thing only.";
+      run.final = finalClaim({
+        authority: "context_evidence",
+        target_id: "rust:crate::one::Thing",
+        evidence_ids: ["context-1"],
+        gap_ids: ["selector_ambiguous"],
+      });
       break;
     case "selected_target_context":
       run.request.selected_target = "rust:crate::ExactThing";
       run.steps = [mcp("context", {
         project: "/workspace/repo",
         selector: { canonical_id: "rust:crate::ExactThing" },
-      }, { kind: "complete", target: "rust:crate::ExactThing", evidence: ["src/lib.rs:10"] })];
-      run.final = "Context provides evidence for selected target rust:crate::ExactThing only.";
+      }, {
+        kind: "complete",
+        publication: { core_generation_id: "core-1", retrieval_generation_id: "retrieval-1" },
+        target: { canonical_id: "rust:crate::ExactThing" },
+        evidence: [{ evidence_id: "context-1", path: "src/lib.rs" }],
+        gaps: [],
+      })];
+      run.final = finalClaim({
+        authority: "context_evidence",
+        target_id: "rust:crate::ExactThing",
+        evidence_ids: ["context-1"],
+      });
       break;
     case "broad_packet":
       run.steps = [mcp("packet", { project: "/workspace/repo", question: "How does the flow work?" }, {
         kind: "complete",
         packet_id: "packet-1",
         status: "complete",
-        evidence: [{ evidence_id: "evidence-1" }],
+        publication: { core_generation_id: "core-1", retrieval_generation_id: "retrieval-1" },
+        evidence: [{ evidence_id: "evidence-1", path: "src/flow.rs" }],
         gaps: [],
       })];
-      run.final = "Packet evidence evidence-1 supports the broad answer; packet availability is not proof.";
+      run.final = finalClaim({ authority: "packet_evidence", evidence_ids: ["evidence-1"] });
       break;
     case "packet_single_continuation":
       run.steps = [
@@ -204,7 +402,7 @@ function baseRun(scenarioId) {
           status: "continuation_available",
           publication: { core_generation_id: "core-1", retrieval_generation_id: "retrieval-1" },
           continuation: { continuation_id: "continuation-1", gap_ids: ["gap-1"] },
-          evidence: [{ evidence_id: "evidence-1" }],
+          evidence: [{ evidence_id: "evidence-1", path: "src/flow.rs" }],
           gaps: [{ gap_id: "gap-1" }],
         }),
         mcp("packet", {
@@ -218,11 +416,16 @@ function baseRun(scenarioId) {
           kind: "complete",
           packet_id: "packet-2",
           status: "complete",
-          evidence: [{ evidence_id: "evidence-2" }],
+          publication: { core_generation_id: "core-1", retrieval_generation_id: "retrieval-1" },
+          evidence: [{ evidence_id: "evidence-2", path: "src/more.rs" }],
           gaps: [],
         }),
       ];
-      run.final = "The one bounded continuation supplied evidence-2 and closed gap-1.";
+      run.final = finalClaim({
+        authority: "packet_evidence",
+        evidence_ids: ["evidence-1", "evidence-2"],
+        gap_ids: ["gap-1"],
+      });
       break;
     case "packet_gap_to_focused_source":
       run.steps = [
@@ -230,12 +433,13 @@ function baseRun(scenarioId) {
           kind: "complete",
           packet_id: "packet-1",
           status: "no_useful_evidence",
+          publication: { core_generation_id: "core-1", retrieval_generation_id: "retrieval-1" },
           evidence: [],
           gaps: [{ gap_id: "gap-1", authorized_source_paths: ["src/gap.rs"] }],
         }),
         read("src/gap.rs"),
       ];
-      run.final = "Packet gap gap-1 required a focused read of src/gap.rs; the source is the cited evidence.";
+      run.final = finalClaim({ authority: "source", evidence_ids: ["source:src/gap.rs"], gap_ids: ["gap-1"] });
       break;
     case "packet_unavailable_to_source":
       run.steps = [
@@ -243,37 +447,55 @@ function baseRun(scenarioId) {
           kind: "budget_exceeded",
           status: "unavailable",
           reason: "retrieval_unavailable",
+          publication: { core_generation_id: "core-1", retrieval_generation_id: "retrieval-1" },
+          evidence: [],
           gaps: [],
         }),
         read("src/fallback.rs"),
       ];
-      run.final = "Packet was retrieval_unavailable, so src/fallback.rs is the focused source evidence.";
+      run.final = finalClaim({
+        authority: "source",
+        outcome: "unavailable",
+        evidence_ids: ["source:src/fallback.rs"],
+        reason_codes: ["retrieval_unavailable"],
+      });
       break;
     case "typed_proof_contract_proven":
       run.request.proof_contract = typed;
-      run.steps = [mcp("prove_call_path", { project: "/workspace/repo", ...typed }, proofBody("contract_proven"))];
-      run.final = "The typed verifier returned ContractProven for this indexed source call path only.";
+      run.steps = [mcp("prove_call_path", { project: "/workspace/repo", ...typed }, proofBody("contract_proven", typed))];
+      run.final = finalClaim({ authority: "typed_proof", evidence_ids: ["receipt-1"], proof_disposition: "contract_proven" });
       break;
     case "typed_proof_contract_refuted":
-      run.request.proof_contract = typed;
-      run.steps = [mcp("prove_call_path", { project: "/workspace/repo", ...typed }, proofBody("contract_refuted", {
-        basis: { kind: "positive_contradiction" },
+      const refutedContract = proofContract({ prohibited: true });
+      run.request.proof_contract = refutedContract;
+      run.steps = [mcp("prove_call_path", { project: "/workspace/repo", ...refutedContract }, proofBody("contract_refuted", refutedContract, {
+        basis: { kind: "prohibited_scope_traversal" },
       }))];
-      run.final = "The typed verifier returned ContractRefuted by positive_contradiction.";
+      run.final = finalClaim({
+        authority: "typed_proof",
+        outcome: "refuted",
+        proof_disposition: "contract_refuted",
+        refutation_basis: "prohibited_scope_traversal",
+      });
       break;
     case "typed_proof_unknown":
       run.request.proof_contract = typed;
-      run.steps = [mcp("prove_call_path", { project: "/workspace/repo", ...typed }, proofBody("unknown", {
+      run.steps = [mcp("prove_call_path", { project: "/workspace/repo", ...typed }, proofBody("unknown", typed, {
         gaps: [{ code: "selector_missing" }],
       }))];
-      run.final = "The typed verifier returned Unknown because selector_missing; this does not establish absence.";
+      run.final = finalClaim({ authority: "typed_proof", outcome: "unknown", gap_ids: ["selector_missing"], proof_disposition: "unknown" });
       break;
     case "typed_proof_unavailable":
       run.request.proof_contract = typed;
-      run.steps = [mcp("prove_call_path", { project: "/workspace/repo", ...typed }, proofBody("unavailable", {
-        reason: "proof_semantic_projection_unavailable",
+      run.steps = [mcp("prove_call_path", { project: "/workspace/repo", ...typed }, proofBody("unavailable", typed, {
+        reasons: ["proof_semantic_projection_unavailable"],
       }))];
-      run.final = "The typed verifier returned Unavailable: proof_semantic_projection_unavailable.";
+      run.final = finalClaim({
+        authority: "typed_proof",
+        outcome: "unavailable",
+        reason_codes: ["proof_semantic_projection_unavailable"],
+        proof_disposition: "unavailable",
+      });
       break;
     case "malformed_proof_contract": {
       const malformed = { source_text: "A calls B", clauses: [] };
@@ -282,27 +504,32 @@ function baseRun(scenarioId) {
         code: "invalid_proof_interpretation",
         message: "spec is required",
       }, { isError: true })];
-      run.final = "The typed contract is invalid_proof_interpretation because spec is required; no proof disposition was produced.";
+      run.final = finalClaim({ authority: "none", outcome: "invalid_contract", reason_codes: ["invalid_proof_interpretation"] });
       break;
     }
     case "refuse_free_english_proof":
       run.request.text = "Prove from this sentence that start calls finish.";
-      run.final = "I cannot construct an authoritative typed contract from free English; provide the typed contract.";
+      run.final = finalClaim({ authority: "none", outcome: "refused", reason_codes: ["typed_contract_required"] });
       break;
     case "proof_observational":
       run.request.proof_contract = typed;
-      run.steps = [mcp("prove_call_path", { project: "/workspace/repo", ...typed }, proofBody("unknown", {
-        gaps: [{ code: "edge_not_proof_authoritative" }],
+      run.steps = [mcp("prove_call_path", { project: "/workspace/repo", ...typed }, proofBody("unknown", typed, {
+        gaps: [{ code: "direct_call_missing" }],
       }))];
-      run.final = "The observational verifier returned Unknown: edge_not_proof_authoritative; it did not activate semantic retrieval.";
+      run.final = finalClaim({
+        authority: "typed_proof",
+        outcome: "unknown",
+        gap_ids: ["direct_call_missing"],
+        proof_disposition: "unknown",
+      });
       break;
     case "hidden_proof_tool_discovery":
       run.request.proof_contract = typed;
       run.steps = [
         { kind: "tool_search", query: "codestory mcp prove_call_path", tools: ["mcp__codestory__prove_call_path"] },
-        mcp("prove_call_path", { project: "/workspace/repo", ...typed }, proofBody("contract_proven")),
+        mcp("prove_call_path", { project: "/workspace/repo", ...typed }, proofBody("contract_proven", typed)),
       ];
-      run.final = "After discovering only prove_call_path, the typed verifier returned ContractProven for the indexed source path.";
+      run.final = finalClaim({ authority: "typed_proof", evidence_ids: ["receipt-1"], proof_disposition: "contract_proven" });
       break;
     default:
       throw new Error(`unknown scenario ${scenarioId}`);
@@ -345,47 +572,109 @@ function codexJsonl(run) {
       });
     }
   }
-  events.push({ type: "item.completed", item: { id: "answer", type: "agent_message", text: run.final } });
+  events.push({
+    type: "item.completed",
+    item: { id: "answer", type: "agent_message", text: JSON.stringify(run.final) },
+  });
   return `${events.map((event) => JSON.stringify(event)).join("\n")}\n`;
 }
 
 function cursorJsonl(run) {
-  const events = [{ type: "system", subtype: "init", session_id: "cursor-session-1" }];
+  const sessionId = "cursor-session-1";
+  const events = [
+    {
+      type: "system",
+      subtype: "init",
+      apiKeySource: "login",
+      cwd: "/workspace/repo",
+      session_id: sessionId,
+      model: "fixture-model",
+      permissionMode: "default",
+    },
+    {
+      type: "user",
+      message: { role: "user", content: [{ type: "text", text: run.request.text }] },
+      session_id: sessionId,
+    },
+  ];
   let counter = 0;
   for (const step of run.steps) {
     counter += 1;
     const id = `call-${counter}`;
-    let name;
-    let input;
-    let output;
+    let wrapper;
     if (step.kind === "mcp") {
-      name = `mcp_codestory_${step.tool}`;
-      input = step.args;
-      output = JSON.stringify(step.result);
+      const args = {
+        name: `codestory-${step.tool}`,
+        args: step.args,
+        toolCallId: id,
+        providerIdentifier: "codestory",
+        toolName: step.tool,
+      };
+      wrapper = {
+        started: { mcpToolCall: { args } },
+        completed: { mcpToolCall: { args, result: { success: step.result } } },
+      };
     } else if (step.kind === "tool_search") {
-      name = "tool_search";
-      input = { query: step.query };
-      output = JSON.stringify({ tools: step.tools });
+      const args = { query: step.query };
+      wrapper = {
+        started: { toolSearchToolCall: { args } },
+        completed: { toolSearchToolCall: { args, result: { success: { tools: step.tools } } } },
+      };
     } else {
-      name = "Shell";
-      input = { command: `sed -n '1,120p' '${step.path}'` };
-      output = "source fixture\n";
+      const args = { path: step.path };
+      wrapper = {
+        started: { readToolCall: { args } },
+        completed: {
+          readToolCall: {
+            args,
+            result: {
+              success: {
+                content: "source fixture\n",
+                isEmpty: false,
+                exceededLimit: false,
+                totalLines: 1,
+                totalChars: 15,
+              },
+            },
+          },
+        },
+      };
     }
     events.push({
-      type: "assistant",
-      message: { role: "assistant", content: [{ type: "tool_use", id, name, input }] },
+      type: "tool_call",
+      subtype: "started",
+      call_id: id,
+      tool_call: wrapper.started,
+      session_id: sessionId,
     });
     events.push({
-      type: "user",
-      message: {
-        role: "user",
-        content: [{ type: "tool_result", tool_use_id: id, content: output, is_error: false }],
-      },
+      type: "tool_call",
+      subtype: "completed",
+      call_id: id,
+      tool_call: wrapper.completed,
+      session_id: sessionId,
     });
   }
+  const final = JSON.stringify(run.final);
+  const split = Math.floor(final.length / 2);
   events.push({
     type: "assistant",
-    message: { role: "assistant", content: [{ type: "text", text: run.final }] },
+    message: { role: "assistant", content: [{ type: "text", text: final.slice(0, split) }] },
+    session_id: sessionId,
+  });
+  events.push({
+    type: "assistant",
+    message: { role: "assistant", content: [{ type: "text", text: final.slice(split) }] },
+    session_id: sessionId,
+  });
+  events.push({
+    type: "result",
+    subtype: "success",
+    duration_ms: 10,
+    duration_api_ms: 9,
+    is_error: false,
+    result: final,
+    session_id: sessionId,
   });
   return `${events.map((event) => JSON.stringify(event)).join("\n")}\n`;
 }
@@ -394,13 +683,14 @@ function transcript(host, run) {
   return host === "codex" ? codexJsonl(run) : cursorJsonl(run);
 }
 
-function validate(host, run) {
+function validate(host, run, expectedIdentity = EXPECTED_IDENTITY, receipt = installedReceipt, root = installedRoot) {
   return validateInstalledSession({
     host,
     scenarioId: run.scenario_id,
     request: run.request,
-    installedIdentity: run.installed_identity,
-    expectedIdentity: EXPECTED_IDENTITY,
+    installedRoot: root,
+    installedReceipt: receipt,
+    expectedIdentity,
     transcript: transcript(host, run),
   });
 }
@@ -410,6 +700,7 @@ test("freezes exactly the sixteen accepted routing scenarios", () => {
   assert.equal(new Set(ROUTING_SCENARIOS.map(({ id }) => id)).size, 16);
   for (const scenario of ROUTING_SCENARIOS) {
     assert.equal(typeof scenario.expected_first_tool, "string", scenario.id);
+    assert.ok(Array.isArray(scenario.required_action_sequence), scenario.id);
     assert.ok(Array.isArray(scenario.permitted_followups), scenario.id);
     assert.ok(Array.isArray(scenario.forbidden_tools), scenario.id);
     assert.equal(typeof scenario.source_read_authorization?.kind, "string", scenario.id);
@@ -455,14 +746,92 @@ test("actual parsers reject malformed, incomplete, and cross-host transcripts", 
   );
 });
 
+const CURSOR_CAPTURED_DIRECT_READ = [
+  { type: "system", subtype: "init", apiKeySource: "login", cwd: "/workspace/repo", session_id: "captured-1", model: "Claude 4 Sonnet", permissionMode: "default" },
+  { type: "user", message: { role: "user", content: [{ type: "text", text: "Read src/named.rs" }] }, session_id: "captured-1" },
+  { type: "tool_call", subtype: "started", call_id: "toolu_read", tool_call: { readToolCall: { args: { path: "src/named.rs" } } }, session_id: "captured-1" },
+  { type: "tool_call", subtype: "completed", call_id: "toolu_read", tool_call: { readToolCall: { args: { path: "src/named.rs" }, result: { success: { content: "fn named() {}\n", isEmpty: false, exceededLimit: false, totalLines: 1, totalChars: 14 } } } }, session_id: "captured-1" },
+  { type: "assistant", message: { role: "assistant", content: [{ type: "text", text: "{\"authority\":\"source\"," }] }, session_id: "captured-1" },
+  { type: "assistant", message: { role: "assistant", content: [{ type: "text", text: "\"outcome\":\"supported\"}" }] }, session_id: "captured-1" },
+  { type: "result", subtype: "success", duration_ms: 12, duration_api_ms: 10, is_error: false, result: "{\"authority\":\"source\",\"outcome\":\"supported\"}", session_id: "captured-1", request_id: "request-1" },
+];
+
+const CURSOR_CAPTURED_MCP = [
+  { type: "system", subtype: "init", apiKeySource: "login", cwd: "/workspace/repo", session_id: "captured-2", model: "Claude 4 Sonnet", permissionMode: "default" },
+  { type: "user", message: { role: "user", content: [{ type: "text", text: "Search ExactThing" }] }, session_id: "captured-2" },
+  { type: "tool_call", subtype: "started", call_id: "toolu_mcp", tool_call: { mcpToolCall: { args: { name: "codestory-search", args: { project: "/workspace/repo", query: "ExactThing" }, toolCallId: "toolu_mcp", providerIdentifier: "codestory", toolName: "search" } } }, session_id: "captured-2" },
+  { type: "tool_call", subtype: "completed", call_id: "toolu_mcp", tool_call: { mcpToolCall: { args: { name: "codestory-search", args: { project: "/workspace/repo", query: "ExactThing" }, toolCallId: "toolu_mcp", providerIdentifier: "codestory", toolName: "search" }, result: { success: { content: [{ type: "text", text: "{}" }] } } } }, session_id: "captured-2" },
+  { type: "assistant", message: { role: "assistant", content: [{ type: "text", text: "{}" }] }, session_id: "captured-2" },
+  { type: "result", subtype: "success", duration_ms: 12, duration_api_ms: 10, is_error: false, result: "{}", session_id: "captured-2" },
+];
+
+function capturedJsonl(events) {
+  return `${events.map((event) => JSON.stringify(event)).join("\n")}\n`;
+}
+
+test("Cursor official stream-json captured shapes are correlated and terminal", () => {
+  const direct = parseInstalledTranscript("cursor", capturedJsonl(CURSOR_CAPTURED_DIRECT_READ));
+  assert.deepEqual(direct.actions.map(({ kind }) => kind), ["source_read"]);
+  assert.equal(direct.final, "{\"authority\":\"source\",\"outcome\":\"supported\"}");
+  assert.equal(direct.user_text, "Read src/named.rs");
+
+  const mcp = parseInstalledTranscript("cursor", capturedJsonl(CURSOR_CAPTURED_MCP));
+  assert.deepEqual(mcp.actions.map(({ kind }) => kind), ["search"]);
+
+  const failure = clone(CURSOR_CAPTURED_DIRECT_READ);
+  failure.at(-1).subtype = "error";
+  failure.at(-1).is_error = true;
+  assert.throws(() => parseInstalledTranscript("cursor", capturedJsonl(failure)), /terminal result.*success/u);
+
+  assert.throws(
+    () => parseInstalledTranscript("cursor", capturedJsonl(CURSOR_CAPTURED_DIRECT_READ.slice(0, -1))),
+    /terminal result/u,
+  );
+
+  const partial = clone(CURSOR_CAPTURED_DIRECT_READ);
+  delete partial[3].tool_call.readToolCall.result;
+  assert.throws(() => parseInstalledTranscript("cursor", capturedJsonl(partial)), /completed tool call.*success/u);
+
+  const overlap = clone(CURSOR_CAPTURED_DIRECT_READ);
+  overlap.splice(3, 0, clone(CURSOR_CAPTURED_MCP[2]));
+  overlap[3].session_id = "captured-1";
+  assert.throws(() => parseInstalledTranscript("cursor", capturedJsonl(overlap)), /started before .* completed/u);
+
+  const terminalMismatch = clone(CURSOR_CAPTURED_DIRECT_READ);
+  terminalMismatch.at(-1).result = "different";
+  assert.throws(() => parseInstalledTranscript("cursor", capturedJsonl(terminalMismatch)), /assistant deltas.*terminal result/u);
+});
+
+function mutateBody(run, index, mutate) {
+  const body = run.steps[index].result.structuredContent;
+  mutate(body);
+  run.steps[index].result.content[0].text = JSON.stringify(body);
+}
+
 const MUTATIONS = [
+  {
+    name: "missing required packet continuation",
+    scenario: "packet_single_continuation",
+    mutate(run) {
+      run.steps.pop();
+    },
+    error: /required action sequence/u,
+  },
+  {
+    name: "missing required selected-target context",
+    scenario: "ambiguous_symbol_then_context",
+    mutate(run) {
+      run.steps.pop();
+    },
+    error: /required action sequence/u,
+  },
   {
     name: "wrong first tool",
     scenario: "broad_packet",
     mutate(run) {
       run.steps.unshift(baseRun("selected_target_context").steps[0]);
     },
-    error: /expected first tool packet/u,
+    error: /required action sequence|expected first tool packet/u,
   },
   {
     name: "forbidden followup",
@@ -470,7 +839,7 @@ const MUTATIONS = [
     mutate(run) {
       run.steps.push(baseRun("selected_target_context").steps[0]);
     },
-    error: /follow-up context is not permitted/u,
+    error: /required action sequence|follow-up context is not permitted/u,
   },
   {
     name: "unauthorized source read",
@@ -484,9 +853,78 @@ const MUTATIONS = [
     name: "authority escalation in final claim",
     scenario: "exact_symbol_search",
     mutate(run) {
-      run.final = "This is not a proof claim, but search verified the call definitely exists.";
+      run.final.authority = "typed_proof";
+      run.final.proof_disposition = "contract_proven";
     },
-    error: /missing required final claim|final claim violates/u,
+    error: /final claim authority/u,
+  },
+  {
+    name: "prose cannot replace structured final claims",
+    scenario: "typed_proof_unknown",
+    mutate(run) {
+      run.final = "Unknown, so I did not establish absence.";
+    },
+    error: /final claim.*required schema/u,
+  },
+  {
+    name: "final evidence must come from the selected result",
+    scenario: "selected_target_context",
+    mutate(run) {
+      run.final.evidence_ids = ["fabricated-evidence"];
+    },
+    error: /final claim evidence_ids/u,
+  },
+  {
+    name: "search result without leads",
+    scenario: "exact_symbol_search",
+    mutate(run) {
+      mutateBody(run, 0, (body) => delete body.leads);
+    },
+    error: /search result/u,
+  },
+  {
+    name: "context result without evidence",
+    scenario: "selected_target_context",
+    mutate(run) {
+      mutateBody(run, 0, (body) => delete body.evidence);
+    },
+    error: /context result/u,
+  },
+  {
+    name: "packet result without evidence",
+    scenario: "broad_packet",
+    mutate(run) {
+      mutateBody(run, 0, (body) => delete body.evidence);
+    },
+    error: /packet result/u,
+  },
+  {
+    name: "complete proof result without steps",
+    scenario: "typed_proof_contract_proven",
+    mutate(run) {
+      mutateBody(run, 0, (body) => delete body.steps);
+    },
+    error: /proof result/u,
+  },
+  {
+    name: "proof result contract projection drift",
+    scenario: "typed_proof_contract_proven",
+    mutate(run) {
+      mutateBody(run, 0, (body) => {
+        body.source_text_sha256 = "a".repeat(64);
+      });
+    },
+    error: /source_text_sha256.*host-supplied contract/u,
+  },
+  {
+    name: "proof receipt must match exact-resolution evidence",
+    scenario: "typed_proof_contract_proven",
+    mutate(run) {
+      mutateBody(run, 0, (body) => {
+        body.receipts[0].callsite_identity = "different-callsite";
+      });
+    },
+    error: /does not match exact-resolution evidence/u,
   },
   {
     name: "unexpected CodeStory tool error",
@@ -504,7 +942,7 @@ const MUTATIONS = [
       run.steps[0].result.structuredContent.disposition.kind = "contract_proven";
       run.steps[0].result.content[0].text = JSON.stringify(run.steps[0].result.structuredContent);
     },
-    error: /expected proof disposition unknown/u,
+    error: /proof result.*disposition/u,
   },
   {
     name: "proof retrieval activation",
@@ -529,7 +967,7 @@ const MUTATIONS = [
     mutate(run) {
       run.steps.push(clone(run.steps[1]));
     },
-    error: /at most one packet continuation/u,
+    error: /required action sequence|at most one packet continuation/u,
   },
   {
     name: "selector relaxation retry",
@@ -539,32 +977,66 @@ const MUTATIONS = [
       retry.args.spec.start = { kind: "qualified", qualified_name: "crate::start" };
       run.steps.push(retry);
     },
-    error: /follow-up prove_call_path is not permitted|proof request must preserve the host-supplied typed contract|proof may be called only once/u,
+    error: /required action sequence|follow-up prove_call_path is not permitted|proof request must preserve the host-supplied typed contract|proof may be called only once/u,
   },
   {
     name: "unknown becomes absence",
     scenario: "typed_proof_unknown",
     mutate(run) {
-      run.final = "The call is absent and never happens.";
+      run.final.absence_claim = true;
     },
-    error: /Unknown must not become absence|missing required final claim/u,
+    error: /final claim absence_claim|Unknown must not become absence/u,
   },
   {
     name: "silent material gap",
     scenario: "packet_gap_to_focused_source",
     mutate(run) {
-      run.final = "The source answers the question.";
+      run.final.gap_ids = [];
     },
-    error: /missing required final claim.*gap-1/u,
+    error: /final claim gap_ids/u,
   },
   {
     name: "free English proof construction",
     scenario: "refuse_free_english_proof",
     mutate(run) {
       run.steps.push(baseRun("typed_proof_contract_proven").steps[0]);
-      run.final = "ContractProven.";
+      run.final = finalClaim({ authority: "typed_proof", proof_disposition: "contract_proven" });
     },
-    error: /proof requires a host-supplied typed contract|expected no tool/u,
+    error: /required action sequence|proof requires a host-supplied typed contract|expected no tool/u,
+  },
+  {
+    name: "unavailable reason omitted",
+    scenario: "typed_proof_unavailable",
+    mutate(run) {
+      run.final.reason_codes = [];
+    },
+    error: /reason_codes/u,
+  },
+  {
+    name: "refutation basis omitted",
+    scenario: "typed_proof_contract_refuted",
+    mutate(run) {
+      run.final.refutation_basis = null;
+    },
+    error: /refutation_basis/u,
+  },
+  {
+    name: "packet claim contradicts packet authority",
+    scenario: "broad_packet",
+    mutate(run) {
+      run.final.absence_claim = true;
+    },
+    error: /absence_claim|packet authority/u,
+  },
+  {
+    name: "context result target must match the selected target",
+    scenario: "selected_target_context",
+    mutate(run) {
+      mutateBody(run, 0, (body) => {
+        body.target.canonical_id = "rust:crate::OtherThing";
+      });
+    },
+    error: /context result does not match the selected target/u,
   },
 ];
 
@@ -580,18 +1052,68 @@ for (const host of ["codex", "cursor"]) {
 
 test("every installed identity field is exact and every CodeStory result repeats runtime identity", () => {
   for (const field of INSTALLED_IDENTITY_FIELDS) {
-    const run = baseRun("broad_packet");
+    const expected = clone(EXPECTED_IDENTITY);
     const parts = field.split(".");
-    let owner = run.installed_identity;
+    let owner = expected;
     for (const part of parts.slice(0, -1)) owner = owner[part];
     const leaf = parts.at(-1);
     owner[leaf] = typeof owner[leaf] === "number" ? owner[leaf] + 1 : `${owner[leaf]}-drift`;
-    assert.throws(() => validate("codex", run), new RegExp(field.replaceAll(".", "\\."), "u"), field);
+    const expectedError = field === "receipt.relative_path"
+      ? /installed receipt/u
+      : new RegExp(field.replaceAll(".", "\\."), "u");
+    assert.throws(
+      () => validate("codex", baseRun("broad_packet"), expected),
+      expectedError,
+      field,
+    );
   }
 
   const resultDrift = baseRun("broad_packet");
   resultDrift.steps[0].result._meta.codestory_protocol.discovery_contract_sha256 = "e".repeat(64);
   assert.throws(() => validate("codex", resultDrift), /result identity.*discovery/u);
+});
+
+test("installed receipt authentication rejects substituted package launcher CLI and forged receipt", () => {
+  for (const relativePath of [
+    "archives/codestory-0.18.tgz",
+    "scripts/codestory-mcp.cjs",
+    "managed/codestory-cli",
+  ]) {
+    const path = join(installedRoot, relativePath);
+    const original = readFileSync(path);
+    try {
+      writeFileSync(path, "substituted bytes\n");
+      assert.throws(() => validate("codex", baseRun("broad_packet")), /authenticated .* bytes/u, relativePath);
+    } finally {
+      writeFileSync(path, original);
+    }
+  }
+
+  const originalReceipt = readFileSync(installedReceipt);
+  try {
+    const forged = JSON.parse(originalReceipt.toString("utf8"));
+    forged.identity.package.sha256 = "1".repeat(64);
+    const forgedBytes = Buffer.from(`${JSON.stringify(forged, null, 2)}\n`);
+    writeFileSync(installedReceipt, forgedBytes);
+    const expected = clone(EXPECTED_IDENTITY);
+    expected.package.sha256 = forged.identity.package.sha256;
+    expected.receipt.sha256 = sha256(forgedBytes);
+    assert.throws(
+      () => validate("codex", baseRun("broad_packet"), expected),
+      /package\.sha256 does not match authenticated package bytes/u,
+    );
+  } finally {
+    writeFileSync(installedReceipt, originalReceipt);
+  }
+
+  try {
+    writeFileSync(installedReceipt, "{not-json}\n");
+    const expected = clone(EXPECTED_IDENTITY);
+    expected.receipt.sha256 = sha256(readFileSync(installedReceipt));
+    assert.throws(() => validate("codex", baseRun("broad_packet"), expected), /receipt is invalid JSON/u);
+  } finally {
+    writeFileSync(installedReceipt, originalReceipt);
+  }
 });
 
 test("packet continuation and selected-context correlation are exact", () => {
@@ -604,12 +1126,11 @@ test("packet continuation and selected-context correlation are exact", () => {
   assert.throws(() => validate("codex", context), /selected target/u);
 });
 
-test("static Claude Code and Copilot surfaces bind one package, launcher, hook, and rule core", async () => {
-  assert.deepEqual(Object.keys(STATIC_PARITY_HOSTS), ["claude_code", "copilot_cli", "copilot_editor"]);
-  const manifest = JSON.parse(await readFile(join(pluginRoot, "plugin.json"), "utf8"));
-  const pin = JSON.parse(await readFile(join(pluginRoot, "cli-version.json"), "utf8"));
-  const catalog = JSON.parse(await readFile(join(pluginRoot, "generated-mcp-catalog.json"), "utf8"));
-  const launcher = await readFile(join(pluginRoot, "scripts", "codestory-mcp.cjs"));
+function staticIdentityFor(root) {
+  const manifest = JSON.parse(readFileSync(join(root, "plugin.json"), "utf8"));
+  const pin = JSON.parse(readFileSync(join(root, "cli-version.json"), "utf8"));
+  const catalog = JSON.parse(readFileSync(join(root, "generated-mcp-catalog.json"), "utf8"));
+  const launcher = readFileSync(join(root, "scripts", "codestory-mcp.cjs"));
   const staticIdentity = clone(EXPECTED_IDENTITY);
   staticIdentity.package.version = manifest.version;
   staticIdentity.cli.version = pin.cli_version;
@@ -618,6 +1139,28 @@ test("static Claude Code and Copilot surfaces bind one package, launcher, hook, 
   staticIdentity.protocol.revision = catalog.wireContract.preferredMcpProtocolVersion;
   staticIdentity.protocol.discovery_contract_sha256 =
     catalog.wireContract.discoveryContracts[staticIdentity.protocol.revision];
+  const rosterPaths = [
+    "plugin.json",
+    "cli-version.json",
+    "generated-mcp-catalog.json",
+    "mcp.json",
+    "scripts/codestory-mcp.cjs",
+    ".claude-plugin/plugin.json",
+    ".github/plugin/plugin.json",
+    "hooks/claude-codex-hooks.json",
+    "hooks/copilot-hooks.json",
+    "skills/codestory-grounding/SKILL.md",
+  ];
+  staticIdentity.static_roster = Object.fromEntries(
+    rosterPaths.map((path) => [path, sha256(readFileSync(join(root, path)))]),
+  );
+  return staticIdentity;
+}
+
+test("static Claude Code and Copilot surfaces bind one package, launcher, hook, and rule core", async () => {
+  assert.deepEqual(Object.keys(STATIC_PARITY_HOSTS), ["claude_code", "copilot_cli", "copilot_editor"]);
+  const manifest = JSON.parse(await readFile(join(pluginRoot, "plugin.json"), "utf8"));
+  const staticIdentity = staticIdentityFor(pluginRoot);
 
   const report = await validateStaticHostParity(pluginRoot, staticIdentity);
   assert.equal(report.status, "pass");
@@ -628,5 +1171,42 @@ test("static Claude Code and Copilot surfaces bind one package, launcher, hook, 
     assert.equal(host.rule_sha256.length, 64);
     assert.equal(host.hook_sha256.length, 64);
     assert.equal(host.model_routing_evaluated, false);
+  }
+});
+
+test("static parity rejects substituted bytes invalid or no-op hooks metadata drift and heading-only rules", async () => {
+  const root = mkdtempSync(join(tmpdir(), "codestory-routing-static-"));
+  cpSync(pluginRoot, root, { recursive: true });
+  try {
+    const launcherIdentity = staticIdentityFor(root);
+    writeFileSync(join(root, "scripts", "codestory-mcp.cjs"), "substituted launcher\n");
+    await assert.rejects(validateStaticHostParity(root, launcherIdentity), /static digest roster.*codestory-mcp/u);
+
+    cpSync(join(pluginRoot, "scripts", "codestory-mcp.cjs"), join(root, "scripts", "codestory-mcp.cjs"));
+    writeFileSync(join(root, "hooks", "copilot-hooks.json"), "{not-json}\n");
+    const invalidJson = staticIdentityFor(root);
+    await assert.rejects(validateStaticHostParity(root, invalidJson), /hook.*canonical JSON/u);
+
+    writeFileSync(join(root, "hooks", "copilot-hooks.json"), JSON.stringify({
+      version: 1,
+      hooks: { sessionStart: [{ type: "command", bash: "echo codestory-activate.cjs", powershell: "echo codestory-activate.cjs", timeoutSec: 300 }] },
+    }));
+    const noOpHook = staticIdentityFor(root);
+    await assert.rejects(validateStaticHostParity(root, noOpHook), /hook command is not the canonical launcher/u);
+
+    cpSync(join(pluginRoot, "hooks", "copilot-hooks.json"), join(root, "hooks", "copilot-hooks.json"));
+    const copilotMetadataPath = join(root, ".github", "plugin", "plugin.json");
+    const metadata = JSON.parse(readFileSync(copilotMetadataPath, "utf8"));
+    metadata.hooks = "hooks/other.json";
+    writeFileSync(copilotMetadataPath, JSON.stringify(metadata));
+    const driftedMetadata = staticIdentityFor(root);
+    await assert.rejects(validateStaticHostParity(root, driftedMetadata), /metadata does not bind/u);
+
+    cpSync(join(pluginRoot, ".github", "plugin", "plugin.json"), copilotMetadataPath);
+    writeFileSync(join(root, "skills", "codestory-grounding", "SKILL.md"), "---\nname: codestory-grounding\n---\n# CodeStory Grounding\n");
+    const headingOnly = staticIdentityFor(root);
+    await assert.rejects(validateStaticHostParity(root, headingOnly), /complete canonical grounding contract/u);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
   }
 });

--- a/scripts/tests/codestory-agent-routing-conformance.test.mjs
+++ b/scripts/tests/codestory-agent-routing-conformance.test.mjs
@@ -20,6 +20,7 @@ import {
   INSTALLED_IDENTITY_FIELDS,
   ROUTING_SCENARIOS,
   STATIC_PARITY_HOSTS,
+  canonicalRequestContractDigest,
   parseInstalledTranscript,
   validateInstalledSession,
   validateStaticHostParity,
@@ -179,33 +180,33 @@ function result(body, { isError = false, meta = runtimeMeta() } = {}) {
 }
 
 function proofBody(disposition, contract, detail = {}) {
-  const contractDigest = "f".repeat(64);
+  const contractDigest = canonicalRequestContractDigest(contract);
   const common = { kind: disposition, contract_digest: contractDigest };
   let projectedDisposition;
   let stepStatus;
-  let receipts = [];
+  const hasReceipt = ["contract_proven", "contract_refuted"].includes(disposition);
+  const receipts = hasReceipt ? [{
+    receipt_id: "receipt-1",
+    edge_id: "edge-1",
+    source: 0,
+    target: 1,
+    evidence: 0,
+    exact_callsite_start_byte: 0,
+    callsite_identity: "1:1:1:2|rust",
+    column_or_ordinal: 1,
+    containment: { file: 0, owner: 0, start_line: 1, end_line: 1 },
+    line_window: {
+      kind: "indexed_line_v1",
+      file: 0,
+      anchor_line: 1,
+      byte_start: 0,
+      byte_end: 10,
+      text: "finish();\n",
+    },
+  }] : [];
   if (disposition === "contract_proven") {
     projectedDisposition = { ...common, receipts: [0] };
     stepStatus = "proven";
-    receipts = [{
-      receipt_id: "receipt-1",
-      edge_id: "edge-1",
-      source: 0,
-      target: 1,
-      evidence: 0,
-      exact_callsite_start_byte: 0,
-      callsite_identity: "file-1:1:1:finish|rust",
-      column_or_ordinal: 1,
-      containment: { file: 0, owner: 0, start_line: 1, end_line: 1 },
-      line_window: {
-        kind: "indexed_line_v1",
-        file: 0,
-        anchor_line: 1,
-        byte_start: 0,
-        byte_end: 10,
-        text: "finish();\n",
-      },
-    }];
   } else if (disposition === "contract_refuted") {
     projectedDisposition = {
       ...common,
@@ -213,7 +214,7 @@ function proofBody(disposition, contract, detail = {}) {
         kind: detail.basis?.kind ?? "prohibited_scope_traversal",
         step_index: 0,
         prohibition_index: 0,
-        connected_receipts: [],
+        connected_receipts: [0],
       },
     };
     stepStatus = "positive_contradiction";
@@ -239,16 +240,16 @@ function proofBody(disposition, contract, detail = {}) {
     source_text_sha256: sha256(Buffer.from(contract.source_text)),
     contract_digest: contractDigest,
     core_publication: { project_id: "project-1", generation_id: "core-1", run_id: "run-1" },
-    identities: {
+    identities: hasReceipt ? {
       files: [{
-        file_node_id: "file-1",
+        file_node_id: "1",
         project_file_components: ["src", "lib.rs"],
         indexed_sha256: "a".repeat(64),
         observed_sha256: "a".repeat(64),
       }],
       symbols: [
-        { node_id: "node-1", canonical_id: "rust:crate::start", qualified_name: "crate::start", file: 0 },
-        { node_id: "node-2", canonical_id: "rust:crate::finish", qualified_name: "crate::finish", file: 0 },
+        { node_id: "1", canonical_id: "rust:crate::start", qualified_name: "crate::start", file: 0 },
+        { node_id: "2", canonical_id: "rust:crate::finish", qualified_name: "crate::finish", file: 0 },
       ],
       provenance_profiles: [{
         producer: "codestory-internal",
@@ -259,24 +260,27 @@ function proofBody(disposition, contract, detail = {}) {
         parser_fingerprint: "b".repeat(64),
       }],
       evidence: [{
-        fact_id: "c".repeat(64),
+        fact_id: "c475943eeae97a7565be3dba007562b65e662b5111d1165b72ce2401e0d88eac",
         caller: 0,
         target: 1,
         edge_id: "edge-1",
-        callsite_identity: "file-1:1:1:finish|rust",
+        callsite_identity: "1:1:1:2|rust",
         chain: [{ kind: "same_file_declaration", symbols: [1] }],
         provenance: { profile: 0, dependency_files: [0], evidence_sha256: "d".repeat(64) },
       }],
-    },
+    } : { files: [], symbols: [], provenance_profiles: [], evidence: [] },
     spec: {
-      start: { kind: "canonical_id_ref", symbol: 0 },
-      steps: [{ relation: "direct_outgoing_call", target: { kind: "canonical_id_ref", symbol: 1 } }],
+      start: hasReceipt ? { kind: "canonical_id_ref", symbol: 0 } : clone(contract.spec.start),
+      steps: [{
+        relation: "direct_outgoing_call",
+        target: hasReceipt ? { kind: "canonical_id_ref", symbol: 1 } : clone(contract.spec.steps[0].target),
+      }],
       prohibit_traversal_through: clone(contract.spec.prohibit_traversal_through),
       exclude_from_projection: clone(contract.spec.exclude_from_projection),
     },
     clauses: clone(contract.clauses),
     disposition: projectedDisposition,
-    steps: [{ step_index: 0, status: stepStatus, receipt: receipts.length ? 0 : null }],
+    steps: [{ step_index: 0, status: stepStatus, receipt: hasReceipt ? 0 : null }],
     receipts,
   };
 }
@@ -474,6 +478,7 @@ function baseRun(scenarioId) {
       run.final = finalClaim({
         authority: "typed_proof",
         outcome: "refuted",
+        evidence_ids: ["receipt-1"],
         proof_disposition: "contract_refuted",
         refutation_basis: "prohibited_scope_traversal",
       });
@@ -914,7 +919,7 @@ const MUTATIONS = [
         body.source_text_sha256 = "a".repeat(64);
       });
     },
-    error: /source_text_sha256.*host-supplied contract/u,
+    error: /semantic invariant.*source_text_sha256/u,
   },
   {
     name: "proof receipt must match exact-resolution evidence",
@@ -1047,6 +1052,114 @@ for (const host of ["codex", "cursor"]) {
       mutation.mutate(run);
       assert.throws(() => validate(host, run), mutation.error, mutation.name);
     }
+  });
+}
+
+const SEMANTIC_BINDING_MUTATIONS = [
+  {
+    name: "ContractProven with Unknown step and no receipt",
+    scenario: "typed_proof_contract_proven",
+    mutate(body) {
+      body.steps[0].status = "unknown";
+      body.steps[0].receipt = null;
+    },
+  },
+  {
+    name: "ContractRefuted with Unknown step",
+    scenario: "typed_proof_contract_refuted",
+    mutate(body) {
+      body.steps[0].status = "unknown";
+      body.steps[0].receipt = null;
+    },
+  },
+  {
+    name: "Unknown with Proven step",
+    scenario: "typed_proof_unknown",
+    mutate(body) {
+      body.steps[0].status = "proven";
+    },
+  },
+  {
+    name: "Unavailable with Proven step",
+    scenario: "typed_proof_unavailable",
+    mutate(body) {
+      body.steps[0].status = "proven";
+    },
+  },
+  {
+    name: "changed digest not derived from the request",
+    scenario: "typed_proof_contract_proven",
+    mutate(body) {
+      body.contract_digest = "a".repeat(64);
+      body.disposition.contract_digest = body.contract_digest;
+    },
+  },
+  {
+    name: "exact callsite start outside its hash-bound window",
+    scenario: "typed_proof_contract_proven",
+    mutate(body) {
+      body.receipts[0].exact_callsite_start_byte = body.receipts[0].line_window.byte_end;
+    },
+  },
+];
+
+for (const host of ["codex", "cursor"]) {
+  test(`${host} canonical proof semantic-binding matrix fails closed`, () => {
+    const accepted = [];
+    for (const mutation of SEMANTIC_BINDING_MUTATIONS) {
+      const run = baseRun(mutation.scenario);
+      mutateBody(run, 0, mutation.mutate);
+      try {
+        validate(host, run);
+        accepted.push(mutation.name);
+      } catch (error) {
+        assert.match(error.message, /proof result semantic invariant/u, mutation.name);
+      }
+    }
+    assert.deepEqual(accepted, [], `semantic mutations accepted through ${host}`);
+  });
+}
+
+const SELECTOR_GAP_KINDS = ["selector_missing", "selector_ambiguous", "non_callable_selector"];
+const STEP_GAP_KINDS = [
+  "direct_call_missing",
+  "recursive_call_not_representable",
+  "source_window_too_large",
+  "invalid_utf8",
+  "source_line_out_of_range",
+  "edge_containment_unproven",
+  "missing_direct_call_receipt",
+  "receipt_or_edge_already_used",
+  "projection_exclusion_conflicts_with_required_receipt",
+];
+
+for (const host of ["codex", "cursor"]) {
+  test(`${host} canonical proof gap indices use the projected step count`, () => {
+    const acceptedOutOfRange = [];
+    for (const [kind, indexField, validIndex, invalidIndex] of [
+      ...SELECTOR_GAP_KINDS.map((kind) => [kind, "selector_index", 1, 2]),
+      ...STEP_GAP_KINDS.map((kind) => [kind, "step_index", 0, 1]),
+    ]) {
+      const boundary = baseRun("typed_proof_unknown");
+      mutateBody(boundary, 0, (body) => {
+        body.disposition.gaps = [{ kind, [indexField]: validIndex }];
+      });
+      boundary.final.gap_ids = [kind];
+      assert.equal(validate(host, boundary).status, "pass", `${kind} accepted boundary`);
+
+      const outOfRange = baseRun("typed_proof_unknown");
+      mutateBody(outOfRange, 0, (body) => {
+        body.disposition.gaps = [{ kind, [indexField]: invalidIndex }];
+      });
+      outOfRange.final.gap_ids = [kind];
+      try {
+        validate(host, outOfRange);
+        acceptedOutOfRange.push(kind);
+      } catch (error) {
+        assert.match(error.message, /proof result semantic invariant.*gap index/u, kind);
+      }
+    }
+    assert.deepEqual(acceptedOutOfRange, [], `out-of-range gaps accepted through ${host}`);
   });
 }
 

--- a/scripts/tests/codestory-agent-routing-conformance.test.mjs
+++ b/scripts/tests/codestory-agent-routing-conformance.test.mjs
@@ -1,0 +1,632 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import {
+  INSTALLED_IDENTITY_FIELDS,
+  ROUTING_SCENARIOS,
+  STATIC_PARITY_HOSTS,
+  parseInstalledTranscript,
+  validateInstalledSession,
+  validateStaticHostParity,
+} from "../codestory-agent-routing-conformance.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, "..", "..");
+const pluginRoot = join(repoRoot, "plugins", "codestory");
+const SHA_A = "a".repeat(64);
+const SHA_B = "b".repeat(64);
+const SHA_C = "c".repeat(64);
+const SHA_D = "d".repeat(64);
+
+const EXPECTED_IDENTITY = Object.freeze({
+  package: Object.freeze({ name: "codestory", version: "0.18.0-candidate.7", sha256: SHA_A }),
+  launcher: Object.freeze({ relative_path: "scripts/codestory-mcp.cjs", sha256: SHA_B }),
+  cli: Object.freeze({ version: "0.18.0-candidate.7", sha256: SHA_C, source: "managed" }),
+  publication: Object.freeze({ schema_version: 3 }),
+  protocol: Object.freeze({
+    revision: "2025-11-25",
+    discovery_contract_sha256: SHA_D,
+  }),
+});
+
+const SCENARIO_IDS = [
+  "named_file_direct_read",
+  "exact_symbol_search",
+  "ambiguous_symbol_then_context",
+  "selected_target_context",
+  "broad_packet",
+  "packet_single_continuation",
+  "packet_gap_to_focused_source",
+  "packet_unavailable_to_source",
+  "typed_proof_contract_proven",
+  "typed_proof_contract_refuted",
+  "typed_proof_unknown",
+  "typed_proof_unavailable",
+  "malformed_proof_contract",
+  "refuse_free_english_proof",
+  "proof_observational",
+  "hidden_proof_tool_discovery",
+];
+
+function clone(value) {
+  return structuredClone(value);
+}
+
+function proofContract() {
+  return {
+    source_text: "`crate::start` directly calls `crate::finish`.",
+    clauses: [
+      {
+        clause_id: "start",
+        start_byte: 0,
+        end_byte_exclusive: 14,
+        quote: "`crate::start`",
+        classification: { kind: "resolved_material", fields: [{ kind: "start" }] },
+      },
+      {
+        clause_id: "target",
+        start_byte: 30,
+        end_byte_exclusive: 45,
+        quote: "`crate::finish`",
+        classification: {
+          kind: "resolved_material",
+          fields: [{ kind: "step_target", step: 1 }, { kind: "directness", step: 1 }],
+        },
+      },
+    ],
+    spec: {
+      start: { kind: "canonical_id", canonical_id: "rust:crate::start" },
+      steps: [{ target: { kind: "canonical_id", canonical_id: "rust:crate::finish" } }],
+      prohibit_traversal_through: [],
+      exclude_from_projection: [],
+    },
+  };
+}
+
+function runtimeMeta(overrides = {}) {
+  return {
+    codestory_publication: {
+      schema_version: EXPECTED_IDENTITY.publication.schema_version,
+      contract_runtime: {
+        plugin_version: EXPECTED_IDENTITY.package.version,
+        plugin_cli_version: EXPECTED_IDENTITY.cli.version,
+        cli_version: EXPECTED_IDENTITY.cli.version,
+        cli_sha256: EXPECTED_IDENTITY.cli.sha256,
+        cli_source: EXPECTED_IDENTITY.cli.source,
+        pinned_pair_matches: true,
+        known_override_skew_channel: false,
+      },
+    },
+    codestory_protocol: {
+      negotiated: EXPECTED_IDENTITY.protocol.revision,
+      discovery_contract_sha256: EXPECTED_IDENTITY.protocol.discovery_contract_sha256,
+    },
+    codestory_execution: { semantic_retrieval_activated: false },
+    ...overrides,
+  };
+}
+
+function result(body, { isError = false, meta = runtimeMeta() } = {}) {
+  return {
+    content: [{ type: "text", text: JSON.stringify(body) }],
+    ...(isError ? { isError: true } : { structuredContent: body }),
+    _meta: meta,
+  };
+}
+
+function proofBody(disposition, detail = {}) {
+  return {
+    kind: "complete",
+    proof_contract_schema_version: 1,
+    proof_domain: "indexed_source_call_path_v1",
+    clause_guard_version: "clause_guard_v1",
+    disposition: { kind: disposition, ...detail },
+  };
+}
+
+function baseRun(scenarioId) {
+  const typed = proofContract();
+  const run = {
+    scenario_id: scenarioId,
+    request: {
+      text: "Inspect the requested repository evidence.",
+      named_files: [],
+      selected_target: null,
+      proof_contract: null,
+    },
+    installed_identity: clone(EXPECTED_IDENTITY),
+    steps: [],
+    final: "Completed from the permitted evidence.",
+  };
+
+  const mcp = (tool, args, body, options) => ({ kind: "mcp", tool, args, result: result(body, options) });
+  const read = (path) => ({ kind: "source_read", path });
+
+  switch (scenarioId) {
+    case "named_file_direct_read":
+      run.request.named_files = ["src/named.rs"];
+      run.steps = [read("src/named.rs")];
+      run.final = "The named file src/named.rs contains the requested definition.";
+      break;
+    case "exact_symbol_search":
+      run.steps = [mcp("search", { project: "/workspace/repo", query: "ExactThing" }, {
+        kind: "complete",
+        leads: [{ canonical_id: "rust:crate::ExactThing" }],
+        gaps: [],
+      })];
+      run.final = "Search found the discovery lead rust:crate::ExactThing; this is not a proof claim.";
+      break;
+    case "ambiguous_symbol_then_context":
+      run.request.selected_target = "rust:crate::one::Thing";
+      run.steps = [
+        mcp("search", { project: "/workspace/repo", query: "Thing" }, {
+          kind: "complete",
+          leads: [
+            { canonical_id: "rust:crate::one::Thing" },
+            { canonical_id: "rust:crate::two::Thing" },
+          ],
+          gaps: [{ code: "selector_ambiguous" }],
+        }),
+        mcp("context", {
+          project: "/workspace/repo",
+          selector: { canonical_id: "rust:crate::one::Thing" },
+        }, { kind: "complete", target: "rust:crate::one::Thing", evidence: ["src/one.rs:1"] }),
+      ];
+      run.final = "The search was selector_ambiguous. Context covers selected target rust:crate::one::Thing only.";
+      break;
+    case "selected_target_context":
+      run.request.selected_target = "rust:crate::ExactThing";
+      run.steps = [mcp("context", {
+        project: "/workspace/repo",
+        selector: { canonical_id: "rust:crate::ExactThing" },
+      }, { kind: "complete", target: "rust:crate::ExactThing", evidence: ["src/lib.rs:10"] })];
+      run.final = "Context provides evidence for selected target rust:crate::ExactThing only.";
+      break;
+    case "broad_packet":
+      run.steps = [mcp("packet", { project: "/workspace/repo", question: "How does the flow work?" }, {
+        kind: "complete",
+        packet_id: "packet-1",
+        status: "complete",
+        evidence: [{ evidence_id: "evidence-1" }],
+        gaps: [],
+      })];
+      run.final = "Packet evidence evidence-1 supports the broad answer; packet availability is not proof.";
+      break;
+    case "packet_single_continuation":
+      run.steps = [
+        mcp("packet", { project: "/workspace/repo", question: "How does the flow work?" }, {
+          kind: "complete",
+          packet_id: "packet-1",
+          status: "continuation_available",
+          publication: { core_generation_id: "core-1", retrieval_generation_id: "retrieval-1" },
+          continuation: { continuation_id: "continuation-1", gap_ids: ["gap-1"] },
+          evidence: [{ evidence_id: "evidence-1" }],
+          gaps: [{ gap_id: "gap-1" }],
+        }),
+        mcp("packet", {
+          project: "/workspace/repo",
+          question: "How does the flow work?",
+          parent_packet_id: "continuation-1",
+          option_ids: ["gap-1"],
+          core_generation_id: "core-1",
+          retrieval_generation_id: "retrieval-1",
+        }, {
+          kind: "complete",
+          packet_id: "packet-2",
+          status: "complete",
+          evidence: [{ evidence_id: "evidence-2" }],
+          gaps: [],
+        }),
+      ];
+      run.final = "The one bounded continuation supplied evidence-2 and closed gap-1.";
+      break;
+    case "packet_gap_to_focused_source":
+      run.steps = [
+        mcp("packet", { project: "/workspace/repo", question: "How does the flow work?" }, {
+          kind: "complete",
+          packet_id: "packet-1",
+          status: "no_useful_evidence",
+          evidence: [],
+          gaps: [{ gap_id: "gap-1", authorized_source_paths: ["src/gap.rs"] }],
+        }),
+        read("src/gap.rs"),
+      ];
+      run.final = "Packet gap gap-1 required a focused read of src/gap.rs; the source is the cited evidence.";
+      break;
+    case "packet_unavailable_to_source":
+      run.steps = [
+        mcp("packet", { project: "/workspace/repo", question: "How does the flow work?" }, {
+          kind: "budget_exceeded",
+          status: "unavailable",
+          reason: "retrieval_unavailable",
+          gaps: [],
+        }),
+        read("src/fallback.rs"),
+      ];
+      run.final = "Packet was retrieval_unavailable, so src/fallback.rs is the focused source evidence.";
+      break;
+    case "typed_proof_contract_proven":
+      run.request.proof_contract = typed;
+      run.steps = [mcp("prove_call_path", { project: "/workspace/repo", ...typed }, proofBody("contract_proven"))];
+      run.final = "The typed verifier returned ContractProven for this indexed source call path only.";
+      break;
+    case "typed_proof_contract_refuted":
+      run.request.proof_contract = typed;
+      run.steps = [mcp("prove_call_path", { project: "/workspace/repo", ...typed }, proofBody("contract_refuted", {
+        basis: { kind: "positive_contradiction" },
+      }))];
+      run.final = "The typed verifier returned ContractRefuted by positive_contradiction.";
+      break;
+    case "typed_proof_unknown":
+      run.request.proof_contract = typed;
+      run.steps = [mcp("prove_call_path", { project: "/workspace/repo", ...typed }, proofBody("unknown", {
+        gaps: [{ code: "selector_missing" }],
+      }))];
+      run.final = "The typed verifier returned Unknown because selector_missing; this does not establish absence.";
+      break;
+    case "typed_proof_unavailable":
+      run.request.proof_contract = typed;
+      run.steps = [mcp("prove_call_path", { project: "/workspace/repo", ...typed }, proofBody("unavailable", {
+        reason: "proof_semantic_projection_unavailable",
+      }))];
+      run.final = "The typed verifier returned Unavailable: proof_semantic_projection_unavailable.";
+      break;
+    case "malformed_proof_contract": {
+      const malformed = { source_text: "A calls B", clauses: [] };
+      run.request.proof_contract = malformed;
+      run.steps = [mcp("prove_call_path", { project: "/workspace/repo", ...malformed }, {
+        code: "invalid_proof_interpretation",
+        message: "spec is required",
+      }, { isError: true })];
+      run.final = "The typed contract is invalid_proof_interpretation because spec is required; no proof disposition was produced.";
+      break;
+    }
+    case "refuse_free_english_proof":
+      run.request.text = "Prove from this sentence that start calls finish.";
+      run.final = "I cannot construct an authoritative typed contract from free English; provide the typed contract.";
+      break;
+    case "proof_observational":
+      run.request.proof_contract = typed;
+      run.steps = [mcp("prove_call_path", { project: "/workspace/repo", ...typed }, proofBody("unknown", {
+        gaps: [{ code: "edge_not_proof_authoritative" }],
+      }))];
+      run.final = "The observational verifier returned Unknown: edge_not_proof_authoritative; it did not activate semantic retrieval.";
+      break;
+    case "hidden_proof_tool_discovery":
+      run.request.proof_contract = typed;
+      run.steps = [
+        { kind: "tool_search", query: "codestory mcp prove_call_path", tools: ["mcp__codestory__prove_call_path"] },
+        mcp("prove_call_path", { project: "/workspace/repo", ...typed }, proofBody("contract_proven")),
+      ];
+      run.final = "After discovering only prove_call_path, the typed verifier returned ContractProven for the indexed source path.";
+      break;
+    default:
+      throw new Error(`unknown scenario ${scenarioId}`);
+  }
+  return run;
+}
+
+function codexJsonl(run) {
+  const events = [{ type: "thread.started", thread_id: "thread-1" }];
+  let counter = 0;
+  for (const step of run.steps) {
+    counter += 1;
+    const id = `call-${counter}`;
+    if (step.kind === "mcp") {
+      const item = {
+        id,
+        type: "mcp_tool_call",
+        server: "codestory",
+        tool: step.tool,
+        arguments: step.args,
+      };
+      events.push({ type: "item.started", item });
+      events.push({ type: "item.completed", item: { ...item, status: "completed", result: step.result } });
+    } else if (step.kind === "tool_search") {
+      const item = {
+        id,
+        type: "mcp_tool_call",
+        server: "codex-tools",
+        tool: "tool_search",
+        arguments: { query: step.query },
+      };
+      events.push({ type: "item.started", item });
+      events.push({ type: "item.completed", item: { ...item, status: "completed", result: { tools: step.tools } } });
+    } else if (step.kind === "source_read") {
+      const item = { id, type: "command_execution", command: `sed -n '1,120p' '${step.path}'` };
+      events.push({ type: "item.started", item });
+      events.push({
+        type: "item.completed",
+        item: { ...item, status: "completed", exit_code: 0, aggregated_output: "source fixture\n" },
+      });
+    }
+  }
+  events.push({ type: "item.completed", item: { id: "answer", type: "agent_message", text: run.final } });
+  return `${events.map((event) => JSON.stringify(event)).join("\n")}\n`;
+}
+
+function cursorJsonl(run) {
+  const events = [{ type: "system", subtype: "init", session_id: "cursor-session-1" }];
+  let counter = 0;
+  for (const step of run.steps) {
+    counter += 1;
+    const id = `call-${counter}`;
+    let name;
+    let input;
+    let output;
+    if (step.kind === "mcp") {
+      name = `mcp_codestory_${step.tool}`;
+      input = step.args;
+      output = JSON.stringify(step.result);
+    } else if (step.kind === "tool_search") {
+      name = "tool_search";
+      input = { query: step.query };
+      output = JSON.stringify({ tools: step.tools });
+    } else {
+      name = "Shell";
+      input = { command: `sed -n '1,120p' '${step.path}'` };
+      output = "source fixture\n";
+    }
+    events.push({
+      type: "assistant",
+      message: { role: "assistant", content: [{ type: "tool_use", id, name, input }] },
+    });
+    events.push({
+      type: "user",
+      message: {
+        role: "user",
+        content: [{ type: "tool_result", tool_use_id: id, content: output, is_error: false }],
+      },
+    });
+  }
+  events.push({
+    type: "assistant",
+    message: { role: "assistant", content: [{ type: "text", text: run.final }] },
+  });
+  return `${events.map((event) => JSON.stringify(event)).join("\n")}\n`;
+}
+
+function transcript(host, run) {
+  return host === "codex" ? codexJsonl(run) : cursorJsonl(run);
+}
+
+function validate(host, run) {
+  return validateInstalledSession({
+    host,
+    scenarioId: run.scenario_id,
+    request: run.request,
+    installedIdentity: run.installed_identity,
+    expectedIdentity: EXPECTED_IDENTITY,
+    transcript: transcript(host, run),
+  });
+}
+
+test("freezes exactly the sixteen accepted routing scenarios", () => {
+  assert.deepEqual(ROUTING_SCENARIOS.map(({ id }) => id), SCENARIO_IDS);
+  assert.equal(new Set(ROUTING_SCENARIOS.map(({ id }) => id)).size, 16);
+  for (const scenario of ROUTING_SCENARIOS) {
+    assert.equal(typeof scenario.expected_first_tool, "string", scenario.id);
+    assert.ok(Array.isArray(scenario.permitted_followups), scenario.id);
+    assert.ok(Array.isArray(scenario.forbidden_tools), scenario.id);
+    assert.equal(typeof scenario.source_read_authorization?.kind, "string", scenario.id);
+    assert.equal(typeof scenario.final_claim_constraints, "object", scenario.id);
+    assert.deepEqual(scenario.identity_requirements.fields, INSTALLED_IDENTITY_FIELDS, scenario.id);
+    assert.equal(scenario.identity_requirements.mode, "exact", scenario.id);
+  }
+  assert.equal(Object.isFrozen(ROUTING_SCENARIOS), true);
+  assert.equal(Object.isFrozen(ROUTING_SCENARIOS[0]), true);
+});
+
+for (const host of ["codex", "cursor"]) {
+  test(`${host} real-session parser accepts all sixteen frozen scenarios`, () => {
+    for (const scenarioId of SCENARIO_IDS) {
+      const report = validate(host, baseRun(scenarioId));
+      assert.equal(report.status, "pass", scenarioId);
+      assert.equal(report.host, host, scenarioId);
+      assert.equal(report.scenario_id, scenarioId, scenarioId);
+    }
+  });
+}
+
+test("actual parsers reject malformed, incomplete, and cross-host transcripts", () => {
+  assert.throws(() => parseInstalledTranscript("codex", "{not-json}\n"), /malformed JSONL/u);
+  assert.throws(
+    () => parseInstalledTranscript("codex", `${JSON.stringify({
+      type: "item.started",
+      item: { id: "dangling", type: "mcp_tool_call", server: "codestory", tool: "packet" },
+    })}\n`),
+    /unmatched tool call/u,
+  );
+  assert.throws(() => parseInstalledTranscript("cursor", codexJsonl(baseRun("broad_packet"))), /Cursor/u);
+  assert.throws(() => parseInstalledTranscript("unknown", "{}\n"), /unsupported host/u);
+
+  const overlapping = codexJsonl(baseRun("packet_gap_to_focused_source"))
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line));
+  [overlapping[2], overlapping[3]] = [overlapping[3], overlapping[2]];
+  assert.throws(
+    () => parseInstalledTranscript("codex", `${overlapping.map(JSON.stringify).join("\n")}\n`),
+    /started before .* completed/u,
+  );
+});
+
+const MUTATIONS = [
+  {
+    name: "wrong first tool",
+    scenario: "broad_packet",
+    mutate(run) {
+      run.steps.unshift(baseRun("selected_target_context").steps[0]);
+    },
+    error: /expected first tool packet/u,
+  },
+  {
+    name: "forbidden followup",
+    scenario: "broad_packet",
+    mutate(run) {
+      run.steps.push(baseRun("selected_target_context").steps[0]);
+    },
+    error: /follow-up context is not permitted/u,
+  },
+  {
+    name: "unauthorized source read",
+    scenario: "packet_gap_to_focused_source",
+    mutate(run) {
+      run.steps[1].path = "src/unrelated.rs";
+    },
+    error: /source read is not authorized/u,
+  },
+  {
+    name: "authority escalation in final claim",
+    scenario: "exact_symbol_search",
+    mutate(run) {
+      run.final = "This is not a proof claim, but search verified the call definitely exists.";
+    },
+    error: /missing required final claim|final claim violates/u,
+  },
+  {
+    name: "unexpected CodeStory tool error",
+    scenario: "broad_packet",
+    mutate(run) {
+      run.steps[0].result.isError = true;
+      delete run.steps[0].result.structuredContent;
+    },
+    error: /unexpected failed packet action/u,
+  },
+  {
+    name: "disposition drift",
+    scenario: "typed_proof_unknown",
+    mutate(run) {
+      run.steps[0].result.structuredContent.disposition.kind = "contract_proven";
+      run.steps[0].result.content[0].text = JSON.stringify(run.steps[0].result.structuredContent);
+    },
+    error: /expected proof disposition unknown/u,
+  },
+  {
+    name: "proof retrieval activation",
+    scenario: "proof_observational",
+    mutate(run) {
+      run.steps[0].result._meta.codestory_execution.semantic_retrieval_activated = true;
+    },
+    error: /proof activated semantic retrieval/u,
+  },
+  {
+    name: "hidden discovery broadens lookup",
+    scenario: "hidden_proof_tool_discovery",
+    mutate(run) {
+      run.steps[0].query = "codestory mcp";
+      run.steps[0].tools.push("mcp__codestory__packet");
+    },
+    error: /hidden-tool discovery/u,
+  },
+  {
+    name: "second packet continuation",
+    scenario: "packet_single_continuation",
+    mutate(run) {
+      run.steps.push(clone(run.steps[1]));
+    },
+    error: /at most one packet continuation/u,
+  },
+  {
+    name: "selector relaxation retry",
+    scenario: "typed_proof_contract_proven",
+    mutate(run) {
+      const retry = clone(run.steps[0]);
+      retry.args.spec.start = { kind: "qualified", qualified_name: "crate::start" };
+      run.steps.push(retry);
+    },
+    error: /follow-up prove_call_path is not permitted|proof request must preserve the host-supplied typed contract|proof may be called only once/u,
+  },
+  {
+    name: "unknown becomes absence",
+    scenario: "typed_proof_unknown",
+    mutate(run) {
+      run.final = "The call is absent and never happens.";
+    },
+    error: /Unknown must not become absence|missing required final claim/u,
+  },
+  {
+    name: "silent material gap",
+    scenario: "packet_gap_to_focused_source",
+    mutate(run) {
+      run.final = "The source answers the question.";
+    },
+    error: /missing required final claim.*gap-1/u,
+  },
+  {
+    name: "free English proof construction",
+    scenario: "refuse_free_english_proof",
+    mutate(run) {
+      run.steps.push(baseRun("typed_proof_contract_proven").steps[0]);
+      run.final = "ContractProven.";
+    },
+    error: /proof requires a host-supplied typed contract|expected no tool/u,
+  },
+];
+
+for (const host of ["codex", "cursor"]) {
+  test(`${host} hostile routing matrix fails closed through its parser`, () => {
+    for (const mutation of MUTATIONS) {
+      const run = baseRun(mutation.scenario);
+      mutation.mutate(run);
+      assert.throws(() => validate(host, run), mutation.error, mutation.name);
+    }
+  });
+}
+
+test("every installed identity field is exact and every CodeStory result repeats runtime identity", () => {
+  for (const field of INSTALLED_IDENTITY_FIELDS) {
+    const run = baseRun("broad_packet");
+    const parts = field.split(".");
+    let owner = run.installed_identity;
+    for (const part of parts.slice(0, -1)) owner = owner[part];
+    const leaf = parts.at(-1);
+    owner[leaf] = typeof owner[leaf] === "number" ? owner[leaf] + 1 : `${owner[leaf]}-drift`;
+    assert.throws(() => validate("codex", run), new RegExp(field.replaceAll(".", "\\."), "u"), field);
+  }
+
+  const resultDrift = baseRun("broad_packet");
+  resultDrift.steps[0].result._meta.codestory_protocol.discovery_contract_sha256 = "e".repeat(64);
+  assert.throws(() => validate("codex", resultDrift), /result identity.*discovery/u);
+});
+
+test("packet continuation and selected-context correlation are exact", () => {
+  const continuation = baseRun("packet_single_continuation");
+  continuation.steps[1].args.option_ids = ["other-gap"];
+  assert.throws(() => validate("cursor", continuation), /continuation arguments/u);
+
+  const context = baseRun("ambiguous_symbol_then_context");
+  context.steps[1].args.selector.canonical_id = "rust:crate::two::Thing";
+  assert.throws(() => validate("codex", context), /selected target/u);
+});
+
+test("static Claude Code and Copilot surfaces bind one package, launcher, hook, and rule core", async () => {
+  assert.deepEqual(Object.keys(STATIC_PARITY_HOSTS), ["claude_code", "copilot_cli", "copilot_editor"]);
+  const manifest = JSON.parse(await readFile(join(pluginRoot, "plugin.json"), "utf8"));
+  const pin = JSON.parse(await readFile(join(pluginRoot, "cli-version.json"), "utf8"));
+  const catalog = JSON.parse(await readFile(join(pluginRoot, "generated-mcp-catalog.json"), "utf8"));
+  const launcher = await readFile(join(pluginRoot, "scripts", "codestory-mcp.cjs"));
+  const staticIdentity = clone(EXPECTED_IDENTITY);
+  staticIdentity.package.version = manifest.version;
+  staticIdentity.cli.version = pin.cli_version;
+  staticIdentity.launcher.sha256 = createHash("sha256").update(launcher).digest("hex");
+  staticIdentity.publication.schema_version = catalog.wireContract.publicationStampSchemaVersion;
+  staticIdentity.protocol.revision = catalog.wireContract.preferredMcpProtocolVersion;
+  staticIdentity.protocol.discovery_contract_sha256 =
+    catalog.wireContract.discoveryContracts[staticIdentity.protocol.revision];
+
+  const report = await validateStaticHostParity(pluginRoot, staticIdentity);
+  assert.equal(report.status, "pass");
+  assert.deepEqual(report.hosts.map(({ host }) => host), ["claude_code", "copilot_cli", "copilot_editor"]);
+  for (const host of report.hosts) {
+    assert.equal(host.package_version, manifest.version);
+    assert.equal(host.launcher_sha256, staticIdentity.launcher.sha256);
+    assert.equal(host.rule_sha256.length, 64);
+    assert.equal(host.hook_sha256.length, 64);
+    assert.equal(host.model_routing_evaluated, false);
+  }
+});


### PR DESCRIPTION
## Context

CodeStory 0.18 needs installed-agent qualification that checks how the host chooses direct source, search, context, packet, and exact proof before the public route or packaged guidance changes. This PR adds that harness and remains production-unreachable.

Closes #2070
Refs #2066

Implementation base: `b90c2913658a7f2ef62225ff4f139a5d4ff8d3c3`
Reviewed head: `92db0504eccc7e3f7edb6d298df4548f4b9ca471`

## What changed

- Added exactly sixteen routing scenarios covering direct reads, search, context, packet and continuation, evidence fallback, all four proof dispositions, malformed and free-English proof requests, observational proof execution, and hidden-tool discovery.
- Added real Codex and documented Cursor stream-JSON ingestion, including delta concatenation, tool start/completion correlation, and terminal-result requirements.
- Added required action sequences, permitted follow-ups, forbidden tools, authorized source reads, and result-backed final-claim validation.
- Added canonical proof-result validation for request digest, disposition/step/receipt sequence, connectivity, selectors, evidence, hash-bound callsite windows, and all gap-index kinds.
- Added installed-root authentication for actual package, launcher, and managed CLI bytes.
- Added parsed and digest-bound Claude Code and Copilot package/metadata/hook/rule parity without claiming their model-routing behavior.

No public skill, rule, metadata, hook, catalog, CLI/MCP route, runtime, or release surface changes.

## Verification

- Routing conformance suite - 16 passed
- Plugin static suite - 140 passed, 1 expected Windows skip
- Node syntax checks - passed
- `git diff --check` - passed
- Consolidated adversarial review - accepted after Cursor serialization, result causality, installed identity, and proof-semantic corrections

## Review focus

- Cursor fixtures follow the documented `user`, assistant-delta, `tool_call`, and terminal `result` stream.
- Claims cannot be supplied by prose when tool results lack evidence.
- `Unknown` and `Unavailable` cannot contain proven steps or absence/runtime claims.
- Static parity hashes and parses actual installed files rather than matching self-supplied values.

## Risk and follow-up

This harness has not run live installed sessions. Codex and Cursor execution against the exact final package remains part of the frozen activation qualification. Claude Code and Copilot remain static parity claims only.
