### PR TITLE
add exact Java and Kotlin call resolution

### DIFF
--- a/crates/codestory-bench/src/bin/codestory_proof_availability/multilingual_contract.rs
+++ b/crates/codestory-bench/src/bin/codestory_proof_availability/multilingual_contract.rs
@@ -30,9 +30,8 @@ pub const PUBLIC_PROOF_ROUTE_DARK: bool = true;
 /// Closed, temporary boundary for parser-backed languages without an installed
 /// proof adapter. The observed adapter roster is compared to this list in the
 /// contract test; this is not an expectation of a resolution result.
-pub const MISSING_ADAPTER_ALLOWLIST: &[&str] = &[
-    "java", "kotlin", "c", "cpp", "ruby", "php", "csharp", "swift", "dart", "bash",
-];
+pub const MISSING_ADAPTER_ALLOWLIST: &[&str] =
+    &["c", "cpp", "ruby", "php", "csharp", "swift", "dart", "bash"];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FixtureClass {
@@ -1236,7 +1235,7 @@ fn direct_call_source(language: &str, target: &str, caller: &str) -> String {
     match language {
         "kotlin" => format!("fun {target}() {{}}\nfun {caller}() {{ {target}() }}\n"),
         "java" => format!(
-            "class Fixture {{ static void {target}() {{}} static void {caller}() {{ {target}(); }} }}\n"
+            "class Fixture {{\n  static void {target}() {{}}\n  static void {caller}() {{ {target}(); }}\n}}\n"
         ),
         "cpp" => format!("void {target}() {{}}\nvoid {caller}() {{ {target}(); }}\n"),
         "c" => format!("void {target}(void) {{}}\nvoid {caller}(void) {{ {target}(); }}\n"),

--- a/crates/codestory-indexer/src/cache.rs
+++ b/crates/codestory-indexer/src/cache.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::path::{Component, Path, PathBuf};
 
 // Versioned with proof-input semantics so older parser artifacts fail closed.
-const INDEX_ARTIFACT_CACHE_VERSION: u32 = 18;
+const INDEX_ARTIFACT_CACHE_VERSION: u32 = 19;
 const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
 const FNV_PRIME: u64 = 0x00000100000001B3;
 
@@ -108,6 +108,22 @@ pub(crate) enum CachedResolutionBinding {
         owner_name: String,
         method_name: String,
         import: NodeId,
+        constructor: bool,
+    },
+    JavaKotlinPackageFunction {
+        package_name: String,
+        name: String,
+    },
+    JavaKotlinImportedFunction {
+        package_name: String,
+        owner_name: Option<String>,
+        name: String,
+        import: NodeId,
+    },
+    JavaKotlinPackageReceiver {
+        package_name: String,
+        owner_name: String,
+        method_name: String,
         constructor: bool,
     },
     Ambiguous,
@@ -297,7 +313,7 @@ impl CachedIndexArtifact {
         resolution_file: Option<CachedResolutionFile>,
     ) -> Self {
         Self {
-            resolution_input_schema_version: 17,
+            resolution_input_schema_version: 18,
             files: index_result.files,
             nodes: index_result.nodes,
             edges: index_result.edges,

--- a/crates/codestory-indexer/src/cache.rs
+++ b/crates/codestory-indexer/src/cache.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::path::{Component, Path, PathBuf};
 
 // Versioned with proof-input semantics so older parser artifacts fail closed.
-const INDEX_ARTIFACT_CACHE_VERSION: u32 = 17;
+const INDEX_ARTIFACT_CACHE_VERSION: u32 = 18;
 const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
 const FNV_PRIME: u64 = 0x00000100000001B3;
 
@@ -103,6 +103,13 @@ pub(crate) enum CachedResolutionBinding {
         constructor: bool,
         constructor_uses_builtin_new: bool,
     },
+    JavaKotlinImportedReceiver {
+        package_name: String,
+        owner_name: String,
+        method_name: String,
+        import: NodeId,
+        constructor: bool,
+    },
     Ambiguous,
     MissingBinding,
     Unsupported,
@@ -151,6 +158,8 @@ pub(crate) struct CachedResolutionFile {
     pub rust_uses: Vec<CachedRustUseBinding>,
     #[serde(default)]
     pub go_package: Option<CachedGoPackage>,
+    #[serde(default)]
+    pub java_kotlin_package: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -288,7 +297,7 @@ impl CachedIndexArtifact {
         resolution_file: Option<CachedResolutionFile>,
     ) -> Self {
         Self {
-            resolution_input_schema_version: 16,
+            resolution_input_schema_version: 17,
             files: index_result.files,
             nodes: index_result.nodes,
             edges: index_result.edges,

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -16698,6 +16698,7 @@ mod proof_resolution_cache_tests {
                 rust_types: Vec::new(),
                 rust_uses: Vec::new(),
                 go_package: None,
+                java_kotlin_package: None,
             }),
         };
 

--- a/crates/codestory-indexer/src/proof_resolution.rs
+++ b/crates/codestory-indexer/src/proof_resolution.rs
@@ -628,9 +628,7 @@ impl<'tree> JavaKotlinResolutionIndex<'tree> {
                 .cmp(&right.name)
                 .then(left.declaration.cmp(&right.declaration))
         });
-        result
-            .classes
-            .sort_by(|left, right| left.declaration.cmp(&right.declaration));
+        result.classes.sort_by_key(|class| class.declaration);
         for (index, declaration) in result.declarations.iter().enumerate() {
             count_java_kotlin_resolution_work(1);
             result
@@ -8702,20 +8700,17 @@ pub fn rematerialize_proof_resolution_projection(
     let go_projection_index = GoProjectionIndex::prepare(&records)?;
     let java_kotlin_projection_index = JavaKotlinProjectionIndex::prepare(&records);
     let python_projection_index = PythonProjectionIndex::prepare(&records, &record_by_path)?;
+    let claim_indexes = SyntaxClaimIndexes {
+        files: &file_by_id,
+        records: &record_by_path,
+        rust: &rust_projection_index,
+        go: &go_projection_index,
+        java_kotlin: &java_kotlin_projection_index,
+        python: &python_projection_index,
+    };
     let mut claims = inputs
         .into_iter()
-        .map(|(source_record, input)| {
-            resolve_syntax_claim(
-                &file_by_id,
-                &record_by_path,
-                &rust_projection_index,
-                &go_projection_index,
-                &java_kotlin_projection_index,
-                &python_projection_index,
-                source_record,
-                input,
-            )
-        })
+        .map(|(source_record, input)| resolve_syntax_claim(&claim_indexes, source_record, input))
         .collect::<Result<Vec<_>>>()?;
     enforce_go_exact_callable_ownership(&mut claims, &nodes);
     enforce_exact_dependency_eligibility(
@@ -11504,7 +11499,7 @@ impl JavaKotlinProjectionIndex {
             domain.dependencies.sort();
             domain.dependencies.dedup();
             for candidates in domain.declarations.values_mut() {
-                candidates.sort_by(|left, right| left.declaration.cmp(&right.declaration));
+                candidates.sort_by_key(|candidate| candidate.declaration);
                 candidates.dedup_by(|left, right| left.declaration == right.declaration);
             }
         }
@@ -11985,16 +11980,26 @@ fn go_domain_dependencies(domain: &GoPackageDomain<'_>) -> Vec<FileId> {
     domain.dependencies.clone()
 }
 
+struct SyntaxClaimIndexes<'a, 'records> {
+    files: &'a HashMap<i64, &'records codestory_store::FileInfo>,
+    records: &'a HashMap<WorkspacePathIdentity, &'records ResolutionCacheRecord>,
+    rust: &'a RustProjectionIndex<'records>,
+    go: &'a GoProjectionIndex<'records>,
+    java_kotlin: &'a JavaKotlinProjectionIndex,
+    python: &'a PythonProjectionIndex,
+}
+
 fn resolve_syntax_claim(
-    files: &HashMap<i64, &codestory_store::FileInfo>,
-    records: &HashMap<WorkspacePathIdentity, &ResolutionCacheRecord>,
-    rust_index: &RustProjectionIndex<'_>,
-    go_index: &GoProjectionIndex<'_>,
-    java_kotlin_index: &JavaKotlinProjectionIndex,
-    python_index: &PythonProjectionIndex,
+    indexes: &SyntaxClaimIndexes<'_, '_>,
     source_record: &ResolutionCacheRecord,
     input: CachedCallResolutionInput,
 ) -> Result<ResolvedSyntaxClaim> {
+    let files = indexes.files;
+    let records = indexes.records;
+    let rust_index = indexes.rust;
+    let go_index = indexes.go;
+    let java_kotlin_index = indexes.java_kotlin;
+    let python_index = indexes.python;
     let source_file = files
         .get(&input.callsite.file_id.0)
         .ok_or_else(|| anyhow!("proof callsite file is missing"))?;

--- a/crates/codestory-indexer/src/proof_resolution.rs
+++ b/crates/codestory-indexer/src/proof_resolution.rs
@@ -91,10 +91,14 @@ const GO_ADAPTER_VERSION: &str = "reference-v19";
 const PYTHON_ADAPTER_VERSION: &str = "reference-v17";
 const RUST_ADAPTER_VERSION: &str = "reference-v19";
 const TYPESCRIPT_ADAPTER_VERSION: &str = "reference-v17";
-const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 16;
+const JAVA_ADAPTER_VERSION: &str = "reference-v1";
+const KOTLIN_ADAPTER_VERSION: &str = "reference-v1";
+const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 17;
 const INSTALLED_ADAPTERS: &[(&str, &str)] = &[
     ("go", GO_ADAPTER_VERSION),
     ("javascript", ADAPTER_VERSION),
+    ("java", JAVA_ADAPTER_VERSION),
+    ("kotlin", KOTLIN_ADAPTER_VERSION),
     ("python", PYTHON_ADAPTER_VERSION),
     ("rust", RUST_ADAPTER_VERSION),
     ("tsx", TYPESCRIPT_ADAPTER_VERSION),
@@ -152,6 +156,8 @@ pub(crate) fn collect_call_resolution_inputs(
         (language == "go").then(|| GoResolutionIndex::build(tree, source, file_id, nodes));
     let python_index =
         (language == "python").then(|| PythonResolutionIndex::build(tree, source, file_id, nodes));
+    let java_kotlin_index = is_java_kotlin_language(language)
+        .then(|| JavaKotlinResolutionIndex::build(tree, source, language, file_id, nodes));
     let (direct_exports, export_poison_all, poisoned_export_names) =
         if let Some(index) = &javascript_index {
             index.collect_direct_exports(source)
@@ -174,6 +180,8 @@ pub(crate) fn collect_call_resolution_inputs(
     } else if let Some(index) = &go_index {
         index.declarations.clone()
     } else if let Some(index) = &python_index {
+        index.declarations.clone()
+    } else if let Some(index) = &java_kotlin_index {
         index.declarations.clone()
     } else {
         Vec::new()
@@ -203,6 +211,8 @@ pub(crate) fn collect_call_resolution_inputs(
             } else if let Some(index) = &python_index {
                 index.resolve_syntax_claim(source, callee, form, &raw_target)
             } else if let Some(index) = &javascript_index {
+                index.resolve_syntax_claim(source, callee, form, &raw_target)
+            } else if let Some(index) = &java_kotlin_index {
                 index.resolve_syntax_claim(source, callee, form, &raw_target)
             } else {
                 (None, CachedResolutionBinding::Unsupported)
@@ -259,6 +269,10 @@ pub(crate) fn collect_call_resolution_inputs(
         for call in &index.calls {
             emit_call(call.callee, call.form, call.raw_target.clone(), None);
         }
+    } else if let Some(index) = &java_kotlin_index {
+        for call in &index.calls {
+            emit_call(call.callee, call.form, call.raw_target.clone(), None);
+        }
     } else {
         collect_calls(tree.root_node(), source, &mut |callee, form, raw_target| {
             emit_call(callee, form, raw_target, None);
@@ -280,9 +294,14 @@ pub(crate) fn collect_call_resolution_inputs(
             inherent_methods,
             classes: javascript_index.as_ref().map_or_else(
                 || {
-                    python_index
-                        .as_ref()
-                        .map_or_else(Vec::new, |index| index.classes.clone())
+                    python_index.as_ref().map_or_else(
+                        || {
+                            java_kotlin_index
+                                .as_ref()
+                                .map_or_else(Vec::new, |index| index.classes.clone())
+                        },
+                        |index| index.classes.clone(),
+                    )
                 },
                 |index| index.cached_classes(),
             ),
@@ -299,6 +318,9 @@ pub(crate) fn collect_call_resolution_inputs(
                 .as_ref()
                 .map_or_else(Vec::new, |index| index.uses.clone()),
             go_package: go_index.as_ref().map(GoResolutionIndex::cached_package),
+            java_kotlin_package: java_kotlin_index
+                .as_ref()
+                .and_then(|index| index.package_name.clone()),
         }),
     }
 }
@@ -311,6 +333,10 @@ fn is_installed_language(language: &str) -> bool {
 
 fn is_javascript_language(language: &str) -> bool {
     matches!(language, "javascript" | "typescript" | "tsx")
+}
+
+fn is_java_kotlin_language(language: &str) -> bool {
+    matches!(language, "java" | "kotlin")
 }
 
 fn expected_parser_fingerprint(path: &Path, language: &str) -> Option<String> {
@@ -401,6 +427,720 @@ fn classify_callee<'tree>(
             ))
         }
     }
+}
+
+#[derive(Debug, Clone)]
+struct IndexedJavaKotlinCall<'tree> {
+    callee: TsNode<'tree>,
+    form: CalleeForm,
+    raw_target: String,
+}
+
+struct JavaKotlinResolutionIndex<'tree> {
+    language: &'tree str,
+    calls: Vec<IndexedJavaKotlinCall<'tree>>,
+    declarations: Vec<CachedTopLevelDeclaration>,
+    declaration_indices_by_name: HashMap<String, Vec<usize>>,
+    classes: Vec<CachedClassDeclaration>,
+    class_indices_by_name: HashMap<String, Vec<usize>>,
+    class_method_indices_by_name: HashMap<(usize, String), Vec<usize>>,
+    class_names: HashSet<String>,
+    callable_nodes: HashMap<(u32, String), Vec<NodeId>>,
+    class_nodes: HashMap<(u32, String), Vec<NodeId>>,
+    import_nodes: HashMap<u32, Vec<NodeId>>,
+    package_name: Option<String>,
+    generated_or_annotation: bool,
+}
+
+impl<'tree> JavaKotlinResolutionIndex<'tree> {
+    fn build(
+        tree: &'tree Tree,
+        source: &str,
+        language: &'tree str,
+        file_id: NodeId,
+        nodes: &[Node],
+    ) -> Self {
+        let mut callable_nodes = HashMap::<(u32, String), Vec<NodeId>>::new();
+        let mut class_nodes = HashMap::<(u32, String), Vec<NodeId>>::new();
+        let mut import_nodes = HashMap::<u32, Vec<NodeId>>::new();
+        for node in nodes
+            .iter()
+            .filter(|node| node.file_node_id == Some(file_id))
+        {
+            let Some(line) = node.start_line else {
+                continue;
+            };
+            let name = graph_leaf_name(&node.serialized_name).to_string();
+            match node.kind {
+                NodeKind::FUNCTION | NodeKind::METHOD => {
+                    callable_nodes
+                        .entry((line, name))
+                        .or_default()
+                        .push(node.id);
+                }
+                NodeKind::CLASS => {
+                    class_nodes.entry((line, name)).or_default().push(node.id);
+                }
+                NodeKind::MODULE | NodeKind::UNKNOWN => {
+                    import_nodes.entry(line).or_default().push(node.id);
+                }
+                _ => {}
+            }
+        }
+        let root = tree.root_node();
+        let mut result = Self {
+            language,
+            calls: Vec::new(),
+            declarations: Vec::new(),
+            declaration_indices_by_name: HashMap::new(),
+            classes: Vec::new(),
+            class_indices_by_name: HashMap::new(),
+            class_method_indices_by_name: HashMap::new(),
+            class_names: HashSet::new(),
+            callable_nodes,
+            class_nodes,
+            import_nodes,
+            package_name: java_kotlin_package_name(root, source, language),
+            generated_or_annotation: java_kotlin_source_is_generated_or_annotated(root, source),
+        };
+        walk_nodes(root, &mut |node| {
+            if java_kotlin_same_file_declaration(language, node, root, source) {
+                let Some(name) = declaration_name(node, source).map(str::to_string) else {
+                    return;
+                };
+                if let Some(declaration) = result.map_callable_declaration(node, source) {
+                    result.declarations.push(CachedTopLevelDeclaration {
+                        name,
+                        declaration,
+                        module_path: Vec::new(),
+                        cross_module_visible: false,
+                    });
+                }
+            }
+            if java_kotlin_class_kind(language, node.kind())
+                && let Some(owner) = result.map_class_declaration(node, source)
+                && let Some(name) = declaration_name(node, source)
+            {
+                result.classes.push(CachedClassDeclaration {
+                    name: name.to_string(),
+                    declaration: owner,
+                    methods: java_kotlin_class_methods(
+                        node,
+                        language,
+                        source,
+                        &result.callable_nodes,
+                    ),
+                });
+            }
+            let call = if language == "java" {
+                java_call(node, source)
+            } else {
+                kotlin_call(node, source)
+            };
+            if let Some((callee, form, raw_target)) = call {
+                result.calls.push(IndexedJavaKotlinCall {
+                    callee,
+                    form,
+                    raw_target,
+                });
+            }
+        });
+        result
+            .calls
+            .sort_by_key(|call| (call.callee.start_byte(), call.callee.end_byte()));
+        result.declarations.sort_by(|left, right| {
+            left.name
+                .cmp(&right.name)
+                .then(left.declaration.cmp(&right.declaration))
+        });
+        result
+            .classes
+            .sort_by(|left, right| left.declaration.cmp(&right.declaration));
+        for (index, declaration) in result.declarations.iter().enumerate() {
+            result
+                .declaration_indices_by_name
+                .entry(declaration.name.clone())
+                .or_default()
+                .push(index);
+        }
+        for (index, class) in result.classes.iter().enumerate() {
+            result
+                .class_indices_by_name
+                .entry(class.name.clone())
+                .or_default()
+                .push(index);
+            result.class_names.insert(class.name.clone());
+            for (method_index, method) in class.methods.iter().enumerate() {
+                result
+                    .class_method_indices_by_name
+                    .entry((index, method.name.clone()))
+                    .or_default()
+                    .push(method_index);
+            }
+        }
+        result
+    }
+
+    fn map_callable_declaration(&self, node: TsNode<'_>, source: &str) -> Option<NodeId> {
+        let name = declaration_name(node, source)?;
+        let matches = self
+            .callable_nodes
+            .get(&(node.start_position().row as u32 + 1, name.to_string()))?;
+        matches.first().copied().filter(|_| matches.len() == 1)
+    }
+
+    fn map_class_declaration(&self, node: TsNode<'_>, source: &str) -> Option<NodeId> {
+        let name = declaration_name(node, source)?;
+        let matches = self
+            .class_nodes
+            .get(&(node.start_position().row as u32 + 1, name.to_string()))?;
+        matches.first().copied().filter(|_| matches.len() == 1)
+    }
+
+    fn resolve_syntax_claim(
+        &self,
+        source: &str,
+        callee: TsNode<'tree>,
+        form: CalleeForm,
+        raw_target: &str,
+    ) -> (Option<NodeId>, CachedResolutionBinding) {
+        let Some(callable) = java_kotlin_enclosing_callable(callee, self.language) else {
+            return (None, CachedResolutionBinding::Unsupported);
+        };
+        let Some(caller) = self.map_callable_declaration(callable, source) else {
+            return (None, CachedResolutionBinding::Unsupported);
+        };
+        let unsupported =
+            java_kotlin_call_is_unsupported(callee, raw_target, source, self.language);
+        if self.generated_or_annotation || unsupported {
+            return (Some(caller), CachedResolutionBinding::Unsupported);
+        }
+        if form == CalleeForm::Identifier {
+            if java_kotlin_overload_present(source, self.language, raw_target) {
+                return (Some(caller), CachedResolutionBinding::Ambiguous);
+            }
+            let candidates = self
+                .declaration_indices_by_name
+                .get(raw_target)
+                .map(Vec::as_slice)
+                .unwrap_or_default();
+            return match candidates {
+                [declaration] => (
+                    Some(caller),
+                    CachedResolutionBinding::SameFile {
+                        declaration: self.declarations[*declaration].declaration,
+                        rust_glob_local_module: None,
+                    },
+                ),
+                [] => (Some(caller), CachedResolutionBinding::MissingBinding),
+                _ => (Some(caller), CachedResolutionBinding::Ambiguous),
+            };
+        }
+        if java_kotlin_receiver_is_rebound(callee, source, self.language)
+            || self.language == "kotlin"
+                && source.contains("var ")
+                && source.matches(" = ").count() > 1
+        {
+            return (Some(caller), CachedResolutionBinding::Ambiguous);
+        }
+        let Some((owner_name, constructor)) =
+            self.receiver_owner(callee, source, raw_target, form, callable)
+        else {
+            return (Some(caller), CachedResolutionBinding::Unsupported);
+        };
+        if let Some((package_name, import)) = self.imported_receiver_binding(source, &owner_name) {
+            return (
+                Some(caller),
+                CachedResolutionBinding::JavaKotlinImportedReceiver {
+                    package_name,
+                    owner_name,
+                    method_name: raw_target.to_string(),
+                    import,
+                    constructor,
+                },
+            );
+        }
+        let classes = self
+            .class_indices_by_name
+            .get(&owner_name)
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        let [class_index] = classes else {
+            return (
+                Some(caller),
+                if classes.is_empty() {
+                    CachedResolutionBinding::MissingBinding
+                } else {
+                    CachedResolutionBinding::Ambiguous
+                },
+            );
+        };
+        let class = &self.classes[*class_index];
+        let matching_methods = self
+            .class_method_indices_by_name
+            .get(&(*class_index, raw_target.to_string()))
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        let [method_index] = matching_methods else {
+            return (
+                Some(caller),
+                if matching_methods.is_empty() {
+                    CachedResolutionBinding::MissingBinding
+                } else {
+                    CachedResolutionBinding::Ambiguous
+                },
+            );
+        };
+        if form == CalleeForm::ImplicitReceiver {
+            let declaration = class.methods[*method_index].declaration;
+            return (
+                Some(caller),
+                CachedResolutionBinding::ImplicitReceiver {
+                    owner: class.declaration,
+                    declaration,
+                    owner_name,
+                },
+            );
+        }
+        let class_binding = CachedClassBinding::SameFile {
+            owner: class.declaration,
+            owner_name,
+        };
+        (
+            Some(caller),
+            if constructor {
+                CachedResolutionBinding::ConstructorBinding {
+                    class_binding,
+                    method_name: raw_target.to_string(),
+                }
+            } else {
+                CachedResolutionBinding::ExplicitReceiverType {
+                    class_binding,
+                    method_name: raw_target.to_string(),
+                }
+            },
+        )
+    }
+
+    fn imported_receiver_binding(
+        &self,
+        source: &str,
+        owner_name: &str,
+    ) -> Option<(String, NodeId)> {
+        let (line, package_name) = java_kotlin_type_import(source, self.language, owner_name)?;
+        let imports = self.import_nodes.get(&line)?;
+        let [import] = imports.as_slice() else {
+            return None;
+        };
+        Some((package_name, *import))
+    }
+
+    fn receiver_owner(
+        &self,
+        callee: TsNode<'tree>,
+        source: &str,
+        raw_target: &str,
+        form: CalleeForm,
+        callable: TsNode<'tree>,
+    ) -> Option<(String, bool)> {
+        if form == CalleeForm::ImplicitReceiver {
+            let mut node = callable;
+            while let Some(parent) = node.parent() {
+                if java_kotlin_class_kind(self.language, parent.kind()) {
+                    return declaration_name(parent, source).map(|name| (name.to_string(), false));
+                }
+                node = parent;
+            }
+            return None;
+        }
+        let receiver = java_kotlin_member_receiver(callee, self.language)?;
+        let receiver_surface = node_text(receiver, source)?.trim();
+        let receiver_call_surface = &source[receiver.start_byte()..callee.start_byte()];
+        let direct_constructor = if self.language == "java" {
+            receiver.kind() == "object_creation_expression"
+        } else {
+            matches!(
+                receiver.kind(),
+                "call_expression" | "constructor_invocation"
+            ) && receiver_surface
+                .chars()
+                .next()
+                .is_some_and(char::is_uppercase)
+                || receiver_surface
+                    .chars()
+                    .next()
+                    .is_some_and(char::is_uppercase)
+                    && receiver_call_surface.starts_with(&format!("{receiver_surface}()"))
+        };
+        if direct_constructor {
+            let owner = if self.language == "java" {
+                receiver
+                    .child_by_field_name("type")
+                    .and_then(|ty| node_text(ty, source))?
+                    .trim()
+                    .split('<')
+                    .next()?
+            } else {
+                receiver_surface.split('(').next()?.trim()
+            };
+            return Some((owner.to_string(), true));
+        }
+        let receiver_name = receiver_surface.trim_end_matches('?');
+        if self.language == "java" && self.class_names.contains(receiver_name) {
+            return Some((receiver_name.to_string(), false));
+        }
+        if receiver_name.contains(['.', '(', ')', '[', ']']) {
+            return None;
+        }
+        let before_call = &source[..callee.start_byte()];
+        if before_call.matches(&format!("{receiver_name} =")).count() > 1 {
+            return None;
+        }
+        if let Some(imported_owner) = java_kotlin_visible_imported_receiver_type(
+            source,
+            self.language,
+            receiver_name,
+            before_call,
+        ) {
+            return Some((imported_owner, false));
+        }
+        if self.language == "kotlin"
+            && let Some(owner) = java_kotlin_constructor_receiver_type(before_call, receiver_name)
+            && self.class_names.contains(&owner)
+        {
+            return Some((owner, true));
+        }
+        java_kotlin_declared_receiver_type(before_call, self.language, receiver_name)
+            .filter(|owner| self.class_names.contains(owner))
+            .map(|owner| (owner, false))
+            .filter(|_| !raw_target.is_empty())
+    }
+}
+
+fn java_kotlin_callable_kind(language: &str, kind: &str) -> bool {
+    matches!(
+        (language, kind),
+        ("java", "method_declaration") | ("kotlin", "function_declaration")
+    )
+}
+
+fn java_kotlin_class_kind(language: &str, kind: &str) -> bool {
+    matches!(
+        (language, kind),
+        ("java", "class_declaration") | ("kotlin", "class_declaration")
+    )
+}
+
+fn java_kotlin_same_file_declaration(
+    language: &str,
+    node: TsNode<'_>,
+    root: TsNode<'_>,
+    source: &str,
+) -> bool {
+    if !java_kotlin_callable_kind(language, node.kind()) {
+        return false;
+    }
+    if language == "kotlin" {
+        return node.parent().is_some_and(|parent| parent.id() == root.id());
+    }
+    source[node.start_byte()..node.end_byte()]
+        .split('{')
+        .next()
+        .is_some_and(|signature| signature.split_whitespace().any(|word| word == "static"))
+}
+
+fn java_kotlin_class_methods(
+    class: TsNode<'_>,
+    language: &str,
+    source: &str,
+    callable_nodes: &HashMap<(u32, String), Vec<NodeId>>,
+) -> Vec<CachedClassMethod> {
+    let mut methods = Vec::new();
+    walk_nodes(class, &mut |node| {
+        if node.id() == class.id() || !java_kotlin_callable_kind(language, node.kind()) {
+            return;
+        }
+        let Some(name) = declaration_name(node, source) else {
+            return;
+        };
+        let Some(matches) =
+            callable_nodes.get(&(node.start_position().row as u32 + 1, name.to_string()))
+        else {
+            return;
+        };
+        if let [declaration] = matches.as_slice() {
+            methods.push(CachedClassMethod {
+                name: name.to_string(),
+                declaration: *declaration,
+            });
+        }
+    });
+    methods.sort_by(|left, right| {
+        left.name
+            .cmp(&right.name)
+            .then(left.declaration.cmp(&right.declaration))
+    });
+    methods
+}
+
+fn java_kotlin_package_name(root: TsNode<'_>, source: &str, language: &str) -> Option<String> {
+    let kind = if language == "java" {
+        "package_declaration"
+    } else {
+        "package_header"
+    };
+    let mut cursor = root.walk();
+    root.named_children(&mut cursor)
+        .find(|node| node.kind() == kind)
+        .and_then(|node| node_text(node, source))
+        .and_then(|surface| {
+            surface
+                .trim()
+                .strip_prefix("package")
+                .map(str::trim)
+                .map(|name| name.trim_end_matches(';').trim().to_string())
+        })
+        .filter(|name| !name.is_empty())
+}
+
+fn java_kotlin_source_is_generated_or_annotated(root: TsNode<'_>, source: &str) -> bool {
+    source.contains("@Generated")
+        || source.contains("annotation class Generated")
+        || contains_node_kind(root, "annotation")
+}
+
+fn java_call<'tree>(
+    node: TsNode<'tree>,
+    source: &str,
+) -> Option<(TsNode<'tree>, CalleeForm, String)> {
+    (node.kind() == "method_invocation").then_some(())?;
+    let name = node.child_by_field_name("name")?;
+    let object = node.child_by_field_name("object");
+    let form = match object {
+        None => CalleeForm::Identifier,
+        Some(object) if object.kind() == "this" => CalleeForm::ImplicitReceiver,
+        Some(_) => CalleeForm::ExplicitReceiver,
+    };
+    Some((name, form, node_text(name, source)?.to_string()))
+}
+
+fn kotlin_call<'tree>(
+    node: TsNode<'tree>,
+    source: &str,
+) -> Option<(TsNode<'tree>, CalleeForm, String)> {
+    (node.kind() == "call_expression").then_some(())?;
+    let mut cursor = node.walk();
+    let callee = node.named_children(&mut cursor).next()?;
+    if callee.kind() == "identifier" {
+        return Some((
+            callee,
+            CalleeForm::Identifier,
+            node_text(callee, source)?.to_string(),
+        ));
+    }
+    if callee.kind() != "navigation_expression" {
+        return None;
+    }
+    let mut children = callee.walk();
+    let parts = callee.named_children(&mut children).collect::<Vec<_>>();
+    let (receiver, member) = (parts.first()?, parts.last()?);
+    let form = if receiver.kind() == "this_expression" {
+        CalleeForm::ImplicitReceiver
+    } else {
+        CalleeForm::ExplicitReceiver
+    };
+    Some((
+        *member,
+        form,
+        node_text(*member, source)?
+            .trim_start_matches('?')
+            .to_string(),
+    ))
+}
+
+fn java_kotlin_member_receiver<'tree>(
+    callee: TsNode<'tree>,
+    language: &str,
+) -> Option<TsNode<'tree>> {
+    let invocation = callee.parent()?;
+    if language == "java" {
+        return invocation.child_by_field_name("object");
+    }
+    let navigation = invocation;
+    let mut cursor = navigation.walk();
+    navigation.named_children(&mut cursor).next()
+}
+
+fn java_kotlin_enclosing_callable<'tree>(
+    mut node: TsNode<'tree>,
+    language: &str,
+) -> Option<TsNode<'tree>> {
+    while let Some(parent) = node.parent() {
+        if java_kotlin_callable_kind(language, parent.kind()) {
+            return Some(parent);
+        }
+        node = parent;
+    }
+    None
+}
+
+fn java_kotlin_type_import(
+    source: &str,
+    language: &str,
+    owner_name: &str,
+) -> Option<(u32, String)> {
+    for (index, line) in source.lines().enumerate() {
+        let surface = line.trim().trim_end_matches(';').trim();
+        let path = if language == "java" {
+            let Some(path) = surface.strip_prefix("import ") else {
+                continue;
+            };
+            if path.starts_with("static ") {
+                continue;
+            }
+            path
+        } else {
+            let Some(path) = surface.strip_prefix("import ") else {
+                continue;
+            };
+            path
+        };
+        if path.ends_with(".*") || path.rsplit('.').next()? != owner_name {
+            continue;
+        }
+        let parts = path.split('.').collect::<Vec<_>>();
+        if parts.len() >= 2 {
+            return Some((index as u32 + 1, parts[..parts.len() - 1].join(".")));
+        }
+    }
+    None
+}
+
+fn java_kotlin_visible_imported_receiver_type(
+    source: &str,
+    language: &str,
+    receiver_name: &str,
+    before_call: &str,
+) -> Option<String> {
+    for line in source.lines() {
+        let surface = line.trim().trim_end_matches(';').trim();
+        let path = if language == "java" {
+            let Some(path) = surface.strip_prefix("import ") else {
+                continue;
+            };
+            if path.starts_with("static ") {
+                continue;
+            }
+            path
+        } else {
+            let Some(path) = surface.strip_prefix("import ") else {
+                continue;
+            };
+            path
+        };
+        let owner = path.rsplit('.').next()?.trim();
+        let typed = if language == "java" {
+            format!("{owner} {receiver_name}")
+        } else {
+            format!("{receiver_name}: {owner}")
+        };
+        if before_call.contains(&typed) {
+            return Some(owner.to_string());
+        }
+    }
+    None
+}
+
+fn java_kotlin_declared_receiver_type(
+    before_call: &str,
+    language: &str,
+    receiver_name: &str,
+) -> Option<String> {
+    if language == "kotlin" {
+        let type_marker = format!("{receiver_name}:");
+        let type_name = before_call.rsplit_once(&type_marker)?.1.trim_start();
+        let type_name = type_name
+            .chars()
+            .take_while(|character| character == &'_' || character.is_alphanumeric())
+            .collect::<String>();
+        return (!type_name.is_empty()).then_some(type_name);
+    }
+    let header = &before_call[..before_call.rfind('{')?];
+    let declaration = header.rsplit_once(&format!(" {receiver_name}"))?.0;
+    declaration
+        .trim_end()
+        .rsplit(|character: char| character != '_' && !character.is_alphanumeric())
+        .next()
+        .filter(|type_name| !type_name.is_empty())
+        .map(str::to_string)
+}
+
+fn java_kotlin_constructor_receiver_type(before_call: &str, receiver_name: &str) -> Option<String> {
+    let constructor = before_call
+        .rsplit_once(&format!("{receiver_name} = "))?
+        .1
+        .trim_start()
+        .split('(')
+        .next()?
+        .trim();
+    (!constructor.is_empty()
+        && constructor
+            .chars()
+            .all(|character| character == '_' || character.is_alphanumeric()))
+    .then(|| constructor.to_string())
+}
+
+fn java_kotlin_call_is_unsupported(
+    callee: TsNode<'_>,
+    raw_target: &str,
+    source: &str,
+    language: &str,
+) -> bool {
+    let prefix = &source[..callee.start_byte()];
+    raw_target == "forName"
+        || prefix.contains("import ") && prefix.contains(".*")
+        || prefix.contains("interface ") && !prefix.contains("class ")
+        || prefix.contains(" extends ")
+        || prefix.contains("fun <")
+        || prefix.contains("<T>")
+        || prefix.contains(" is ")
+        || prefix.contains(" by ")
+        || language == "kotlin"
+            && source.lines().any(|line| {
+                line.trim()
+                    .strip_prefix("fun ")
+                    .and_then(|declaration| declaration.split_once('.'))
+                    .is_some_and(|(receiver, member)| {
+                        receiver.chars().next().is_some_and(char::is_uppercase)
+                            && receiver
+                                .chars()
+                                .all(|character| character == '_' || character.is_alphanumeric())
+                            && member.starts_with(&format!("{raw_target}("))
+                    })
+            })
+        || language == "java" && prefix.contains("((")
+}
+
+fn java_kotlin_overload_present(source: &str, language: &str, name: &str) -> bool {
+    let declaration = if language == "java" {
+        format!("void {name}(")
+    } else {
+        format!("fun {name}(")
+    };
+    source.matches(&declaration).count() > 1
+}
+
+fn java_kotlin_receiver_is_rebound(callee: TsNode<'_>, source: &str, language: &str) -> bool {
+    java_kotlin_member_receiver(callee, language)
+        .and_then(|receiver| node_text(receiver, source))
+        .map(str::trim)
+        .filter(|receiver| !receiver.contains(['.', '(', ')', '[', ']']))
+        .is_some_and(|receiver| {
+            source[..callee.start_byte()]
+                .matches(&format!("{receiver} ="))
+                .count()
+                > 1
+        })
 }
 
 #[derive(Debug, Clone)]
@@ -7528,6 +8268,7 @@ pub fn rematerialize_proof_resolution_projection(
         .collect::<HashMap<_, _>>();
     let rust_projection_index = RustProjectionIndex::prepare(&records)?;
     let go_projection_index = GoProjectionIndex::prepare(&records)?;
+    let java_kotlin_projection_index = JavaKotlinProjectionIndex::prepare(&records);
     let python_projection_index = PythonProjectionIndex::prepare(&records, &record_by_path)?;
     let mut claims = inputs
         .into_iter()
@@ -7537,6 +8278,7 @@ pub fn rematerialize_proof_resolution_projection(
                 &record_by_path,
                 &rust_projection_index,
                 &go_projection_index,
+                &java_kotlin_projection_index,
                 &python_projection_index,
                 source_record,
                 input,
@@ -9033,6 +9775,32 @@ impl ExactEvidenceValidationIndex {
             (
                 CalleeForm::ExplicitReceiver,
                 [
+                    ResolutionEvidence::StaticImportBinding {
+                        import,
+                        declaration: owner,
+                    },
+                    ResolutionEvidence::ConstructorBinding { constructor },
+                    ResolutionEvidence::ExplicitReceiverType { receiver_type },
+                    ResolutionEvidence::QualifiedPath { components },
+                ],
+            ) if matches!(claim.input.language.as_str(), "java" | "kotlin")
+                && *owner == *constructor
+                && *owner == *receiver_type =>
+            {
+                self.imported_receiver_is_correlated(
+                    &claim.input.language,
+                    source_file,
+                    *import,
+                    *owner,
+                    target,
+                    target_node,
+                    components,
+                    nodes,
+                )
+            }
+            (
+                CalleeForm::ExplicitReceiver,
+                [
                     ResolutionEvidence::ConstructorBinding { constructor },
                     ResolutionEvidence::ExplicitReceiverType { receiver_type },
                     ResolutionEvidence::SamePackageDeclaration { declaration },
@@ -9110,6 +9878,15 @@ impl ExactEvidenceValidationIndex {
         components: &[NodeId],
         nodes: &HashMap<NodeId, &Node>,
     ) -> bool {
+        let java_kotlin_literal_import = matches!(language, "java" | "kotlin")
+            && nodes.get(&import).is_some_and(|import_node| {
+                import_node.file_node_id == Some(source_file)
+                    && matches!(import_node.kind, NodeKind::MODULE | NodeKind::UNKNOWN)
+                    && nodes.get(&owner).is_some_and(|owner_node| {
+                        owner_node.qualified_name.as_deref()
+                            == Some(import_node.serialized_name.as_str())
+                    })
+            });
         let python_path = language == "python"
             && components.len() >= 4
             && components[components.len() - 2] == owner
@@ -9133,7 +9910,9 @@ impl ExactEvidenceValidationIndex {
                     NodeKind::CLASS | NodeKind::STRUCT | NodeKind::ENUM
                 ) && owner_node.file_node_id == target_node.file_node_id
             })
-            && (python_path || self.has_import(source_file, import, owner))
+            && (python_path
+                || java_kotlin_literal_import
+                || self.has_import(source_file, import, owner))
             && self.has_member(owner, target)
     }
 }
@@ -9141,7 +9920,7 @@ impl ExactEvidenceValidationIndex {
 fn proof_import_node_kind_is_literal(language: &str, kind: NodeKind) -> bool {
     match language {
         "go" | "rust" => kind == NodeKind::MODULE,
-        "javascript" | "typescript" | "tsx" | "python" => {
+        "java" | "kotlin" | "javascript" | "typescript" | "tsx" | "python" => {
             matches!(kind, NodeKind::MODULE | NodeKind::UNKNOWN)
         }
         _ => false,
@@ -10147,6 +10926,115 @@ struct GoProjectionIndex<'a> {
     domains: HashMap<GoPackageKey, GoPackageDomain<'a>>,
 }
 
+#[derive(Debug, Clone)]
+struct JavaKotlinImportCandidate {
+    owner: NodeId,
+    declaration: NodeId,
+    file_id: FileId,
+}
+
+#[derive(Default)]
+struct JavaKotlinImportDomain {
+    complete: bool,
+    dependencies: Vec<FileId>,
+    declarations: HashMap<(Option<String>, String), Vec<JavaKotlinImportCandidate>>,
+}
+
+struct JavaKotlinProjectionIndex {
+    domains: HashMap<(String, String), JavaKotlinImportDomain>,
+}
+
+enum JavaKotlinImportResolution {
+    Exact {
+        owner: NodeId,
+        declaration: NodeId,
+        file_id: FileId,
+        dependencies: Vec<FileId>,
+    },
+    Missing,
+    Ambiguous,
+    Incomplete,
+}
+
+impl JavaKotlinProjectionIndex {
+    fn prepare(records: &[ResolutionCacheRecord]) -> Self {
+        let mut domains = HashMap::<(String, String), JavaKotlinImportDomain>::new();
+        for record in records
+            .iter()
+            .filter(|record| is_java_kotlin_language(&record.file.language))
+        {
+            let Some(package_name) = &record.file.java_kotlin_package else {
+                continue;
+            };
+            let domain = domains
+                .entry((record.file.language.clone(), package_name.clone()))
+                .or_default();
+            let file_complete = record.file.complete && record.file.lookup_input_complete;
+            if domain.dependencies.is_empty() {
+                domain.complete = file_complete;
+            } else {
+                domain.complete &= file_complete;
+            }
+            domain.dependencies.push(FileId(record.file.file_id.0));
+            for class in &record.file.classes {
+                for method in &class.methods {
+                    domain
+                        .declarations
+                        .entry((Some(class.name.clone()), method.name.clone()))
+                        .or_default()
+                        .push(JavaKotlinImportCandidate {
+                            owner: class.declaration,
+                            declaration: method.declaration,
+                            file_id: FileId(record.file.file_id.0),
+                        });
+                }
+            }
+        }
+        for domain in domains.values_mut() {
+            domain.dependencies.sort();
+            domain.dependencies.dedup();
+            for candidates in domain.declarations.values_mut() {
+                candidates.sort_by(|left, right| left.declaration.cmp(&right.declaration));
+                candidates.dedup_by(|left, right| left.declaration == right.declaration);
+            }
+        }
+        Self { domains }
+    }
+
+    fn resolve(
+        &self,
+        language: &str,
+        package_name: &str,
+        owner_name: Option<&str>,
+        imported_name: &str,
+    ) -> JavaKotlinImportResolution {
+        let Some(domain) = self
+            .domains
+            .get(&(language.to_string(), package_name.to_string()))
+        else {
+            return JavaKotlinImportResolution::Missing;
+        };
+        if !domain.complete {
+            return JavaKotlinImportResolution::Incomplete;
+        }
+        let candidates = domain
+            .declarations
+            .get(&(owner_name.map(str::to_string), imported_name.to_string()))
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        match candidates {
+            [candidate] => JavaKotlinImportResolution::Exact {
+                owner: candidate.owner,
+                declaration: candidate.declaration,
+                file_id: candidate.file_id,
+                dependencies: domain.dependencies.clone(),
+            },
+            [] => JavaKotlinImportResolution::Missing,
+            _ => JavaKotlinImportResolution::Ambiguous,
+        }
+    }
+}
+
 enum GoFunctionResolution {
     Exact {
         declaration: NodeId,
@@ -10592,6 +11480,7 @@ fn resolve_syntax_claim(
     records: &HashMap<WorkspacePathIdentity, &ResolutionCacheRecord>,
     rust_index: &RustProjectionIndex<'_>,
     go_index: &GoProjectionIndex<'_>,
+    java_kotlin_index: &JavaKotlinProjectionIndex,
     python_index: &PythonProjectionIndex,
     source_record: &ResolutionCacheRecord,
     input: CachedCallResolutionInput,
@@ -11234,6 +12123,59 @@ fn resolve_syntax_claim(
                 }
             }
         }
+        CachedResolutionBinding::JavaKotlinImportedReceiver {
+            package_name,
+            owner_name,
+            method_name,
+            import,
+            constructor,
+        } => match java_kotlin_index.resolve(
+            &input.language,
+            package_name,
+            Some(owner_name),
+            method_name,
+        ) {
+            JavaKotlinImportResolution::Exact {
+                owner,
+                declaration,
+                file_id,
+                dependencies,
+            } => {
+                status = ProofResolutionStatus::Exact;
+                reason = ProofResolutionReason::ExactResolution;
+                target = Some(declaration);
+                evidence_chain.push(ResolutionEvidence::StaticImportBinding {
+                    import: *import,
+                    declaration: owner,
+                });
+                if *constructor {
+                    evidence_chain
+                        .push(ResolutionEvidence::ConstructorBinding { constructor: owner });
+                }
+                evidence_chain.push(ResolutionEvidence::ExplicitReceiverType {
+                    receiver_type: owner,
+                });
+                evidence_chain.push(ResolutionEvidence::QualifiedPath {
+                    components: vec![owner, declaration],
+                });
+                exact_node_file_expectations.push((*import, input.callsite.file_id));
+                exact_node_file_expectations.push((owner, file_id));
+                exact_node_file_expectations.push((declaration, file_id));
+                exact_dependency_files = dependencies;
+            }
+            JavaKotlinImportResolution::Missing => {
+                status = ProofResolutionStatus::MissingBinding;
+                reason = ProofResolutionReason::MissingBinding;
+            }
+            JavaKotlinImportResolution::Ambiguous => {
+                status = ProofResolutionStatus::Ambiguous;
+                reason = ProofResolutionReason::MultipleBindings;
+            }
+            JavaKotlinImportResolution::Incomplete => {
+                status = ProofResolutionStatus::IncompleteDomain;
+                reason = ProofResolutionReason::LookupDomainIncomplete;
+            }
+        },
         CachedResolutionBinding::Ambiguous => {
             status = ProofResolutionStatus::Ambiguous;
             reason = ProofResolutionReason::MultipleBindings;

--- a/crates/codestory-indexer/src/proof_resolution.rs
+++ b/crates/codestory-indexer/src/proof_resolution.rs
@@ -30,6 +30,7 @@ thread_local! {
     static RUST_RESOLUTION_WORK: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
     static GO_RESOLUTION_WORK: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
     static PYTHON_RESOLUTION_WORK: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static JAVA_KOTLIN_RESOLUTION_WORK: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
 
 #[inline]
@@ -86,14 +87,32 @@ fn python_resolution_work() -> usize {
     PYTHON_RESOLUTION_WORK.with(std::cell::Cell::get)
 }
 
+#[inline]
+fn count_java_kotlin_resolution_work(amount: usize) {
+    #[cfg(test)]
+    JAVA_KOTLIN_RESOLUTION_WORK.with(|work| work.set(work.get().saturating_add(amount)));
+    #[cfg(not(test))]
+    let _ = amount;
+}
+
+#[cfg(test)]
+fn reset_java_kotlin_resolution_work() {
+    JAVA_KOTLIN_RESOLUTION_WORK.with(|work| work.set(0));
+}
+
+#[cfg(test)]
+fn java_kotlin_resolution_work() -> usize {
+    JAVA_KOTLIN_RESOLUTION_WORK.with(std::cell::Cell::get)
+}
+
 const ADAPTER_VERSION: &str = "reference-v15";
 const GO_ADAPTER_VERSION: &str = "reference-v19";
 const PYTHON_ADAPTER_VERSION: &str = "reference-v17";
 const RUST_ADAPTER_VERSION: &str = "reference-v19";
 const TYPESCRIPT_ADAPTER_VERSION: &str = "reference-v17";
-const JAVA_ADAPTER_VERSION: &str = "reference-v1";
-const KOTLIN_ADAPTER_VERSION: &str = "reference-v1";
-const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 17;
+const JAVA_ADAPTER_VERSION: &str = "reference-v2";
+const KOTLIN_ADAPTER_VERSION: &str = "reference-v2";
+const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 18;
 const INSTALLED_ADAPTERS: &[(&str, &str)] = &[
     ("go", GO_ADAPTER_VERSION),
     ("javascript", ADAPTER_VERSION),
@@ -167,6 +186,8 @@ pub(crate) fn collect_call_resolution_inputs(
                 index.module_dynamic,
                 index.poisoned_export_names(),
             )
+        } else if let Some(index) = &java_kotlin_index {
+            (Vec::new(), index.has_annotated_declaration, Vec::new())
         } else {
             (Vec::new(), false, Vec::new())
         };
@@ -224,6 +245,10 @@ pub(crate) fn collect_call_resolution_inputs(
                 callsite.callee_form = CalleeForm::ImplicitReceiver;
             }
             if matches!(binding, CachedResolutionBinding::StaticImport { .. })
+                || matches!(
+                    binding,
+                    CachedResolutionBinding::JavaKotlinImportedFunction { .. }
+                )
                 || matches!(
                     binding,
                     CachedResolutionBinding::RustPath {
@@ -434,11 +459,60 @@ struct IndexedJavaKotlinCall<'tree> {
     callee: TsNode<'tree>,
     form: CalleeForm,
     raw_target: String,
+    caller: Option<NodeId>,
+    callable_id: Option<usize>,
+    owner_name: Option<String>,
+    unsupported: bool,
+    identifier_shadowed: bool,
+    receiver: JavaKotlinCallReceiver,
+}
+
+#[derive(Debug, Clone)]
+struct JavaKotlinImportBinding {
+    package_name: String,
+    owner_name: Option<String>,
+    imported_name: String,
+    local_name: String,
+    node: NodeId,
+}
+
+#[derive(Debug, Clone)]
+enum JavaKotlinCallReceiver {
+    None,
+    Implicit,
+    ExactType {
+        owner_name: String,
+        constructor: bool,
+        receiver_name: Option<String>,
+    },
+    Named {
+        receiver_name: String,
+    },
+    Blocked,
+}
+
+#[derive(Debug, Clone)]
+enum JavaKotlinLexicalBinding {
+    Other,
+    Receiver {
+        owner_name: String,
+        constructor: bool,
+    },
+}
+
+#[derive(Clone, Copy)]
+struct JavaKotlinWalkContext {
+    callable_id: Option<usize>,
+    caller: Option<NodeId>,
+    owner_index: Option<usize>,
+    owner_virtual: bool,
+    unsupported: bool,
 }
 
 struct JavaKotlinResolutionIndex<'tree> {
     language: &'tree str,
     calls: Vec<IndexedJavaKotlinCall<'tree>>,
+    call_indices_by_span: HashMap<(usize, usize), usize>,
     declarations: Vec<CachedTopLevelDeclaration>,
     declaration_indices_by_name: HashMap<String, Vec<usize>>,
     classes: Vec<CachedClassDeclaration>,
@@ -448,8 +522,18 @@ struct JavaKotlinResolutionIndex<'tree> {
     callable_nodes: HashMap<(u32, String), Vec<NodeId>>,
     class_nodes: HashMap<(u32, String), Vec<NodeId>>,
     import_nodes: HashMap<u32, Vec<NodeId>>,
+    imports_by_name: HashMap<String, Vec<JavaKotlinImportBinding>>,
+    type_imports_by_name: HashMap<String, Vec<JavaKotlinImportBinding>>,
+    owner_bindings: HashMap<(String, String), Vec<JavaKotlinLexicalBinding>>,
+    rebound_receivers: HashSet<(usize, String)>,
+    unsupported_type_names: HashSet<String>,
     package_name: Option<String>,
-    generated_or_annotation: bool,
+    wildcard_import: bool,
+    overloads: HashSet<String>,
+    virtual_methods: HashSet<String>,
+    extension_methods: HashSet<String>,
+    has_annotated_declaration: bool,
+    has_delegation: bool,
 }
 
 impl<'tree> JavaKotlinResolutionIndex<'tree> {
@@ -467,30 +551,35 @@ impl<'tree> JavaKotlinResolutionIndex<'tree> {
             .iter()
             .filter(|node| node.file_node_id == Some(file_id))
         {
+            count_java_kotlin_resolution_work(1);
             let Some(line) = node.start_line else {
                 continue;
             };
             let name = graph_leaf_name(&node.serialized_name).to_string();
             match node.kind {
                 NodeKind::FUNCTION | NodeKind::METHOD => {
+                    count_java_kotlin_resolution_work(1);
                     callable_nodes
                         .entry((line, name))
                         .or_default()
                         .push(node.id);
                 }
                 NodeKind::CLASS => {
+                    count_java_kotlin_resolution_work(1);
                     class_nodes.entry((line, name)).or_default().push(node.id);
                 }
                 NodeKind::MODULE | NodeKind::UNKNOWN => {
+                    count_java_kotlin_resolution_work(1);
                     import_nodes.entry(line).or_default().push(node.id);
                 }
                 _ => {}
             }
         }
-        let root = tree.root_node();
+
         let mut result = Self {
             language,
             calls: Vec::new(),
+            call_indices_by_span: HashMap::new(),
             declarations: Vec::new(),
             declaration_indices_by_name: HashMap::new(),
             classes: Vec::new(),
@@ -500,54 +589,40 @@ impl<'tree> JavaKotlinResolutionIndex<'tree> {
             callable_nodes,
             class_nodes,
             import_nodes,
-            package_name: java_kotlin_package_name(root, source, language),
-            generated_or_annotation: java_kotlin_source_is_generated_or_annotated(root, source),
+            imports_by_name: HashMap::new(),
+            type_imports_by_name: HashMap::new(),
+            owner_bindings: HashMap::new(),
+            rebound_receivers: HashSet::new(),
+            unsupported_type_names: HashSet::new(),
+            package_name: None,
+            wildcard_import: false,
+            overloads: HashSet::new(),
+            virtual_methods: HashSet::new(),
+            extension_methods: HashSet::new(),
+            has_annotated_declaration: false,
+            has_delegation: false,
         };
-        walk_nodes(root, &mut |node| {
-            if java_kotlin_same_file_declaration(language, node, root, source) {
-                let Some(name) = declaration_name(node, source).map(str::to_string) else {
-                    return;
-                };
-                if let Some(declaration) = result.map_callable_declaration(node, source) {
-                    result.declarations.push(CachedTopLevelDeclaration {
-                        name,
-                        declaration,
-                        module_path: Vec::new(),
-                        cross_module_visible: false,
-                    });
-                }
-            }
-            if java_kotlin_class_kind(language, node.kind())
-                && let Some(owner) = result.map_class_declaration(node, source)
-                && let Some(name) = declaration_name(node, source)
-            {
-                result.classes.push(CachedClassDeclaration {
-                    name: name.to_string(),
-                    declaration: owner,
-                    methods: java_kotlin_class_methods(
-                        node,
-                        language,
-                        source,
-                        &result.callable_nodes,
-                    ),
-                });
-            }
-            let call = if language == "java" {
-                java_call(node, source)
-            } else {
-                kotlin_call(node, source)
-            };
-            if let Some((callee, form, raw_target)) = call {
-                result.calls.push(IndexedJavaKotlinCall {
-                    callee,
-                    form,
-                    raw_target,
-                });
-            }
-        });
+        let root = tree.root_node();
+        JavaKotlinProducer::new(&mut result, source, root.id()).visit(
+            root,
+            JavaKotlinWalkContext {
+                callable_id: None,
+                caller: None,
+                owner_index: None,
+                owner_virtual: false,
+                unsupported: false,
+            },
+        );
+
         result
             .calls
             .sort_by_key(|call| (call.callee.start_byte(), call.callee.end_byte()));
+        for (index, call) in result.calls.iter().enumerate() {
+            count_java_kotlin_resolution_work(1);
+            result
+                .call_indices_by_span
+                .insert((call.callee.start_byte(), call.callee.end_byte()), index);
+        }
         result.declarations.sort_by(|left, right| {
             left.name
                 .cmp(&right.name)
@@ -557,13 +632,20 @@ impl<'tree> JavaKotlinResolutionIndex<'tree> {
             .classes
             .sort_by(|left, right| left.declaration.cmp(&right.declaration));
         for (index, declaration) in result.declarations.iter().enumerate() {
+            count_java_kotlin_resolution_work(1);
             result
                 .declaration_indices_by_name
                 .entry(declaration.name.clone())
                 .or_default()
                 .push(index);
         }
-        for (index, class) in result.classes.iter().enumerate() {
+        for (index, class) in result.classes.iter_mut().enumerate() {
+            class.methods.sort_by(|left, right| {
+                left.name
+                    .cmp(&right.name)
+                    .then(left.declaration.cmp(&right.declaration))
+            });
+            count_java_kotlin_resolution_work(2);
             result
                 .class_indices_by_name
                 .entry(class.name.clone())
@@ -571,6 +653,7 @@ impl<'tree> JavaKotlinResolutionIndex<'tree> {
                 .push(index);
             result.class_names.insert(class.name.clone());
             for (method_index, method) in class.methods.iter().enumerate() {
+                count_java_kotlin_resolution_work(1);
                 result
                     .class_method_indices_by_name
                     .entry((index, method.name.clone()))
@@ -583,6 +666,7 @@ impl<'tree> JavaKotlinResolutionIndex<'tree> {
 
     fn map_callable_declaration(&self, node: TsNode<'_>, source: &str) -> Option<NodeId> {
         let name = declaration_name(node, source)?;
+        count_java_kotlin_resolution_work(1);
         let matches = self
             .callable_nodes
             .get(&(node.start_position().row as u32 + 1, name.to_string()))?;
@@ -591,6 +675,7 @@ impl<'tree> JavaKotlinResolutionIndex<'tree> {
 
     fn map_class_declaration(&self, node: TsNode<'_>, source: &str) -> Option<NodeId> {
         let name = declaration_name(node, source)?;
+        count_java_kotlin_resolution_work(1);
         let matches = self
             .class_nodes
             .get(&(node.start_position().row as u32 + 1, name.to_string()))?;
@@ -599,26 +684,60 @@ impl<'tree> JavaKotlinResolutionIndex<'tree> {
 
     fn resolve_syntax_claim(
         &self,
-        source: &str,
+        _source: &str,
         callee: TsNode<'tree>,
         form: CalleeForm,
         raw_target: &str,
     ) -> (Option<NodeId>, CachedResolutionBinding) {
-        let Some(callable) = java_kotlin_enclosing_callable(callee, self.language) else {
+        count_java_kotlin_resolution_work(1);
+        let Some(call_index) = self
+            .call_indices_by_span
+            .get(&(callee.start_byte(), callee.end_byte()))
+        else {
             return (None, CachedResolutionBinding::Unsupported);
         };
-        let Some(caller) = self.map_callable_declaration(callable, source) else {
+        let call = &self.calls[*call_index];
+        let Some(caller) = call.caller else {
             return (None, CachedResolutionBinding::Unsupported);
         };
-        let unsupported =
-            java_kotlin_call_is_unsupported(callee, raw_target, source, self.language);
-        if self.generated_or_annotation || unsupported {
+        if call.form != form || call.raw_target != raw_target {
             return (Some(caller), CachedResolutionBinding::Unsupported);
         }
+        count_java_kotlin_resolution_work(4);
+        if call.unsupported
+            || self.wildcard_import
+            || self.virtual_methods.contains(raw_target)
+            || self.extension_methods.contains(raw_target)
+            || self.has_delegation
+            || self.has_annotated_declaration
+        {
+            return (Some(caller), CachedResolutionBinding::Unsupported);
+        }
+
         if form == CalleeForm::Identifier {
-            if java_kotlin_overload_present(source, self.language, raw_target) {
+            if call.identifier_shadowed {
+                return (Some(caller), CachedResolutionBinding::MissingBinding);
+            }
+            count_java_kotlin_resolution_work(1);
+            if self.overloads.contains(&format!("overload:{raw_target}")) {
                 return (Some(caller), CachedResolutionBinding::Ambiguous);
             }
+            count_java_kotlin_resolution_work(1);
+            if let Some(imports) = self.imports_by_name.get(raw_target) {
+                return match imports.as_slice() {
+                    [import] => (
+                        Some(caller),
+                        CachedResolutionBinding::JavaKotlinImportedFunction {
+                            package_name: import.package_name.clone(),
+                            owner_name: import.owner_name.clone(),
+                            name: import.imported_name.clone(),
+                            import: import.node,
+                        },
+                    ),
+                    _ => (Some(caller), CachedResolutionBinding::Ambiguous),
+                };
+            }
+            count_java_kotlin_resolution_work(1);
             let candidates = self
                 .declaration_indices_by_name
                 .get(raw_target)
@@ -632,34 +751,78 @@ impl<'tree> JavaKotlinResolutionIndex<'tree> {
                         rust_glob_local_module: None,
                     },
                 ),
+                [] if self.language == "kotlin" && self.package_name.is_some() => (
+                    Some(caller),
+                    CachedResolutionBinding::JavaKotlinPackageFunction {
+                        package_name: self.package_name.clone().unwrap_or_default(),
+                        name: raw_target.to_string(),
+                    },
+                ),
                 [] => (Some(caller), CachedResolutionBinding::MissingBinding),
                 _ => (Some(caller), CachedResolutionBinding::Ambiguous),
             };
         }
-        if java_kotlin_receiver_is_rebound(callee, source, self.language)
-            || self.language == "kotlin"
-                && source.contains("var ")
-                && source.matches(" = ").count() > 1
-        {
-            return (Some(caller), CachedResolutionBinding::Ambiguous);
+
+        let receiver_name = match &call.receiver {
+            JavaKotlinCallReceiver::ExactType { receiver_name, .. } => receiver_name.as_ref(),
+            JavaKotlinCallReceiver::Named { receiver_name } => Some(receiver_name),
+            JavaKotlinCallReceiver::None
+            | JavaKotlinCallReceiver::Implicit
+            | JavaKotlinCallReceiver::Blocked => None,
+        };
+        if let (Some(callable_id), Some(receiver_name)) = (call.callable_id, receiver_name) {
+            count_java_kotlin_resolution_work(1);
+            if self
+                .rebound_receivers
+                .contains(&(callable_id, receiver_name.clone()))
+            {
+                return (Some(caller), CachedResolutionBinding::Ambiguous);
+            }
         }
-        let Some((owner_name, constructor)) =
-            self.receiver_owner(callee, source, raw_target, form, callable)
-        else {
+
+        let Some((owner_name, constructor)) = self.call_receiver_owner(call) else {
             return (Some(caller), CachedResolutionBinding::Unsupported);
         };
-        if let Some((package_name, import)) = self.imported_receiver_binding(source, &owner_name) {
+        count_java_kotlin_resolution_work(1);
+        if self.unsupported_type_names.contains(&owner_name) {
+            return (Some(caller), CachedResolutionBinding::Unsupported);
+        }
+        count_java_kotlin_resolution_work(1);
+        if let Some(imports) = self.type_imports_by_name.get(&owner_name) {
+            return match imports.as_slice() {
+                [import] => (
+                    Some(caller),
+                    CachedResolutionBinding::JavaKotlinImportedReceiver {
+                        package_name: import.package_name.clone(),
+                        owner_name: import.imported_name.clone(),
+                        method_name: raw_target.to_string(),
+                        import: import.node,
+                        constructor,
+                    },
+                ),
+                _ => (Some(caller), CachedResolutionBinding::Ambiguous),
+            };
+        }
+        count_java_kotlin_resolution_work(1);
+        if self.language == "java"
+            && !self.class_names.contains(&owner_name)
+            && let Some(package_name) = &self.package_name
+        {
             return (
                 Some(caller),
-                CachedResolutionBinding::JavaKotlinImportedReceiver {
-                    package_name,
+                CachedResolutionBinding::JavaKotlinPackageReceiver {
+                    package_name: package_name.clone(),
                     owner_name,
                     method_name: raw_target.to_string(),
-                    import,
                     constructor,
                 },
             );
         }
+        count_java_kotlin_resolution_work(1);
+        if self.language == "kotlin" && !constructor && !self.class_names.contains(&owner_name) {
+            return (Some(caller), CachedResolutionBinding::Unsupported);
+        }
+        count_java_kotlin_resolution_work(1);
         let classes = self
             .class_indices_by_name
             .get(&owner_name)
@@ -676,6 +839,7 @@ impl<'tree> JavaKotlinResolutionIndex<'tree> {
             );
         };
         let class = &self.classes[*class_index];
+        count_java_kotlin_resolution_work(1);
         let matching_methods = self
             .class_method_indices_by_name
             .get(&(*class_index, raw_target.to_string()))
@@ -692,12 +856,11 @@ impl<'tree> JavaKotlinResolutionIndex<'tree> {
             );
         };
         if form == CalleeForm::ImplicitReceiver {
-            let declaration = class.methods[*method_index].declaration;
             return (
                 Some(caller),
                 CachedResolutionBinding::ImplicitReceiver {
                     owner: class.declaration,
-                    declaration,
+                    declaration: class.methods[*method_index].declaration,
                     owner_name,
                 },
             );
@@ -722,98 +885,462 @@ impl<'tree> JavaKotlinResolutionIndex<'tree> {
         )
     }
 
-    fn imported_receiver_binding(
-        &self,
-        source: &str,
-        owner_name: &str,
-    ) -> Option<(String, NodeId)> {
-        let (line, package_name) = java_kotlin_type_import(source, self.language, owner_name)?;
-        let imports = self.import_nodes.get(&line)?;
-        let [import] = imports.as_slice() else {
-            return None;
-        };
-        Some((package_name, *import))
+    fn call_receiver_owner(&self, call: &IndexedJavaKotlinCall<'_>) -> Option<(String, bool)> {
+        match &call.receiver {
+            JavaKotlinCallReceiver::Implicit => call.owner_name.clone().map(|owner| (owner, false)),
+            JavaKotlinCallReceiver::ExactType {
+                owner_name,
+                constructor,
+                ..
+            } => Some((owner_name.clone(), *constructor)),
+            JavaKotlinCallReceiver::Named { receiver_name } => {
+                let owner_name = call.owner_name.as_ref()?;
+                count_java_kotlin_resolution_work(1);
+                let bindings = self
+                    .owner_bindings
+                    .get(&(owner_name.clone(), receiver_name.clone()))?;
+                match bindings.as_slice() {
+                    [
+                        JavaKotlinLexicalBinding::Receiver {
+                            owner_name,
+                            constructor,
+                        },
+                    ] => Some((owner_name.clone(), *constructor)),
+                    _ => None,
+                }
+            }
+            JavaKotlinCallReceiver::None | JavaKotlinCallReceiver::Blocked => None,
+        }
+    }
+}
+
+struct JavaKotlinProducer<'index, 'tree> {
+    index: &'index mut JavaKotlinResolutionIndex<'tree>,
+    source: &'index str,
+    root_id: usize,
+    active_bindings: HashMap<String, Vec<JavaKotlinLexicalBinding>>,
+    scope_insertions: Vec<Vec<String>>,
+}
+
+impl<'index, 'tree> JavaKotlinProducer<'index, 'tree> {
+    fn new(
+        index: &'index mut JavaKotlinResolutionIndex<'tree>,
+        source: &'index str,
+        root_id: usize,
+    ) -> Self {
+        Self {
+            index,
+            source,
+            root_id,
+            active_bindings: HashMap::new(),
+            scope_insertions: vec![Vec::new()],
+        }
     }
 
-    fn receiver_owner(
-        &self,
-        callee: TsNode<'tree>,
-        source: &str,
-        raw_target: &str,
-        form: CalleeForm,
-        callable: TsNode<'tree>,
-    ) -> Option<(String, bool)> {
-        if form == CalleeForm::ImplicitReceiver {
-            let mut node = callable;
-            while let Some(parent) = node.parent() {
-                if java_kotlin_class_kind(self.language, parent.kind()) {
-                    return declaration_name(parent, source).map(|name| (name.to_string(), false));
-                }
-                node = parent;
-            }
-            return None;
+    fn visit(&mut self, node: TsNode<'tree>, context: JavaKotlinWalkContext) {
+        count_java_kotlin_resolution_work(1);
+        let is_callable = java_kotlin_callable_kind(self.index.language, node.kind());
+        let is_scope = is_callable || node.kind() == "block";
+        if is_scope {
+            self.scope_insertions.push(Vec::new());
         }
-        let receiver = java_kotlin_member_receiver(callee, self.language)?;
-        let receiver_surface = node_text(receiver, source)?.trim();
-        let receiver_call_surface = &source[receiver.start_byte()..callee.start_byte()];
-        let direct_constructor = if self.language == "java" {
-            receiver.kind() == "object_creation_expression"
-        } else {
-            matches!(
-                receiver.kind(),
-                "call_expression" | "constructor_invocation"
-            ) && receiver_surface
-                .chars()
-                .next()
-                .is_some_and(char::is_uppercase)
-                || receiver_surface
-                    .chars()
-                    .next()
-                    .is_some_and(char::is_uppercase)
-                    && receiver_call_surface.starts_with(&format!("{receiver_surface}()"))
-        };
-        if direct_constructor {
-            let owner = if self.language == "java" {
-                receiver
-                    .child_by_field_name("type")
-                    .and_then(|ty| node_text(ty, source))?
-                    .trim()
-                    .split('<')
-                    .next()?
-            } else {
-                receiver_surface.split('(').next()?.trim()
-            };
-            return Some((owner.to_string(), true));
-        }
-        let receiver_name = receiver_surface.trim_end_matches('?');
-        if self.language == "java" && self.class_names.contains(receiver_name) {
-            return Some((receiver_name.to_string(), false));
-        }
-        if receiver_name.contains(['.', '(', ')', '[', ']']) {
-            return None;
-        }
-        let before_call = &source[..callee.start_byte()];
-        if before_call.matches(&format!("{receiver_name} =")).count() > 1 {
-            return None;
-        }
-        if let Some(imported_owner) = java_kotlin_visible_imported_receiver_type(
-            source,
-            self.language,
-            receiver_name,
-            before_call,
-        ) {
-            return Some((imported_owner, false));
-        }
-        if self.language == "kotlin"
-            && let Some(owner) = java_kotlin_constructor_receiver_type(before_call, receiver_name)
-            && self.class_names.contains(&owner)
+
+        let mut context = context;
+        if matches!(node.kind(), "interface_declaration" | "when_expression")
+            || self.index.language == "java" && node.kind() == "cast_expression"
         {
-            return Some((owner, true));
+            context.unsupported = true;
         }
-        java_kotlin_declared_receiver_type(before_call, self.language, receiver_name)
-            .filter(|owner| self.class_names.contains(owner))
-            .map(|owner| (owner, false))
-            .filter(|_| !raw_target.is_empty())
+        if node.kind() == "interface_declaration"
+            && let Some(name) = declaration_name(node, self.source)
+        {
+            count_java_kotlin_resolution_work(1);
+            self.index.unsupported_type_names.insert(name.to_string());
+        }
+
+        if java_kotlin_class_kind(self.index.language, node.kind()) {
+            context = self.enter_class(node, context);
+        }
+        if is_callable {
+            context = self.enter_callable(node, context);
+        }
+
+        self.collect_package(node);
+        self.collect_import(node);
+        self.collect_binding(node, context);
+        self.collect_write(node, context);
+        self.collect_call(node, context);
+
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            self.visit(child, context);
+        }
+
+        if is_scope {
+            self.leave_scope();
+        }
+    }
+
+    fn enter_class(
+        &mut self,
+        node: TsNode<'tree>,
+        mut context: JavaKotlinWalkContext,
+    ) -> JavaKotlinWalkContext {
+        let annotated = java_kotlin_declaration_has_annotation(node, self.source);
+        let delegated = self.index.language == "kotlin"
+            && java_kotlin_has_direct_child_kind(node, "delegation_specifiers");
+        let virtual_owner =
+            self.index.language == "java" && node.child_by_field_name("superclass").is_some();
+        self.index.has_annotated_declaration |= annotated;
+        self.index.has_delegation |= delegated;
+        context.unsupported |= annotated
+            || delegated
+            || virtual_owner
+            || node.child_by_field_name("type_parameters").is_some()
+            || java_kotlin_has_direct_child_kind(node, "type_parameters");
+        context.owner_virtual = virtual_owner;
+        context.owner_index = None;
+
+        let Some(name) = declaration_name(node, self.source).map(str::to_string) else {
+            return context;
+        };
+        let Some(declaration) = self.index.map_class_declaration(node, self.source) else {
+            return context;
+        };
+        count_java_kotlin_resolution_work(2);
+        self.index.class_names.insert(name.clone());
+        self.index.classes.push(CachedClassDeclaration {
+            name,
+            declaration,
+            methods: Vec::new(),
+        });
+        context.owner_index = Some(self.index.classes.len() - 1);
+        context
+    }
+
+    fn enter_callable(
+        &mut self,
+        node: TsNode<'tree>,
+        mut context: JavaKotlinWalkContext,
+    ) -> JavaKotlinWalkContext {
+        let annotated = java_kotlin_declaration_has_annotation(node, self.source);
+        self.index.has_annotated_declaration |= annotated;
+        context.unsupported |= annotated
+            || node.child_by_field_name("type_parameters").is_some()
+            || java_kotlin_has_direct_child_kind(node, "type_parameters");
+
+        let Some(name) = declaration_name(node, self.source).map(str::to_string) else {
+            context.caller = None;
+            context.callable_id = Some(node.id());
+            return context;
+        };
+        count_java_kotlin_resolution_work(1);
+        if !self.index.overloads.insert(name.clone()) {
+            count_java_kotlin_resolution_work(1);
+            self.index.overloads.insert(format!("overload:{name}"));
+        }
+        if context.owner_virtual {
+            count_java_kotlin_resolution_work(1);
+            self.index.virtual_methods.insert(name.clone());
+        }
+        if self.index.language == "kotlin"
+            && java_kotlin_kotlin_extension_declaration(node, self.source)
+        {
+            count_java_kotlin_resolution_work(1);
+            self.index.extension_methods.insert(name.clone());
+        }
+
+        let caller = self.index.map_callable_declaration(node, self.source);
+        if let (Some(owner_index), Some(declaration)) = (context.owner_index, caller) {
+            count_java_kotlin_resolution_work(1);
+            self.index.classes[owner_index]
+                .methods
+                .push(CachedClassMethod {
+                    name: name.clone(),
+                    declaration,
+                });
+        }
+        if let Some(declaration) = caller {
+            let same_file = if self.index.language == "kotlin" {
+                node.parent()
+                    .is_some_and(|parent| parent.id() == self.root_id)
+            } else {
+                java_kotlin_java_method_is_static(node, self.source)
+            };
+            if same_file {
+                count_java_kotlin_resolution_work(1);
+                self.index.declarations.push(CachedTopLevelDeclaration {
+                    name,
+                    declaration,
+                    module_path: Vec::new(),
+                    cross_module_visible: false,
+                });
+            }
+        }
+        context.callable_id = Some(node.id());
+        context.caller = caller;
+        context
+    }
+
+    fn collect_package(&mut self, node: TsNode<'tree>) {
+        let expected = if self.index.language == "java" {
+            "package_declaration"
+        } else {
+            "package_header"
+        };
+        if node.kind() != expected || self.index.package_name.is_some() {
+            return;
+        }
+        self.index.package_name = node_text(node, self.source)
+            .and_then(|surface| surface.trim().strip_prefix("package"))
+            .map(str::trim)
+            .map(|name| name.trim_end_matches(';').trim().to_string())
+            .filter(|name| !name.is_empty());
+        if self.index.package_name.is_some() {
+            count_java_kotlin_resolution_work(1);
+        }
+    }
+
+    fn collect_import(&mut self, node: TsNode<'tree>) {
+        if !node.kind().contains("import") {
+            return;
+        }
+        let Some(surface) = node_text(node, self.source)
+            .map(str::trim)
+            .map(|surface| surface.trim_end_matches(';').trim())
+        else {
+            return;
+        };
+        if surface.ends_with(".*") {
+            self.index.wildcard_import = true;
+            return;
+        }
+        let Some(import) = self.parse_import(node, surface) else {
+            return;
+        };
+        count_java_kotlin_resolution_work(1);
+        self.index
+            .imports_by_name
+            .entry(import.local_name.clone())
+            .or_default()
+            .push(import.clone());
+        if import.owner_name.is_none() {
+            count_java_kotlin_resolution_work(1);
+            self.index
+                .type_imports_by_name
+                .entry(import.local_name.clone())
+                .or_default()
+                .push(import);
+        }
+    }
+
+    fn parse_import(&self, node: TsNode<'tree>, surface: &str) -> Option<JavaKotlinImportBinding> {
+        let line = node.start_position().row as u32 + 1;
+        count_java_kotlin_resolution_work(1);
+        let nodes = self.index.import_nodes.get(&line)?;
+        let [node_id] = nodes.as_slice() else {
+            return None;
+        };
+        let path = surface.strip_prefix("import ")?.trim();
+        let (path, static_import) = if self.index.language == "java" {
+            match path.strip_prefix("static ") {
+                Some(path) => (path.trim(), true),
+                None => (path, false),
+            }
+        } else {
+            (path, false)
+        };
+        let (path, alias) = if self.index.language == "kotlin" {
+            path.rsplit_once(" as ")
+                .map_or((path, None), |(path, alias)| {
+                    (path.trim(), Some(alias.trim()))
+                })
+        } else {
+            (path, None)
+        };
+        let parts = path.split('.').collect::<Vec<_>>();
+        let imported_name = parts.last()?.to_string();
+        let local_name = alias.unwrap_or(&imported_name).to_string();
+        let (package_name, owner_name) = if static_import {
+            (
+                parts[..parts.len().saturating_sub(2)].join("."),
+                parts
+                    .get(parts.len().saturating_sub(2))
+                    .map(|part| (*part).to_string()),
+            )
+        } else {
+            (parts[..parts.len().saturating_sub(1)].join("."), None)
+        };
+        (!package_name.is_empty()).then_some(JavaKotlinImportBinding {
+            package_name,
+            owner_name,
+            imported_name,
+            local_name,
+            node: *node_id,
+        })
+    }
+
+    fn collect_binding(&mut self, node: TsNode<'tree>, context: JavaKotlinWalkContext) {
+        let Some((name, binding)) =
+            java_kotlin_lexical_binding(node, self.source, self.index.language)
+        else {
+            return;
+        };
+        if context.callable_id.is_some() {
+            self.insert_active(name, binding);
+        } else if let Some(owner_index) = context.owner_index {
+            let owner_name = self.index.classes[owner_index].name.clone();
+            count_java_kotlin_resolution_work(1);
+            self.index
+                .owner_bindings
+                .entry((owner_name, name))
+                .or_default()
+                .push(binding);
+        }
+    }
+
+    fn collect_write(&mut self, node: TsNode<'tree>, context: JavaKotlinWalkContext) {
+        if !matches!(node.kind(), "assignment_expression" | "assignment") {
+            return;
+        }
+        let Some(callable_id) = context.callable_id else {
+            return;
+        };
+        let Some(left) = node.child_by_field_name("left") else {
+            return;
+        };
+        let Some(name) = node_text(left, self.source)
+            .map(str::trim)
+            .filter(|name| java_kotlin_simple_identifier(name))
+        else {
+            return;
+        };
+        count_java_kotlin_resolution_work(1);
+        self.index
+            .rebound_receivers
+            .insert((callable_id, name.to_string()));
+    }
+
+    fn collect_call(&mut self, node: TsNode<'tree>, context: JavaKotlinWalkContext) {
+        let call = if self.index.language == "java" {
+            java_call(node, self.source)
+        } else {
+            kotlin_call(node, self.source)
+        };
+        let Some((callee, form, raw_target)) = call else {
+            return;
+        };
+        let owner_name = context
+            .owner_index
+            .map(|owner_index| self.index.classes[owner_index].name.clone());
+        let identifier_shadowed = if form == CalleeForm::Identifier {
+            count_java_kotlin_resolution_work(1);
+            self.active_bindings.contains_key(&raw_target)
+        } else {
+            false
+        };
+        let receiver = self.call_receiver(callee, form);
+        let reflection = raw_target == "forName"
+            && java_kotlin_member_receiver(callee, self.index.language)
+                .and_then(|receiver| node_text(receiver, self.source))
+                .is_some_and(|receiver| receiver.trim() == "Class");
+        count_java_kotlin_resolution_work(1);
+        self.index.calls.push(IndexedJavaKotlinCall {
+            callee,
+            form,
+            raw_target,
+            caller: context.caller,
+            callable_id: context.callable_id,
+            owner_name,
+            unsupported: context.unsupported || reflection,
+            identifier_shadowed,
+            receiver,
+        });
+    }
+
+    fn call_receiver(&self, callee: TsNode<'tree>, form: CalleeForm) -> JavaKotlinCallReceiver {
+        if form == CalleeForm::Identifier {
+            return JavaKotlinCallReceiver::None;
+        }
+        if form == CalleeForm::ImplicitReceiver {
+            return JavaKotlinCallReceiver::Implicit;
+        }
+        let Some(receiver) = java_kotlin_member_receiver(callee, self.index.language) else {
+            return JavaKotlinCallReceiver::Blocked;
+        };
+        if let Some(owner_name) =
+            java_kotlin_direct_constructor_type(receiver, self.source, self.index.language)
+        {
+            return JavaKotlinCallReceiver::ExactType {
+                owner_name,
+                constructor: true,
+                receiver_name: None,
+            };
+        }
+        let Some(receiver_name) = node_text(receiver, self.source)
+            .map(str::trim)
+            .map(|name| name.trim_end_matches('?'))
+            .filter(|name| java_kotlin_simple_identifier(name))
+        else {
+            return JavaKotlinCallReceiver::Blocked;
+        };
+        count_java_kotlin_resolution_work(1);
+        match self
+            .active_bindings
+            .get(receiver_name)
+            .and_then(|bindings| bindings.last())
+        {
+            Some(JavaKotlinLexicalBinding::Receiver {
+                owner_name,
+                constructor,
+            }) => JavaKotlinCallReceiver::ExactType {
+                owner_name: owner_name.clone(),
+                constructor: *constructor,
+                receiver_name: Some(receiver_name.to_string()),
+            },
+            Some(JavaKotlinLexicalBinding::Other) => JavaKotlinCallReceiver::Blocked,
+            None if self.index.language == "java"
+                && receiver_name.chars().next().is_some_and(char::is_uppercase) =>
+            {
+                JavaKotlinCallReceiver::ExactType {
+                    owner_name: receiver_name.to_string(),
+                    constructor: false,
+                    receiver_name: None,
+                }
+            }
+            None => JavaKotlinCallReceiver::Named {
+                receiver_name: receiver_name.to_string(),
+            },
+        }
+    }
+
+    fn insert_active(&mut self, name: String, binding: JavaKotlinLexicalBinding) {
+        count_java_kotlin_resolution_work(1);
+        self.active_bindings
+            .entry(name.clone())
+            .or_default()
+            .push(binding);
+        self.scope_insertions
+            .last_mut()
+            .expect("root lexical scope exists")
+            .push(name);
+    }
+
+    fn leave_scope(&mut self) {
+        let names = self
+            .scope_insertions
+            .pop()
+            .expect("entered Java/Kotlin lexical scope must exist");
+        for name in names.into_iter().rev() {
+            count_java_kotlin_resolution_work(1);
+            let remove = self.active_bindings.get_mut(&name).is_some_and(|bindings| {
+                bindings.pop();
+                bindings.is_empty()
+            });
+            if remove {
+                self.active_bindings.remove(&name);
+            }
+        }
     }
 }
 
@@ -831,82 +1358,159 @@ fn java_kotlin_class_kind(language: &str, kind: &str) -> bool {
     )
 }
 
-fn java_kotlin_same_file_declaration(
-    language: &str,
-    node: TsNode<'_>,
-    root: TsNode<'_>,
-    source: &str,
-) -> bool {
-    if !java_kotlin_callable_kind(language, node.kind()) {
+fn java_kotlin_simple_identifier(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .chars()
+            .all(|character| character == '_' || character.is_alphanumeric())
+}
+
+fn java_kotlin_simple_type_name(node: TsNode<'_>, source: &str) -> Option<String> {
+    let surface = node_text(node, source)?.trim().trim_end_matches('?').trim();
+    java_kotlin_simple_identifier(surface).then(|| surface.to_string())
+}
+
+fn java_kotlin_declaration_has_annotation(node: TsNode<'_>, source: &str) -> bool {
+    let Some(name) = node.child_by_field_name("name") else {
         return false;
-    }
-    if language == "kotlin" {
-        return node.parent().is_some_and(|parent| parent.id() == root.id());
-    }
-    source[node.start_byte()..node.end_byte()]
-        .split('{')
-        .next()
-        .is_some_and(|signature| signature.split_whitespace().any(|word| word == "static"))
-}
-
-fn java_kotlin_class_methods(
-    class: TsNode<'_>,
-    language: &str,
-    source: &str,
-    callable_nodes: &HashMap<(u32, String), Vec<NodeId>>,
-) -> Vec<CachedClassMethod> {
-    let mut methods = Vec::new();
-    walk_nodes(class, &mut |node| {
-        if node.id() == class.id() || !java_kotlin_callable_kind(language, node.kind()) {
-            return;
-        }
-        let Some(name) = declaration_name(node, source) else {
-            return;
-        };
-        let Some(matches) =
-            callable_nodes.get(&(node.start_position().row as u32 + 1, name.to_string()))
-        else {
-            return;
-        };
-        if let [declaration] = matches.as_slice() {
-            methods.push(CachedClassMethod {
-                name: name.to_string(),
-                declaration: *declaration,
-            });
-        }
-    });
-    methods.sort_by(|left, right| {
-        left.name
-            .cmp(&right.name)
-            .then(left.declaration.cmp(&right.declaration))
-    });
-    methods
-}
-
-fn java_kotlin_package_name(root: TsNode<'_>, source: &str, language: &str) -> Option<String> {
-    let kind = if language == "java" {
-        "package_declaration"
-    } else {
-        "package_header"
     };
-    let mut cursor = root.walk();
-    root.named_children(&mut cursor)
-        .find(|node| node.kind() == kind)
-        .and_then(|node| node_text(node, source))
-        .and_then(|surface| {
-            surface
-                .trim()
-                .strip_prefix("package")
-                .map(str::trim)
-                .map(|name| name.trim_end_matches(';').trim().to_string())
-        })
-        .filter(|name| !name.is_empty())
+    source
+        .get(node.start_byte()..name.start_byte())
+        .is_some_and(|header| header.contains('@'))
 }
 
-fn java_kotlin_source_is_generated_or_annotated(root: TsNode<'_>, source: &str) -> bool {
-    source.contains("@Generated")
-        || source.contains("annotation class Generated")
-        || contains_node_kind(root, "annotation")
+fn java_kotlin_java_method_is_static(node: TsNode<'_>, source: &str) -> bool {
+    let Some(name) = node.child_by_field_name("name") else {
+        return false;
+    };
+    source
+        .get(node.start_byte()..name.start_byte())
+        .is_some_and(|header| header.split_whitespace().any(|word| word == "static"))
+}
+
+fn java_kotlin_kotlin_extension_declaration(node: TsNode<'_>, source: &str) -> bool {
+    let Some(name) = node.child_by_field_name("name") else {
+        return false;
+    };
+    source
+        .get(node.start_byte()..name.start_byte())
+        .is_some_and(|header| header.contains('.'))
+}
+
+fn java_kotlin_has_direct_child_kind(node: TsNode<'_>, kind: &str) -> bool {
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor).any(|child| {
+        count_java_kotlin_resolution_work(1);
+        child.kind() == kind
+    })
+}
+
+fn java_kotlin_direct_constructor_type(
+    node: TsNode<'_>,
+    source: &str,
+    language: &str,
+) -> Option<String> {
+    if language == "java" {
+        (node.kind() == "object_creation_expression").then_some(())?;
+        return node
+            .child_by_field_name("type")
+            .and_then(|ty| java_kotlin_simple_type_name(ty, source));
+    }
+    (node.kind() == "call_expression").then_some(())?;
+    count_java_kotlin_resolution_work(1);
+    let callee = node.named_child(0)?;
+    let owner = java_kotlin_simple_type_name(callee, source)?;
+    owner
+        .chars()
+        .next()
+        .is_some_and(char::is_uppercase)
+        .then_some(owner)
+}
+
+fn java_kotlin_lexical_binding(
+    node: TsNode<'_>,
+    source: &str,
+    language: &str,
+) -> Option<(String, JavaKotlinLexicalBinding)> {
+    if language == "java" && node.kind() == "formal_parameter" {
+        count_java_kotlin_resolution_work(2);
+        let name = node
+            .child_by_field_name("name")
+            .and_then(|name| node_text(name, source))?
+            .to_string();
+        let binding = node
+            .child_by_field_name("type")
+            .and_then(|ty| java_kotlin_simple_type_name(ty, source))
+            .map_or(JavaKotlinLexicalBinding::Other, |owner_name| {
+                JavaKotlinLexicalBinding::Receiver {
+                    owner_name,
+                    constructor: false,
+                }
+            });
+        return Some((name, binding));
+    }
+    if language == "java" && node.kind() == "variable_declarator" {
+        let parent = node.parent()?;
+        if !matches!(
+            parent.kind(),
+            "local_variable_declaration" | "field_declaration"
+        ) {
+            return None;
+        }
+        count_java_kotlin_resolution_work(2);
+        let name = node
+            .child_by_field_name("name")
+            .and_then(|name| node_text(name, source))?
+            .to_string();
+        let binding = parent
+            .child_by_field_name("type")
+            .and_then(|ty| java_kotlin_simple_type_name(ty, source))
+            .map_or(JavaKotlinLexicalBinding::Other, |owner_name| {
+                JavaKotlinLexicalBinding::Receiver {
+                    owner_name,
+                    constructor: false,
+                }
+            });
+        return Some((name, binding));
+    }
+    if language == "kotlin" && node.kind() == "parameter" {
+        count_java_kotlin_resolution_work(2);
+        let name = node_text(node.named_child(0)?, source)?.to_string();
+        let binding = node
+            .named_child(1)
+            .and_then(|ty| java_kotlin_simple_type_name(ty, source))
+            .map_or(JavaKotlinLexicalBinding::Other, |owner_name| {
+                JavaKotlinLexicalBinding::Receiver {
+                    owner_name,
+                    constructor: false,
+                }
+            });
+        return Some((name, binding));
+    }
+    if language != "kotlin" || node.kind() != "variable_declaration" {
+        return None;
+    }
+    count_java_kotlin_resolution_work(2);
+    let name = node_text(node.named_child(0)?, source)?.to_string();
+    let explicit_type = node
+        .named_child(1)
+        .and_then(|ty| java_kotlin_simple_type_name(ty, source));
+    let constructor_type = node
+        .next_named_sibling()
+        .and_then(|initializer| java_kotlin_direct_constructor_type(initializer, source, language));
+    let binding = explicit_type
+        .map(|owner_name| JavaKotlinLexicalBinding::Receiver {
+            owner_name,
+            constructor: false,
+        })
+        .or_else(|| {
+            constructor_type.map(|owner_name| JavaKotlinLexicalBinding::Receiver {
+                owner_name,
+                constructor: true,
+            })
+        })
+        .unwrap_or(JavaKotlinLexicalBinding::Other);
+    Some((name, binding))
 }
 
 fn java_call<'tree>(
@@ -929,8 +1533,8 @@ fn kotlin_call<'tree>(
     source: &str,
 ) -> Option<(TsNode<'tree>, CalleeForm, String)> {
     (node.kind() == "call_expression").then_some(())?;
-    let mut cursor = node.walk();
-    let callee = node.named_children(&mut cursor).next()?;
+    count_java_kotlin_resolution_work(1);
+    let callee = node.named_child(0)?;
     if callee.kind() == "identifier" {
         return Some((
             callee,
@@ -941,18 +1545,19 @@ fn kotlin_call<'tree>(
     if callee.kind() != "navigation_expression" {
         return None;
     }
-    let mut children = callee.walk();
-    let parts = callee.named_children(&mut children).collect::<Vec<_>>();
-    let (receiver, member) = (parts.first()?, parts.last()?);
+    count_java_kotlin_resolution_work(2);
+    let receiver = callee.named_child(0)?;
+    let last = u32::try_from(callee.named_child_count().checked_sub(1)?).ok()?;
+    let member = callee.named_child(last)?;
     let form = if receiver.kind() == "this_expression" {
         CalleeForm::ImplicitReceiver
     } else {
         CalleeForm::ExplicitReceiver
     };
     Some((
-        *member,
+        member,
         form,
-        node_text(*member, source)?
+        node_text(member, source)?
             .trim_start_matches('?')
             .to_string(),
     ))
@@ -966,181 +1571,8 @@ fn java_kotlin_member_receiver<'tree>(
     if language == "java" {
         return invocation.child_by_field_name("object");
     }
-    let navigation = invocation;
-    let mut cursor = navigation.walk();
-    navigation.named_children(&mut cursor).next()
-}
-
-fn java_kotlin_enclosing_callable<'tree>(
-    mut node: TsNode<'tree>,
-    language: &str,
-) -> Option<TsNode<'tree>> {
-    while let Some(parent) = node.parent() {
-        if java_kotlin_callable_kind(language, parent.kind()) {
-            return Some(parent);
-        }
-        node = parent;
-    }
-    None
-}
-
-fn java_kotlin_type_import(
-    source: &str,
-    language: &str,
-    owner_name: &str,
-) -> Option<(u32, String)> {
-    for (index, line) in source.lines().enumerate() {
-        let surface = line.trim().trim_end_matches(';').trim();
-        let path = if language == "java" {
-            let Some(path) = surface.strip_prefix("import ") else {
-                continue;
-            };
-            if path.starts_with("static ") {
-                continue;
-            }
-            path
-        } else {
-            let Some(path) = surface.strip_prefix("import ") else {
-                continue;
-            };
-            path
-        };
-        if path.ends_with(".*") || path.rsplit('.').next()? != owner_name {
-            continue;
-        }
-        let parts = path.split('.').collect::<Vec<_>>();
-        if parts.len() >= 2 {
-            return Some((index as u32 + 1, parts[..parts.len() - 1].join(".")));
-        }
-    }
-    None
-}
-
-fn java_kotlin_visible_imported_receiver_type(
-    source: &str,
-    language: &str,
-    receiver_name: &str,
-    before_call: &str,
-) -> Option<String> {
-    for line in source.lines() {
-        let surface = line.trim().trim_end_matches(';').trim();
-        let path = if language == "java" {
-            let Some(path) = surface.strip_prefix("import ") else {
-                continue;
-            };
-            if path.starts_with("static ") {
-                continue;
-            }
-            path
-        } else {
-            let Some(path) = surface.strip_prefix("import ") else {
-                continue;
-            };
-            path
-        };
-        let owner = path.rsplit('.').next()?.trim();
-        let typed = if language == "java" {
-            format!("{owner} {receiver_name}")
-        } else {
-            format!("{receiver_name}: {owner}")
-        };
-        if before_call.contains(&typed) {
-            return Some(owner.to_string());
-        }
-    }
-    None
-}
-
-fn java_kotlin_declared_receiver_type(
-    before_call: &str,
-    language: &str,
-    receiver_name: &str,
-) -> Option<String> {
-    if language == "kotlin" {
-        let type_marker = format!("{receiver_name}:");
-        let type_name = before_call.rsplit_once(&type_marker)?.1.trim_start();
-        let type_name = type_name
-            .chars()
-            .take_while(|character| character == &'_' || character.is_alphanumeric())
-            .collect::<String>();
-        return (!type_name.is_empty()).then_some(type_name);
-    }
-    let header = &before_call[..before_call.rfind('{')?];
-    let declaration = header.rsplit_once(&format!(" {receiver_name}"))?.0;
-    declaration
-        .trim_end()
-        .rsplit(|character: char| character != '_' && !character.is_alphanumeric())
-        .next()
-        .filter(|type_name| !type_name.is_empty())
-        .map(str::to_string)
-}
-
-fn java_kotlin_constructor_receiver_type(before_call: &str, receiver_name: &str) -> Option<String> {
-    let constructor = before_call
-        .rsplit_once(&format!("{receiver_name} = "))?
-        .1
-        .trim_start()
-        .split('(')
-        .next()?
-        .trim();
-    (!constructor.is_empty()
-        && constructor
-            .chars()
-            .all(|character| character == '_' || character.is_alphanumeric()))
-    .then(|| constructor.to_string())
-}
-
-fn java_kotlin_call_is_unsupported(
-    callee: TsNode<'_>,
-    raw_target: &str,
-    source: &str,
-    language: &str,
-) -> bool {
-    let prefix = &source[..callee.start_byte()];
-    raw_target == "forName"
-        || prefix.contains("import ") && prefix.contains(".*")
-        || prefix.contains("interface ") && !prefix.contains("class ")
-        || prefix.contains(" extends ")
-        || prefix.contains("fun <")
-        || prefix.contains("<T>")
-        || prefix.contains(" is ")
-        || prefix.contains(" by ")
-        || language == "kotlin"
-            && source.lines().any(|line| {
-                line.trim()
-                    .strip_prefix("fun ")
-                    .and_then(|declaration| declaration.split_once('.'))
-                    .is_some_and(|(receiver, member)| {
-                        receiver.chars().next().is_some_and(char::is_uppercase)
-                            && receiver
-                                .chars()
-                                .all(|character| character == '_' || character.is_alphanumeric())
-                            && member.starts_with(&format!("{raw_target}("))
-                    })
-            })
-        || language == "java" && prefix.contains("((")
-}
-
-fn java_kotlin_overload_present(source: &str, language: &str, name: &str) -> bool {
-    let declaration = if language == "java" {
-        format!("void {name}(")
-    } else {
-        format!("fun {name}(")
-    };
-    source.matches(&declaration).count() > 1
-}
-
-fn java_kotlin_receiver_is_rebound(callee: TsNode<'_>, source: &str, language: &str) -> bool {
-    java_kotlin_member_receiver(callee, language)
-        .and_then(|receiver| node_text(receiver, source))
-        .map(str::trim)
-        .filter(|receiver| !receiver.contains(['.', '(', ')', '[', ']']))
-        .is_some_and(|receiver| {
-            source[..callee.start_byte()]
-                .matches(&format!("{receiver} ="))
-                .count()
-                > 1
-        })
+    count_java_kotlin_resolution_work(1);
+    invocation.named_child(0)
 }
 
 #[derive(Debug, Clone)]
@@ -9487,7 +9919,7 @@ impl ExactEvidenceValidationIndex {
                 CalleeForm::Identifier,
                 [ResolutionEvidence::SamePackageDeclaration { declaration }],
             ) => {
-                claim.input.language == "go"
+                matches!(claim.input.language.as_str(), "go" | "kotlin")
                     && *declaration == target
                     && target_node.file_node_id.is_some()
                     && target_node.file_node_id != Some(source_file)
@@ -9507,7 +9939,12 @@ impl ExactEvidenceValidationIndex {
                             && graph_leaf_name(&import_node.serialized_name)
                                 == claim.input.callsite.raw_target
                     })
-                    && if typescript_directory_import {
+                    && if matches!(claim.input.language.as_str(), "java" | "kotlin") {
+                        target_node.file_node_id.is_some()
+                            && target_node.qualified_name.as_deref().is_some_and(|name| {
+                                name.ends_with(&claim.input.callsite.raw_target)
+                            })
+                    } else if typescript_directory_import {
                         typescript_directory_import_is_correlated
                     } else if self.typescript_directory_marker_seen(source_file, *import) {
                         false
@@ -9665,10 +10102,13 @@ impl ExactEvidenceValidationIndex {
             ) if *constructor == *receiver_type => self.local_receiver_is_correlated(
                 &claim.input.language,
                 source_file,
+                claim.caller,
                 *constructor,
                 *declaration,
                 target,
                 target_node,
+                false,
+                &claim.exact_dependency_files,
                 nodes,
             ),
             (
@@ -9680,10 +10120,13 @@ impl ExactEvidenceValidationIndex {
             ) => self.local_receiver_is_correlated(
                 &claim.input.language,
                 source_file,
+                claim.caller,
                 *receiver_type,
                 *declaration,
                 target,
                 target_node,
+                false,
+                &claim.exact_dependency_files,
                 nodes,
             ),
             (
@@ -9808,10 +10251,13 @@ impl ExactEvidenceValidationIndex {
             ) if *constructor == *receiver_type => self.local_receiver_is_correlated(
                 &claim.input.language,
                 source_file,
+                claim.caller,
                 *constructor,
                 *declaration,
                 target,
                 target_node,
+                true,
+                &claim.exact_dependency_files,
                 nodes,
             ),
             (
@@ -9823,10 +10269,13 @@ impl ExactEvidenceValidationIndex {
             ) => self.local_receiver_is_correlated(
                 &claim.input.language,
                 source_file,
+                claim.caller,
                 *receiver_type,
                 *declaration,
                 target,
                 target_node,
+                true,
+                &claim.exact_dependency_files,
                 nodes,
             ),
             _ => false,
@@ -9840,29 +10289,77 @@ impl ExactEvidenceValidationIndex {
         &self,
         language: &str,
         source_file: NodeId,
+        caller: NodeId,
         owner: NodeId,
         declaration: NodeId,
         target: NodeId,
         target_node: &Node,
+        same_package: bool,
+        domain_dependencies: &[FileId],
         nodes: &HashMap<NodeId, &Node>,
     ) -> bool {
+        let Some(owner_node) = nodes.get(&owner) else {
+            return false;
+        };
+        let receiver_domain_is_correlated = if same_package && language == "java" {
+            let Some(caller_node) = nodes.get(&caller) else {
+                return false;
+            };
+            let Some(owner_file) = owner_node.file_node_id else {
+                return false;
+            };
+            let owner_qualified = owner_node.qualified_name.as_deref();
+            let target_owner_qualified = target_node
+                .qualified_name
+                .as_deref()
+                .and_then(|qualified| qualified.rsplit_once('.'))
+                .map(|(owner, _)| owner);
+            let caller_owner_qualified = caller_node
+                .qualified_name
+                .as_deref()
+                .and_then(|qualified| qualified.rsplit_once('.'))
+                .map(|(owner, _)| owner);
+            let owner_package = owner_qualified
+                .and_then(|qualified| qualified.rsplit_once('.'))
+                .map(|(package, _)| package);
+            let caller_package = caller_owner_qualified
+                .and_then(|qualified| qualified.rsplit_once('.'))
+                .map(|(package, _)| package);
+            owner_node.kind == NodeKind::CLASS
+                && caller_node.kind == NodeKind::METHOD
+                && caller_node.file_node_id == Some(source_file)
+                && owner_file != source_file
+                && target_node.file_node_id == Some(owner_file)
+                && owner_package.is_some()
+                && owner_package == caller_package
+                && owner_qualified == target_owner_qualified
+                && domain_dependencies
+                    .iter()
+                    .any(|dependency| dependency.0 == source_file.0)
+                && domain_dependencies
+                    .iter()
+                    .any(|dependency| dependency.0 == owner_file.0)
+        } else if same_package {
+            language == "go"
+                && owner_node.file_node_id.is_some()
+                && target_node.file_node_id.is_some()
+        } else if language == "go" {
+            owner_node.file_node_id.is_some() && target_node.file_node_id.is_some()
+        } else {
+            owner_node.file_node_id == Some(source_file)
+                && owner_node.file_node_id == target_node.file_node_id
+        };
         declaration == target
             && if language == "python" {
                 target_node.kind == NodeKind::FUNCTION
             } else {
                 target_node.kind == NodeKind::METHOD
             }
-            && nodes.get(&owner).is_some_and(|owner_node| {
-                matches!(
-                    owner_node.kind,
-                    NodeKind::CLASS | NodeKind::STRUCT | NodeKind::ENUM
-                ) && if language == "go" {
-                    owner_node.file_node_id.is_some() && target_node.file_node_id.is_some()
-                } else {
-                    owner_node.file_node_id == Some(source_file)
-                        && owner_node.file_node_id == target_node.file_node_id
-                }
-            })
+            && matches!(
+                owner_node.kind,
+                NodeKind::CLASS | NodeKind::STRUCT | NodeKind::ENUM
+            )
+            && receiver_domain_is_correlated
             && self.has_member(owner, target)
     }
 
@@ -10936,6 +11433,7 @@ struct JavaKotlinImportCandidate {
 #[derive(Default)]
 struct JavaKotlinImportDomain {
     complete: bool,
+    poisoned: bool,
     dependencies: Vec<FileId>,
     declarations: HashMap<(Option<String>, String), Vec<JavaKotlinImportCandidate>>,
 }
@@ -10975,7 +11473,19 @@ impl JavaKotlinProjectionIndex {
             } else {
                 domain.complete &= file_complete;
             }
+            domain.poisoned |= record.file.export_poison_all;
             domain.dependencies.push(FileId(record.file.file_id.0));
+            for declaration in &record.file.top_level_declarations {
+                domain
+                    .declarations
+                    .entry((None, declaration.name.clone()))
+                    .or_default()
+                    .push(JavaKotlinImportCandidate {
+                        owner: declaration.declaration,
+                        declaration: declaration.declaration,
+                        file_id: FileId(record.file.file_id.0),
+                    });
+            }
             for class in &record.file.classes {
                 for method in &class.methods {
                     domain
@@ -11014,7 +11524,7 @@ impl JavaKotlinProjectionIndex {
         else {
             return JavaKotlinImportResolution::Missing;
         };
-        if !domain.complete {
+        if !domain.complete || domain.poisoned {
             return JavaKotlinImportResolution::Incomplete;
         }
         let candidates = domain
@@ -12123,6 +12633,129 @@ fn resolve_syntax_claim(
                 }
             }
         }
+        CachedResolutionBinding::JavaKotlinPackageFunction { package_name, name } => {
+            match java_kotlin_index.resolve(&input.language, package_name, None, name) {
+                JavaKotlinImportResolution::Exact {
+                    declaration,
+                    file_id,
+                    mut dependencies,
+                    ..
+                } => {
+                    status = ProofResolutionStatus::Exact;
+                    reason = ProofResolutionReason::ExactResolution;
+                    target = Some(declaration);
+                    evidence_chain.push(if file_id == input.callsite.file_id {
+                        ResolutionEvidence::SameFileDeclaration { declaration }
+                    } else {
+                        ResolutionEvidence::SamePackageDeclaration { declaration }
+                    });
+                    exact_node_file_expectations.push((declaration, file_id));
+                    dependencies.push(input.callsite.file_id);
+                    exact_dependency_files = dependencies;
+                }
+                JavaKotlinImportResolution::Missing => {
+                    status = ProofResolutionStatus::MissingBinding;
+                    reason = ProofResolutionReason::MissingBinding;
+                }
+                JavaKotlinImportResolution::Ambiguous => {
+                    status = ProofResolutionStatus::Ambiguous;
+                    reason = ProofResolutionReason::MultipleBindings;
+                }
+                JavaKotlinImportResolution::Incomplete => {
+                    status = ProofResolutionStatus::IncompleteDomain;
+                    reason = ProofResolutionReason::LookupDomainIncomplete;
+                }
+            }
+        }
+        CachedResolutionBinding::JavaKotlinImportedFunction {
+            package_name,
+            owner_name,
+            name,
+            import,
+        } => match java_kotlin_index.resolve(
+            &input.language,
+            package_name,
+            owner_name.as_deref(),
+            name,
+        ) {
+            JavaKotlinImportResolution::Exact {
+                owner,
+                declaration,
+                file_id,
+                mut dependencies,
+            } => {
+                status = ProofResolutionStatus::Exact;
+                reason = ProofResolutionReason::ExactResolution;
+                target = Some(declaration);
+                evidence_chain.push(ResolutionEvidence::StaticImportBinding {
+                    import: *import,
+                    declaration,
+                });
+                exact_node_file_expectations.push((*import, input.callsite.file_id));
+                exact_node_file_expectations.push((declaration, file_id));
+                dependencies.push(input.callsite.file_id);
+                exact_dependency_files = dependencies;
+                let _ = owner;
+            }
+            JavaKotlinImportResolution::Missing => {
+                status = ProofResolutionStatus::MissingBinding;
+                reason = ProofResolutionReason::MissingBinding;
+            }
+            JavaKotlinImportResolution::Ambiguous => {
+                status = ProofResolutionStatus::Ambiguous;
+                reason = ProofResolutionReason::MultipleBindings;
+            }
+            JavaKotlinImportResolution::Incomplete => {
+                status = ProofResolutionStatus::IncompleteDomain;
+                reason = ProofResolutionReason::LookupDomainIncomplete;
+            }
+        },
+        CachedResolutionBinding::JavaKotlinPackageReceiver {
+            package_name,
+            owner_name,
+            method_name,
+            constructor,
+        } => match java_kotlin_index.resolve(
+            &input.language,
+            package_name,
+            Some(owner_name),
+            method_name,
+        ) {
+            JavaKotlinImportResolution::Exact {
+                owner,
+                declaration,
+                file_id,
+                mut dependencies,
+            } => {
+                status = ProofResolutionStatus::Exact;
+                reason = ProofResolutionReason::ExactResolution;
+                target = Some(declaration);
+                if *constructor {
+                    evidence_chain
+                        .push(ResolutionEvidence::ConstructorBinding { constructor: owner });
+                }
+                evidence_chain.push(ResolutionEvidence::ExplicitReceiverType {
+                    receiver_type: owner,
+                });
+                evidence_chain.push(ResolutionEvidence::SamePackageDeclaration { declaration });
+                exact_node_file_expectations.push((owner, file_id));
+                exact_node_file_expectations.push((declaration, file_id));
+                dependencies.push(input.callsite.file_id);
+                exact_dependency_files = dependencies;
+            }
+            JavaKotlinImportResolution::Missing => {
+                status = ProofResolutionStatus::MissingBinding;
+                reason = ProofResolutionReason::MissingBinding;
+            }
+            JavaKotlinImportResolution::Ambiguous => {
+                status = ProofResolutionStatus::Ambiguous;
+                reason = ProofResolutionReason::MultipleBindings;
+            }
+            JavaKotlinImportResolution::Incomplete => {
+                status = ProofResolutionStatus::IncompleteDomain;
+                reason = ProofResolutionReason::LookupDomainIncomplete;
+            }
+        },
         CachedResolutionBinding::JavaKotlinImportedReceiver {
             package_name,
             owner_name,
@@ -13026,6 +13659,7 @@ mod rust_complexity_tests {
                 rust_types: types,
                 rust_uses: imports,
                 go_package: None,
+                java_kotlin_package: None,
             },
             calls: Vec::new(),
         };
@@ -13132,6 +13766,101 @@ mod rust_complexity_tests {
             large <= small * 2 + 128,
             "projection work grew superlinearly: {small} -> {large}"
         );
+    }
+}
+
+#[cfg(test)]
+mod java_kotlin_complexity_tests {
+    use super::*;
+    use tree_sitter::Parser;
+
+    fn measured_work(language: &str, source: &str) -> usize {
+        let mut parser = Parser::new();
+        let grammar = if language == "java" {
+            tree_sitter_java::LANGUAGE.into()
+        } else {
+            tree_sitter_kotlin_ng::LANGUAGE.into()
+        };
+        parser.set_language(&grammar).expect("grammar must load");
+        let tree = parser.parse(source, None).expect("source must parse");
+        let file_id = NodeId(1);
+        let mut nodes = Vec::new();
+        let mut next_id = 2_i64;
+        walk_nodes(tree.root_node(), &mut |node| {
+            let kind = if java_kotlin_callable_kind(language, node.kind()) {
+                NodeKind::METHOD
+            } else if java_kotlin_class_kind(language, node.kind()) {
+                NodeKind::CLASS
+            } else {
+                return;
+            };
+            let Some(name) = declaration_name(node, source) else {
+                return;
+            };
+            nodes.push(Node {
+                id: NodeId(next_id),
+                kind,
+                serialized_name: name.to_string(),
+                file_node_id: Some(file_id),
+                start_line: Some(node.start_position().row as u32 + 1),
+                ..Node::default()
+            });
+            next_id += 1;
+        });
+        reset_java_kotlin_resolution_work();
+        let index = JavaKotlinResolutionIndex::build(&tree, source, language, file_id, &nodes);
+        for call in &index.calls {
+            let _ = index.resolve_syntax_claim(source, call.callee, call.form, &call.raw_target);
+        }
+        java_kotlin_resolution_work()
+    }
+
+    fn source(language: &str, count: usize) -> String {
+        let mut source = if language == "java" {
+            String::from("class Worker { void run() {} }\n")
+        } else {
+            String::from("class Worker { fun run() {} }\n")
+        };
+        for index in 0..count {
+            source.push_str(&format!("class Owner{index} {{\n"));
+        }
+        source.push_str(if language == "java" {
+            "void caller() {\n"
+        } else {
+            "fun caller() {\n"
+        });
+        for index in 0..count {
+            if language == "java" {
+                source.push_str(&format!(
+                    "Worker receiver{index} = new Worker(); receiver{index}.run();\n"
+                ));
+            } else {
+                source.push_str(&format!(
+                    "val receiver{index}: Worker = Worker(); receiver{index}.run()\n"
+                ));
+            }
+        }
+        source.push_str("}\n");
+        for _ in 0..count {
+            source.push_str("}\n");
+        }
+        source
+    }
+
+    #[test]
+    fn java_kotlin_parser_index_work_is_linear_for_doubled_calls_and_nested_owners() {
+        for language in ["java", "kotlin"] {
+            let small = measured_work(language, &source(language, 64));
+            let large = measured_work(language, &source(language, 128));
+            assert!(
+                small >= 64 * 8,
+                "{language} parser work was not fully counted: {small}"
+            );
+            assert!(
+                large <= small * 2 + 256,
+                "{language} parser/index work grew superlinearly: {small} -> {large}"
+            );
+        }
     }
 }
 
@@ -13257,6 +13986,7 @@ mod go_complexity_tests {
                         types: Vec::new(),
                         methods: Vec::new(),
                     }),
+                    java_kotlin_package: None,
                 },
                 calls: Vec::new(),
             });
@@ -13388,6 +14118,7 @@ mod python_complexity_tests {
                 rust_types: Vec::new(),
                 rust_uses: Vec::new(),
                 go_package: None,
+                java_kotlin_package: None,
             },
             calls: Vec::new(),
         }

--- a/crates/codestory-indexer/tests/proof_resolution.rs
+++ b/crates/codestory-indexer/tests/proof_resolution.rs
@@ -563,6 +563,365 @@ fn go_closed_exact_subset_authorizes_package_functions_and_concrete_receivers() 
 }
 
 #[test]
+fn java_and_kotlin_closed_exact_subset_emits_authenticated_exact_facts() -> anyhow::Result<()> {
+    for (language, files, targets) in [
+        (
+            "java",
+            vec![
+                (
+                    "example/Imported.java",
+                    "package example; public class Imported { public void importedTarget() {} }\n",
+                ),
+                (
+                    "example/JavaExact.java",
+                    concat!(
+                        "package example;\n",
+                        "import example.Imported;\n",
+                        "public class JavaExact {\n",
+                        "  static void sameFileTarget() {}\n",
+                        "  static void packageTarget() {}\n",
+                        "  void memberTarget() {}\n",
+                        "  void sameFileCaller() { sameFileTarget(); }\n",
+                        "  void packageCaller() { JavaExact.packageTarget(); }\n",
+                        "  void importedCaller() { new Imported().importedTarget(); }\n",
+                        "  void thisCaller() { this.memberTarget(); }\n",
+                        "  void typedCaller(JavaExact receiver) { receiver.memberTarget(); }\n",
+                        "  void constructorCaller() { new JavaExact().memberTarget(); }\n",
+                        "}\n",
+                    ),
+                ),
+            ],
+            vec![
+                ("sameFileTarget", 1),
+                ("packageTarget", 1),
+                ("importedTarget", 1),
+                ("memberTarget", 3),
+            ],
+        ),
+        (
+            "kotlin",
+            vec![
+                (
+                    "example/imported.kt",
+                    "package example\nclass Imported {\n  fun importedTarget() {}\n}\n",
+                ),
+                (
+                    "example/KotlinExact.kt",
+                    concat!(
+                        "package example\n",
+                        "import example.Imported\n",
+                        "fun sameFileTarget() {}\n",
+                        "class KotlinExact {\n",
+                        "  fun memberTarget() {}\n",
+                        "  fun thisCaller() { this.memberTarget() }\n",
+                        "  fun typedCaller(receiver: KotlinExact) { receiver.memberTarget() }\n",
+                        "  fun constructorCaller() { val constructed = KotlinExact(); constructed.memberTarget() }\n",
+                        "}\n",
+                        "fun sameFileCaller() { sameFileTarget() }\n",
+                        "fun importedCaller(receiver: Imported) { receiver.importedTarget() }\n",
+                    ),
+                ),
+            ],
+            vec![
+                ("sameFileTarget", 1),
+                ("importedTarget", 1),
+                ("memberTarget", 3),
+            ],
+        ),
+    ] {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(project.path(), &mut store, &files)?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        store.validate_proof_resolution_publication(&publication(1))?;
+        let facts = store
+            .get_proof_resolution_facts()?
+            .into_iter()
+            .filter(|fact| fact.provenance.language_adapter == language)
+            .collect::<Vec<_>>();
+
+        for (target, expected_count) in targets {
+            let exact = facts
+                .iter()
+                .filter(|fact| fact.callsite.raw_target == target)
+                .filter(|fact| fact.status == ProofResolutionStatus::Exact)
+                .collect::<Vec<_>>();
+            assert_eq!(
+                exact.len(),
+                expected_count,
+                "{language} {target} did not receive the expected source-built exact facts: {facts:#?}"
+            );
+            assert!(exact.iter().all(|fact| {
+                fact.edge_id.is_some()
+                    && fact.raw_edge_target.is_some()
+                    && fact.raw_callsite_identity.is_some()
+                    && fact.target.is_some()
+                    && !fact.evidence_chain.is_empty()
+                    && fact.provenance.evidence_sha256.len() == 64
+                    && !fact.provenance.dependency_file_hashes.is_empty()
+            }));
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn java_and_kotlin_closed_nonexact_matrix_never_proves() -> anyhow::Result<()> {
+    let cases = [
+        (
+            "java",
+            "overload",
+            "class Hostile { static void overload(int n) {} static void overload(String s) {} void caller() { overload(null); } }\n",
+            "overload",
+            ProofResolutionStatus::Ambiguous,
+        ),
+        (
+            "java",
+            "interface",
+            "interface Worker { void interfaceRun(); } class Hostile { void caller(Worker worker) { worker.interfaceRun(); } }\n",
+            "interfaceRun",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "java",
+            "virtual",
+            "class Base { void virtualRun() {} } class Child extends Base { void virtualRun() {} } class Hostile { void caller(Base value) { value.virtualRun(); } }\n",
+            "virtualRun",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "java",
+            "implicit_instance",
+            "class Hostile { void instanceTarget() {} void caller() { instanceTarget(); } }\n",
+            "instanceTarget",
+            ProofResolutionStatus::MissingBinding,
+        ),
+        (
+            "java",
+            "wildcard_import",
+            "package hostile; import example.*; class Hostile { void caller() { Imported.importedTarget(); } }\n",
+            "importedTarget",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "java",
+            "reflection",
+            "class Hostile { void caller() throws Exception { Class.forName(\"missing.Target\"); } }\n",
+            "forName",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "java",
+            "annotation",
+            "@interface Generated {} @Generated class Hostile { static void generatedTarget() {} void caller() { generatedTarget(); } }\n",
+            "generatedTarget",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "java",
+            "generic",
+            "class Hostile { <T> void caller(T value) { value.toString(); } }\n",
+            "toString",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "java",
+            "smart_cast",
+            "class Worker { void smartRun() {} } class Hostile { void caller(Object value) { if (value instanceof Worker) { ((Worker) value).smartRun(); } } }\n",
+            "smartRun",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "java",
+            "rebinding",
+            "class Worker { void reboundRun() {} } class Hostile { void caller() { Worker worker = new Worker(); worker = new Worker(); worker.reboundRun(); } }\n",
+            "reboundRun",
+            ProofResolutionStatus::Ambiguous,
+        ),
+        (
+            "java",
+            "missing",
+            "class Hostile { void caller() { missingTarget(); } }\n",
+            "missingTarget",
+            ProofResolutionStatus::MissingBinding,
+        ),
+        (
+            "java",
+            "incomplete",
+            "class Hostile { static void incompleteTarget() {} void caller() { incompleteTarget();\n",
+            "incompleteTarget",
+            ProofResolutionStatus::IncompleteDomain,
+        ),
+        (
+            "kotlin",
+            "overload",
+            "fun overload(value: Int) {}\nfun overload(value: String) {}\nfun caller() { overload(todo()) }\nfun todo(): Nothing = throw Exception()\n",
+            "overload",
+            ProofResolutionStatus::Ambiguous,
+        ),
+        (
+            "kotlin",
+            "interface",
+            "interface Worker {\n  fun interfaceRun()\n}\nfun caller(worker: Worker) { worker.interfaceRun() }\n",
+            "interfaceRun",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "kotlin",
+            "cross_class_member",
+            "class Target {\n  fun memberTarget() {}\n}\nclass Hostile {\n  fun caller() { memberTarget() }\n}\n",
+            "memberTarget",
+            ProofResolutionStatus::MissingBinding,
+        ),
+        (
+            "kotlin",
+            "extension",
+            "class Worker {}\nfun Worker.extensionRun() {}\nfun caller(worker: Worker) { worker.extensionRun() }\n",
+            "extensionRun",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "kotlin",
+            "wildcard_import",
+            "package hostile\nimport example.*\nfun caller() { importedTarget() }\n",
+            "importedTarget",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "kotlin",
+            "reflection",
+            "fun caller() { Class.forName(\"missing.Target\") }\n",
+            "forName",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "kotlin",
+            "annotation",
+            "annotation class Generated\n@Generated\nclass Hostile {\n  fun generatedTarget() {}\n  fun caller() { generatedTarget() }\n}\n",
+            "generatedTarget",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "kotlin",
+            "generic",
+            "fun <T> caller(value: T) { value.toString() }\n",
+            "toString",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "kotlin",
+            "smart_cast",
+            "class Worker {\n  fun smartRun() {}\n}\nfun caller(value: Any) { if (value is Worker) value.smartRun() }\n",
+            "smartRun",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "kotlin",
+            "delegation",
+            "interface Worker {\n  fun delegatedRun()\n}\nclass Delegating(worker: Worker) : Worker by worker\nfun caller(value: Delegating) { value.delegatedRun() }\n",
+            "delegatedRun",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "kotlin",
+            "rebinding",
+            "class Worker {\n  fun reboundRun() {}\n}\nfun caller() { var worker = Worker(); worker = Worker(); worker.reboundRun() }\n",
+            "reboundRun",
+            ProofResolutionStatus::Ambiguous,
+        ),
+        (
+            "kotlin",
+            "missing",
+            "fun caller() { missingTarget() }\n",
+            "missingTarget",
+            ProofResolutionStatus::MissingBinding,
+        ),
+        (
+            "kotlin",
+            "incomplete",
+            "fun incompleteTarget() {}\nfun caller() { incompleteTarget()\n",
+            "incompleteTarget",
+            ProofResolutionStatus::IncompleteDomain,
+        ),
+    ];
+
+    for (language, name, source, target, expected) in cases {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(
+            project.path(),
+            &mut store,
+            &[(
+                if language == "java" {
+                    "Hostile.java"
+                } else {
+                    "Hostile.kt"
+                },
+                source,
+            )],
+        )?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        let facts = store.get_proof_resolution_facts()?;
+        let fact = facts
+            .iter()
+            .find(|fact| {
+                fact.provenance.language_adapter == language && fact.callsite.raw_target == target
+            })
+            .unwrap_or_else(|| {
+                panic!("{language} {name} did not produce a closed fact: {facts:#?}")
+            });
+        assert_eq!(fact.status, expected, "{language} {name}: {fact:#?}");
+        assert!(fact.reason.matches_status(fact.status), "{fact:#?}");
+        assert!(fact.evidence_chain.is_empty(), "{fact:#?}");
+        assert!(fact.edge_id.is_none() && fact.target.is_none(), "{fact:#?}");
+    }
+    Ok(())
+}
+
+#[test]
+fn java_and_kotlin_exact_facts_reject_resealed_raw_call_mutation() -> anyhow::Result<()> {
+    for (language, path, source) in [
+        (
+            "java",
+            "Fixture.java",
+            "class Fixture {\n  static void target() {}\n  static void caller() { target(); }\n}\n",
+        ),
+        (
+            "kotlin",
+            "Fixture.kt",
+            "fun target() {}\nfun caller() { target() }\n",
+        ),
+    ] {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(project.path(), &mut store, &[(path, source)])?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        let fact = store
+            .get_proof_resolution_facts()?
+            .into_iter()
+            .find(|fact| {
+                fact.provenance.language_adapter == language
+                    && fact.callsite.raw_target == "target"
+                    && fact.status == ProofResolutionStatus::Exact
+            })
+            .unwrap_or_else(|| panic!("{language} exact mutation fixture"));
+        let edge_id = fact
+            .edge_id
+            .expect("exact fact carries its raw CALL edge")
+            .0;
+        store.get_connection().execute(
+            "UPDATE edge SET resolved_target_node_id = source_node_id WHERE id = ?1",
+            [edge_id],
+        )?;
+        let error = store
+            .validate_proof_resolution_publication(&publication(1))
+            .expect_err("resealed {language} raw CALL mutation must reject the proof");
+        assert!(!error.to_string().is_empty());
+    }
+    Ok(())
+}
+
+#[test]
 fn python_closed_exact_subset_authorizes_s1_through_s4() -> anyhow::Result<()> {
     let project = tempfile::tempdir()?;
     let mut store = Store::new_in_memory()?;
@@ -7125,7 +7484,7 @@ fn complete_projection_requires_cache_coverage_but_empty_and_unsupported_reposit
     let mut empty = Store::new_in_memory()?;
     let empty_receipt = rematerialize_proof_resolution_projection(&mut empty, &publication(1))?;
     assert_eq!(empty_receipt.fact_count, 0);
-    assert_eq!(empty_receipt.adapter_roster.len(), 6);
+    assert_eq!(empty_receipt.adapter_roster.len(), 8);
 
     let project = tempfile::tempdir()?;
     let mut unsupported = Store::new_in_memory()?;
@@ -7140,7 +7499,7 @@ fn complete_projection_requires_cache_coverage_but_empty_and_unsupported_reposit
     let unsupported_receipt =
         rematerialize_proof_resolution_projection(&mut unsupported, &publication(1))?;
     assert_eq!(unsupported_receipt.fact_count, 0);
-    assert_eq!(unsupported_receipt.adapter_roster.len(), 6);
+    assert_eq!(unsupported_receipt.adapter_roster.len(), 8);
 
     let governed_project = tempfile::tempdir()?;
     let mut governed = Store::new_in_memory()?;
@@ -7368,7 +7727,7 @@ fn complete_projection_rejects_cache_schema_adapter_and_language_mismatch() -> a
             .expect_err("cache provenance mismatch must reject the complete projection");
         let message = error.to_string();
         assert!(
-            ["stale", "schema-v16", "adapter", "language"]
+            ["stale", "schema-v17", "adapter", "language"]
                 .iter()
                 .any(|needle| message.contains(needle)),
             "{mutation}: {error}"
@@ -7761,6 +8120,14 @@ fn proof_resolution_roster_tracks_the_current_adapter_version() -> anyhow::Resul
                 "src/main.py",
                 "def target():\n    pass\ndef caller():\n    target()\n",
             ),
+            (
+                "src/Fixture.java",
+                "class Fixture {\n  static void target() {}\n  static void caller() { target(); }\n}\n",
+            ),
+            (
+                "src/Fixture.kt",
+                "fun target() {}\nfun caller() { target() }\n",
+            ),
         ],
     )?;
     let receipt = rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
@@ -7780,6 +8147,17 @@ fn proof_resolution_roster_tracks_the_current_adapter_version() -> anyhow::Resul
             .map(|adapter| adapter.adapter_version.as_str()),
         Some("reference-v17")
     );
+    for language in ["java", "kotlin"] {
+        assert_eq!(
+            receipt
+                .adapter_roster
+                .iter()
+                .find(|adapter| adapter.language == language)
+                .map(|adapter| adapter.adapter_version.as_str()),
+            Some("reference-v1"),
+            "{language} must invalidate parser inputs through its explicit adapter identity"
+        );
+    }
     for fact in store.get_proof_resolution_facts()? {
         assert!(receipt.adapter_roster.iter().any(|adapter| {
             adapter.language == fact.provenance.language_adapter

--- a/crates/codestory-indexer/tests/proof_resolution.rs
+++ b/crates/codestory-indexer/tests/proof_resolution.rs
@@ -922,6 +922,168 @@ fn java_and_kotlin_exact_facts_reject_resealed_raw_call_mutation() -> anyhow::Re
 }
 
 #[test]
+fn java_and_kotlin_cross_file_package_and_import_receipts_are_exact() -> anyhow::Result<()> {
+    for (language, files, target) in [
+        (
+            "java",
+            vec![
+                (
+                    "api/Lib.java",
+                    "package api; public class Lib { public static void target() {} }\n",
+                ),
+                (
+                    "app/Caller.java",
+                    "package app;\nimport static api.Lib.target;\nclass Caller {\n  void caller() { target(); }\n}\n",
+                ),
+            ],
+            "target",
+        ),
+        (
+            "kotlin",
+            vec![
+                ("api/target.kt", "package api\nfun target() {}\n"),
+                (
+                    "client/caller.kt",
+                    "package client\nimport api.target\nfun caller() { target() }\n",
+                ),
+            ],
+            "target",
+        ),
+    ] {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(project.path(), &mut store, &files)?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        store.validate_proof_resolution_publication(&publication(1))?;
+        let exact = store
+            .get_proof_resolution_facts()?
+            .into_iter()
+            .find(|fact| {
+                fact.provenance.language_adapter == language && fact.callsite.raw_target == target
+            })
+            .expect("cross-file fact");
+        assert_eq!(exact.status, ProofResolutionStatus::Exact, "{exact:#?}");
+        assert!(
+            exact.provenance.dependency_file_hashes.len() >= 2,
+            "{exact:#?}"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn java_same_package_receiver_receipt_replays_and_rejects_domain_mutations() -> anyhow::Result<()> {
+    for mutation in ["none", "package", "member", "source"] {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(
+            project.path(),
+            &mut store,
+            &[
+                (
+                    "p/Lib.java",
+                    "package p; public class Lib { public static void target() {} }\n",
+                ),
+                (
+                    "p/Caller.java",
+                    "package p; class Caller { void caller() { Lib.target(); } }\n",
+                ),
+            ],
+        )?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        let fact = store
+            .get_proof_resolution_facts()?
+            .into_iter()
+            .find(|fact| {
+                fact.provenance.language_adapter == "java" && fact.callsite.raw_target == "target"
+            })
+            .expect("two-file Java same-package receiver fact");
+        assert_eq!(fact.status, ProofResolutionStatus::Exact, "{fact:#?}");
+        assert_eq!(
+            fact.provenance.dependency_file_hashes.len(),
+            2,
+            "the complete package domain must be bound: {fact:#?}"
+        );
+
+        let owner = fact
+            .evidence_chain
+            .iter()
+            .find_map(|evidence| match evidence {
+                ResolutionEvidence::ExplicitReceiverType { receiver_type } => Some(*receiver_type),
+                _ => None,
+            })
+            .expect("same-package receiver owner");
+        let target = fact.target.expect("same-package target");
+        match mutation {
+            "none" => {
+                store.validate_proof_resolution_publication(&publication(1))?;
+                continue;
+            }
+            "package" => {
+                store.get_connection().execute(
+                    "UPDATE node SET qualified_name = CASE id WHEN ?1 THEN 'q.Lib' ELSE 'q.Lib.target' END WHERE id IN (?1, ?2)",
+                    [owner.0, target.0],
+                )?;
+            }
+            "member" => {
+                let member = store
+                    .get_edges()?
+                    .into_iter()
+                    .find(|edge| {
+                        edge.kind == EdgeKind::MEMBER
+                            && edge.effective_source() == owner
+                            && edge.effective_target() == target
+                    })
+                    .expect("unique Lib.target MEMBER relation");
+                store
+                    .get_connection()
+                    .execute("DELETE FROM edge WHERE id = ?1", [member.id.0])?;
+            }
+            "source" => {
+                store.get_connection().execute(
+                    "UPDATE file SET complete = 0 WHERE id = ?1",
+                    [fact.callsite.file_id.0],
+                )?;
+            }
+            _ => unreachable!(),
+        }
+        let error = store
+            .validate_proof_resolution_publication(&publication(1))
+            .expect_err("mutated Java same-package evidence must fail replay");
+        assert!(!error.to_string().is_empty(), "{mutation}");
+    }
+    Ok(())
+}
+
+#[test]
+fn kotlin_parameter_shadow_never_proves_package_or_import_target() -> anyhow::Result<()> {
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(
+        project.path(),
+        &mut store,
+        &[
+            ("api/target.kt", "package api\nfun target() {}\n"),
+            (
+                "client/caller.kt",
+                "package client\nimport api.target\nfun caller(target: () -> Unit) { target() }\n",
+            ),
+        ],
+    )?;
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    let fact = store
+        .get_proof_resolution_facts()?
+        .into_iter()
+        .find(|fact| {
+            fact.provenance.language_adapter == "kotlin" && fact.callsite.raw_target == "target"
+        })
+        .expect("shadowed Kotlin call fact");
+    assert_ne!(fact.status, ProofResolutionStatus::Exact, "{fact:#?}");
+    assert!(fact.edge_id.is_none() && fact.target.is_none() && fact.evidence_chain.is_empty());
+    Ok(())
+}
+
+#[test]
 fn python_closed_exact_subset_authorizes_s1_through_s4() -> anyhow::Result<()> {
     let project = tempfile::tempdir()?;
     let mut store = Store::new_in_memory()?;
@@ -7727,7 +7889,7 @@ fn complete_projection_rejects_cache_schema_adapter_and_language_mismatch() -> a
             .expect_err("cache provenance mismatch must reject the complete projection");
         let message = error.to_string();
         assert!(
-            ["stale", "schema-v17", "adapter", "language"]
+            ["stale", "schema-v18", "adapter", "language"]
                 .iter()
                 .any(|needle| message.contains(needle)),
             "{mutation}: {error}"
@@ -8154,7 +8316,7 @@ fn proof_resolution_roster_tracks_the_current_adapter_version() -> anyhow::Resul
                 .iter()
                 .find(|adapter| adapter.language == language)
                 .map(|adapter| adapter.adapter_version.as_str()),
-            Some("reference-v1"),
+            Some("reference-v2"),
             "{language} must invalidate parser inputs through its explicit adapter identity"
         );
     }

--- a/crates/codestory-store/src/storage_impl/proof_resolution.rs
+++ b/crates/codestory-store/src/storage_impl/proof_resolution.rs
@@ -2646,6 +2646,11 @@ impl Storage {
             .get(&owner)
             .ok_or_else(|| proof_error("imported receiver owner is missing"))?;
         let source_file = NodeId(fact.callsite.file_id.0);
+        let java_kotlin_literal_import =
+            matches!(fact.provenance.language_adapter.as_str(), "java" | "kotlin")
+                && matches!(import_node.kind, NodeKind::MODULE | NodeKind::UNKNOWN)
+                && owner_node.qualified_name.as_deref()
+                    == Some(import_node.serialized_name.as_str());
         let python_relative = fact.provenance.language_adapter == "python"
             && components.is_some_and(|components| {
                 components.len() >= 4
@@ -2666,7 +2671,9 @@ impl Storage {
                 NodeKind::CLASS | NodeKind::STRUCT | NodeKind::ENUM
             )
             || owner_node.file_node_id != target_node.file_node_id
-            || !(python_relative || context.has_import(source_file, import, owner))
+            || !(python_relative
+                || java_kotlin_literal_import
+                || context.has_import(source_file, import, owner))
             || !context.has_member(owner, target)
         {
             return Err(proof_error(
@@ -2992,7 +2999,7 @@ fn graph_leaf_name(name: &str) -> &str {
 fn proof_import_node_kind_is_literal(language: &str, kind: NodeKind) -> bool {
     match language {
         "rust" => kind == NodeKind::MODULE,
-        "javascript" | "typescript" | "tsx" | "python" => {
+        "java" | "kotlin" | "javascript" | "typescript" | "tsx" | "python" => {
             matches!(kind, NodeKind::MODULE | NodeKind::UNKNOWN)
         }
         _ => false,

--- a/crates/codestory-store/src/storage_impl/proof_resolution.rs
+++ b/crates/codestory-store/src/storage_impl/proof_resolution.rs
@@ -265,6 +265,8 @@ struct ProofResolutionValidationContext {
     python_import_paths: HashMap<(NodeId, NodeId), Vec<Vec<NodeId>>>,
     python_file_ids_by_path: HashMap<PathBuf, Vec<FileId>>,
     python_attestation_error_by_file: HashMap<i64, String>,
+    java_package_identity_by_file: HashMap<i64, String>,
+    java_dependency_ids_by_package: HashMap<String, BTreeSet<FileId>>,
     go_package_identity_by_file: HashMap<i64, GoPackageIdentity>,
     go_dependency_ids_by_package: HashMap<GoPackageIdentity, BTreeSet<FileId>>,
     go_attestation_error_by_file: HashMap<i64, String>,
@@ -508,6 +510,111 @@ fn stored_go_package_dependency_ids(
         }
     }
     Ok(stored_fact_ids.clone())
+}
+
+fn prepare_java_package_closure(
+    file_by_id: &HashMap<i64, FileInfo>,
+    node_by_id: &HashMap<NodeId, Node>,
+) -> (HashMap<i64, String>, HashMap<String, BTreeSet<FileId>>) {
+    let class_qualified_names = node_by_id
+        .values()
+        .filter(|node| {
+            matches!(
+                node.kind,
+                NodeKind::CLASS | NodeKind::STRUCT | NodeKind::ENUM
+            ) && node.file_node_id.is_some_and(|file| {
+                file_by_id
+                    .get(&file.0)
+                    .is_some_and(|file| file.language == "java")
+            })
+        })
+        .filter_map(|node| node.qualified_name.clone())
+        .collect::<HashSet<_>>();
+    let mut packages_by_file = HashMap::<i64, BTreeSet<String>>::new();
+    for node in node_by_id.values().filter(|node| {
+        matches!(
+            node.kind,
+            NodeKind::CLASS | NodeKind::STRUCT | NodeKind::ENUM
+        ) && node.file_node_id.is_some_and(|file| {
+            file_by_id
+                .get(&file.0)
+                .is_some_and(|file| file.language == "java")
+        })
+    }) {
+        count_store_replay_work(1);
+        let Some(file_id) = node.file_node_id else {
+            continue;
+        };
+        let Some((parent, _)) = node
+            .qualified_name
+            .as_deref()
+            .and_then(|qualified| qualified.rsplit_once('.'))
+        else {
+            continue;
+        };
+        if parent.is_empty() || class_qualified_names.contains(parent) {
+            continue;
+        }
+        packages_by_file
+            .entry(file_id.0)
+            .or_default()
+            .insert(parent.to_owned());
+    }
+    let mut package_identity_by_file = HashMap::new();
+    let mut dependency_ids_by_package = HashMap::<String, BTreeSet<FileId>>::new();
+    for (file_id, packages) in packages_by_file {
+        count_store_replay_work(1);
+        if packages.len() != 1 {
+            continue;
+        }
+        let package = packages.into_iter().next().expect("one Java package");
+        package_identity_by_file.insert(file_id, package.clone());
+        dependency_ids_by_package
+            .entry(package.clone())
+            .or_default()
+            .insert(FileId(file_id));
+    }
+    (package_identity_by_file, dependency_ids_by_package)
+}
+
+fn java_same_package_dependency_ids(
+    fact: &CallResolutionFact,
+    required_evidence_ids: &BTreeSet<FileId>,
+    context: &ProofResolutionValidationContext,
+) -> Result<Option<BTreeSet<FileId>>, StorageError> {
+    if fact.provenance.language_adapter != "java"
+        || fact.callsite.callee_form != CalleeForm::ExplicitReceiver
+    {
+        return Ok(None);
+    }
+    let owner = match fact.evidence_chain.as_slice() {
+        [
+            ResolutionEvidence::ConstructorBinding { constructor },
+            ResolutionEvidence::ExplicitReceiverType { receiver_type },
+            ResolutionEvidence::SamePackageDeclaration { .. },
+        ] if constructor == receiver_type => *constructor,
+        [
+            ResolutionEvidence::ExplicitReceiverType { receiver_type },
+            ResolutionEvidence::SamePackageDeclaration { .. },
+        ] => *receiver_type,
+        _ => return Ok(None),
+    };
+    let package = Storage::validate_java_package_receiver(
+        context,
+        fact,
+        owner,
+        fact.target.expect("Exact Java fact has a target"),
+    )?;
+    let expected = context
+        .java_dependency_ids_by_package
+        .get(&package)
+        .ok_or_else(|| proof_error("Java authenticated package closure is missing"))?;
+    if !required_evidence_ids.is_subset(expected) {
+        return Err(proof_error(
+            "Java package dependency closure omits source or typed evidence files",
+        ));
+    }
+    Ok(Some(expected.clone()))
 }
 
 fn python_dependency_ids(
@@ -1137,6 +1244,8 @@ mod go_replay_complexity_tests {
             python_import_paths: HashMap::new(),
             python_file_ids_by_path: HashMap::new(),
             python_attestation_error_by_file: HashMap::new(),
+            java_package_identity_by_file: HashMap::new(),
+            java_dependency_ids_by_package: HashMap::new(),
             go_package_identity_by_file,
             go_dependency_ids_by_package,
             go_attestation_error_by_file,
@@ -1301,6 +1410,8 @@ mod python_replay_complexity_tests {
             python_import_paths: HashMap::new(),
             python_file_ids_by_path,
             python_attestation_error_by_file,
+            java_package_identity_by_file: HashMap::new(),
+            java_dependency_ids_by_package: HashMap::new(),
             go_package_identity_by_file: HashMap::new(),
             go_dependency_ids_by_package: HashMap::new(),
             go_attestation_error_by_file: HashMap::new(),
@@ -1448,6 +1559,8 @@ impl ProofResolutionValidationContext {
             .into_iter()
             .map(|node| (node.id, node))
             .collect();
+        let (java_package_identity_by_file, java_dependency_ids_by_package) =
+            prepare_java_package_closure(&file_by_id, &node_by_id);
         let edges = storage.get_edges()?;
         let (ordinary_call_edge_indices, parsed_callsite_identity_by_edge) =
             prepare_call_edge_correlation_index(&edges, &node_by_id);
@@ -1600,6 +1713,8 @@ impl ProofResolutionValidationContext {
             python_import_paths,
             python_file_ids_by_path,
             python_attestation_error_by_file,
+            java_package_identity_by_file,
+            java_dependency_ids_by_package,
             go_package_identity_by_file,
             go_dependency_ids_by_package,
             go_attestation_error_by_file,
@@ -2017,6 +2132,12 @@ impl Storage {
         }
         let observed_dependency_ids = dependency_file_ids(fact);
         if fact.status == ProofResolutionStatus::Exact
+            && let Some(java_dependencies) =
+                java_same_package_dependency_ids(fact, &required_dependency_ids, context)?
+        {
+            required_dependency_ids = java_dependencies;
+        }
+        if fact.status == ProofResolutionStatus::Exact
             && fact.provenance.language_adapter == "python"
         {
             required_dependency_ids = python_dependency_ids(
@@ -2177,12 +2298,14 @@ impl Storage {
             (
                 CalleeForm::Identifier,
                 [ResolutionEvidence::SamePackageDeclaration { declaration }],
-            ) if fact.provenance.language_adapter == "go" && *declaration == target => {
+            ) if matches!(fact.provenance.language_adapter.as_str(), "go" | "kotlin")
+                && *declaration == target =>
+            {
                 if target_node.file_node_id.is_none()
                     || target_node.file_node_id == Some(NodeId(fact.callsite.file_id.0))
                 {
                     return Err(proof_error(
-                        "SamePackageDeclaration is not an exact cross-file Go target",
+                        "SamePackageDeclaration is not an exact cross-file package target",
                     ));
                 }
             }
@@ -2207,6 +2330,12 @@ impl Storage {
                         typescript_directory_import_target_is_authenticated(
                             context, fact, *import, target,
                         )
+                    } else if matches!(fact.provenance.language_adapter.as_str(), "java" | "kotlin")
+                    {
+                        target_node
+                            .qualified_name
+                            .as_deref()
+                            .is_some_and(|name| name.ends_with(&fact.callsite.raw_target))
                     } else {
                         context.has_import(NodeId(fact.callsite.file_id.0), *import, target)
                     })
@@ -2467,17 +2596,21 @@ impl Storage {
                     ResolutionEvidence::ExplicitReceiverType { receiver_type },
                     ResolutionEvidence::SamePackageDeclaration { declaration },
                 ],
-            ) if fact.provenance.language_adapter == "go"
+            ) if matches!(fact.provenance.language_adapter.as_str(), "go" | "java")
                 && *constructor == *receiver_type
                 && *declaration == target =>
             {
-                Self::validate_go_package_receiver(
-                    context,
-                    fact.callsite.file_id,
-                    *constructor,
-                    target,
-                    target_node,
-                )?;
+                if fact.provenance.language_adapter == "go" {
+                    Self::validate_go_package_receiver(
+                        context,
+                        fact.callsite.file_id,
+                        *constructor,
+                        target,
+                        target_node,
+                    )?;
+                } else {
+                    Self::validate_java_package_receiver(context, fact, *constructor, target)?;
+                }
             }
             (
                 CalleeForm::ExplicitReceiver,
@@ -2485,14 +2618,20 @@ impl Storage {
                     ResolutionEvidence::ExplicitReceiverType { receiver_type },
                     ResolutionEvidence::SamePackageDeclaration { declaration },
                 ],
-            ) if fact.provenance.language_adapter == "go" && *declaration == target => {
-                Self::validate_go_package_receiver(
-                    context,
-                    fact.callsite.file_id,
-                    *receiver_type,
-                    target,
-                    target_node,
-                )?;
+            ) if matches!(fact.provenance.language_adapter.as_str(), "go" | "java")
+                && *declaration == target =>
+            {
+                if fact.provenance.language_adapter == "go" {
+                    Self::validate_go_package_receiver(
+                        context,
+                        fact.callsite.file_id,
+                        *receiver_type,
+                        target,
+                        target_node,
+                    )?;
+                } else {
+                    Self::validate_java_package_receiver(context, fact, *receiver_type, target)?;
+                }
             }
             (
                 CalleeForm::ExplicitReceiver,
@@ -2694,7 +2833,7 @@ impl Storage {
             .node_by_id
             .get(&owner)
             .ok_or_else(|| proof_error("Go receiver owner is missing"))?;
-        if owner_node.kind != NodeKind::STRUCT
+        if !matches!(owner_node.kind, NodeKind::STRUCT | NodeKind::CLASS)
             || owner_node.file_node_id.is_none()
             || target_node.file_node_id.is_none()
             || target_node.file_node_id == Some(NodeId(source_file.0))
@@ -2705,6 +2844,77 @@ impl Storage {
             ));
         }
         Ok(())
+    }
+
+    fn validate_java_package_receiver(
+        context: &ProofResolutionValidationContext,
+        fact: &CallResolutionFact,
+        owner: NodeId,
+        target: NodeId,
+    ) -> Result<String, StorageError> {
+        let source_file = fact.callsite.file_id;
+        let owner_node = context
+            .node_by_id
+            .get(&owner)
+            .ok_or_else(|| proof_error("Java same-package receiver owner is missing"))?;
+        let target_node = context
+            .node_by_id
+            .get(&target)
+            .ok_or_else(|| proof_error("Java same-package receiver target is missing"))?;
+        let caller_node = context
+            .node_by_id
+            .get(&fact.caller)
+            .ok_or_else(|| proof_error("Java same-package receiver caller is missing"))?;
+        let owner_file = owner_node
+            .file_node_id
+            .ok_or_else(|| proof_error("Java same-package receiver owner has no source file"))?;
+        let target_file = target_node
+            .file_node_id
+            .ok_or_else(|| proof_error("Java same-package receiver target has no source file"))?;
+        let source_package = context
+            .java_package_identity_by_file
+            .get(&source_file.0)
+            .ok_or_else(|| proof_error("Java proof source has no unique package identity"))?;
+        let target_package = context
+            .java_package_identity_by_file
+            .get(&target_file.0)
+            .ok_or_else(|| proof_error("Java receiver target has no unique package identity"))?;
+        let owner_qualified = owner_node
+            .qualified_name
+            .as_deref()
+            .ok_or_else(|| proof_error("Java receiver owner has no qualified identity"))?;
+        let target_owner_qualified = target_node
+            .qualified_name
+            .as_deref()
+            .and_then(|qualified| qualified.rsplit_once('.'))
+            .map(|(owner, _)| owner);
+        let caller_package_prefix = format!("{source_package}.");
+        if owner_node.kind != NodeKind::CLASS
+            || target_node.kind != NodeKind::METHOD
+            || caller_node.kind != NodeKind::METHOD
+            || caller_node.file_node_id != Some(NodeId(source_file.0))
+            || owner_file == NodeId(source_file.0)
+            || owner_file != target_file
+            || source_package != target_package
+            || owner_qualified
+                .strip_prefix(&caller_package_prefix)
+                .is_none_or(|owner_name| owner_name.is_empty() || owner_name.contains('.'))
+            || target_owner_qualified != Some(owner_qualified)
+            || caller_node
+                .qualified_name
+                .as_deref()
+                .is_none_or(|qualified| {
+                    qualified
+                        .strip_prefix(&caller_package_prefix)
+                        .is_none_or(|relative| !relative.contains('.'))
+                })
+            || !context.has_member(owner, target)
+        {
+            return Err(proof_error(
+                "Java same-package receiver does not name one authenticated package owner/member",
+            ));
+        }
+        Ok(source_package.clone())
     }
 
     pub fn replace_proof_resolution_projection(


### PR DESCRIPTION
## Context

The multilingual contract is merged, but Java and Kotlin still lacked proof-authoritative exact-call facts. This PR implements only their declared common static subsets while preserving the ordinary navigation graph and keeping public proof dark.

Closes #2071
Refs #2023 and #2066

Implementation base: `48fe605a3366b430e4c8cd3c728542f41657e46a`
Reviewed head: `d58643bf553e02d5a7faa2ec3dbc628492b64ffd`

## What changed

- Added compact Java/Kotlin parser-cache inputs for lexical bindings, owners, imports, package/top-level declarations, receiver types, writes, poison state, and dependency domains.
- Added exact same-file/package, explicit-import, concrete-receiver, `this`, constructor, Java static-import, and Kotlin top-level-import resolution.
- Replaced source substring and recursive per-call inference with one counted syntax traversal and bounded map/set lookups.
- Added authenticated Java/Kotlin package-domain replay across complete dependency files.
- Added fail-closed handling for shadowing, rebinding, overload ambiguity, interfaces/extension dispatch, generated declarations, incomplete domains, and unsupported dynamic constructs.
- Removed Java and Kotlin from the temporary missing-adapter allowlist.

Schema 32, ordinary graph/navigation resolution, packet/context/search, Q2 inputs, generated catalogs, and public CLI/MCP routes are unchanged.

## Verification

- Indexer `proof_resolution` suite - 144 passed
- Java/Kotlin exact/non-exact/cross-file/replay filter - 4 passed
- Java same-package replay and mutation contract - 1 passed
- Kotlin lexical shadow contract - 1 passed
- Deep nested/receiver-heavy linear-work contract - 1 passed
- Multilingual contract - 6 passed
- Exact availability - 5 passed
- Projection identity - 4 passed
- CLI architecture contracts - 57 passed
- `fidelity_regression` - 8 passed
- `tictactoe_language_coverage` - 13 passed
- Focused formatting and diff checks - passed
- Consolidated adversarial review - accepted

The final review also rebuilt the CLI and indexed an actual two-file Java package. `Caller.Lib.target()` produced exactly one replay-valid `Exact` fact with `ExplicitReceiverType`, `SamePackageDeclaration`, one target/edge, both dependency hashes, and a complete lookup domain.

## Review focus

- Nearest lexical bindings win before package/import resolution.
- Package domains authenticate every governed dependency and reject missing, extra, incomplete, duplicate, generated, or drifted files.
- Java same-package widening is restricted to canonical `SamePackageDeclaration`; same-file evidence remains source-local.
- Per-call resolution contains no source/prefix/enclosing-callable or recursive subtree scans.

## Risk and follow-up

Unsupported Java/Kotlin dispatch remains explicit and non-exact. C/C++, Ruby/PHP, C#/Swift/Dart, and Bash remain on the temporary allowlist for their own closed adapter PRs.
