### PR TITLE
Add Ruby and PHP exact proof resolution

### DIFF
--- a/crates/codestory-bench/src/bin/codestory_proof_availability/multilingual_contract.rs
+++ b/crates/codestory-bench/src/bin/codestory_proof_availability/multilingual_contract.rs
@@ -64,6 +64,7 @@ pub struct DispatchFixture {
 /// A source blob obtained from an exact Git commit and independently projected
 /// through the parser and installed proof adapters. This is the benchmark's
 /// materialization boundary: callers cannot manufacture a row from a string.
+#[cfg_attr(test, allow(dead_code))]
 #[derive(Debug, Clone)]
 pub struct MaterializedRepositorySource {
     pub repository: String,
@@ -434,6 +435,7 @@ pub fn materialize_repository_source(
 
 /// Network-capable final-qualification boundary. Ordinary tests call the
 /// checkout materializer above with temporary local repositories instead.
+#[cfg_attr(test, allow(dead_code))]
 pub fn materialize_declared_repositories(
     checkout_root: &Path,
 ) -> Result<Vec<MaterializedRepositorySource>> {
@@ -859,42 +861,69 @@ fn observe_planned_language_cases(
     root: &Path,
     planned: Vec<PlannedLanguageCase>,
 ) -> Result<MultilingualObservation> {
-    write_sources(
-        &planned
-            .iter()
-            .map(|fixture| (fixture.path.clone(), fixture.source.clone()))
-            .collect::<Vec<_>>(),
-    )?;
-    let mut store = Store::new_in_memory()?;
-    index_paths(
-        root,
-        &mut store,
-        planned.iter().map(|fixture| fixture.path.clone()).collect(),
-    )?;
-    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
     let adapter_roster = observed_adapter_roster();
-    let cases = planned
-        .iter()
-        .map(|fixture| {
-            observe_case_from_store(
-                &store,
-                fixture.language,
-                fixture.class,
-                fixture.ordinal,
-                &fixture.path,
-                fixture.pinned_selector,
-                adapter_roster.contains(fixture.language),
-                fixture.materialized_commit.clone(),
-                fixture.materialized_blob_sha256.clone(),
-            )
-        })
-        .collect::<Result<Vec<_>>>()?;
+    let mut cases = Vec::with_capacity(planned.len());
+    for dispatch in DISPATCHES {
+        for class in [
+            FixtureClass::Supported,
+            FixtureClass::Unsupported,
+            FixtureClass::Hostile,
+        ] {
+            let fixtures = planned
+                .iter()
+                .filter(|fixture| fixture.language == dispatch.language && fixture.class == class)
+                .collect::<Vec<_>>();
+            let group_root =
+                tempfile::tempdir().context("create language-class fixture workspace")?;
+            let isolated = fixtures
+                .iter()
+                .map(|fixture| {
+                    let relative = fixture
+                        .path
+                        .strip_prefix(root)
+                        .context("fixture escaped multilingual workspace")?;
+                    Ok((
+                        *fixture,
+                        group_root.path().join(relative),
+                        fixture.source.clone(),
+                    ))
+                })
+                .collect::<Result<Vec<_>>>()?;
+            write_sources(
+                &isolated
+                    .iter()
+                    .map(|(_, path, source)| (path.clone(), source.clone()))
+                    .collect::<Vec<_>>(),
+            )?;
+            let mut store = Store::new_in_memory()?;
+            index_paths(
+                group_root.path(),
+                &mut store,
+                isolated.iter().map(|(_, path, _)| path.clone()).collect(),
+            )?;
+            rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+            for (fixture, path, _) in isolated {
+                cases.push(observe_case_from_store(
+                    &store,
+                    fixture.language,
+                    fixture.class,
+                    fixture.ordinal,
+                    &path,
+                    fixture.pinned_selector,
+                    adapter_roster.contains(fixture.language),
+                    fixture.materialized_commit.clone(),
+                    fixture.materialized_blob_sha256.clone(),
+                )?);
+            }
+        }
+    }
     Ok(MultilingualObservation {
         cases,
         adapter_roster,
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn observe_case_from_store(
     store: &Store,
     language: &'static str,

--- a/crates/codestory-bench/src/bin/codestory_proof_availability/multilingual_contract.rs
+++ b/crates/codestory-bench/src/bin/codestory_proof_availability/multilingual_contract.rs
@@ -30,7 +30,7 @@ pub const PUBLIC_PROOF_ROUTE_DARK: bool = true;
 /// Closed, temporary boundary for parser-backed languages without an installed
 /// proof adapter. The observed adapter roster is compared to this list in the
 /// contract test; this is not an expectation of a resolution result.
-pub const MISSING_ADAPTER_ALLOWLIST: &[&str] = &["ruby", "php", "csharp", "swift", "dart", "bash"];
+pub const MISSING_ADAPTER_ALLOWLIST: &[&str] = &["csharp", "swift", "dart", "bash"];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FixtureClass {
@@ -1254,7 +1254,7 @@ fn direct_call_source(language: &str, target: &str, caller: &str) -> String {
         }
         "ruby" => format!("def {target}\nend\ndef {caller}\n  {target}()\nend\n"),
         "php" => format!(
-            "<?php\nclass Fixture {{ function {target}(): void {{}} function {caller}(): void {{ $this->{target}(); }} }}\n"
+            "<?php\nnamespace Fixture\\{caller};\nclass Fixture {{ function {target}(): void {{}} function {caller}(): void {{ $this->{target}(); }} }}\n"
         ),
         "csharp" => format!(
             "class Fixture {{ static void {target}() {{}} static void {caller}() {{ {target}(); }} }}\n"

--- a/crates/codestory-bench/tests/multilingual_proof_contract.rs
+++ b/crates/codestory-bench/tests/multilingual_proof_contract.rs
@@ -137,7 +137,10 @@ fn all_language_rows_are_real_parser_and_adapter_observations() -> anyhow::Resul
 fn funnel_uses_canonical_types_and_observed_nonexact_states() -> anyhow::Result<()> {
     let observation = observe_multilingual_contract()?;
     let funnel = resolution_funnel(&observation);
-    assert_eq!(funnel.len(), 16 * 24);
+    assert!(
+        funnel.len() >= 16 * 24,
+        "every fixture must produce at least one closed funnel row"
+    );
     let statuses = funnel
         .iter()
         .filter_map(|row| row.status)

--- a/crates/codestory-bench/tests/multilingual_proof_contract.rs
+++ b/crates/codestory-bench/tests/multilingual_proof_contract.rs
@@ -429,5 +429,5 @@ fn git_materializer_rejects_commit_path_symbol_source_swap_and_injected_fact() -
 
 #[test]
 fn contract_stays_dark_to_the_public_proof_route() {
-    assert!(PUBLIC_PROOF_ROUTE_DARK);
+    const { assert!(PUBLIC_PROOF_ROUTE_DARK) };
 }

--- a/crates/codestory-indexer/src/cache.rs
+++ b/crates/codestory-indexer/src/cache.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::path::{Component, Path, PathBuf};
 
 // Versioned with proof-input semantics so older parser artifacts fail closed.
-const INDEX_ARTIFACT_CACHE_VERSION: u32 = 22;
+const INDEX_ARTIFACT_CACHE_VERSION: u32 = 23;
 const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
 const FNV_PRIME: u64 = 0x00000100000001B3;
 
@@ -180,6 +180,8 @@ pub(crate) struct CachedResolutionFile {
     #[serde(default)]
     pub java_kotlin_package: Option<String>,
     #[serde(default)]
+    pub php_namespace: Option<String>,
+    #[serde(default)]
     pub c_cpp_file: Option<CachedCCppFile>,
 }
 
@@ -338,7 +340,7 @@ impl CachedIndexArtifact {
         resolution_file: Option<CachedResolutionFile>,
     ) -> Self {
         Self {
-            resolution_input_schema_version: 21,
+            resolution_input_schema_version: 22,
             files: index_result.files,
             nodes: index_result.nodes,
             edges: index_result.edges,

--- a/crates/codestory-indexer/src/cache.rs
+++ b/crates/codestory-indexer/src/cache.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::path::{Component, Path, PathBuf};
 
 // Versioned with proof-input semantics so older parser artifacts fail closed.
-const INDEX_ARTIFACT_CACHE_VERSION: u32 = 23;
+const INDEX_ARTIFACT_CACHE_VERSION: u32 = 24;
 const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
 const FNV_PRIME: u64 = 0x00000100000001B3;
 
@@ -180,7 +180,7 @@ pub(crate) struct CachedResolutionFile {
     #[serde(default)]
     pub java_kotlin_package: Option<String>,
     #[serde(default)]
-    pub php_namespace: Option<String>,
+    pub php_namespace: CachedPhpNamespace,
     #[serde(default)]
     pub c_cpp_file: Option<CachedCCppFile>,
 }
@@ -190,6 +190,15 @@ pub(crate) struct CachedCCppFile {
     pub source_path: PathBuf,
     pub source_role: CachedCCppSourceRole,
     pub namespaces: Vec<CachedCCppNamespace>,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "name", rename_all = "snake_case")]
+pub(crate) enum CachedPhpNamespace {
+    Global,
+    Named(String),
+    #[default]
+    Invalid,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -340,7 +349,7 @@ impl CachedIndexArtifact {
         resolution_file: Option<CachedResolutionFile>,
     ) -> Self {
         Self {
-            resolution_input_schema_version: 22,
+            resolution_input_schema_version: 23,
             files: index_result.files,
             nodes: index_result.nodes,
             edges: index_result.edges,

--- a/crates/codestory-indexer/src/cache.rs
+++ b/crates/codestory-indexer/src/cache.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::path::{Component, Path, PathBuf};
 
 // Versioned with proof-input semantics so older parser artifacts fail closed.
-const INDEX_ARTIFACT_CACHE_VERSION: u32 = 24;
+const INDEX_ARTIFACT_CACHE_VERSION: u32 = 25;
 const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
 const FNV_PRIME: u64 = 0x00000100000001B3;
 

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -16585,7 +16585,8 @@ mod proof_resolution_cache_tests {
     use crate::cache::{
         CachedCallResolutionInput, CachedClassBinding, CachedClassDeclaration, CachedClassMethod,
         CachedDeclarationKind, CachedDirectExport, CachedIndexArtifact, CachedInherentMethod,
-        CachedResolutionBinding, CachedResolutionFile, CachedTopLevelDeclaration,
+        CachedPhpNamespace, CachedResolutionBinding, CachedResolutionFile,
+        CachedTopLevelDeclaration,
     };
     use codestory_contracts::proof_resolution::{CalleeForm, ExactCallsite, FileId};
     use codestory_store::{FileInfo, FileRole};
@@ -16721,7 +16722,7 @@ mod proof_resolution_cache_tests {
                 rust_uses: Vec::new(),
                 go_package: None,
                 java_kotlin_package: None,
-                php_namespace: None,
+                php_namespace: CachedPhpNamespace::Invalid,
                 c_cpp_file: None,
             }),
         };

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -16721,6 +16721,7 @@ mod proof_resolution_cache_tests {
                 rust_uses: Vec::new(),
                 go_package: None,
                 java_kotlin_package: None,
+                php_namespace: None,
                 c_cpp_file: None,
             }),
         };

--- a/crates/codestory-indexer/src/proof_resolution.rs
+++ b/crates/codestory-indexer/src/proof_resolution.rs
@@ -16759,6 +16759,111 @@ mod ruby_php_complexity_tests {
         ruby_php_resolution_work()
     }
 
+    fn ruby_declaration_work(declarations: usize, duplicate: bool) -> usize {
+        let mut source = String::new();
+        let mut nodes = Vec::new();
+        for index in 0..declarations {
+            let name = if duplicate {
+                "target".to_owned()
+            } else {
+                format!("target_{index}")
+            };
+            source.push_str(&format!("def {name}\nend\n"));
+            nodes.push(graph_node(
+                i64::try_from(index + 2).expect("node id"),
+                NodeKind::FUNCTION,
+                &name,
+                u32::try_from(index * 2 + 1).expect("line"),
+            ));
+        }
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_ruby::LANGUAGE.into())
+            .expect("Ruby grammar");
+        let tree = parser.parse(&source, None).expect("Ruby declarations");
+        reset_ruby_php_resolution_work();
+        let _ = RubyResolutionIndex::build(&tree, &source, NodeId(1), &nodes);
+        ruby_php_resolution_work()
+    }
+
+    fn projection_record(
+        language: &str,
+        file_id: i64,
+        declarations: usize,
+        duplicate: bool,
+    ) -> ResolutionCacheRecord {
+        let declarations = (0..declarations)
+            .map(|index| CachedTopLevelDeclaration {
+                name: if duplicate {
+                    "target".to_owned()
+                } else {
+                    format!("target_{file_id}_{index}")
+                },
+                declaration: NodeId(file_id * 10_000 + index as i64 + 1),
+                module_path: Vec::new(),
+                cross_module_visible: true,
+            })
+            .collect();
+        ResolutionCacheRecord {
+            path: PathBuf::from(format!(
+                "file_{file_id}.{}",
+                if language == "ruby" { "rb" } else { "php" }
+            )),
+            file: CachedResolutionFile {
+                file_id: NodeId(file_id),
+                source_sha256: "0".repeat(64),
+                language: language.to_owned(),
+                adapter_version: adapter_version(language).to_owned(),
+                parser_fingerprint: "0".repeat(64),
+                complete: true,
+                lookup_input_complete: true,
+                typescript_module: false,
+                top_level_declarations: declarations,
+                inherent_methods: Vec::new(),
+                classes: Vec::new(),
+                direct_exports: Vec::new(),
+                export_poison_all: false,
+                poisoned_export_names: Vec::new(),
+                rust_modules: Vec::new(),
+                rust_types: Vec::new(),
+                rust_uses: Vec::new(),
+                go_package: None,
+                java_kotlin_package: None,
+                php_namespace: (language == "php").then(|| "App".to_owned()),
+                c_cpp_file: None,
+            },
+            calls: Vec::new(),
+        }
+    }
+
+    fn projection_domain_work(files: usize, declarations: usize, duplicate: bool) -> usize {
+        let records = (0..files)
+            .flat_map(|index| {
+                [
+                    projection_record("ruby", index as i64 + 1, declarations, duplicate),
+                    projection_record(
+                        "php",
+                        index as i64 + files as i64 + 1,
+                        declarations,
+                        duplicate,
+                    ),
+                ]
+            })
+            .collect::<Vec<_>>();
+        reset_ruby_php_resolution_work();
+        let index = JavaKotlinProjectionIndex::prepare(&records);
+        for record in &records {
+            for declaration in &record.file.top_level_declarations {
+                if record.file.language == "ruby" {
+                    let _ = index.ruby_function(&declaration.name, declaration.declaration);
+                } else if let Some(namespace) = record.file.php_namespace.as_deref() {
+                    let _ = index.resolve("php", namespace, None, &declaration.name);
+                }
+            }
+        }
+        ruby_php_resolution_work()
+    }
+
     #[test]
     fn receiver_heavy_ruby_and_php_resolution_work_is_linear() {
         for (language, small, large) in [
@@ -16768,6 +16873,36 @@ mod ruby_php_complexity_tests {
             assert!(
                 large <= small.saturating_mul(2).saturating_add(32),
                 "{language} work grew superlinearly: 1x={small}, 2x={large}"
+            );
+        }
+    }
+
+    #[test]
+    fn ruby_php_preparation_domain_and_projection_work_is_independently_linear() {
+        let calls_1x = ruby_receiver_work(64) + php_receiver_work(64);
+        let calls_2x = ruby_receiver_work(128) + php_receiver_work(128);
+        let declarations_1x = ruby_declaration_work(64, false);
+        let declarations_2x = ruby_declaration_work(128, false);
+        let hostile_1x = ruby_declaration_work(64, true);
+        let hostile_2x = ruby_declaration_work(128, true);
+        let files_1x = projection_domain_work(32, 1, false);
+        let files_2x = projection_domain_work(64, 1, false);
+        let domains_1x = projection_domain_work(8, 8, true);
+        let domains_2x = projection_domain_work(16, 8, true);
+        let combined_1x = projection_domain_work(16, 4, false);
+        let combined_2x = projection_domain_work(32, 4, false);
+        for (class, small, large, allowance) in [
+            ("calls", calls_1x, calls_2x, 64),
+            ("declarations", declarations_1x, declarations_2x, 64),
+            ("duplicate hostile declarations", hostile_1x, hostile_2x, 64),
+            ("files", files_1x, files_2x, 64),
+            ("hostile domains", domains_1x, domains_2x, 64),
+            ("combined", combined_1x, combined_2x, 128),
+        ] {
+            assert!(small > 0, "{class} work was not counted");
+            assert!(
+                large <= small.saturating_mul(2).saturating_add(allowance),
+                "{class} work grew superlinearly: 1x={small}, 2x={large}"
             );
         }
     }

--- a/crates/codestory-indexer/src/proof_resolution.rs
+++ b/crates/codestory-indexer/src/proof_resolution.rs
@@ -704,13 +704,15 @@ impl<'index, 'tree> RubyResolutionProducer<'index, 'tree> {
         file_scope_entry: bool,
     ) {
         count_ruby_php_resolution_work(1);
+        let supported_declaration = matches!(node.kind(), "method" | "class" | "comment");
+        let supported_file_import = file_scope_entry
+            && node.kind() == "call"
+            && ruby_literal_require_relative(node_text(node, self.source).unwrap_or_default())
+                .is_some();
         if declaration_body_entry
-            && !matches!(node.kind(), "method" | "class" | "comment")
-            && !(file_scope_entry
-                && node.kind() == "call"
-                && ruby_literal_require_relative(node_text(node, self.source).unwrap_or_default())
-                    .is_some())
-            && !ruby_inert_declaration_syntax(node)
+            && !(supported_declaration
+                || supported_file_import
+                || ruby_inert_declaration_syntax(node))
         {
             self.index.poisoned = true;
         }

--- a/crates/codestory-indexer/src/proof_resolution.rs
+++ b/crates/codestory-indexer/src/proof_resolution.rs
@@ -2,8 +2,9 @@ use crate::cache::{
     CachedCCppFile, CachedCCppNamespace, CachedCCppSourceRole, CachedCallResolutionInput,
     CachedClassBinding, CachedClassDeclaration, CachedClassMethod, CachedDeclarationKind,
     CachedDirectExport, CachedGoMethod, CachedGoPackage, CachedGoType, CachedIndexArtifact,
-    CachedInherentMethod, CachedResolutionBinding, CachedResolutionFile, CachedRustFileModule,
-    CachedRustModule, CachedRustType, CachedRustUseBinding, CachedTopLevelDeclaration,
+    CachedInherentMethod, CachedPhpNamespace, CachedResolutionBinding, CachedResolutionFile,
+    CachedRustFileModule, CachedRustModule, CachedRustType, CachedRustUseBinding,
+    CachedTopLevelDeclaration,
 };
 use crate::source_content_hash;
 use anyhow::{Context, Result, anyhow};
@@ -152,9 +153,9 @@ const JAVA_ADAPTER_VERSION: &str = "reference-v2";
 const KOTLIN_ADAPTER_VERSION: &str = "reference-v2";
 const C_ADAPTER_VERSION: &str = "reference-v2";
 const CPP_ADAPTER_VERSION: &str = "reference-v3";
-const RUBY_ADAPTER_VERSION: &str = "reference-v1";
-const PHP_ADAPTER_VERSION: &str = "reference-v1";
-const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 22;
+const RUBY_ADAPTER_VERSION: &str = "reference-v2";
+const PHP_ADAPTER_VERSION: &str = "reference-v2";
+const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 23;
 const INSTALLED_ADAPTERS: &[(&str, &str)] = &[
     ("go", GO_ADAPTER_VERSION),
     ("javascript", ADAPTER_VERSION),
@@ -387,7 +388,7 @@ pub(crate) fn collect_call_resolution_inputs(
             emit_call(callee, form, raw_target, None);
         });
     }
-    if c_cpp_index.is_none() {
+    if c_cpp_index.is_none() && ruby_index.is_none() && php_index.is_none() {
         calls.sort_by_key(|input| (input.callsite.start_byte, input.callsite.end_byte_exclusive));
     } else {
         debug_assert!(calls.windows(2).all(|pair| {
@@ -459,7 +460,9 @@ pub(crate) fn collect_call_resolution_inputs(
             java_kotlin_package: java_kotlin_index
                 .as_ref()
                 .and_then(|index| index.package_name.clone()),
-            php_namespace: php_index.as_ref().and_then(|index| index.namespace.clone()),
+            php_namespace: php_index
+                .as_ref()
+                .map_or(CachedPhpNamespace::Invalid, |index| index.namespace.clone()),
             c_cpp_file: c_cpp_index.as_ref().map(|index| CachedCCppFile {
                 source_path: source_path.to_path_buf(),
                 source_role: index.source_role,
@@ -617,7 +620,7 @@ impl<'tree> RubyResolutionIndex<'tree> {
             bindings: HashMap::new(),
             require_relative: None,
         };
-        producer.visit(tree.root_node(), None, None);
+        producer.visit(tree.root_node(), None, None, true);
         for class_indices in producer.class_indices.values() {
             if class_indices.len() != 1 {
                 producer.index.poisoned = true;
@@ -696,6 +699,7 @@ impl<'index, 'tree> RubyResolutionProducer<'index, 'tree> {
         node: TsNode<'tree>,
         mut caller: Option<NodeId>,
         mut owner_index: Option<usize>,
+        declarations_static: bool,
     ) {
         count_ruby_php_resolution_work(1);
         if node.kind() == "class" {
@@ -712,33 +716,38 @@ impl<'index, 'tree> RubyResolutionProducer<'index, 'tree> {
                 self.index.poisoned = true;
                 return;
             };
-            owner_index = Some(self.index.classes.len());
-            self.index.classes.push(CachedClassDeclaration {
-                name: name.clone(),
-                declaration,
-                methods: Vec::new(),
-            });
-            self.index.direct_exports.push(CachedDirectExport {
-                exported_name: name.clone(),
-                declaration,
-                is_default: false,
-                declaration_kind: CachedDeclarationKind::Class,
-            });
-            self.class_indices
-                .entry(name)
-                .or_default()
-                .push(owner_index.expect("Ruby class index"));
-            count_ruby_php_resolution_work(1);
-            count_ruby_php_resolution_work(1);
-            self.index
-                .classes_by_name
-                .entry(
-                    self.index.classes[owner_index.expect("Ruby class index")]
-                        .name
-                        .clone(),
-                )
-                .or_default()
-                .push(owner_index.expect("Ruby class index"));
+            if declarations_static {
+                owner_index = Some(self.index.classes.len());
+                self.index.classes.push(CachedClassDeclaration {
+                    name: name.clone(),
+                    declaration,
+                    methods: Vec::new(),
+                });
+                self.index.direct_exports.push(CachedDirectExport {
+                    exported_name: name.clone(),
+                    declaration,
+                    is_default: false,
+                    declaration_kind: CachedDeclarationKind::Class,
+                });
+                self.class_indices
+                    .entry(name)
+                    .or_default()
+                    .push(owner_index.expect("Ruby class index"));
+                count_ruby_php_resolution_work(1);
+                count_ruby_php_resolution_work(1);
+                self.index
+                    .classes_by_name
+                    .entry(
+                        self.index.classes[owner_index.expect("Ruby class index")]
+                            .name
+                            .clone(),
+                    )
+                    .or_default()
+                    .push(owner_index.expect("Ruby class index"));
+            } else {
+                self.index.poisoned = true;
+                owner_index = None;
+            }
         } else if matches!(node.kind(), "module" | "singleton_method") {
             self.index.poisoned = true;
         }
@@ -758,45 +767,50 @@ impl<'index, 'tree> RubyResolutionProducer<'index, 'tree> {
                 return;
             };
             caller = Some(declaration);
-            if let Some(owner_index) = owner_index {
-                self.index.classes[owner_index]
-                    .methods
-                    .push(CachedClassMethod {
+            if name == "method_missing" || !declarations_static {
+                self.index.poisoned = true;
+            }
+            if declarations_static {
+                if let Some(owner_index) = owner_index {
+                    self.index.classes[owner_index]
+                        .methods
+                        .push(CachedClassMethod {
+                            name: name.clone(),
+                            declaration,
+                        });
+                    count_ruby_php_resolution_work(1);
+                    self.index
+                        .methods_by_owner_and_name
+                        .entry((owner_index, name))
+                        .or_default()
+                        .push(declaration);
+                } else {
+                    self.index.declarations.push(CachedTopLevelDeclaration {
                         name: name.clone(),
                         declaration,
+                        module_path: Vec::new(),
+                        cross_module_visible: false,
                     });
-                count_ruby_php_resolution_work(1);
-                self.index
-                    .methods_by_owner_and_name
-                    .entry((owner_index, name))
-                    .or_default()
-                    .push(declaration);
-            } else {
-                self.index.declarations.push(CachedTopLevelDeclaration {
-                    name: name.clone(),
-                    declaration,
-                    module_path: Vec::new(),
-                    cross_module_visible: false,
-                });
-                self.index.direct_exports.push(CachedDirectExport {
-                    exported_name: name,
-                    declaration,
-                    is_default: false,
-                    declaration_kind: CachedDeclarationKind::Callable,
-                });
-                count_ruby_php_resolution_work(1);
-                self.index
-                    .declarations_by_name
-                    .entry(
-                        self.index
-                            .declarations
-                            .last()
-                            .expect("Ruby declaration")
-                            .name
-                            .clone(),
-                    )
-                    .or_default()
-                    .push(declaration);
+                    self.index.direct_exports.push(CachedDirectExport {
+                        exported_name: name,
+                        declaration,
+                        is_default: false,
+                        declaration_kind: CachedDeclarationKind::Callable,
+                    });
+                    count_ruby_php_resolution_work(1);
+                    self.index
+                        .declarations_by_name
+                        .entry(
+                            self.index
+                                .declarations
+                                .last()
+                                .expect("Ruby declaration")
+                                .name
+                                .clone(),
+                        )
+                        .or_default()
+                        .push(declaration);
+                }
             }
         }
 
@@ -816,8 +830,10 @@ impl<'index, 'tree> RubyResolutionProducer<'index, 'tree> {
         }
 
         let mut cursor = node.walk();
+        let child_declarations_static =
+            declarations_static && matches!(node.kind(), "program" | "body_statement" | "class");
         for child in node.named_children(&mut cursor) {
-            self.visit(child, caller, owner_index);
+            self.visit(child, caller, owner_index, child_declarations_static);
         }
     }
 
@@ -1125,19 +1141,13 @@ struct PhpResolutionIndex<'tree> {
     declarations_by_name: HashMap<String, Vec<NodeId>>,
     classes_by_name: HashMap<String, Vec<usize>>,
     methods_by_owner_and_name: HashMap<(usize, String), Vec<NodeId>>,
-    namespace: Option<String>,
+    namespace: CachedPhpNamespace,
     poisoned: bool,
 }
 
 impl<'tree> PhpResolutionIndex<'tree> {
     fn build(tree: &'tree Tree, source: &str, file_id: NodeId, nodes: &[Node]) -> Self {
         let (graph_declarations, graph_imports) = ruby_php_graph_maps(nodes, file_id);
-        let namespace = php_unique_namespace(tree.root_node(), source);
-        let namespace_declarations = tree
-            .root_node()
-            .named_children(&mut tree.root_node().walk())
-            .filter(|node| node.kind() == "namespace_definition")
-            .count();
         let mut index = Self {
             calls: Vec::new(),
             call_indices_by_span: HashMap::new(),
@@ -1146,8 +1156,8 @@ impl<'tree> PhpResolutionIndex<'tree> {
             declarations_by_name: HashMap::new(),
             classes_by_name: HashMap::new(),
             methods_by_owner_and_name: HashMap::new(),
-            namespace,
-            poisoned: namespace_declarations > 1,
+            namespace: CachedPhpNamespace::Invalid,
+            poisoned: false,
         };
         let mut producer = PhpResolutionProducer {
             index: &mut index,
@@ -1157,8 +1167,19 @@ impl<'tree> PhpResolutionIndex<'tree> {
             class_indices: HashMap::new(),
             imports: HashMap::new(),
             bindings: HashMap::new(),
+            namespace: None,
+            namespace_invalid: false,
         };
-        producer.visit(tree.root_node(), None, None);
+        producer.visit(tree.root_node(), None, None, true);
+        producer.index.namespace = if producer.namespace_invalid {
+            producer.index.poisoned = true;
+            CachedPhpNamespace::Invalid
+        } else {
+            producer
+                .namespace
+                .take()
+                .map_or(CachedPhpNamespace::Global, CachedPhpNamespace::Named)
+        };
         if producer
             .class_indices
             .values()
@@ -1231,6 +1252,8 @@ struct PhpResolutionProducer<'index, 'tree> {
     class_indices: HashMap<String, Vec<usize>>,
     imports: HashMap<String, PhpImportBinding>,
     bindings: HashMap<(NodeId, String), PhpReceiverBinding>,
+    namespace: Option<String>,
+    namespace_invalid: bool,
 }
 
 impl<'index, 'tree> PhpResolutionProducer<'index, 'tree> {
@@ -1239,8 +1262,18 @@ impl<'index, 'tree> PhpResolutionProducer<'index, 'tree> {
         node: TsNode<'tree>,
         mut caller: Option<NodeId>,
         mut owner_index: Option<usize>,
+        declarations_static: bool,
     ) {
         count_ruby_php_resolution_work(1);
+        if node.kind() == "namespace_definition" {
+            let name = declaration_name(node, self.source).and_then(canonical_php_namespace_name);
+            if self.namespace.is_some() || name.is_none() {
+                self.namespace_invalid = true;
+            } else {
+                self.namespace = name;
+            }
+            count_ruby_php_resolution_work(1);
+        }
         if node.kind() == "namespace_use_declaration" {
             self.observe_import(node);
         }
@@ -1261,23 +1294,28 @@ impl<'index, 'tree> PhpResolutionProducer<'index, 'tree> {
                 self.index.poisoned = true;
                 return;
             };
-            owner_index = Some(self.index.classes.len());
-            self.index.classes.push(CachedClassDeclaration {
-                name: name.clone(),
-                declaration,
-                methods: Vec::new(),
-            });
-            self.class_indices
-                .entry(name.clone())
-                .or_default()
-                .push(owner_index.expect("PHP class index"));
-            count_ruby_php_resolution_work(1);
-            count_ruby_php_resolution_work(1);
-            self.index
-                .classes_by_name
-                .entry(name)
-                .or_default()
-                .push(owner_index.expect("PHP class index"));
+            if declarations_static {
+                owner_index = Some(self.index.classes.len());
+                self.index.classes.push(CachedClassDeclaration {
+                    name: name.clone(),
+                    declaration,
+                    methods: Vec::new(),
+                });
+                self.class_indices
+                    .entry(name.clone())
+                    .or_default()
+                    .push(owner_index.expect("PHP class index"));
+                count_ruby_php_resolution_work(1);
+                count_ruby_php_resolution_work(1);
+                self.index
+                    .classes_by_name
+                    .entry(name)
+                    .or_default()
+                    .push(owner_index.expect("PHP class index"));
+            } else {
+                self.index.poisoned = true;
+                owner_index = None;
+            }
         }
         if matches!(node.kind(), "function_definition" | "method_declaration") {
             let Some(name) = declaration_name(node, self.source).map(str::to_string) else {
@@ -1294,34 +1332,39 @@ impl<'index, 'tree> PhpResolutionProducer<'index, 'tree> {
                 return;
             };
             caller = Some(declaration);
-            if let Some(owner_index) = owner_index {
-                self.index.classes[owner_index]
-                    .methods
-                    .push(CachedClassMethod {
+            if name.starts_with("__") || !declarations_static {
+                self.index.poisoned = true;
+            }
+            if declarations_static {
+                if let Some(owner_index) = owner_index {
+                    self.index.classes[owner_index]
+                        .methods
+                        .push(CachedClassMethod {
+                            name: name.clone(),
+                            declaration,
+                        });
+                    count_ruby_php_resolution_work(1);
+                    self.index
+                        .methods_by_owner_and_name
+                        .entry((owner_index, name))
+                        .or_default()
+                        .push(declaration);
+                } else {
+                    self.index.declarations.push(CachedTopLevelDeclaration {
                         name: name.clone(),
                         declaration,
+                        module_path: Vec::new(),
+                        cross_module_visible: true,
                     });
-                count_ruby_php_resolution_work(1);
-                self.index
-                    .methods_by_owner_and_name
-                    .entry((owner_index, name))
-                    .or_default()
-                    .push(declaration);
-            } else {
-                self.index.declarations.push(CachedTopLevelDeclaration {
-                    name: name.clone(),
-                    declaration,
-                    module_path: Vec::new(),
-                    cross_module_visible: true,
-                });
-                count_ruby_php_resolution_work(1);
-                self.index
-                    .declarations_by_name
-                    .entry(name)
-                    .or_default()
-                    .push(declaration);
+                    count_ruby_php_resolution_work(1);
+                    self.index
+                        .declarations_by_name
+                        .entry(name)
+                        .or_default()
+                        .push(declaration);
+                }
+                self.observe_parameters(node, declaration);
             }
-            self.observe_parameters(node, declaration);
         }
 
         self.observe_poison(node);
@@ -1350,8 +1393,17 @@ impl<'index, 'tree> PhpResolutionProducer<'index, 'tree> {
         }
 
         let mut cursor = node.walk();
+        let child_declarations_static = declarations_static
+            && matches!(
+                node.kind(),
+                "program"
+                    | "namespace_definition"
+                    | "compound_statement"
+                    | "class_declaration"
+                    | "declaration_list"
+            );
         for child in node.named_children(&mut cursor) {
-            self.visit(child, caller, owner_index);
+            self.visit(child, caller, owner_index, child_declarations_static);
         }
     }
 
@@ -1682,17 +1734,18 @@ impl<'index, 'tree> PhpResolutionProducer<'index, 'tree> {
     }
 }
 
-fn php_unique_namespace(root: TsNode<'_>, source: &str) -> Option<String> {
-    let mut namespaces = Vec::new();
-    let mut cursor = root.walk();
-    for node in root.named_children(&mut cursor) {
-        if node.kind() == "namespace_definition" {
-            namespaces.push(declaration_name(node, source)?.replace('\\', "."));
-        }
-    }
-    namespaces.sort();
-    namespaces.dedup();
-    namespaces.pop().filter(|_| namespaces.is_empty())
+fn canonical_php_namespace_name(name: &str) -> Option<String> {
+    let components = name.split('\\').collect::<Vec<_>>();
+    count_ruby_php_resolution_work(components.len());
+    (!components.is_empty()
+        && components.iter().all(|component| {
+            let mut chars = component.chars();
+            chars
+                .next()
+                .is_some_and(|ch| ch == '_' || ch.is_ascii_alphabetic())
+                && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+        }))
+    .then(|| components.join("."))
 }
 
 fn php_simple_type(surface: &str) -> Option<String> {
@@ -11349,6 +11402,19 @@ pub fn rematerialize_proof_resolution_projection(
         .iter()
         .map(|node| (node.id, node))
         .collect::<HashMap<_, _>>();
+    let mut php_graph_names_by_file = HashMap::<i64, Vec<String>>::new();
+    for node in nodes.iter().filter(|node| node.kind == NodeKind::NAMESPACE) {
+        count_ruby_php_resolution_work(1);
+        if let (Some(file_id), Some(name)) = (
+            node.file_node_id,
+            canonical_php_namespace_name(&node.serialized_name),
+        ) {
+            php_graph_names_by_file
+                .entry(file_id.0)
+                .or_default()
+                .push(name);
+        }
+    }
     let mut edges = store.get_edges()?;
     let exact_evidence_validation = ExactEvidenceValidationIndex::prepare(&edges, &node_by_id);
     let governed = files
@@ -11482,12 +11548,29 @@ pub fn rematerialize_proof_resolution_projection(
         } else {
             record.file.c_cpp_file.is_none()
         };
+        let php_namespace_identity_matches = if indexed_file.language == "php" {
+            count_ruby_php_resolution_work(1);
+            let graph_names = php_graph_names_by_file
+                .get(&indexed_file.id)
+                .map(Vec::as_slice)
+                .unwrap_or_default();
+            match &record.file.php_namespace {
+                CachedPhpNamespace::Global => graph_names.is_empty(),
+                CachedPhpNamespace::Named(name) => {
+                    matches!(graph_names, [graph_name] if graph_name == name)
+                }
+                CachedPhpNamespace::Invalid => record.file.export_poison_all,
+            }
+        } else {
+            record.file.php_namespace == CachedPhpNamespace::Invalid
+        };
         if record.file.file_id != NodeId(indexed_file.id)
             || record.file.source_sha256 != *stored_hash
             || record.file.language != indexed_file.language
             || record.file.complete != indexed_file.complete
             || record.file.adapter_version != adapter_version(&indexed_file.language)
             || !c_cpp_source_identity_matches
+            || !php_namespace_identity_matches
             || record.calls.iter().any(|call| {
                 call.callsite.file_id != FileId(indexed_file.id)
                     || call.callsite.source_sha256 != *stored_hash
@@ -11502,7 +11585,21 @@ pub fn rematerialize_proof_resolution_projection(
         }
         records.push(record);
     }
+    let mut linear_records = Vec::new();
+    let mut records = records
+        .into_iter()
+        .filter_map(|record| {
+            if matches!(record.file.language.as_str(), "ruby" | "php") {
+                count_ruby_php_resolution_work(1);
+                linear_records.push(record);
+                None
+            } else {
+                Some(record)
+            }
+        })
+        .collect::<Vec<_>>();
     records.sort_by(|left, right| left.path.cmp(&right.path));
+    records.extend(linear_records);
     let mut record_by_path = HashMap::new();
     for record in &records {
         let identity = governed_identities
@@ -11515,9 +11612,19 @@ pub fn rematerialize_proof_resolution_projection(
             ));
         }
     }
+    let mut linear_inputs = Vec::new();
     let mut inputs = records
         .iter()
         .flat_map(|record| record.calls.iter().cloned().map(move |call| (record, call)))
+        .filter_map(|(record, call)| {
+            if matches!(record.file.language.as_str(), "ruby" | "php") {
+                count_ruby_php_resolution_work(1);
+                linear_inputs.push((record, call));
+                None
+            } else {
+                Some((record, call))
+            }
+        })
         .collect::<Vec<_>>();
     inputs.sort_by(|left, right| {
         left.1
@@ -11532,10 +11639,17 @@ pub fn rematerialize_proof_resolution_projection(
                     .cmp(&right.1.callsite.end_byte_exclusive),
             )
     });
-    if inputs.windows(2).any(|pair| {
-        pair[0].1.callsite.file_id == pair[1].1.callsite.file_id
-            && pair[0].1.callsite.start_byte == pair[1].1.callsite.start_byte
-            && pair[0].1.callsite.end_byte_exclusive == pair[1].1.callsite.end_byte_exclusive
+    inputs.extend(linear_inputs);
+    let mut callsite_members = HashSet::new();
+    if inputs.iter().any(|(_, input)| {
+        if matches!(input.language.as_str(), "ruby" | "php") {
+            count_ruby_php_resolution_work(1);
+        }
+        !callsite_members.insert((
+            input.callsite.file_id,
+            input.callsite.start_byte,
+            input.callsite.end_byte_exclusive,
+        ))
     }) {
         return Err(anyhow!(
             "proof resolution projection has duplicate exact callsites"
@@ -12328,8 +12442,16 @@ fn resolve_relative_import<'a>(
             uncovered = true;
         }
     }
-    matches.sort_by_key(|record| record.file.file_id);
-    matches.dedup_by_key(|record| record.file.file_id);
+    if source_record.file.language == "ruby" {
+        let mut members = HashSet::new();
+        matches.retain(|record| {
+            count_ruby_php_resolution_work(1);
+            members.insert(record.file.file_id)
+        });
+    } else {
+        matches.sort_by_key(|record| record.file.file_id);
+        matches.dedup_by_key(|record| record.file.file_id);
+    }
     Ok(if uncovered || matches.len() > 1 {
         RelativeImportResolution::Incomplete
     } else if let [record] = matches.as_slice() {
@@ -14372,14 +14494,19 @@ struct JavaKotlinImportDomain {
     complete: bool,
     poisoned: bool,
     dependencies: Vec<FileId>,
+    dependency_members: HashSet<FileId>,
     declarations: HashMap<(Option<String>, String), Vec<JavaKotlinImportCandidate>>,
+    classes: HashMap<String, Vec<JavaKotlinImportCandidate>>,
 }
 
 struct JavaKotlinProjectionIndex {
     domains: HashMap<(String, String), JavaKotlinImportDomain>,
+    php_domains: HashMap<CachedPhpNamespace, JavaKotlinImportDomain>,
+    php_identity_by_file: HashMap<i64, CachedPhpNamespace>,
     ruby_complete: bool,
     ruby_dependencies: Vec<FileId>,
     ruby_functions: HashMap<String, Vec<JavaKotlinImportCandidate>>,
+    ruby_classes: HashMap<String, Vec<JavaKotlinImportCandidate>>,
     ruby_methods: HashMap<(String, String), Vec<JavaKotlinImportCandidate>>,
 }
 
@@ -14398,9 +14525,14 @@ enum JavaKotlinImportResolution {
 impl JavaKotlinProjectionIndex {
     fn prepare(records: &[ResolutionCacheRecord]) -> Self {
         let mut domains = HashMap::<(String, String), JavaKotlinImportDomain>::new();
+        let mut php_domains = HashMap::<CachedPhpNamespace, JavaKotlinImportDomain>::new();
+        let mut php_identity_by_file = HashMap::new();
+        let mut php_invalid_namespace = false;
         let mut ruby_complete = true;
         let mut ruby_dependencies = Vec::new();
+        let mut ruby_dependency_members = HashSet::new();
         let mut ruby_functions = HashMap::<String, Vec<JavaKotlinImportCandidate>>::new();
+        let mut ruby_classes = HashMap::<String, Vec<JavaKotlinImportCandidate>>::new();
         let mut ruby_methods = HashMap::<(String, String), Vec<JavaKotlinImportCandidate>>::new();
         for record in records
             .iter()
@@ -14409,8 +14541,13 @@ impl JavaKotlinProjectionIndex {
             ruby_complete &= record.file.complete
                 && record.file.lookup_input_complete
                 && !record.file.export_poison_all;
-            ruby_dependencies.push(FileId(record.file.file_id.0));
+            let file_id = FileId(record.file.file_id.0);
+            count_ruby_php_resolution_work(1);
+            if ruby_dependency_members.insert(file_id) {
+                ruby_dependencies.push(file_id);
+            }
             for declaration in &record.file.top_level_declarations {
+                count_ruby_php_resolution_work(1);
                 ruby_functions
                     .entry(declaration.name.clone())
                     .or_default()
@@ -14421,7 +14558,16 @@ impl JavaKotlinProjectionIndex {
                     });
             }
             for class in &record.file.classes {
+                count_ruby_php_resolution_work(1);
+                ruby_classes.entry(class.name.clone()).or_default().push(
+                    JavaKotlinImportCandidate {
+                        owner: class.declaration,
+                        declaration: class.declaration,
+                        file_id,
+                    },
+                );
                 for method in &class.methods {
+                    count_ruby_php_resolution_work(1);
                     ruby_methods
                         .entry((class.name.clone(), method.name.clone()))
                         .or_default()
@@ -14433,20 +14579,19 @@ impl JavaKotlinProjectionIndex {
                 }
             }
         }
-        for record in records.iter().filter(|record| {
-            is_java_kotlin_language(&record.file.language) || record.file.language == "php"
-        }) {
-            let package_name = if record.file.language == "php" {
-                record.file.php_namespace.as_ref()
-            } else {
-                record.file.java_kotlin_package.as_ref()
-            };
-            let Some(package_name) = package_name else {
+        for record in records
+            .iter()
+            .filter(|record| record.file.language == "php")
+        {
+            count_ruby_php_resolution_work(1);
+            let namespace = record.file.php_namespace.clone();
+            if namespace == CachedPhpNamespace::Invalid {
+                php_invalid_namespace = true;
                 continue;
-            };
-            let domain = domains
-                .entry((record.file.language.clone(), package_name.clone()))
-                .or_default();
+            }
+            php_identity_by_file.insert(record.file.file_id.0, namespace.clone());
+            count_ruby_php_resolution_work(1);
+            let domain = php_domains.entry(namespace).or_default();
             let file_complete = record.file.complete && record.file.lookup_input_complete;
             if domain.dependencies.is_empty() {
                 domain.complete = file_complete;
@@ -14454,8 +14599,13 @@ impl JavaKotlinProjectionIndex {
                 domain.complete &= file_complete;
             }
             domain.poisoned |= record.file.export_poison_all;
-            domain.dependencies.push(FileId(record.file.file_id.0));
+            let file_id = FileId(record.file.file_id.0);
+            count_ruby_php_resolution_work(1);
+            if domain.dependency_members.insert(file_id) {
+                domain.dependencies.push(file_id);
+            }
             for declaration in &record.file.top_level_declarations {
+                count_ruby_php_resolution_work(1);
                 domain
                     .declarations
                     .entry((None, declaration.name.clone()))
@@ -14467,7 +14617,16 @@ impl JavaKotlinProjectionIndex {
                     });
             }
             for class in &record.file.classes {
+                count_ruby_php_resolution_work(1);
+                domain.classes.entry(class.name.clone()).or_default().push(
+                    JavaKotlinImportCandidate {
+                        owner: class.declaration,
+                        declaration: class.declaration,
+                        file_id,
+                    },
+                );
                 for method in &class.methods {
+                    count_ruby_php_resolution_work(1);
                     domain
                         .declarations
                         .entry((Some(class.name.clone()), method.name.clone()))
@@ -14480,6 +14639,58 @@ impl JavaKotlinProjectionIndex {
                 }
             }
         }
+        if php_invalid_namespace {
+            for domain in php_domains.values_mut() {
+                count_ruby_php_resolution_work(1);
+                domain.poisoned = true;
+            }
+        }
+        for record in records
+            .iter()
+            .filter(|record| is_java_kotlin_language(&record.file.language))
+        {
+            let Some(package_name) = record.file.java_kotlin_package.as_ref() else {
+                continue;
+            };
+            let domain = domains
+                .entry((record.file.language.clone(), package_name.clone()))
+                .or_default();
+            let file_complete = record.file.complete && record.file.lookup_input_complete;
+            if domain.dependencies.is_empty() {
+                domain.complete = file_complete;
+            } else {
+                domain.complete &= file_complete;
+            }
+            domain.poisoned |= record.file.export_poison_all;
+            let file_id = FileId(record.file.file_id.0);
+            if domain.dependency_members.insert(file_id) {
+                domain.dependencies.push(file_id);
+            }
+            for declaration in &record.file.top_level_declarations {
+                domain
+                    .declarations
+                    .entry((None, declaration.name.clone()))
+                    .or_default()
+                    .push(JavaKotlinImportCandidate {
+                        owner: declaration.declaration,
+                        declaration: declaration.declaration,
+                        file_id,
+                    });
+            }
+            for class in &record.file.classes {
+                for method in &class.methods {
+                    domain
+                        .declarations
+                        .entry((Some(class.name.clone()), method.name.clone()))
+                        .or_default()
+                        .push(JavaKotlinImportCandidate {
+                            owner: class.declaration,
+                            declaration: method.declaration,
+                            file_id,
+                        });
+                }
+            }
+        }
         for domain in domains.values_mut() {
             domain.dependencies.sort();
             domain.dependencies.dedup();
@@ -14488,13 +14699,14 @@ impl JavaKotlinProjectionIndex {
                 candidates.dedup_by(|left, right| left.declaration == right.declaration);
             }
         }
-        ruby_dependencies.sort();
-        ruby_dependencies.dedup();
         Self {
             domains,
+            php_domains,
+            php_identity_by_file,
             ruby_complete,
             ruby_dependencies,
             ruby_functions,
+            ruby_classes,
             ruby_methods,
         }
     }
@@ -14512,9 +14724,58 @@ impl JavaKotlinProjectionIndex {
         else {
             return JavaKotlinImportResolution::Missing;
         };
+        Self::resolve_domain(domain, owner_name, imported_name)
+    }
+
+    fn resolve_php(
+        &self,
+        namespace: &CachedPhpNamespace,
+        owner_name: Option<&str>,
+        imported_name: &str,
+    ) -> JavaKotlinImportResolution {
+        count_ruby_php_resolution_work(1);
+        let Some(domain) = self.php_domains.get(namespace) else {
+            return JavaKotlinImportResolution::Missing;
+        };
+        let resolution = Self::resolve_domain(domain, owner_name, imported_name);
+        let (Some(owner_name), JavaKotlinImportResolution::Exact { owner, .. }) =
+            (owner_name, &resolution)
+        else {
+            return resolution;
+        };
+        count_ruby_php_resolution_work(1);
+        if matches!(
+            domain.classes.get(owner_name).map(Vec::as_slice),
+            Some([candidate]) if candidate.owner == *owner
+        ) {
+            resolution
+        } else {
+            JavaKotlinImportResolution::Ambiguous
+        }
+    }
+
+    fn resolve_php_named(
+        &self,
+        namespace: &str,
+        owner_name: Option<&str>,
+        imported_name: &str,
+    ) -> JavaKotlinImportResolution {
+        self.resolve_php(
+            &CachedPhpNamespace::Named(namespace.to_owned()),
+            owner_name,
+            imported_name,
+        )
+    }
+
+    fn resolve_domain(
+        domain: &JavaKotlinImportDomain,
+        owner_name: Option<&str>,
+        imported_name: &str,
+    ) -> JavaKotlinImportResolution {
         if !domain.complete || domain.poisoned {
             return JavaKotlinImportResolution::Incomplete;
         }
+        count_ruby_php_resolution_work(1);
         let candidates = domain
             .declarations
             .get(&(owner_name.map(str::to_string), imported_name.to_string()))
@@ -14532,7 +14793,32 @@ impl JavaKotlinProjectionIndex {
         }
     }
 
+    fn php_dependencies(
+        &self,
+        source_file: FileId,
+        evidence_files: impl IntoIterator<Item = FileId>,
+    ) -> Option<Vec<FileId>> {
+        let mut dependencies = Vec::new();
+        let mut members = HashSet::new();
+        for file_id in std::iter::once(source_file).chain(evidence_files) {
+            count_ruby_php_resolution_work(1);
+            let namespace = self.php_identity_by_file.get(&file_id.0)?;
+            let domain = self.php_domains.get(namespace)?;
+            if !domain.complete || domain.poisoned {
+                return None;
+            }
+            for dependency in &domain.dependencies {
+                count_ruby_php_resolution_work(1);
+                if members.insert(*dependency) {
+                    dependencies.push(*dependency);
+                }
+            }
+        }
+        Some(dependencies)
+    }
+
     fn ruby_function(&self, name: &str, declaration: NodeId) -> Option<Vec<FileId>> {
+        count_ruby_php_resolution_work(1);
         self.ruby_complete
             .then_some(())
             .filter(|_| {
@@ -14551,10 +14837,14 @@ impl JavaKotlinProjectionIndex {
         owner: NodeId,
         declaration: NodeId,
     ) -> Option<Vec<FileId>> {
+        count_ruby_php_resolution_work(2);
         self.ruby_complete
             .then_some(())
             .filter(|_| {
                 matches!(
+                    self.ruby_classes.get(owner_name).map(Vec::as_slice),
+                    Some([candidate]) if candidate.owner == owner
+                ) && matches!(
                     self.ruby_methods
                         .get(&(owner_name.to_string(), method_name.to_string()))
                         .map(Vec::as_slice),
@@ -15100,23 +15390,16 @@ fn resolve_syntax_claim(
                         evidence_chain.clear();
                     }
                 } else if source_record.file.language == "php" {
-                    let resolution = source_record
-                        .file
-                        .php_namespace
-                        .as_deref()
-                        .map(|namespace| {
-                            java_kotlin_index.resolve(
-                                "php",
-                                namespace,
-                                None,
-                                &input.callsite.raw_target,
-                            )
-                        });
-                    if let Some(JavaKotlinImportResolution::Exact {
+                    let resolution = java_kotlin_index.resolve_php(
+                        &source_record.file.php_namespace,
+                        None,
+                        &input.callsite.raw_target,
+                    );
+                    if let JavaKotlinImportResolution::Exact {
                         declaration: resolved,
                         dependencies,
                         ..
-                    }) = resolution
+                    } = resolution
                         && resolved == *declaration
                     {
                         exact_dependency_files = dependencies;
@@ -15192,24 +15475,17 @@ fn resolve_syntax_claim(
                         evidence_chain.clear();
                     }
                 } else if source_record.file.language == "php" {
-                    let resolution = source_record
-                        .file
-                        .php_namespace
-                        .as_deref()
-                        .map(|namespace| {
-                            java_kotlin_index.resolve(
-                                "php",
-                                namespace,
-                                Some(owner_name),
-                                &input.callsite.raw_target,
-                            )
-                        });
-                    if let Some(JavaKotlinImportResolution::Exact {
+                    let resolution = java_kotlin_index.resolve_php(
+                        &source_record.file.php_namespace,
+                        Some(owner_name),
+                        &input.callsite.raw_target,
+                    );
+                    if let JavaKotlinImportResolution::Exact {
                         owner: resolved_owner,
                         declaration: resolved,
                         dependencies,
                         ..
-                    }) = resolution
+                    } = resolution
                         && resolved_owner == *owner
                         && resolved == *declaration
                     {
@@ -15785,12 +16061,11 @@ fn resolve_syntax_claim(
             owner_name,
             name,
             import,
-        } => match java_kotlin_index.resolve(
-            &input.language,
-            package_name,
-            owner_name.as_deref(),
-            name,
-        ) {
+        } => match if input.language == "php" {
+            java_kotlin_index.resolve_php_named(package_name, owner_name.as_deref(), name)
+        } else {
+            java_kotlin_index.resolve(&input.language, package_name, owner_name.as_deref(), name)
+        } {
             JavaKotlinImportResolution::Exact {
                 owner,
                 declaration,
@@ -15875,12 +16150,11 @@ fn resolve_syntax_claim(
             method_name,
             import,
             constructor,
-        } => match java_kotlin_index.resolve(
-            &input.language,
-            package_name,
-            Some(owner_name),
-            method_name,
-        ) {
+        } => match if input.language == "php" {
+            java_kotlin_index.resolve_php_named(package_name, Some(owner_name), method_name)
+        } else {
+            java_kotlin_index.resolve(&input.language, package_name, Some(owner_name), method_name)
+        } {
             JavaKotlinImportResolution::Exact {
                 owner,
                 declaration,
@@ -16215,19 +16489,13 @@ fn resolve_syntax_claim(
                         evidence_chain.clear();
                     }
                 } else if source_record.file.language == "php" {
-                    let resolution = target_record
-                        .file
-                        .php_namespace
-                        .as_deref()
-                        .zip(owner_name)
-                        .map(|(namespace, owner_name)| {
-                            java_kotlin_index.resolve(
-                                "php",
-                                namespace,
-                                Some(owner_name),
-                                method_name,
-                            )
-                        });
+                    let resolution = owner_name.map(|owner_name| {
+                        java_kotlin_index.resolve_php(
+                            &target_record.file.php_namespace,
+                            Some(owner_name),
+                            method_name,
+                        )
+                    });
                     if let Some(JavaKotlinImportResolution::Exact {
                         owner: resolved_owner,
                         declaration: resolved,
@@ -16257,6 +16525,22 @@ fn resolve_syntax_claim(
                     ProofResolutionReason::MultipleBindings
                 };
             }
+        }
+    }
+    if status == ProofResolutionStatus::Exact && source_record.file.language == "php" {
+        let evidence_files = exact_node_file_expectations
+            .iter()
+            .map(|(_, file_id)| *file_id);
+        if let Some(dependencies) =
+            java_kotlin_index.php_dependencies(input.callsite.file_id, evidence_files)
+        {
+            exact_dependency_files = dependencies;
+        } else {
+            status = ProofResolutionStatus::IncompleteDomain;
+            reason = ProofResolutionReason::LookupDomainIncomplete;
+            target = None;
+            evidence_chain.clear();
+            exact_dependency_files.clear();
         }
     }
     if !source_file.complete
@@ -16411,14 +16695,22 @@ fn seal_resolved_claim(
         None
     };
     let input = &claim.input;
-    let mut dependency_ids = HashSet::from([NodeId(input.callsite.file_id.0)]);
+    let linear_dependency_order = matches!(input.language.as_str(), "ruby" | "php");
+    let mut dependency_ids = Vec::new();
+    let mut dependency_members = HashSet::new();
+    let mut push_dependency = |file_id: NodeId| {
+        if dependency_members.insert(file_id) {
+            dependency_ids.push(file_id);
+        }
+        if linear_dependency_order {
+            count_ruby_php_resolution_work(1);
+        }
+    };
+    push_dependency(NodeId(input.callsite.file_id.0));
     if status == ProofResolutionStatus::Exact {
-        dependency_ids.extend(
-            claim
-                .exact_dependency_files
-                .iter()
-                .map(|file| NodeId(file.0)),
-        );
+        for file in &claim.exact_dependency_files {
+            push_dependency(NodeId(file.0));
+        }
     }
     for node_id in evidence_chain
         .iter()
@@ -16426,7 +16718,7 @@ fn seal_resolved_claim(
         .chain(target)
     {
         if let Some(file_id) = nodes.get(&node_id).and_then(|node| node.file_node_id) {
-            dependency_ids.insert(file_id);
+            push_dependency(file_id);
         }
     }
     let mut dependency_file_hashes = dependency_ids
@@ -16442,7 +16734,9 @@ fn seal_resolved_claim(
             })
         })
         .collect::<Result<Vec<_>>>()?;
-    dependency_file_hashes.sort();
+    if !linear_dependency_order {
+        dependency_file_hashes.sort();
+    }
     codestory_store::seal_call_resolution_fact(CallResolutionFact {
         fact_id: String::new(),
         edge_id: edge.map(|edge| edge.id),
@@ -16474,15 +16768,23 @@ pub fn build_funnel(facts: &[CallResolutionFact]) -> Vec<ProofResolutionFunnelRo
         (String, Option<CalleeForm>, Option<ResolutionEvidenceKind>),
         ProofResolutionFunnelCounts,
     >::new();
+    let mut linear_rows = HashMap::<
+        (String, Option<CalleeForm>, Option<ResolutionEvidenceKind>),
+        ProofResolutionFunnelCounts,
+    >::new();
     for fact in facts {
         let evidence_kind = fact.evidence_chain.first().map(ResolutionEvidence::kind);
-        let counts = rows
-            .entry((
-                fact.provenance.language_adapter.clone(),
-                Some(fact.callsite.callee_form),
-                evidence_kind,
-            ))
-            .or_default();
+        let key = (
+            fact.provenance.language_adapter.clone(),
+            Some(fact.callsite.callee_form),
+            evidence_kind,
+        );
+        let counts = if matches!(fact.provenance.language_adapter.as_str(), "ruby" | "php") {
+            count_ruby_php_resolution_work(1);
+            linear_rows.entry(key).or_default()
+        } else {
+            rows.entry(key).or_default()
+        };
         counts.syntax_calls += 1;
         counts.adapter_supported += u64::from(fact.status != ProofResolutionStatus::Unsupported);
         match fact.status {
@@ -16518,6 +16820,40 @@ pub fn build_funnel(facts: &[CallResolutionFact]) -> Vec<ProofResolutionFunnelRo
                 right.evidence_kind.map(|kind| kind.as_str()),
             ))
     });
+    for language in ["php", "ruby"] {
+        for callee_form in [
+            CalleeForm::Constructor,
+            CalleeForm::DynamicAccess,
+            CalleeForm::ExplicitReceiver,
+            CalleeForm::Identifier,
+            CalleeForm::ImplicitReceiver,
+            CalleeForm::NamedImport,
+            CalleeForm::QualifiedPath,
+        ] {
+            for evidence_kind in [
+                None,
+                Some(ResolutionEvidenceKind::ConstructorBinding),
+                Some(ResolutionEvidenceKind::ExplicitReceiverType),
+                Some(ResolutionEvidenceKind::ImplicitReceiver),
+                Some(ResolutionEvidenceKind::QualifiedPath),
+                Some(ResolutionEvidenceKind::SameFileDeclaration),
+                Some(ResolutionEvidenceKind::SamePackageDeclaration),
+                Some(ResolutionEvidenceKind::StaticImportBinding),
+            ] {
+                let key = (language.to_owned(), Some(callee_form), evidence_kind);
+                count_ruby_php_resolution_work(1);
+                if let Some(counts) = linear_rows.remove(&key) {
+                    result.push(ProofResolutionFunnelRow {
+                        language: language.to_owned(),
+                        callee_form: Some(callee_form),
+                        evidence_kind,
+                        counts,
+                    });
+                }
+            }
+        }
+    }
+    debug_assert!(linear_rows.is_empty());
     result
 }
 
@@ -16829,7 +17165,11 @@ mod ruby_php_complexity_tests {
                 rust_uses: Vec::new(),
                 go_package: None,
                 java_kotlin_package: None,
-                php_namespace: (language == "php").then(|| "App".to_owned()),
+                php_namespace: if language == "php" {
+                    CachedPhpNamespace::Named("App".to_owned())
+                } else {
+                    CachedPhpNamespace::Invalid
+                },
                 c_cpp_file: None,
             },
             calls: Vec::new(),
@@ -16856,8 +17196,8 @@ mod ruby_php_complexity_tests {
             for declaration in &record.file.top_level_declarations {
                 if record.file.language == "ruby" {
                     let _ = index.ruby_function(&declaration.name, declaration.declaration);
-                } else if let Some(namespace) = record.file.php_namespace.as_deref() {
-                    let _ = index.resolve("php", namespace, None, &declaration.name);
+                } else {
+                    let _ = index.resolve_php(&record.file.php_namespace, None, &declaration.name);
                 }
             }
         }
@@ -17078,7 +17418,7 @@ mod rust_complexity_tests {
                 rust_uses: imports,
                 go_package: None,
                 java_kotlin_package: None,
-                php_namespace: None,
+                php_namespace: CachedPhpNamespace::Invalid,
                 c_cpp_file: None,
             },
             calls: Vec::new(),
@@ -17490,7 +17830,7 @@ mod go_complexity_tests {
                         methods: Vec::new(),
                     }),
                     java_kotlin_package: None,
-                    php_namespace: None,
+                    php_namespace: CachedPhpNamespace::Invalid,
                     c_cpp_file: None,
                 },
                 calls: Vec::new(),
@@ -17624,7 +17964,7 @@ mod python_complexity_tests {
                 rust_uses: Vec::new(),
                 go_package: None,
                 java_kotlin_package: None,
-                php_namespace: None,
+                php_namespace: CachedPhpNamespace::Invalid,
                 c_cpp_file: None,
             },
             calls: Vec::new(),

--- a/crates/codestory-indexer/src/proof_resolution.rs
+++ b/crates/codestory-indexer/src/proof_resolution.rs
@@ -32,6 +32,7 @@ thread_local! {
     static PYTHON_RESOLUTION_WORK: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
     static JAVA_KOTLIN_RESOLUTION_WORK: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
     static C_CPP_RESOLUTION_WORK: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static RUBY_PHP_RESOLUTION_WORK: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
 
 #[inline]
@@ -124,6 +125,24 @@ fn c_cpp_resolution_work() -> usize {
     C_CPP_RESOLUTION_WORK.with(std::cell::Cell::get)
 }
 
+#[inline]
+fn count_ruby_php_resolution_work(amount: usize) {
+    #[cfg(test)]
+    RUBY_PHP_RESOLUTION_WORK.with(|work| work.set(work.get().saturating_add(amount)));
+    #[cfg(not(test))]
+    let _ = amount;
+}
+
+#[cfg(test)]
+fn reset_ruby_php_resolution_work() {
+    RUBY_PHP_RESOLUTION_WORK.with(|work| work.set(0));
+}
+
+#[cfg(test)]
+fn ruby_php_resolution_work() -> usize {
+    RUBY_PHP_RESOLUTION_WORK.with(std::cell::Cell::get)
+}
+
 const ADAPTER_VERSION: &str = "reference-v15";
 const GO_ADAPTER_VERSION: &str = "reference-v19";
 const PYTHON_ADAPTER_VERSION: &str = "reference-v17";
@@ -133,7 +152,9 @@ const JAVA_ADAPTER_VERSION: &str = "reference-v2";
 const KOTLIN_ADAPTER_VERSION: &str = "reference-v2";
 const C_ADAPTER_VERSION: &str = "reference-v2";
 const CPP_ADAPTER_VERSION: &str = "reference-v3";
-const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 21;
+const RUBY_ADAPTER_VERSION: &str = "reference-v1";
+const PHP_ADAPTER_VERSION: &str = "reference-v1";
+const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 22;
 const INSTALLED_ADAPTERS: &[(&str, &str)] = &[
     ("go", GO_ADAPTER_VERSION),
     ("javascript", ADAPTER_VERSION),
@@ -142,6 +163,8 @@ const INSTALLED_ADAPTERS: &[(&str, &str)] = &[
     ("java", JAVA_ADAPTER_VERSION),
     ("kotlin", KOTLIN_ADAPTER_VERSION),
     ("python", PYTHON_ADAPTER_VERSION),
+    ("php", PHP_ADAPTER_VERSION),
+    ("ruby", RUBY_ADAPTER_VERSION),
     ("rust", RUST_ADAPTER_VERSION),
     ("tsx", TYPESCRIPT_ADAPTER_VERSION),
     ("typescript", TYPESCRIPT_ADAPTER_VERSION),
@@ -202,6 +225,10 @@ pub(crate) fn collect_call_resolution_inputs(
         .then(|| JavaKotlinResolutionIndex::build(tree, source, language, file_id, nodes));
     let c_cpp_index = is_c_cpp_language(language)
         .then(|| CCppResolutionIndex::build(tree, source, source_path, language, file_id, nodes));
+    let ruby_index =
+        (language == "ruby").then(|| RubyResolutionIndex::build(tree, source, file_id, nodes));
+    let php_index =
+        (language == "php").then(|| PhpResolutionIndex::build(tree, source, file_id, nodes));
     let (direct_exports, export_poison_all, poisoned_export_names) =
         if let Some(index) = &javascript_index {
             index.collect_direct_exports(source)
@@ -213,6 +240,10 @@ pub(crate) fn collect_call_resolution_inputs(
             )
         } else if let Some(index) = &java_kotlin_index {
             (Vec::new(), index.has_annotated_declaration, Vec::new())
+        } else if let Some(index) = &ruby_index {
+            (index.direct_exports.clone(), index.poisoned, Vec::new())
+        } else if let Some(index) = &php_index {
+            (Vec::new(), index.poisoned, Vec::new())
         } else {
             (Vec::new(), false, Vec::new())
         };
@@ -230,6 +261,10 @@ pub(crate) fn collect_call_resolution_inputs(
     } else if let Some(index) = &java_kotlin_index {
         index.declarations.clone()
     } else if let Some(index) = &c_cpp_index {
+        index.declarations.clone()
+    } else if let Some(index) = &ruby_index {
+        index.declarations.clone()
+    } else if let Some(index) = &php_index {
         index.declarations.clone()
     } else {
         Vec::new()
@@ -263,6 +298,10 @@ pub(crate) fn collect_call_resolution_inputs(
             } else if let Some(index) = &java_kotlin_index {
                 index.resolve_syntax_claim(source, callee, form, &raw_target)
             } else if let Some(index) = &c_cpp_index {
+                index.resolve_syntax_claim(callee, form, &raw_target)
+            } else if let Some(index) = &ruby_index {
+                index.resolve_syntax_claim(callee, form, &raw_target)
+            } else if let Some(index) = &php_index {
                 index.resolve_syntax_claim(callee, form, &raw_target)
             } else {
                 (None, CachedResolutionBinding::Unsupported)
@@ -335,6 +374,14 @@ pub(crate) fn collect_call_resolution_inputs(
         for call in &index.calls {
             emit_call(call.callee, call.form, call.raw_target.clone(), None);
         }
+    } else if let Some(index) = &ruby_index {
+        for call in &index.calls {
+            emit_call(call.callee, call.form, call.raw_target.clone(), None);
+        }
+    } else if let Some(index) = &php_index {
+        for call in &index.calls {
+            emit_call(call.callee, call.form, call.raw_target.clone(), None);
+        }
     } else {
         collect_calls(tree.root_node(), source, &mut |callee, form, raw_target| {
             emit_call(callee, form, raw_target, None);
@@ -372,9 +419,21 @@ pub(crate) fn collect_call_resolution_inputs(
                         || {
                             java_kotlin_index.as_ref().map_or_else(
                                 || {
-                                    c_cpp_index
-                                        .as_ref()
-                                        .map_or_else(Vec::new, |index| index.classes.clone())
+                                    c_cpp_index.as_ref().map_or_else(
+                                        || {
+                                            ruby_index.as_ref().map_or_else(
+                                                || {
+                                                    php_index
+                                                        .as_ref()
+                                                        .map_or_else(Vec::new, |index| {
+                                                            index.classes.clone()
+                                                        })
+                                                },
+                                                |index| index.classes.clone(),
+                                            )
+                                        },
+                                        |index| index.classes.clone(),
+                                    )
                                 },
                                 |index| index.classes.clone(),
                             )
@@ -400,6 +459,7 @@ pub(crate) fn collect_call_resolution_inputs(
             java_kotlin_package: java_kotlin_index
                 .as_ref()
                 .and_then(|index| index.package_name.clone()),
+            php_namespace: php_index.as_ref().and_then(|index| index.namespace.clone()),
             c_cpp_file: c_cpp_index.as_ref().map(|index| CachedCCppFile {
                 source_path: source_path.to_path_buf(),
                 source_role: index.source_role,
@@ -425,6 +485,1289 @@ fn is_java_kotlin_language(language: &str) -> bool {
 
 fn is_c_cpp_language(language: &str) -> bool {
     matches!(language, "c" | "cpp")
+}
+
+#[derive(Clone)]
+struct IndexedRubyPhpCall<'tree> {
+    callee: TsNode<'tree>,
+    form: CalleeForm,
+    raw_target: String,
+    caller: Option<NodeId>,
+    binding: CachedResolutionBinding,
+}
+
+type RubyPhpGraphDeclarations = HashMap<(u32, String, NodeKind), Vec<NodeId>>;
+type RubyPhpGraphImports = HashMap<(u32, NodeKind), Vec<NodeId>>;
+
+fn ruby_php_graph_maps(
+    nodes: &[Node],
+    file_id: NodeId,
+) -> (RubyPhpGraphDeclarations, RubyPhpGraphImports) {
+    let mut declarations = HashMap::new();
+    let mut imports = HashMap::new();
+    for node in nodes
+        .iter()
+        .filter(|node| node.file_node_id == Some(file_id))
+    {
+        count_ruby_php_resolution_work(1);
+        let Some(line) = node.start_line else {
+            continue;
+        };
+        declarations
+            .entry((
+                line,
+                graph_leaf_name(&node.serialized_name).to_string(),
+                node.kind,
+            ))
+            .or_insert_with(Vec::new)
+            .push(node.id);
+        count_ruby_php_resolution_work(1);
+        if matches!(node.kind, NodeKind::MODULE | NodeKind::UNKNOWN) {
+            imports
+                .entry((line, node.kind))
+                .or_insert_with(Vec::new)
+                .push(node.id);
+            count_ruby_php_resolution_work(1);
+        }
+    }
+    (declarations, imports)
+}
+
+fn unique_graph_declaration(
+    declarations: &RubyPhpGraphDeclarations,
+    line: u32,
+    name: &str,
+    kinds: &[NodeKind],
+) -> Option<NodeId> {
+    count_ruby_php_resolution_work(kinds.len());
+    let matches = kinds
+        .iter()
+        .flat_map(|kind| {
+            declarations
+                .get(&(line, name.to_string(), *kind))
+                .into_iter()
+                .flatten()
+                .copied()
+        })
+        .collect::<Vec<_>>();
+    matches.first().copied().filter(|_| matches.len() == 1)
+}
+
+fn unique_import_node(
+    imports: &HashMap<(u32, NodeKind), Vec<NodeId>>,
+    line: u32,
+) -> Option<NodeId> {
+    for kind in [NodeKind::MODULE, NodeKind::UNKNOWN] {
+        count_ruby_php_resolution_work(1);
+        let matches = imports
+            .get(&(line, kind))
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        if let [node] = matches {
+            return Some(*node);
+        }
+        if !matches.is_empty() {
+            return None;
+        }
+    }
+    None
+}
+
+struct RubyResolutionIndex<'tree> {
+    calls: Vec<IndexedRubyPhpCall<'tree>>,
+    call_indices_by_span: HashMap<(usize, usize), usize>,
+    declarations: Vec<CachedTopLevelDeclaration>,
+    classes: Vec<CachedClassDeclaration>,
+    direct_exports: Vec<CachedDirectExport>,
+    declarations_by_name: HashMap<String, Vec<NodeId>>,
+    classes_by_name: HashMap<String, Vec<usize>>,
+    methods_by_owner_and_name: HashMap<(usize, String), Vec<NodeId>>,
+    poisoned: bool,
+}
+
+#[derive(Clone)]
+enum RubyReceiverBinding {
+    Exact {
+        owner_name: String,
+        constructor: bool,
+    },
+    Ambiguous,
+}
+
+impl<'tree> RubyResolutionIndex<'tree> {
+    fn build(tree: &'tree Tree, source: &str, file_id: NodeId, nodes: &[Node]) -> Self {
+        let (graph_declarations, graph_imports) = ruby_php_graph_maps(nodes, file_id);
+        let mut index = Self {
+            calls: Vec::new(),
+            call_indices_by_span: HashMap::new(),
+            declarations: Vec::new(),
+            classes: Vec::new(),
+            direct_exports: Vec::new(),
+            declarations_by_name: HashMap::new(),
+            classes_by_name: HashMap::new(),
+            methods_by_owner_and_name: HashMap::new(),
+            poisoned: false,
+        };
+        let mut producer = RubyResolutionProducer {
+            index: &mut index,
+            source,
+            graph_declarations,
+            graph_imports,
+            class_indices: HashMap::new(),
+            bindings: HashMap::new(),
+            require_relative: None,
+        };
+        producer.visit(tree.root_node(), None, None);
+        for class_indices in producer.class_indices.values() {
+            if class_indices.len() != 1 {
+                producer.index.poisoned = true;
+            }
+        }
+        for call in &mut producer.index.calls {
+            if call.form != CalleeForm::Identifier
+                || !matches!(call.binding, CachedResolutionBinding::MissingBinding)
+            {
+                continue;
+            }
+            count_ruby_php_resolution_work(1);
+            let candidates = producer
+                .index
+                .declarations_by_name
+                .get(&call.raw_target)
+                .map(Vec::as_slice)
+                .unwrap_or_default();
+            call.binding = match candidates {
+                [declaration] => CachedResolutionBinding::SameFile {
+                    declaration: *declaration,
+                    rust_glob_local_module: None,
+                },
+                [] => CachedResolutionBinding::MissingBinding,
+                _ => CachedResolutionBinding::Ambiguous,
+            };
+        }
+        debug_assert!(producer.index.calls.windows(2).all(|pair| {
+            (pair[0].callee.start_byte(), pair[0].callee.end_byte())
+                <= (pair[1].callee.start_byte(), pair[1].callee.end_byte())
+        }));
+        for (call_index, call) in producer.index.calls.iter().enumerate() {
+            count_ruby_php_resolution_work(1);
+            producer.index.call_indices_by_span.insert(
+                (call.callee.start_byte(), call.callee.end_byte()),
+                call_index,
+            );
+        }
+        index
+    }
+
+    fn resolve_syntax_claim(
+        &self,
+        callee: TsNode<'tree>,
+        form: CalleeForm,
+        raw_target: &str,
+    ) -> (Option<NodeId>, CachedResolutionBinding) {
+        count_ruby_php_resolution_work(1);
+        let Some(call) = self
+            .call_indices_by_span
+            .get(&(callee.start_byte(), callee.end_byte()))
+            .and_then(|index| self.calls.get(*index))
+        else {
+            return (None, CachedResolutionBinding::Unsupported);
+        };
+        if self.poisoned || call.form != form || call.raw_target != raw_target {
+            return (call.caller, CachedResolutionBinding::Unsupported);
+        }
+        (call.caller, call.binding.clone())
+    }
+}
+
+struct RubyResolutionProducer<'index, 'tree> {
+    index: &'index mut RubyResolutionIndex<'tree>,
+    source: &'index str,
+    graph_declarations: RubyPhpGraphDeclarations,
+    graph_imports: HashMap<(u32, NodeKind), Vec<NodeId>>,
+    class_indices: HashMap<String, Vec<usize>>,
+    bindings: HashMap<(NodeId, String), RubyReceiverBinding>,
+    require_relative: Option<(String, NodeId)>,
+}
+
+impl<'index, 'tree> RubyResolutionProducer<'index, 'tree> {
+    fn visit(
+        &mut self,
+        node: TsNode<'tree>,
+        mut caller: Option<NodeId>,
+        mut owner_index: Option<usize>,
+    ) {
+        count_ruby_php_resolution_work(1);
+        if node.kind() == "class" {
+            let Some(name) = declaration_name(node, self.source).map(str::to_string) else {
+                self.index.poisoned = true;
+                return;
+            };
+            let Some(declaration) = unique_graph_declaration(
+                &self.graph_declarations,
+                node.start_position().row as u32 + 1,
+                &name,
+                &[NodeKind::CLASS],
+            ) else {
+                self.index.poisoned = true;
+                return;
+            };
+            owner_index = Some(self.index.classes.len());
+            self.index.classes.push(CachedClassDeclaration {
+                name: name.clone(),
+                declaration,
+                methods: Vec::new(),
+            });
+            self.index.direct_exports.push(CachedDirectExport {
+                exported_name: name.clone(),
+                declaration,
+                is_default: false,
+                declaration_kind: CachedDeclarationKind::Class,
+            });
+            self.class_indices
+                .entry(name)
+                .or_default()
+                .push(owner_index.expect("Ruby class index"));
+            count_ruby_php_resolution_work(1);
+            count_ruby_php_resolution_work(1);
+            self.index
+                .classes_by_name
+                .entry(
+                    self.index.classes[owner_index.expect("Ruby class index")]
+                        .name
+                        .clone(),
+                )
+                .or_default()
+                .push(owner_index.expect("Ruby class index"));
+        } else if matches!(node.kind(), "module" | "singleton_method") {
+            self.index.poisoned = true;
+        }
+
+        if node.kind() == "method" {
+            let Some(name) = declaration_name(node, self.source).map(str::to_string) else {
+                self.index.poisoned = true;
+                return;
+            };
+            let Some(declaration) = unique_graph_declaration(
+                &self.graph_declarations,
+                node.start_position().row as u32 + 1,
+                &name,
+                &[NodeKind::FUNCTION, NodeKind::METHOD],
+            ) else {
+                self.index.poisoned = true;
+                return;
+            };
+            caller = Some(declaration);
+            if let Some(owner_index) = owner_index {
+                self.index.classes[owner_index]
+                    .methods
+                    .push(CachedClassMethod {
+                        name: name.clone(),
+                        declaration,
+                    });
+                count_ruby_php_resolution_work(1);
+                self.index
+                    .methods_by_owner_and_name
+                    .entry((owner_index, name))
+                    .or_default()
+                    .push(declaration);
+            } else {
+                self.index.declarations.push(CachedTopLevelDeclaration {
+                    name: name.clone(),
+                    declaration,
+                    module_path: Vec::new(),
+                    cross_module_visible: false,
+                });
+                self.index.direct_exports.push(CachedDirectExport {
+                    exported_name: name,
+                    declaration,
+                    is_default: false,
+                    declaration_kind: CachedDeclarationKind::Callable,
+                });
+                count_ruby_php_resolution_work(1);
+                self.index
+                    .declarations_by_name
+                    .entry(
+                        self.index
+                            .declarations
+                            .last()
+                            .expect("Ruby declaration")
+                            .name
+                            .clone(),
+                    )
+                    .or_default()
+                    .push(declaration);
+            }
+        }
+
+        self.observe_poison(node);
+        if node.kind() == "assignment" {
+            self.observe_assignment(node, caller);
+        }
+        if node.kind() == "call" {
+            self.observe_call(node, caller, owner_index);
+        } else if matches!(node.kind(), "identifier" | "constant")
+            && crate::is_ruby_bare_call_site(node)
+            && caller.is_some()
+        {
+            let raw_target = node_text(node, self.source).unwrap_or_default().to_string();
+            let binding = self.same_file_function_binding(&raw_target);
+            self.push_call(node, CalleeForm::Identifier, raw_target, caller, binding);
+        }
+
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            self.visit(child, caller, owner_index);
+        }
+    }
+
+    fn observe_poison(&mut self, node: TsNode<'_>) {
+        if node.kind() == "comment"
+            && node_text(node, self.source).is_some_and(|comment| {
+                let comment = comment.to_ascii_lowercase();
+                comment.contains("@generated") || comment.contains("do not edit")
+            })
+        {
+            self.index.poisoned = true;
+        }
+        if matches!(node.kind(), "alias" | "undef" | "singleton_class") {
+            self.index.poisoned = true;
+        }
+        if node.kind() != "call" {
+            return;
+        }
+        let method = node
+            .child_by_field_name("method")
+            .and_then(|method| node_text(method, self.source))
+            .unwrap_or_default();
+        if matches!(
+            method,
+            "define_method"
+                | "include"
+                | "extend"
+                | "prepend"
+                | "send"
+                | "public_send"
+                | "class_eval"
+                | "module_eval"
+                | "method_missing"
+        ) {
+            self.index.poisoned = true;
+        }
+        if method == "require_relative" {
+            let line = node.start_position().row as u32 + 1;
+            let literal =
+                ruby_literal_require_relative(node_text(node, self.source).unwrap_or_default());
+            let import = unique_import_node(&self.graph_imports, line);
+            match (literal, import, self.require_relative.is_none()) {
+                (Some(module), Some(import), true) => {
+                    self.require_relative = Some((module, import))
+                }
+                _ => self.index.poisoned = true,
+            }
+        }
+    }
+
+    fn observe_assignment(&mut self, node: TsNode<'_>, caller: Option<NodeId>) {
+        let (Some(caller), Some(left), Some(right)) = (
+            caller,
+            node.child_by_field_name("left"),
+            node.child_by_field_name("right"),
+        ) else {
+            return;
+        };
+        let Some(name) = node_text(left, self.source)
+            .map(str::trim)
+            .map(str::to_string)
+        else {
+            return;
+        };
+        if name.starts_with(|ch: char| ch.is_ascii_uppercase()) {
+            self.index.poisoned = true;
+            return;
+        }
+        let binding = ruby_constructor_owner(right, self.source)
+            .map(|owner_name| RubyReceiverBinding::Exact {
+                owner_name,
+                constructor: true,
+            })
+            .unwrap_or(RubyReceiverBinding::Ambiguous);
+        let key = (caller, name);
+        self.bindings
+            .entry(key)
+            .and_modify(|existing| *existing = RubyReceiverBinding::Ambiguous)
+            .or_insert(binding);
+        count_ruby_php_resolution_work(1);
+    }
+
+    fn observe_call(
+        &mut self,
+        node: TsNode<'tree>,
+        caller: Option<NodeId>,
+        owner_index: Option<usize>,
+    ) {
+        let Some(method) = node.child_by_field_name("method") else {
+            return;
+        };
+        let raw_target = node_text(method, self.source)
+            .unwrap_or_default()
+            .to_string();
+        if raw_target == "new" || raw_target == "require_relative" {
+            return;
+        }
+        let Some(receiver) = node.child_by_field_name("receiver") else {
+            if caller.is_some() {
+                let binding = self.same_file_function_binding(&raw_target);
+                self.push_call(method, CalleeForm::Identifier, raw_target, caller, binding);
+            }
+            return;
+        };
+        let receiver_surface = node_text(receiver, self.source).unwrap_or_default().trim();
+        let (form, binding) = if receiver.kind() == "self" {
+            let binding = owner_index
+                .and_then(|owner| self.implicit_method_binding(owner, &raw_target))
+                .unwrap_or(CachedResolutionBinding::MissingBinding);
+            (CalleeForm::ImplicitReceiver, binding)
+        } else if let Some(owner_name) = ruby_constructor_owner(receiver, self.source) {
+            (
+                CalleeForm::ExplicitReceiver,
+                self.receiver_binding(&owner_name, &raw_target, true),
+            )
+        } else {
+            let binding = caller
+                .and_then(|caller| {
+                    count_ruby_php_resolution_work(1);
+                    self.bindings
+                        .get(&(caller, receiver_surface.to_string()))
+                        .cloned()
+                })
+                .map(|binding| match binding {
+                    RubyReceiverBinding::Exact {
+                        owner_name,
+                        constructor,
+                    } => self.receiver_binding(&owner_name, &raw_target, constructor),
+                    RubyReceiverBinding::Ambiguous => CachedResolutionBinding::Ambiguous,
+                })
+                .unwrap_or(CachedResolutionBinding::Unsupported);
+            (CalleeForm::ExplicitReceiver, binding)
+        };
+        self.push_call(method, form, raw_target, caller, binding);
+    }
+
+    fn same_file_function_binding(&self, name: &str) -> CachedResolutionBinding {
+        count_ruby_php_resolution_work(1);
+        let candidates = self
+            .index
+            .declarations_by_name
+            .get(name)
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        match candidates {
+            [declaration] => CachedResolutionBinding::SameFile {
+                declaration: *declaration,
+                rust_glob_local_module: None,
+            },
+            [] => CachedResolutionBinding::MissingBinding,
+            _ => CachedResolutionBinding::Ambiguous,
+        }
+    }
+
+    fn implicit_method_binding(
+        &self,
+        owner_index: usize,
+        method_name: &str,
+    ) -> Option<CachedResolutionBinding> {
+        let class = self.index.classes.get(owner_index)?;
+        count_ruby_php_resolution_work(1);
+        let methods = self
+            .index
+            .methods_by_owner_and_name
+            .get(&(owner_index, method_name.to_string()))
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        match methods {
+            [method] => Some(CachedResolutionBinding::ImplicitReceiver {
+                owner: class.declaration,
+                declaration: *method,
+                owner_name: class.name.clone(),
+            }),
+            [] => None,
+            _ => Some(CachedResolutionBinding::Ambiguous),
+        }
+    }
+
+    fn receiver_binding(
+        &self,
+        owner_name: &str,
+        method_name: &str,
+        constructor: bool,
+    ) -> CachedResolutionBinding {
+        count_ruby_php_resolution_work(1);
+        let classes = self
+            .index
+            .classes_by_name
+            .get(owner_name)
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        let class_binding = match classes {
+            [class_index] => CachedClassBinding::SameFile {
+                owner: self.index.classes[*class_index].declaration,
+                owner_name: owner_name.to_string(),
+            },
+            [] => {
+                let Some((module_specifier, import)) = &self.require_relative else {
+                    return CachedResolutionBinding::MissingBinding;
+                };
+                CachedClassBinding::StaticImport {
+                    import: *import,
+                    module_specifier: module_specifier.clone(),
+                    imported_name: owner_name.to_string(),
+                    is_default: false,
+                }
+            }
+            _ => return CachedResolutionBinding::Ambiguous,
+        };
+        if constructor {
+            CachedResolutionBinding::ConstructorBinding {
+                class_binding,
+                method_name: method_name.to_string(),
+            }
+        } else {
+            CachedResolutionBinding::ExplicitReceiverType {
+                class_binding,
+                method_name: method_name.to_string(),
+            }
+        }
+    }
+
+    fn push_call(
+        &mut self,
+        callee: TsNode<'tree>,
+        form: CalleeForm,
+        raw_target: String,
+        caller: Option<NodeId>,
+        binding: CachedResolutionBinding,
+    ) {
+        self.index.calls.push(IndexedRubyPhpCall {
+            callee,
+            form,
+            raw_target,
+            caller,
+            binding,
+        });
+        count_ruby_php_resolution_work(1);
+    }
+}
+
+fn ruby_literal_require_relative(surface: &str) -> Option<String> {
+    let rest = surface.trim().strip_prefix("require_relative")?.trim();
+    let rest = rest.trim_start_matches('(').trim_end_matches(')').trim();
+    let quote = rest.as_bytes().first().copied()?;
+    if !matches!(quote, b'\'' | b'"') || rest.as_bytes().last().copied() != Some(quote) {
+        return None;
+    }
+    let value = rest.get(1..rest.len().checked_sub(1)?)?;
+    if value.is_empty() || value.contains(['\0', '\n', '\r']) || value.contains("#{") {
+        return None;
+    }
+    Some(if value.starts_with("./") || value.starts_with("../") {
+        value.to_string()
+    } else {
+        format!("./{value}")
+    })
+}
+
+fn ruby_constructor_owner(node: TsNode<'_>, source: &str) -> Option<String> {
+    if node.kind() != "call" {
+        return None;
+    }
+    let method = node.child_by_field_name("method")?;
+    (node_text(method, source)?.trim() == "new").then_some(())?;
+    let receiver = node.child_by_field_name("receiver")?;
+    let owner = node_text(receiver, source)?.trim();
+    (!owner.is_empty()
+        && owner.split("::").all(|part| {
+            part.chars()
+                .all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+        }))
+    .then(|| owner.rsplit("::").next().unwrap_or(owner).to_string())
+}
+
+#[derive(Clone)]
+enum PhpImportBinding {
+    Function {
+        namespace: String,
+        name: String,
+        import: NodeId,
+    },
+    Type {
+        namespace: String,
+        name: String,
+        import: NodeId,
+    },
+    Ambiguous,
+}
+
+#[derive(Clone)]
+enum PhpReceiverBinding {
+    Exact {
+        owner_name: String,
+        constructor: bool,
+    },
+    Ambiguous,
+}
+
+struct PhpResolutionIndex<'tree> {
+    calls: Vec<IndexedRubyPhpCall<'tree>>,
+    call_indices_by_span: HashMap<(usize, usize), usize>,
+    declarations: Vec<CachedTopLevelDeclaration>,
+    classes: Vec<CachedClassDeclaration>,
+    declarations_by_name: HashMap<String, Vec<NodeId>>,
+    classes_by_name: HashMap<String, Vec<usize>>,
+    methods_by_owner_and_name: HashMap<(usize, String), Vec<NodeId>>,
+    namespace: Option<String>,
+    poisoned: bool,
+}
+
+impl<'tree> PhpResolutionIndex<'tree> {
+    fn build(tree: &'tree Tree, source: &str, file_id: NodeId, nodes: &[Node]) -> Self {
+        let (graph_declarations, graph_imports) = ruby_php_graph_maps(nodes, file_id);
+        let namespace = php_unique_namespace(tree.root_node(), source);
+        let namespace_declarations = tree
+            .root_node()
+            .named_children(&mut tree.root_node().walk())
+            .filter(|node| node.kind() == "namespace_definition")
+            .count();
+        let mut index = Self {
+            calls: Vec::new(),
+            call_indices_by_span: HashMap::new(),
+            declarations: Vec::new(),
+            classes: Vec::new(),
+            declarations_by_name: HashMap::new(),
+            classes_by_name: HashMap::new(),
+            methods_by_owner_and_name: HashMap::new(),
+            namespace,
+            poisoned: namespace_declarations > 1,
+        };
+        let mut producer = PhpResolutionProducer {
+            index: &mut index,
+            source,
+            graph_declarations,
+            graph_imports,
+            class_indices: HashMap::new(),
+            imports: HashMap::new(),
+            bindings: HashMap::new(),
+        };
+        producer.visit(tree.root_node(), None, None);
+        if producer
+            .class_indices
+            .values()
+            .any(|indices| indices.len() != 1)
+        {
+            producer.index.poisoned = true;
+        }
+        for call in &mut producer.index.calls {
+            if call.form != CalleeForm::Identifier
+                || !matches!(call.binding, CachedResolutionBinding::MissingBinding)
+            {
+                continue;
+            }
+            count_ruby_php_resolution_work(1);
+            let candidates = producer
+                .index
+                .declarations_by_name
+                .get(&call.raw_target)
+                .map(Vec::as_slice)
+                .unwrap_or_default();
+            call.binding = match candidates {
+                [declaration] => CachedResolutionBinding::SameFile {
+                    declaration: *declaration,
+                    rust_glob_local_module: None,
+                },
+                [] => CachedResolutionBinding::MissingBinding,
+                _ => CachedResolutionBinding::Ambiguous,
+            };
+        }
+        debug_assert!(producer.index.calls.windows(2).all(|pair| {
+            (pair[0].callee.start_byte(), pair[0].callee.end_byte())
+                <= (pair[1].callee.start_byte(), pair[1].callee.end_byte())
+        }));
+        for (call_index, call) in producer.index.calls.iter().enumerate() {
+            count_ruby_php_resolution_work(1);
+            producer.index.call_indices_by_span.insert(
+                (call.callee.start_byte(), call.callee.end_byte()),
+                call_index,
+            );
+        }
+        index
+    }
+
+    fn resolve_syntax_claim(
+        &self,
+        callee: TsNode<'tree>,
+        form: CalleeForm,
+        raw_target: &str,
+    ) -> (Option<NodeId>, CachedResolutionBinding) {
+        count_ruby_php_resolution_work(1);
+        let Some(call) = self
+            .call_indices_by_span
+            .get(&(callee.start_byte(), callee.end_byte()))
+            .and_then(|index| self.calls.get(*index))
+        else {
+            return (None, CachedResolutionBinding::Unsupported);
+        };
+        if self.poisoned || call.form != form || call.raw_target != raw_target {
+            return (call.caller, CachedResolutionBinding::Unsupported);
+        }
+        (call.caller, call.binding.clone())
+    }
+}
+
+struct PhpResolutionProducer<'index, 'tree> {
+    index: &'index mut PhpResolutionIndex<'tree>,
+    source: &'index str,
+    graph_declarations: RubyPhpGraphDeclarations,
+    graph_imports: HashMap<(u32, NodeKind), Vec<NodeId>>,
+    class_indices: HashMap<String, Vec<usize>>,
+    imports: HashMap<String, PhpImportBinding>,
+    bindings: HashMap<(NodeId, String), PhpReceiverBinding>,
+}
+
+impl<'index, 'tree> PhpResolutionProducer<'index, 'tree> {
+    fn visit(
+        &mut self,
+        node: TsNode<'tree>,
+        mut caller: Option<NodeId>,
+        mut owner_index: Option<usize>,
+    ) {
+        count_ruby_php_resolution_work(1);
+        if node.kind() == "namespace_use_declaration" {
+            self.observe_import(node);
+        }
+        if matches!(node.kind(), "interface_declaration" | "trait_declaration") {
+            self.index.poisoned = true;
+        }
+        if node.kind() == "class_declaration" {
+            let Some(name) = declaration_name(node, self.source).map(str::to_string) else {
+                self.index.poisoned = true;
+                return;
+            };
+            let Some(declaration) = unique_graph_declaration(
+                &self.graph_declarations,
+                node.start_position().row as u32 + 1,
+                &name,
+                &[NodeKind::CLASS],
+            ) else {
+                self.index.poisoned = true;
+                return;
+            };
+            owner_index = Some(self.index.classes.len());
+            self.index.classes.push(CachedClassDeclaration {
+                name: name.clone(),
+                declaration,
+                methods: Vec::new(),
+            });
+            self.class_indices
+                .entry(name.clone())
+                .or_default()
+                .push(owner_index.expect("PHP class index"));
+            count_ruby_php_resolution_work(1);
+            count_ruby_php_resolution_work(1);
+            self.index
+                .classes_by_name
+                .entry(name)
+                .or_default()
+                .push(owner_index.expect("PHP class index"));
+        }
+        if matches!(node.kind(), "function_definition" | "method_declaration") {
+            let Some(name) = declaration_name(node, self.source).map(str::to_string) else {
+                self.index.poisoned = true;
+                return;
+            };
+            let Some(declaration) = unique_graph_declaration(
+                &self.graph_declarations,
+                node.start_position().row as u32 + 1,
+                &name,
+                &[NodeKind::FUNCTION, NodeKind::METHOD],
+            ) else {
+                self.index.poisoned = true;
+                return;
+            };
+            caller = Some(declaration);
+            if let Some(owner_index) = owner_index {
+                self.index.classes[owner_index]
+                    .methods
+                    .push(CachedClassMethod {
+                        name: name.clone(),
+                        declaration,
+                    });
+                count_ruby_php_resolution_work(1);
+                self.index
+                    .methods_by_owner_and_name
+                    .entry((owner_index, name))
+                    .or_default()
+                    .push(declaration);
+            } else {
+                self.index.declarations.push(CachedTopLevelDeclaration {
+                    name: name.clone(),
+                    declaration,
+                    module_path: Vec::new(),
+                    cross_module_visible: true,
+                });
+                count_ruby_php_resolution_work(1);
+                self.index
+                    .declarations_by_name
+                    .entry(name)
+                    .or_default()
+                    .push(declaration);
+            }
+            self.observe_parameters(node, declaration);
+        }
+
+        self.observe_poison(node);
+        if node.kind() == "assignment_expression" {
+            self.observe_assignment(node, caller);
+        }
+        match node.kind() {
+            "function_call_expression" => self.observe_function_call(node, caller),
+            "member_call_expression" | "nullsafe_member_call_expression" => {
+                self.observe_member_call(node, caller, owner_index)
+            }
+            "scoped_call_expression" => {
+                let callee = node.child_by_field_name("name").unwrap_or(node);
+                let raw_target = node_text(callee, self.source)
+                    .unwrap_or_default()
+                    .to_string();
+                self.push_call(
+                    callee,
+                    CalleeForm::DynamicAccess,
+                    raw_target,
+                    caller,
+                    CachedResolutionBinding::Unsupported,
+                );
+            }
+            _ => {}
+        }
+
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            self.visit(child, caller, owner_index);
+        }
+    }
+
+    fn observe_import(&mut self, node: TsNode<'_>) {
+        let Some(surface) = node_text(node, self.source) else {
+            self.index.poisoned = true;
+            return;
+        };
+        let Some(binding) = php_use_binding(
+            surface,
+            unique_import_node(&self.graph_imports, node.start_position().row as u32 + 1),
+        ) else {
+            self.index.poisoned = true;
+            return;
+        };
+        let local_name = match &binding {
+            PhpImportBinding::Function { name, .. } | PhpImportBinding::Type { name, .. } => {
+                php_use_local_name(surface).unwrap_or_else(|| name.clone())
+            }
+            PhpImportBinding::Ambiguous => return,
+        };
+        self.imports
+            .entry(local_name)
+            .and_modify(|existing| *existing = PhpImportBinding::Ambiguous)
+            .or_insert(binding);
+        count_ruby_php_resolution_work(1);
+    }
+
+    fn observe_parameters(&mut self, callable: TsNode<'_>, caller: NodeId) {
+        let Some(parameters) = callable.child_by_field_name("parameters") else {
+            return;
+        };
+        let mut cursor = parameters.walk();
+        for parameter in parameters.named_children(&mut cursor) {
+            let Some(type_node) = parameter.child_by_field_name("type") else {
+                continue;
+            };
+            let Some(name_node) = parameter.child_by_field_name("name") else {
+                continue;
+            };
+            let Some(owner_name) =
+                php_simple_type(node_text(type_node, self.source).unwrap_or_default())
+            else {
+                self.index.poisoned = true;
+                continue;
+            };
+            let name = node_text(name_node, self.source)
+                .unwrap_or_default()
+                .trim_start_matches('$')
+                .to_string();
+            self.bindings.insert(
+                (caller, name),
+                PhpReceiverBinding::Exact {
+                    owner_name,
+                    constructor: false,
+                },
+            );
+            count_ruby_php_resolution_work(1);
+        }
+    }
+
+    fn observe_assignment(&mut self, node: TsNode<'_>, caller: Option<NodeId>) {
+        let (Some(caller), Some(left), Some(right)) = (
+            caller,
+            node.child_by_field_name("left"),
+            node.child_by_field_name("right"),
+        ) else {
+            return;
+        };
+        let name = node_text(left, self.source)
+            .unwrap_or_default()
+            .trim_start_matches('$')
+            .to_string();
+        let binding = php_object_creation_owner(right, self.source)
+            .map(|owner_name| PhpReceiverBinding::Exact {
+                owner_name,
+                constructor: true,
+            })
+            .unwrap_or(PhpReceiverBinding::Ambiguous);
+        self.bindings
+            .entry((caller, name))
+            .and_modify(|existing| *existing = PhpReceiverBinding::Ambiguous)
+            .or_insert(binding);
+        count_ruby_php_resolution_work(1);
+    }
+
+    fn observe_poison(&mut self, node: TsNode<'_>) {
+        if node.kind() == "comment"
+            && node_text(node, self.source).is_some_and(|comment| {
+                let comment = comment.to_ascii_lowercase();
+                comment.contains("@generated") || comment.contains("do not edit")
+            })
+        {
+            self.index.poisoned = true;
+        }
+        if matches!(
+            node.kind(),
+            "include_expression"
+                | "include_once_expression"
+                | "require_expression"
+                | "require_once_expression"
+                | "trait_use_clause"
+        ) {
+            self.index.poisoned = true;
+        }
+        if node.kind() == "method_declaration"
+            && declaration_name(node, self.source)
+                .is_some_and(|name| matches!(name, "__call" | "__callStatic" | "__get" | "__set"))
+        {
+            self.index.poisoned = true;
+        }
+        if node.kind() == "function_call_expression" {
+            let name = node
+                .child_by_field_name("function")
+                .and_then(|function| node_text(function, self.source))
+                .unwrap_or_default();
+            if matches!(name, "spl_autoload_register" | "call_user_func" | "eval") {
+                self.index.poisoned = true;
+            }
+        }
+        if node.kind() == "object_creation_expression"
+            && node
+                .named_child(0)
+                .is_some_and(|name| name.kind() == "variable_name")
+        {
+            self.index.poisoned = true;
+        }
+    }
+
+    fn observe_function_call(&mut self, node: TsNode<'tree>, caller: Option<NodeId>) {
+        let Some(callee) = node.child_by_field_name("function") else {
+            return;
+        };
+        let raw_target = node_text(callee, self.source)
+            .unwrap_or_default()
+            .to_string();
+        count_ruby_php_resolution_work(1);
+        let binding = if callee.kind() == "variable_name" {
+            CachedResolutionBinding::Unsupported
+        } else if let Some(import) = self.imports.get(&raw_target) {
+            match import {
+                PhpImportBinding::Function {
+                    namespace,
+                    name,
+                    import,
+                } => CachedResolutionBinding::JavaKotlinImportedFunction {
+                    package_name: namespace.clone(),
+                    owner_name: None,
+                    name: name.clone(),
+                    import: *import,
+                },
+                PhpImportBinding::Ambiguous => CachedResolutionBinding::Ambiguous,
+                PhpImportBinding::Type { .. } => CachedResolutionBinding::Unsupported,
+            }
+        } else {
+            count_ruby_php_resolution_work(1);
+            let candidates = self
+                .index
+                .declarations_by_name
+                .get(&raw_target)
+                .map(Vec::as_slice)
+                .unwrap_or_default();
+            match candidates {
+                [declaration] => CachedResolutionBinding::SameFile {
+                    declaration: *declaration,
+                    rust_glob_local_module: None,
+                },
+                [] => CachedResolutionBinding::MissingBinding,
+                _ => CachedResolutionBinding::Ambiguous,
+            }
+        };
+        let form = if matches!(
+            binding,
+            CachedResolutionBinding::JavaKotlinImportedFunction { .. }
+        ) {
+            CalleeForm::NamedImport
+        } else if callee.kind() == "variable_name" {
+            CalleeForm::DynamicAccess
+        } else {
+            CalleeForm::Identifier
+        };
+        self.push_call(callee, form, raw_target, caller, binding);
+    }
+
+    fn observe_member_call(
+        &mut self,
+        node: TsNode<'tree>,
+        caller: Option<NodeId>,
+        owner_index: Option<usize>,
+    ) {
+        let Some(callee) = node.child_by_field_name("name") else {
+            return;
+        };
+        let Some(object) = node.child_by_field_name("object") else {
+            return;
+        };
+        let raw_target = node_text(callee, self.source)
+            .unwrap_or_default()
+            .to_string();
+        let object_surface = node_text(object, self.source).unwrap_or_default().trim();
+        let (form, binding) = if object_surface == "$this" {
+            let binding = owner_index
+                .and_then(|owner| self.implicit_method_binding(owner, &raw_target))
+                .unwrap_or(CachedResolutionBinding::MissingBinding);
+            (CalleeForm::ImplicitReceiver, binding)
+        } else if let Some(owner_name) = php_object_creation_owner(object, self.source) {
+            (
+                CalleeForm::ExplicitReceiver,
+                self.receiver_binding(&owner_name, &raw_target, true),
+            )
+        } else if object.kind() == "variable_name" {
+            let receiver_name = object_surface.trim_start_matches('$');
+            let binding = caller
+                .and_then(|caller| {
+                    count_ruby_php_resolution_work(1);
+                    self.bindings
+                        .get(&(caller, receiver_name.to_string()))
+                        .cloned()
+                })
+                .map(|binding| match binding {
+                    PhpReceiverBinding::Exact {
+                        owner_name,
+                        constructor,
+                    } => self.receiver_binding(&owner_name, &raw_target, constructor),
+                    PhpReceiverBinding::Ambiguous => CachedResolutionBinding::Ambiguous,
+                })
+                .unwrap_or(CachedResolutionBinding::Unsupported);
+            (CalleeForm::ExplicitReceiver, binding)
+        } else {
+            (
+                CalleeForm::DynamicAccess,
+                CachedResolutionBinding::Unsupported,
+            )
+        };
+        self.push_call(callee, form, raw_target, caller, binding);
+    }
+
+    fn implicit_method_binding(
+        &self,
+        owner_index: usize,
+        method_name: &str,
+    ) -> Option<CachedResolutionBinding> {
+        let class = self.index.classes.get(owner_index)?;
+        count_ruby_php_resolution_work(1);
+        let methods = self
+            .index
+            .methods_by_owner_and_name
+            .get(&(owner_index, method_name.to_string()))
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        match methods {
+            [method] => Some(CachedResolutionBinding::ImplicitReceiver {
+                owner: class.declaration,
+                declaration: *method,
+                owner_name: class.name.clone(),
+            }),
+            [] => None,
+            _ => Some(CachedResolutionBinding::Ambiguous),
+        }
+    }
+
+    fn receiver_binding(
+        &self,
+        owner_name: &str,
+        method_name: &str,
+        constructor: bool,
+    ) -> CachedResolutionBinding {
+        count_ruby_php_resolution_work(1);
+        let classes = self
+            .index
+            .classes_by_name
+            .get(owner_name)
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        if let [class_index] = classes {
+            let class_binding = CachedClassBinding::SameFile {
+                owner: self.index.classes[*class_index].declaration,
+                owner_name: owner_name.to_string(),
+            };
+            return if constructor {
+                CachedResolutionBinding::ConstructorBinding {
+                    class_binding,
+                    method_name: method_name.to_string(),
+                }
+            } else {
+                CachedResolutionBinding::ExplicitReceiverType {
+                    class_binding,
+                    method_name: method_name.to_string(),
+                }
+            };
+        }
+        if classes.len() > 1 {
+            return CachedResolutionBinding::Ambiguous;
+        }
+        match self.imports.get(owner_name) {
+            Some(PhpImportBinding::Type {
+                namespace,
+                name,
+                import,
+            }) => CachedResolutionBinding::JavaKotlinImportedReceiver {
+                package_name: namespace.clone(),
+                owner_name: name.clone(),
+                method_name: method_name.to_string(),
+                import: *import,
+                constructor,
+            },
+            Some(PhpImportBinding::Ambiguous) => CachedResolutionBinding::Ambiguous,
+            _ => CachedResolutionBinding::MissingBinding,
+        }
+    }
+
+    fn push_call(
+        &mut self,
+        callee: TsNode<'tree>,
+        form: CalleeForm,
+        raw_target: String,
+        caller: Option<NodeId>,
+        binding: CachedResolutionBinding,
+    ) {
+        self.index.calls.push(IndexedRubyPhpCall {
+            callee,
+            form,
+            raw_target,
+            caller,
+            binding,
+        });
+        count_ruby_php_resolution_work(1);
+    }
+}
+
+fn php_unique_namespace(root: TsNode<'_>, source: &str) -> Option<String> {
+    let mut namespaces = Vec::new();
+    let mut cursor = root.walk();
+    for node in root.named_children(&mut cursor) {
+        if node.kind() == "namespace_definition" {
+            namespaces.push(declaration_name(node, source)?.replace('\\', "."));
+        }
+    }
+    namespaces.sort();
+    namespaces.dedup();
+    namespaces.pop().filter(|_| namespaces.is_empty())
+}
+
+fn php_simple_type(surface: &str) -> Option<String> {
+    let surface = surface.trim().trim_start_matches('?');
+    (!surface.is_empty()
+        && !surface.contains(['\\', '|', '&'])
+        && surface
+            .chars()
+            .all(|ch| ch == '_' || ch.is_ascii_alphanumeric()))
+    .then(|| surface.to_string())
+}
+
+fn php_object_creation_owner(node: TsNode<'_>, source: &str) -> Option<String> {
+    let mut node = node;
+    if node.kind() == "parenthesized_expression" {
+        node = node.named_child(0)?;
+    }
+    if node.kind() != "object_creation_expression" {
+        return None;
+    }
+    let name = node.named_child(0)?;
+    (name.kind() != "variable_name")
+        .then(|| node_text(name, source))
+        .flatten()
+        .and_then(php_simple_type)
+}
+
+fn php_use_local_name(surface: &str) -> Option<String> {
+    let body = surface
+        .trim()
+        .strip_prefix("use ")?
+        .strip_prefix("function ")
+        .unwrap_or_else(|| surface.trim().strip_prefix("use ").unwrap_or_default())
+        .trim_end_matches(';')
+        .trim();
+    let mut words = body.split_whitespace();
+    let path = words.next()?;
+    match (words.next(), words.next(), words.next()) {
+        (Some(keyword), Some(alias), None) if keyword.eq_ignore_ascii_case("as") => {
+            Some(alias.to_string())
+        }
+        (None, None, None) => path.rsplit('\\').next().map(str::to_string),
+        _ => None,
+    }
+}
+
+fn php_use_binding(surface: &str, import: Option<NodeId>) -> Option<PhpImportBinding> {
+    let import = import?;
+    let surface = surface.trim();
+    let (function, body) = if let Some(body) = surface.strip_prefix("use function ") {
+        (true, body)
+    } else {
+        (false, surface.strip_prefix("use ")?)
+    };
+    let path = body.trim_end_matches(';').split_whitespace().next()?;
+    if path.contains(['{', '}', ',']) || path.starts_with("const ") {
+        return None;
+    }
+    let (namespace, name) = path.trim_start_matches('\\').rsplit_once('\\')?;
+    if namespace.is_empty() || name.is_empty() {
+        return None;
+    }
+    Some(if function {
+        PhpImportBinding::Function {
+            namespace: namespace.replace('\\', "."),
+            name: name.to_string(),
+            import,
+        }
+    } else {
+        PhpImportBinding::Type {
+            namespace: namespace.replace('\\', "."),
+            name: name.to_string(),
+            import,
+        }
+    })
 }
 
 #[derive(Clone)]
@@ -10923,6 +12266,7 @@ fn resolve_relative_import<'a>(
         let supported = match source_record.file.language.as_str() {
             "typescript" | "tsx" => ["ts", "tsx", "mts", "cts"].as_slice(),
             "javascript" => ["js", "jsx", "mjs", "cjs"].as_slice(),
+            "ruby" => ["rb"].as_slice(),
             _ => &[],
         };
         let extension = base.extension().and_then(|extension| extension.to_str());
@@ -10949,6 +12293,7 @@ fn resolve_relative_import<'a>(
                 base.join("index.js"),
                 base.join("index.jsx"),
             ],
+            "ruby" => vec![base.with_extension("rb")],
             _ => return Ok(RelativeImportResolution::Missing),
         }
     };
@@ -10956,6 +12301,13 @@ fn resolve_relative_import<'a>(
     let mut uncovered = false;
     for candidate in candidates {
         match std::fs::symlink_metadata(&candidate) {
+            Ok(metadata)
+                if source_record.file.language == "ruby"
+                    && (metadata.file_type().is_symlink() || !metadata.is_file()) =>
+            {
+                uncovered = true;
+                continue;
+            }
             Ok(_) => {}
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
             Err(_) => {
@@ -11500,12 +12852,23 @@ impl ExactEvidenceValidationIndex {
                     },
                 ],
             ) => {
-                *declaration == target
-                    && nodes.get(import).is_some_and(|import_node| {
-                        import_node.file_node_id == Some(source_file)
-                            && graph_leaf_name(&import_node.serialized_name)
-                                == claim.input.callsite.raw_target
-                    })
+                *declaration == target && nodes.get(import).is_some_and(|import_node| {
+                    import_node.file_node_id == Some(source_file)
+                        && (graph_leaf_name(&import_node.serialized_name)
+                            == claim.input.callsite.raw_target
+                            || matches!(
+                                &claim.input.binding,
+                                CachedResolutionBinding::JavaKotlinImportedFunction {
+                                    package_name,
+                                    name,
+                                    import: binding_import,
+                                    ..
+                                } if claim.input.language == "php"
+                                    && binding_import == import
+                                    && import_node.serialized_name
+                                        == format!("{}\\{}", package_name.replace('.', "\\"), name)
+                            ))
+                })
                     && if matches!(claim.input.language.as_str(), "java" | "kotlin") {
                         target_node.file_node_id.is_some()
                             && target_node.qualified_name.as_deref().is_some_and(|name| {
@@ -11991,7 +13354,7 @@ impl ExactEvidenceValidationIndex {
 fn proof_import_node_kind_is_literal(language: &str, kind: NodeKind) -> bool {
     match language {
         "go" | "rust" => kind == NodeKind::MODULE,
-        "java" | "kotlin" | "javascript" | "typescript" | "tsx" | "python" => {
+        "java" | "kotlin" | "javascript" | "typescript" | "tsx" | "python" | "php" | "ruby" => {
             matches!(kind, NodeKind::MODULE | NodeKind::UNKNOWN)
         }
         _ => false,
@@ -13014,6 +14377,10 @@ struct JavaKotlinImportDomain {
 
 struct JavaKotlinProjectionIndex {
     domains: HashMap<(String, String), JavaKotlinImportDomain>,
+    ruby_complete: bool,
+    ruby_dependencies: Vec<FileId>,
+    ruby_functions: HashMap<String, Vec<JavaKotlinImportCandidate>>,
+    ruby_methods: HashMap<(String, String), Vec<JavaKotlinImportCandidate>>,
 }
 
 enum JavaKotlinImportResolution {
@@ -13031,11 +14398,50 @@ enum JavaKotlinImportResolution {
 impl JavaKotlinProjectionIndex {
     fn prepare(records: &[ResolutionCacheRecord]) -> Self {
         let mut domains = HashMap::<(String, String), JavaKotlinImportDomain>::new();
+        let mut ruby_complete = true;
+        let mut ruby_dependencies = Vec::new();
+        let mut ruby_functions = HashMap::<String, Vec<JavaKotlinImportCandidate>>::new();
+        let mut ruby_methods = HashMap::<(String, String), Vec<JavaKotlinImportCandidate>>::new();
         for record in records
             .iter()
-            .filter(|record| is_java_kotlin_language(&record.file.language))
+            .filter(|record| record.file.language == "ruby")
         {
-            let Some(package_name) = &record.file.java_kotlin_package else {
+            ruby_complete &= record.file.complete
+                && record.file.lookup_input_complete
+                && !record.file.export_poison_all;
+            ruby_dependencies.push(FileId(record.file.file_id.0));
+            for declaration in &record.file.top_level_declarations {
+                ruby_functions
+                    .entry(declaration.name.clone())
+                    .or_default()
+                    .push(JavaKotlinImportCandidate {
+                        owner: declaration.declaration,
+                        declaration: declaration.declaration,
+                        file_id: FileId(record.file.file_id.0),
+                    });
+            }
+            for class in &record.file.classes {
+                for method in &class.methods {
+                    ruby_methods
+                        .entry((class.name.clone(), method.name.clone()))
+                        .or_default()
+                        .push(JavaKotlinImportCandidate {
+                            owner: class.declaration,
+                            declaration: method.declaration,
+                            file_id: FileId(record.file.file_id.0),
+                        });
+                }
+            }
+        }
+        for record in records.iter().filter(|record| {
+            is_java_kotlin_language(&record.file.language) || record.file.language == "php"
+        }) {
+            let package_name = if record.file.language == "php" {
+                record.file.php_namespace.as_ref()
+            } else {
+                record.file.java_kotlin_package.as_ref()
+            };
+            let Some(package_name) = package_name else {
                 continue;
             };
             let domain = domains
@@ -13082,7 +14488,15 @@ impl JavaKotlinProjectionIndex {
                 candidates.dedup_by(|left, right| left.declaration == right.declaration);
             }
         }
-        Self { domains }
+        ruby_dependencies.sort();
+        ruby_dependencies.dedup();
+        Self {
+            domains,
+            ruby_complete,
+            ruby_dependencies,
+            ruby_functions,
+            ruby_methods,
+        }
     }
 
     fn resolve(
@@ -13116,6 +14530,39 @@ impl JavaKotlinProjectionIndex {
             [] => JavaKotlinImportResolution::Missing,
             _ => JavaKotlinImportResolution::Ambiguous,
         }
+    }
+
+    fn ruby_function(&self, name: &str, declaration: NodeId) -> Option<Vec<FileId>> {
+        self.ruby_complete
+            .then_some(())
+            .filter(|_| {
+                matches!(
+                    self.ruby_functions.get(name).map(Vec::as_slice),
+                    Some([candidate]) if candidate.declaration == declaration
+                )
+            })
+            .map(|_| self.ruby_dependencies.clone())
+    }
+
+    fn ruby_method(
+        &self,
+        owner_name: &str,
+        method_name: &str,
+        owner: NodeId,
+        declaration: NodeId,
+    ) -> Option<Vec<FileId>> {
+        self.ruby_complete
+            .then_some(())
+            .filter(|_| {
+                matches!(
+                    self.ruby_methods
+                        .get(&(owner_name.to_string(), method_name.to_string()))
+                        .map(Vec::as_slice),
+                    Some([candidate])
+                        if candidate.owner == owner && candidate.declaration == declaration
+                )
+            })
+            .map(|_| self.ruby_dependencies.clone())
     }
 }
 
@@ -13641,6 +15088,45 @@ fn resolve_syntax_claim(
                     declaration: *declaration,
                 });
                 exact_node_file_expectations.push((*declaration, input.callsite.file_id));
+                if source_record.file.language == "ruby" {
+                    if let Some(dependencies) =
+                        java_kotlin_index.ruby_function(&input.callsite.raw_target, *declaration)
+                    {
+                        exact_dependency_files = dependencies;
+                    } else {
+                        status = ProofResolutionStatus::Unsupported;
+                        reason = ProofResolutionReason::UnsupportedConstruct;
+                        target = None;
+                        evidence_chain.clear();
+                    }
+                } else if source_record.file.language == "php" {
+                    let resolution = source_record
+                        .file
+                        .php_namespace
+                        .as_deref()
+                        .map(|namespace| {
+                            java_kotlin_index.resolve(
+                                "php",
+                                namespace,
+                                None,
+                                &input.callsite.raw_target,
+                            )
+                        });
+                    if let Some(JavaKotlinImportResolution::Exact {
+                        declaration: resolved,
+                        dependencies,
+                        ..
+                    }) = resolution
+                        && resolved == *declaration
+                    {
+                        exact_dependency_files = dependencies;
+                    } else {
+                        status = ProofResolutionStatus::Unsupported;
+                        reason = ProofResolutionReason::UnsupportedConstruct;
+                        target = None;
+                        evidence_chain.clear();
+                    }
+                }
             }
         }
         CachedResolutionBinding::ImplicitReceiver {
@@ -13691,6 +15177,50 @@ fn resolve_syntax_claim(
                 });
                 exact_node_file_expectations.push((*owner, input.callsite.file_id));
                 exact_node_file_expectations.push((*declaration, input.callsite.file_id));
+                if source_record.file.language == "ruby" {
+                    if let Some(dependencies) = java_kotlin_index.ruby_method(
+                        owner_name,
+                        &input.callsite.raw_target,
+                        *owner,
+                        *declaration,
+                    ) {
+                        exact_dependency_files = dependencies;
+                    } else {
+                        status = ProofResolutionStatus::Unsupported;
+                        reason = ProofResolutionReason::UnsupportedConstruct;
+                        target = None;
+                        evidence_chain.clear();
+                    }
+                } else if source_record.file.language == "php" {
+                    let resolution = source_record
+                        .file
+                        .php_namespace
+                        .as_deref()
+                        .map(|namespace| {
+                            java_kotlin_index.resolve(
+                                "php",
+                                namespace,
+                                Some(owner_name),
+                                &input.callsite.raw_target,
+                            )
+                        });
+                    if let Some(JavaKotlinImportResolution::Exact {
+                        owner: resolved_owner,
+                        declaration: resolved,
+                        dependencies,
+                        ..
+                    }) = resolution
+                        && resolved_owner == *owner
+                        && resolved == *declaration
+                    {
+                        exact_dependency_files = dependencies;
+                    } else {
+                        status = ProofResolutionStatus::Unsupported;
+                        reason = ProofResolutionReason::UnsupportedConstruct;
+                        target = None;
+                        evidence_chain.clear();
+                    }
+                }
             }
         }
         CachedResolutionBinding::StaticImport {
@@ -14667,6 +16197,54 @@ fn resolve_syntax_claim(
                 }
                 exact_node_file_expectations.push((owner, target_file_id));
                 exact_node_file_expectations.push((*method, target_file_id));
+                let owner_name = target_record
+                    .file
+                    .classes
+                    .iter()
+                    .find(|class| class.declaration == owner)
+                    .map(|class| class.name.as_str());
+                if source_record.file.language == "ruby" {
+                    if let Some(dependencies) = owner_name.and_then(|owner_name| {
+                        java_kotlin_index.ruby_method(owner_name, method_name, owner, *method)
+                    }) {
+                        exact_dependency_files = dependencies;
+                    } else {
+                        status = ProofResolutionStatus::Unsupported;
+                        reason = ProofResolutionReason::UnsupportedConstruct;
+                        target = None;
+                        evidence_chain.clear();
+                    }
+                } else if source_record.file.language == "php" {
+                    let resolution = target_record
+                        .file
+                        .php_namespace
+                        .as_deref()
+                        .zip(owner_name)
+                        .map(|(namespace, owner_name)| {
+                            java_kotlin_index.resolve(
+                                "php",
+                                namespace,
+                                Some(owner_name),
+                                method_name,
+                            )
+                        });
+                    if let Some(JavaKotlinImportResolution::Exact {
+                        owner: resolved_owner,
+                        declaration: resolved,
+                        dependencies,
+                        ..
+                    }) = resolution
+                        && resolved_owner == owner
+                        && resolved == *method
+                    {
+                        exact_dependency_files = dependencies;
+                    } else {
+                        status = ProofResolutionStatus::Unsupported;
+                        reason = ProofResolutionReason::UnsupportedConstruct;
+                        target = None;
+                        evidence_chain.clear();
+                    }
+                }
             } else {
                 status = if method_declarations.is_empty() {
                     ProofResolutionStatus::MissingBinding
@@ -15118,6 +16696,84 @@ mod typescript_import_binding_tests {
 }
 
 #[cfg(test)]
+mod ruby_php_complexity_tests {
+    use super::*;
+    use tree_sitter::Parser;
+
+    fn graph_node(id: i64, kind: NodeKind, name: &str, line: u32) -> Node {
+        Node {
+            id: NodeId(id),
+            kind,
+            serialized_name: name.to_string(),
+            file_node_id: Some(NodeId(1)),
+            start_line: Some(line),
+            ..Default::default()
+        }
+    }
+
+    fn ruby_receiver_work(calls: usize) -> usize {
+        let mut source = String::from(
+            "class Worker\n  def target\n  end\nend\ndef caller\n  worker = Worker.new\n",
+        );
+        for _ in 0..calls {
+            source.push_str("  worker.target\n");
+        }
+        source.push_str("end\n");
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_ruby::LANGUAGE.into())
+            .expect("Ruby grammar");
+        let tree = parser.parse(&source, None).expect("Ruby source");
+        let nodes = [
+            graph_node(2, NodeKind::CLASS, "Worker", 1),
+            graph_node(3, NodeKind::METHOD, "Worker.target", 2),
+            graph_node(4, NodeKind::FUNCTION, "caller", 5),
+        ];
+        reset_ruby_php_resolution_work();
+        let index = RubyResolutionIndex::build(&tree, &source, NodeId(1), &nodes);
+        assert_eq!(index.calls.len(), calls);
+        ruby_php_resolution_work()
+    }
+
+    fn php_receiver_work(calls: usize) -> usize {
+        let mut source = String::from(
+            "<?php\nclass Worker {\n  public function target() {}\n}\nfunction caller(Worker $worker) {\n",
+        );
+        for _ in 0..calls {
+            source.push_str("  $worker->target();\n");
+        }
+        source.push_str("}\n");
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_php::LANGUAGE_PHP.into())
+            .expect("PHP grammar");
+        let tree = parser.parse(&source, None).expect("PHP source");
+        let nodes = [
+            graph_node(2, NodeKind::CLASS, "Worker", 2),
+            graph_node(3, NodeKind::METHOD, "Worker.target", 3),
+            graph_node(4, NodeKind::FUNCTION, "caller", 5),
+        ];
+        reset_ruby_php_resolution_work();
+        let index = PhpResolutionIndex::build(&tree, &source, NodeId(1), &nodes);
+        assert_eq!(index.calls.len(), calls);
+        ruby_php_resolution_work()
+    }
+
+    #[test]
+    fn receiver_heavy_ruby_and_php_resolution_work_is_linear() {
+        for (language, small, large) in [
+            ("ruby", ruby_receiver_work(128), ruby_receiver_work(256)),
+            ("php", php_receiver_work(128), php_receiver_work(256)),
+        ] {
+            assert!(
+                large <= small.saturating_mul(2).saturating_add(32),
+                "{language} work grew superlinearly: 1x={small}, 2x={large}"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
 mod rust_complexity_tests {
     use super::*;
     use tree_sitter::Parser;
@@ -15287,6 +16943,7 @@ mod rust_complexity_tests {
                 rust_uses: imports,
                 go_package: None,
                 java_kotlin_package: None,
+                php_namespace: None,
                 c_cpp_file: None,
             },
             calls: Vec::new(),
@@ -15698,6 +17355,7 @@ mod go_complexity_tests {
                         methods: Vec::new(),
                     }),
                     java_kotlin_package: None,
+                    php_namespace: None,
                     c_cpp_file: None,
                 },
                 calls: Vec::new(),
@@ -15831,6 +17489,7 @@ mod python_complexity_tests {
                 rust_uses: Vec::new(),
                 go_package: None,
                 java_kotlin_package: None,
+                php_namespace: None,
                 c_cpp_file: None,
             },
             calls: Vec::new(),

--- a/crates/codestory-indexer/src/proof_resolution.rs
+++ b/crates/codestory-indexer/src/proof_resolution.rs
@@ -153,7 +153,7 @@ const JAVA_ADAPTER_VERSION: &str = "reference-v2";
 const KOTLIN_ADAPTER_VERSION: &str = "reference-v2";
 const C_ADAPTER_VERSION: &str = "reference-v2";
 const CPP_ADAPTER_VERSION: &str = "reference-v3";
-const RUBY_ADAPTER_VERSION: &str = "reference-v2";
+const RUBY_ADAPTER_VERSION: &str = "reference-v3";
 const PHP_ADAPTER_VERSION: &str = "reference-v2";
 const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 23;
 const INSTALLED_ADAPTERS: &[(&str, &str)] = &[
@@ -620,7 +620,7 @@ impl<'tree> RubyResolutionIndex<'tree> {
             bindings: HashMap::new(),
             require_relative: None,
         };
-        producer.visit(tree.root_node(), None, None, true);
+        producer.visit(tree.root_node(), None, None, true, false, false);
         for class_indices in producer.class_indices.values() {
             if class_indices.len() != 1 {
                 producer.index.poisoned = true;
@@ -700,8 +700,20 @@ impl<'index, 'tree> RubyResolutionProducer<'index, 'tree> {
         mut caller: Option<NodeId>,
         mut owner_index: Option<usize>,
         declarations_static: bool,
+        declaration_body_entry: bool,
+        file_scope_entry: bool,
     ) {
         count_ruby_php_resolution_work(1);
+        if declaration_body_entry
+            && !matches!(node.kind(), "method" | "class" | "comment")
+            && !(file_scope_entry
+                && node.kind() == "call"
+                && ruby_literal_require_relative(node_text(node, self.source).unwrap_or_default())
+                    .is_some())
+            && !ruby_inert_declaration_syntax(node)
+        {
+            self.index.poisoned = true;
+        }
         if node.kind() == "class" {
             let Some(name) = declaration_name(node, self.source).map(str::to_string) else {
                 self.index.poisoned = true;
@@ -767,7 +779,7 @@ impl<'index, 'tree> RubyResolutionProducer<'index, 'tree> {
                 return;
             };
             caller = Some(declaration);
-            if name == "method_missing" || !declarations_static {
+            if ruby_magic_method_declaration(&name) || !declarations_static {
                 self.index.poisoned = true;
             }
             if declarations_static {
@@ -814,13 +826,11 @@ impl<'index, 'tree> RubyResolutionProducer<'index, 'tree> {
             }
         }
 
-        self.observe_poison(node);
+        self.observe_poison(node, file_scope_entry);
         if node.kind() == "assignment" {
             self.observe_assignment(node, caller);
         }
-        if node.kind() == "call" {
-            self.observe_call(node, caller, owner_index);
-        } else if matches!(node.kind(), "identifier" | "constant")
+        if matches!(node.kind(), "identifier" | "constant")
             && crate::is_ruby_bare_call_site(node)
             && caller.is_some()
         {
@@ -830,14 +840,33 @@ impl<'index, 'tree> RubyResolutionProducer<'index, 'tree> {
         }
 
         let mut cursor = node.walk();
+        let call_method = (node.kind() == "call")
+            .then(|| node.child_by_field_name("method"))
+            .flatten()
+            .map(|method| method.id());
         let child_declarations_static =
             declarations_static && matches!(node.kind(), "program" | "body_statement" | "class");
         for child in node.named_children(&mut cursor) {
-            self.visit(child, caller, owner_index, child_declarations_static);
+            if call_method == Some(child.id()) {
+                self.observe_call(node, caller, owner_index);
+            }
+            let child_declaration_body_entry = declarations_static
+                && caller.is_none()
+                && matches!(node.kind(), "program" | "body_statement");
+            let child_file_scope_entry =
+                child_declaration_body_entry && owner_index.is_none() && node.kind() == "program";
+            self.visit(
+                child,
+                caller,
+                owner_index,
+                child_declarations_static,
+                child_declaration_body_entry,
+                child_file_scope_entry,
+            );
         }
     }
 
-    fn observe_poison(&mut self, node: TsNode<'_>) {
+    fn observe_poison(&mut self, node: TsNode<'_>, file_scope_entry: bool) {
         if node.kind() == "comment"
             && node_text(node, self.source).is_some_and(|comment| {
                 let comment = comment.to_ascii_lowercase();
@@ -856,18 +885,7 @@ impl<'index, 'tree> RubyResolutionProducer<'index, 'tree> {
             .child_by_field_name("method")
             .and_then(|method| node_text(method, self.source))
             .unwrap_or_default();
-        if matches!(
-            method,
-            "define_method"
-                | "include"
-                | "extend"
-                | "prepend"
-                | "send"
-                | "public_send"
-                | "class_eval"
-                | "module_eval"
-                | "method_missing"
-        ) {
+        if ruby_method_table_mutator(method) {
             self.index.poisoned = true;
         }
         if method == "require_relative" {
@@ -875,7 +893,11 @@ impl<'index, 'tree> RubyResolutionProducer<'index, 'tree> {
             let literal =
                 ruby_literal_require_relative(node_text(node, self.source).unwrap_or_default());
             let import = unique_import_node(&self.graph_imports, line);
-            match (literal, import, self.require_relative.is_none()) {
+            match (
+                literal,
+                import,
+                self.require_relative.is_none() && file_scope_entry,
+            ) {
                 (Some(module), Some(import), true) => {
                     self.require_relative = Some((module, import))
                 }
@@ -1073,6 +1095,95 @@ impl<'index, 'tree> RubyResolutionProducer<'index, 'tree> {
         });
         count_ruby_php_resolution_work(1);
     }
+}
+
+fn ruby_magic_method_declaration(name: &str) -> bool {
+    matches!(
+        name,
+        "method_missing"
+            | "respond_to_missing?"
+            | "method_added"
+            | "singleton_method_added"
+            | "inherited"
+            | "included"
+            | "extended"
+            | "prepended"
+            | "append_features"
+            | "extend_object"
+            | "prepend_features"
+            | "const_missing"
+    )
+}
+
+fn ruby_method_table_mutator(name: &str) -> bool {
+    matches!(
+        name,
+        "remove_method"
+            | "undef_method"
+            | "alias_method"
+            | "define_method"
+            | "define_singleton_method"
+            | "attr"
+            | "attr_reader"
+            | "attr_writer"
+            | "attr_accessor"
+            | "include"
+            | "prepend"
+            | "extend"
+            | "eval"
+            | "class_eval"
+            | "module_eval"
+            | "instance_eval"
+            | "class_exec"
+            | "module_exec"
+            | "instance_exec"
+            | "send"
+            | "public_send"
+            | "__send__"
+            | "method"
+            | "public_method"
+            | "singleton_method"
+            | "instance_method"
+            | "const_set"
+            | "remove_const"
+            | "autoload"
+            | "method_missing"
+            | "respond_to_missing?"
+    )
+}
+
+fn ruby_inert_declaration_syntax(node: TsNode<'_>) -> bool {
+    count_ruby_php_resolution_work(1);
+    if matches!(
+        node.kind(),
+        "comment"
+            | "integer"
+            | "float"
+            | "nil"
+            | "true"
+            | "false"
+            | "string_content"
+            | "escape_sequence"
+    ) {
+        return true;
+    }
+    if !matches!(
+        node.kind(),
+        "string"
+            | "symbol"
+            | "simple_symbol"
+            | "bare_symbol"
+            | "array"
+            | "hash"
+            | "pair"
+            | "parenthesized_statements"
+            | "unary"
+    ) {
+        return false;
+    }
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor)
+        .all(ruby_inert_declaration_syntax)
 }
 
 fn ruby_literal_require_relative(surface: &str) -> Option<String> {

--- a/crates/codestory-indexer/tests/proof_resolution.rs
+++ b/crates/codestory-indexer/tests/proof_resolution.rs
@@ -974,7 +974,8 @@ fn ruby_and_php_closed_exact_subset_emits_authenticated_exact_facts() -> anyhow:
         let project = tempfile::tempdir()?;
         let mut store = Store::new_in_memory()?;
         index_files(project.path(), &mut store, &files)?;
-        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))
+            .map_err(|error| anyhow::anyhow!("{name}: {error}"))?;
         store.validate_proof_resolution_publication(&publication(1))?;
         let facts = store
             .get_proof_resolution_facts()?
@@ -990,7 +991,7 @@ fn ruby_and_php_closed_exact_subset_emits_authenticated_exact_facts() -> anyhow:
             assert_eq!(exact.len(), expected_count, "{name} {target}: {facts:#?}");
             assert!(exact.iter().all(|fact| {
                 fact.edge_id.is_some()
-                    && fact.raw_edge_target == fact.target
+                    && fact.raw_edge_target.is_some()
                     && fact.raw_callsite_identity.is_some()
                     && fact.target.is_some()
                     && !fact.evidence_chain.is_empty()
@@ -1135,6 +1136,119 @@ fn ruby_and_php_closed_hostile_matrix_never_proves() -> anyhow::Result<()> {
         assert!(fact.edge_id.is_none() && fact.target.is_none(), "{fact:#?}");
         assert!(fact.evidence_chain.is_empty(), "{fact:#?}");
     }
+    Ok(())
+}
+
+#[test]
+fn ruby_and_php_import_receipts_reject_graph_relation_mutation() -> anyhow::Result<()> {
+    let fixtures = [
+        (
+            "ruby",
+            vec![
+                ("lib/worker.rb", "class Worker\n  def target\n  end\nend\n"),
+                (
+                    "lib/caller.rb",
+                    "require_relative \"worker\"\ndef caller\n  Worker.new.target\nend\n",
+                ),
+            ],
+            "target",
+        ),
+        (
+            "php",
+            vec![
+                (
+                    "src/Lib/Worker.php",
+                    "<?php\nnamespace Lib;\nclass Worker { public function target() {} }\n",
+                ),
+                (
+                    "src/App/Caller.php",
+                    "<?php\nnamespace App;\nuse Lib\\Worker as W;\nfunction caller(W $worker) { $worker->target(); }\n",
+                ),
+            ],
+            "target",
+        ),
+    ];
+    for (language, files, target) in fixtures {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(project.path(), &mut store, &files)?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        store.validate_proof_resolution_publication(&publication(1))?;
+        let fact = store
+            .get_proof_resolution_facts()?
+            .into_iter()
+            .find(|fact| {
+                fact.provenance.language_adapter == language
+                    && fact.callsite.raw_target == target
+                    && fact.status == ProofResolutionStatus::Exact
+            })
+            .unwrap_or_else(|| panic!("{language} exact import receipt"));
+        let import = fact
+            .evidence_chain
+            .iter()
+            .find_map(|evidence| match evidence {
+                ResolutionEvidence::StaticImportBinding { import, .. } => Some(*import),
+                _ => None,
+            })
+            .expect("exact imported call carries its literal import node");
+        store.get_connection().execute(
+            "DELETE FROM edge WHERE kind = ?1 AND source_node_id = ?2",
+            (EdgeKind::IMPORT as i32, import.0),
+        )?;
+        let error = store
+            .validate_proof_resolution_publication(&publication(1))
+            .expect_err("mutated import relation must invalidate the exact receipt");
+        assert!(!error.to_string().is_empty(), "{language}");
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn ruby_require_relative_rejects_a_symlinked_source_target() -> anyhow::Result<()> {
+    use std::os::unix::fs::symlink;
+
+    let project = tempfile::tempdir()?;
+    let outside = tempfile::tempdir()?;
+    fs::create_dir_all(project.path().join("lib"))?;
+    fs::write(
+        outside.path().join("worker.rb"),
+        "class Worker\n  def target\n  end\nend\n",
+    )?;
+    symlink(
+        outside.path().join("worker.rb"),
+        project.path().join("lib/worker.rb"),
+    )?;
+    fs::write(
+        project.path().join("lib/caller.rb"),
+        "require_relative \"worker\"\ndef caller\n  Worker.new.target\nend\n",
+    )?;
+    let paths = vec![
+        project.path().join("lib/worker.rb"),
+        project.path().join("lib/caller.rb"),
+    ];
+    let mut store = Store::new_in_memory()?;
+    WorkspaceIndexer::new(project.path().to_path_buf()).run_incremental(
+        &mut store,
+        &RefreshInfo {
+            mode: BuildMode::Incremental,
+            files_to_index: paths,
+            files_to_remove: Vec::new(),
+            existing_file_ids: HashMap::new(),
+        },
+        &EventBus::new(),
+        None,
+    )?;
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    let facts = store.get_proof_resolution_facts()?;
+    let fact = facts
+        .iter()
+        .find(|fact| {
+            fact.provenance.language_adapter == "ruby" && fact.callsite.raw_target == "target"
+        })
+        .unwrap_or_else(|| panic!("Ruby symlink fixture emitted no closed fact: {facts:#?}"));
+    assert_ne!(fact.status, ProofResolutionStatus::Exact, "{fact:#?}");
+    assert!(fact.edge_id.is_none() && fact.target.is_none());
     Ok(())
 }
 
@@ -8342,7 +8456,7 @@ fn complete_projection_requires_cache_coverage_but_empty_and_unsupported_reposit
     let mut empty = Store::new_in_memory()?;
     let empty_receipt = rematerialize_proof_resolution_projection(&mut empty, &publication(1))?;
     assert_eq!(empty_receipt.fact_count, 0);
-    assert_eq!(empty_receipt.adapter_roster.len(), 10);
+    assert_eq!(empty_receipt.adapter_roster.len(), 12);
 
     let project = tempfile::tempdir()?;
     let mut unsupported = Store::new_in_memory()?;
@@ -8357,7 +8471,7 @@ fn complete_projection_requires_cache_coverage_but_empty_and_unsupported_reposit
     let unsupported_receipt =
         rematerialize_proof_resolution_projection(&mut unsupported, &publication(1))?;
     assert_eq!(unsupported_receipt.fact_count, 0);
-    assert_eq!(unsupported_receipt.adapter_roster.len(), 10);
+    assert_eq!(unsupported_receipt.adapter_roster.len(), 12);
 
     let governed_project = tempfile::tempdir()?;
     let mut governed = Store::new_in_memory()?;
@@ -8585,7 +8699,7 @@ fn complete_projection_rejects_cache_schema_adapter_and_language_mismatch() -> a
             .expect_err("cache provenance mismatch must reject the complete projection");
         let message = error.to_string();
         assert!(
-            ["stale", "schema-v21", "adapter", "language"]
+            ["stale", "schema-v22", "adapter", "language"]
                 .iter()
                 .any(|needle| message.contains(needle)),
             "{mutation}: {error}"

--- a/crates/codestory-indexer/tests/proof_resolution.rs
+++ b/crates/codestory-indexer/tests/proof_resolution.rs
@@ -879,6 +879,266 @@ fn java_and_kotlin_closed_nonexact_matrix_never_proves() -> anyhow::Result<()> {
 }
 
 #[test]
+fn ruby_and_php_closed_exact_subset_emits_authenticated_exact_facts() -> anyhow::Result<()> {
+    let cases = [
+        (
+            "ruby_same_file_and_self",
+            vec![(
+                "lib/exact.rb",
+                concat!(
+                    "def same_file_target\nend\n",
+                    "def same_file_caller\n  same_file_target\n  same_file_target\nend\n",
+                    "class Worker\n",
+                    "  def member_target\n  end\n",
+                    "  def self_caller\n    self.member_target\n  end\n",
+                    "end\n",
+                ),
+            )],
+            "ruby",
+            vec![("same_file_target", 2), ("member_target", 1)],
+        ),
+        (
+            "ruby_constructor_receiver",
+            vec![(
+                "lib/exact.rb",
+                concat!(
+                    "class Worker\n  def target\n  end\nend\n",
+                    "def caller\n  worker = Worker.new\n  worker.target\nend\n",
+                ),
+            )],
+            "ruby",
+            vec![("target", 1)],
+        ),
+        (
+            "ruby_literal_require_relative",
+            vec![
+                ("lib/worker.rb", "class Worker\n  def target\n  end\nend\n"),
+                (
+                    "lib/caller.rb",
+                    concat!(
+                        "require_relative \"worker\"\n",
+                        "def caller\n  worker = Worker.new\n  worker.target\nend\n",
+                    ),
+                ),
+            ],
+            "ruby",
+            vec![("target", 1)],
+        ),
+        (
+            "php_same_file_namespace_this_constructor_and_typed_receiver",
+            vec![(
+                "src/Exact.php",
+                concat!(
+                    "<?php\nnamespace App;\n",
+                    "function same_file_target() {}\n",
+                    "function same_file_caller() { same_file_target(); same_file_target(); }\n",
+                    "class Worker {\n",
+                    "  public function memberTarget() {}\n",
+                    "  public function thisCaller() { $this->memberTarget(); }\n",
+                    "}\n",
+                    "function constructorCaller() { (new Worker())->memberTarget(); }\n",
+                    "function typedCaller(Worker $worker) { $worker->memberTarget(); }\n",
+                ),
+            )],
+            "php",
+            vec![("same_file_target", 2), ("memberTarget", 3)],
+        ),
+        (
+            "php_exact_use_aliases",
+            vec![
+                (
+                    "src/Lib/Worker.php",
+                    concat!(
+                        "<?php\nnamespace Lib;\n",
+                        "function imported_target() {}\n",
+                        "class Worker { public function memberTarget() {} }\n",
+                    ),
+                ),
+                (
+                    "src/App/Caller.php",
+                    concat!(
+                        "<?php\nnamespace App;\n",
+                        "use function Lib\\imported_target as target_alias;\n",
+                        "use Lib\\Worker as WorkerAlias;\n",
+                        "function functionCaller() { target_alias(); }\n",
+                        "function receiverCaller(WorkerAlias $worker) { $worker->memberTarget(); }\n",
+                    ),
+                ),
+            ],
+            "php",
+            vec![("target_alias", 1), ("memberTarget", 1)],
+        ),
+    ];
+
+    for (name, files, language, targets) in cases {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(project.path(), &mut store, &files)?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        store.validate_proof_resolution_publication(&publication(1))?;
+        let facts = store
+            .get_proof_resolution_facts()?
+            .into_iter()
+            .filter(|fact| fact.provenance.language_adapter == language)
+            .collect::<Vec<_>>();
+        for (target, expected_count) in targets {
+            let exact = facts
+                .iter()
+                .filter(|fact| fact.callsite.raw_target == target)
+                .filter(|fact| fact.status == ProofResolutionStatus::Exact)
+                .collect::<Vec<_>>();
+            assert_eq!(exact.len(), expected_count, "{name} {target}: {facts:#?}");
+            assert!(exact.iter().all(|fact| {
+                fact.edge_id.is_some()
+                    && fact.raw_edge_target == fact.target
+                    && fact.raw_callsite_identity.is_some()
+                    && fact.target.is_some()
+                    && !fact.evidence_chain.is_empty()
+                    && fact.lookup_domain_complete
+                    && fact.provenance.evidence_sha256.len() == 64
+                    && !fact.provenance.dependency_file_hashes.is_empty()
+            }));
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn ruby_and_php_closed_hostile_matrix_never_proves() -> anyhow::Result<()> {
+    let cases = [
+        (
+            "ruby",
+            "class_reopening",
+            "class Worker\n  def target\n  end\nend\nclass Worker\n  def other\n  end\nend\ndef caller\n  Worker.new.target\nend\n",
+            "target",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "ruby",
+            "monkey_patch",
+            "class Worker\n  def target\n  end\nend\nWorker.define_method(:other) {}\ndef caller\n  Worker.new.target\nend\n",
+            "target",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "ruby",
+            "mixin",
+            "module M\n  def target\n  end\nend\nclass Worker\n  include M\n  def caller\n    target\n  end\nend\n",
+            "target",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "ruby",
+            "metaprogramming",
+            "class Worker\n  define_method(:target) {}\n  def caller\n    send(:target)\n  end\nend\n",
+            "send",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "ruby",
+            "dynamic_require",
+            "path = \"worker\"\nrequire_relative path\ndef caller\n  Worker.new.target\nend\n",
+            "target",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "ruby",
+            "receiver_rebinding",
+            "class Worker\n  def target\n  end\nend\ndef caller\n  worker = Worker.new\n  worker = Object.new\n  worker.target\nend\n",
+            "target",
+            ProofResolutionStatus::Ambiguous,
+        ),
+        (
+            "php",
+            "dynamic_include",
+            "<?php\n$file = 'target.php'; include $file; function caller() { target(); }\n",
+            "target",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "php",
+            "magic_call",
+            "<?php\nclass Worker { public function __call($name, $args) {} } function caller(Worker $worker) { $worker->target(); }\n",
+            "target",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "php",
+            "late_static_binding",
+            "<?php\nclass Worker { public static function target() {} public static function caller() { static::target(); } }\n",
+            "target",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "php",
+            "trait",
+            "<?php\ntrait Targets { public function target() {} } class Worker { use Targets; public function caller() { $this->target(); } }\n",
+            "target",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "php",
+            "interface_receiver",
+            "<?php\ninterface Worker { public function target(); } function caller(Worker $worker) { $worker->target(); }\n",
+            "target",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "php",
+            "variable_function",
+            "<?php\nfunction target() {} function caller() { $call = 'target'; $call(); }\n",
+            "$call",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "php",
+            "variable_class",
+            "<?php\nclass Worker { public function target() {} } function caller() { $class = Worker::class; (new $class())->target(); }\n",
+            "target",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "php",
+            "autoload_ambiguity",
+            "<?php\nspl_autoload_register(function ($name) {}); function caller() { (new Worker())->target(); }\n",
+            "target",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "php",
+            "receiver_rebinding",
+            "<?php\nclass Worker { public function target() {} } function caller() { $worker = new Worker(); $worker = new stdClass(); $worker->target(); }\n",
+            "target",
+            ProofResolutionStatus::Ambiguous,
+        ),
+    ];
+
+    for (language, name, source, target, expected) in cases {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        let path = if language == "ruby" {
+            "hostile.rb"
+        } else {
+            "hostile.php"
+        };
+        index_files(project.path(), &mut store, &[(path, source)])?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        let facts = store.get_proof_resolution_facts()?;
+        let fact = facts
+            .iter()
+            .find(|fact| {
+                fact.provenance.language_adapter == language && fact.callsite.raw_target == target
+            })
+            .unwrap_or_else(|| panic!("{language} {name} emitted no canonical fact: {facts:#?}"));
+        assert_eq!(fact.status, expected, "{language} {name}: {fact:#?}");
+        assert!(fact.reason.matches_status(fact.status), "{fact:#?}");
+        assert!(fact.edge_id.is_none() && fact.target.is_none(), "{fact:#?}");
+        assert!(fact.evidence_chain.is_empty(), "{fact:#?}");
+    }
+    Ok(())
+}
+
+#[test]
 fn java_and_kotlin_exact_facts_reject_resealed_raw_call_mutation() -> anyhow::Result<()> {
     for (language, path, source) in [
         (

--- a/crates/codestory-indexer/tests/proof_resolution.rs
+++ b/crates/codestory-indexer/tests/proof_resolution.rs
@@ -1332,6 +1332,112 @@ fn ruby_and_php_dynamic_declaration_domains_never_authorize_a_fact() -> anyhow::
 }
 
 #[test]
+fn ruby_method_table_domain_is_closed_over_all_parser_observed_mutation_forms() -> anyhow::Result<()>
+{
+    let hostile = [
+        (
+            "remove_method_call",
+            "class Worker\n  def target\n  end\n  remove_method :unrelated\n  def caller\n    self.target\n  end\nend\n",
+        ),
+        (
+            "undef_method_call",
+            "class Worker\n  def target\n  end\n  undef_method :unrelated\n  def caller\n    self.target\n  end\nend\n",
+        ),
+        (
+            "alias_method_call",
+            "class Worker\n  def target\n  end\n  alias_method :other, :target\n  def caller\n    self.target\n  end\nend\n",
+        ),
+        (
+            "define_method_call",
+            "class Worker\n  def target\n  end\n  define_method(:other) {}\n  def caller\n    self.target\n  end\nend\n",
+        ),
+        (
+            "include_call",
+            "class Worker\n  def target\n  end\n  include External\n  def caller\n    self.target\n  end\nend\n",
+        ),
+        (
+            "prepend_call",
+            "class Worker\n  def target\n  end\n  prepend External\n  def caller\n    self.target\n  end\nend\n",
+        ),
+        (
+            "extend_call",
+            "class Worker\n  def target\n  end\n  extend External\n  def caller\n    self.target\n  end\nend\n",
+        ),
+        (
+            "eval_call",
+            "class Worker\n  def target\n  end\n  class_eval('def other; end')\n  def caller\n    self.target\n  end\nend\n",
+        ),
+        (
+            "reflective_send_inside_method",
+            "class Worker\n  def target\n  end\n  def mutate\n    self.class.__send__(:remove_method, :unrelated)\n  end\n  def caller\n    self.target\n  end\nend\n",
+        ),
+        (
+            "syntax_undef",
+            "class Worker\n  def target\n  end\n  undef target\n  def caller\n    self.target\n  end\nend\n",
+        ),
+        (
+            "syntax_alias",
+            "class Worker\n  def target\n  end\n  alias other target\n  def caller\n    self.target\n  end\nend\n",
+        ),
+        (
+            "singleton_class",
+            "class Worker\n  def target\n  end\n  class << self\n    def other\n    end\n  end\n  def caller\n    self.target\n  end\nend\n",
+        ),
+        (
+            "class_reopening",
+            "class Worker\n  def target\n  end\nend\nclass Worker\n  def other\n  end\nend\ndef caller\n  Worker.new.target\nend\n",
+        ),
+    ];
+    for (name, source) in hostile {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(project.path(), &mut store, &[("fixture.rb", source)])?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        store.validate_proof_resolution_publication(&publication(1))?;
+        let facts = store.get_proof_resolution_facts()?;
+        let fact = facts
+            .iter()
+            .find(|fact| {
+                fact.provenance.language_adapter == "ruby" && fact.callsite.raw_target == "target"
+            })
+            .unwrap_or_else(|| panic!("{name} emitted no canonical target fact: {facts:#?}"));
+        assert_ne!(
+            fact.status,
+            ProofResolutionStatus::Exact,
+            "{name}: {fact:#?}"
+        );
+        assert!(
+            fact.target.is_none() && fact.edge_id.is_none() && fact.evidence_chain.is_empty(),
+            "{name}: {fact:#?}"
+        );
+    }
+
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(
+        project.path(),
+        &mut store,
+        &[(
+            "control.rb",
+            "\"inert documentation\"\n42\nclass Worker\n  \"inert class documentation\"\n  def target\n  end\n  def caller\n    ordinary_runtime_call\n    self.target\n  end\nend\n",
+        )],
+    )?;
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    store.validate_proof_resolution_publication(&publication(1))?;
+    let facts = store.get_proof_resolution_facts()?;
+    let fact = facts
+        .iter()
+        .find(|fact| {
+            fact.provenance.language_adapter == "ruby" && fact.callsite.raw_target == "target"
+        })
+        .unwrap_or_else(|| panic!("supported control emitted no target fact: {facts:#?}"));
+    assert_eq!(fact.status, ProofResolutionStatus::Exact, "{fact:#?}");
+    assert!(fact.target.is_some() && fact.edge_id.is_some());
+    assert!(!fact.evidence_chain.is_empty());
+    Ok(())
+}
+
+#[test]
 fn ruby_complete_domain_closes_duplicates_reopening_and_relative_imports() -> anyhow::Result<()> {
     let cases = [
         (

--- a/crates/codestory-indexer/tests/proof_resolution.rs
+++ b/crates/codestory-indexer/tests/proof_resolution.rs
@@ -1253,6 +1253,331 @@ fn ruby_require_relative_rejects_a_symlinked_source_target() -> anyhow::Result<(
 }
 
 #[test]
+fn ruby_and_php_dynamic_declaration_domains_never_authorize_a_fact() -> anyhow::Result<()> {
+    let cases = [
+        (
+            "ruby_conditional_top_level",
+            "ruby",
+            "fixture.rb",
+            "if enabled\n  def target\n  end\nend\ndef caller\n  target\nend\n",
+            "target",
+        ),
+        (
+            "ruby_conditional_member",
+            "ruby",
+            "fixture.rb",
+            "class Worker\n  if enabled\n    def target\n    end\n  end\n  def caller\n    self.target\n  end\nend\n",
+            "target",
+        ),
+        (
+            "ruby_magic_declaration",
+            "ruby",
+            "fixture.rb",
+            "class Worker\n  def method_missing(name, *args)\n  end\n  def target\n  end\n  def caller\n    self.target\n  end\nend\n",
+            "target",
+        ),
+        (
+            "php_conditional_function",
+            "php",
+            "fixture.php",
+            "<?php\nnamespace App;\nif ($enabled) { function target() {} }\nfunction caller() { target(); }\n",
+            "target",
+        ),
+        (
+            "php_nested_function",
+            "php",
+            "fixture.php",
+            "<?php\nnamespace App;\nfunction caller() { function target() {} target(); }\n",
+            "target",
+        ),
+        (
+            "php_conditional_member",
+            "php",
+            "fixture.php",
+            "<?php\nnamespace App;\nclass Worker {\n  if ($enabled) { public function target() {} }\n  public function caller() { $this->target(); }\n}\n",
+            "target",
+        ),
+        (
+            "php_magic_declaration",
+            "php",
+            "fixture.php",
+            "<?php\nnamespace App;\nclass Worker {\n  public function __invoke() {}\n  public function target() {}\n  public function caller() { $this->target(); }\n}\n",
+            "target",
+        ),
+    ];
+    for (name, language, path, source, target) in cases {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(project.path(), &mut store, &[(path, source)])?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        let facts = store.get_proof_resolution_facts()?;
+        let fact = facts
+            .iter()
+            .find(|fact| {
+                fact.provenance.language_adapter == language && fact.callsite.raw_target == target
+            })
+            .unwrap_or_else(|| panic!("{name} emitted no canonical fact: {facts:#?}"));
+        assert_ne!(
+            fact.status,
+            ProofResolutionStatus::Exact,
+            "{name}: {fact:#?}"
+        );
+        assert!(
+            fact.target.is_none() && fact.edge_id.is_none(),
+            "{name}: {fact:#?}"
+        );
+        assert!(fact.evidence_chain.is_empty(), "{name}: {fact:#?}");
+    }
+    Ok(())
+}
+
+#[test]
+fn ruby_complete_domain_closes_duplicates_reopening_and_relative_imports() -> anyhow::Result<()> {
+    let cases = [
+        (
+            "cross_file_local_and_class_reopening",
+            vec![
+                (
+                    "lib/main.rb",
+                    concat!(
+                        "def local_target\nend\n",
+                        "def local_caller\n  local_target\nend\n",
+                        "class Worker\n",
+                        "  def member_target\n  end\n",
+                        "  def self_caller\n    self.member_target\n  end\n",
+                        "end\n",
+                        "def constructor_caller\n  Worker.new.member_target\nend\n",
+                    ),
+                ),
+                (
+                    "lib/reopen.rb",
+                    "def local_target\nend\nclass Worker\n  def unrelated\n  end\nend\n",
+                ),
+            ],
+            vec!["local_target", "member_target"],
+        ),
+        (
+            "relative_import_reopening",
+            vec![
+                (
+                    "lib/worker.rb",
+                    "class Worker\n  def imported_target\n  end\nend\n",
+                ),
+                (
+                    "lib/caller.rb",
+                    "require_relative \"worker\"\ndef caller\n  Worker.new.imported_target\nend\n",
+                ),
+                (
+                    "lib/reopen.rb",
+                    "class Worker\n  def unrelated\n  end\nend\n",
+                ),
+            ],
+            vec!["imported_target"],
+        ),
+    ];
+    for (name, files, targets) in cases {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(project.path(), &mut store, &files)?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        let facts = store.get_proof_resolution_facts()?;
+        for target in targets {
+            let matching = facts
+                .iter()
+                .filter(|fact| {
+                    fact.provenance.language_adapter == "ruby" && fact.callsite.raw_target == target
+                })
+                .collect::<Vec<_>>();
+            assert!(!matching.is_empty(), "{name} {target}: {facts:#?}");
+            assert!(
+                matching.iter().all(|fact| {
+                    fact.status != ProofResolutionStatus::Exact
+                        && fact.target.is_none()
+                        && fact.edge_id.is_none()
+                        && fact.evidence_chain.is_empty()
+                }),
+                "{name} {target}: {matching:#?}"
+            );
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn php_global_and_named_namespace_domains_are_complete_and_replay_bound() -> anyhow::Result<()> {
+    let exact_domains = [
+        (
+            "global",
+            vec![
+                (
+                    "src/Caller.php",
+                    concat!(
+                        "<?php\nfunction global_target() {}\n",
+                        "class Worker { public function memberTarget() {} }\n",
+                        "function global_caller() { global_target(); (new Worker())->memberTarget(); }\n",
+                    ),
+                ),
+                (
+                    "src/Unrelated.php",
+                    "<?php\nfunction unrelated_global() {}\n",
+                ),
+            ],
+            vec!["global_target", "memberTarget"],
+        ),
+        (
+            "named",
+            vec![
+                (
+                    "src/App/Caller.php",
+                    concat!(
+                        "<?php\nnamespace App;\nfunction named_target() {}\n",
+                        "class Worker { public function memberTarget() {} }\n",
+                        "function named_caller() { named_target(); (new Worker())->memberTarget(); }\n",
+                    ),
+                ),
+                (
+                    "src/App/Unrelated.php",
+                    "<?php\nnamespace App;\nfunction unrelated_named() {}\n",
+                ),
+                (
+                    "src/Other/Other.php",
+                    "<?php\nnamespace Other;\nfunction outside_domain() {}\n",
+                ),
+            ],
+            vec!["named_target", "memberTarget"],
+        ),
+    ];
+    for (name, files, targets) in exact_domains {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(project.path(), &mut store, &files)?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        store.validate_proof_resolution_publication(&publication(1))?;
+        let facts = store.get_proof_resolution_facts()?;
+        let domain_file_ids = store
+            .get_files()?
+            .into_iter()
+            .filter(|file| {
+                file.path.ends_with("Caller.php") || file.path.ends_with("Unrelated.php")
+            })
+            .map(|file| FileId(file.id))
+            .collect::<BTreeSet<_>>();
+        for target in targets {
+            let fact = facts
+                .iter()
+                .find(|fact| {
+                    fact.provenance.language_adapter == "php"
+                        && fact.callsite.raw_target == target
+                        && fact.status == ProofResolutionStatus::Exact
+                })
+                .unwrap_or_else(|| panic!("{name} {target}: {facts:#?}"));
+            let dependencies = fact
+                .provenance
+                .dependency_file_hashes
+                .iter()
+                .map(|dependency| dependency.file_id)
+                .collect::<BTreeSet<_>>();
+            assert!(
+                domain_file_ids.is_subset(&dependencies),
+                "{name} {target}: {fact:#?}"
+            );
+        }
+    }
+
+    for sibling in [
+        "<?php\nnamespace App;\nfunction target() {}\n",
+        "<?php\nnamespace App;\nfunction broken( {\n",
+    ] {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(
+            project.path(),
+            &mut store,
+            &[
+                (
+                    "src/App/Caller.php",
+                    "<?php\nnamespace App;\nfunction target() {}\nfunction caller() { target(); }\n",
+                ),
+                ("src/App/Sibling.php", sibling),
+            ],
+        )?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        let fact = store
+            .get_proof_resolution_facts()?
+            .into_iter()
+            .find(|fact| {
+                fact.provenance.language_adapter == "php" && fact.callsite.raw_target == "target"
+            })
+            .expect("PHP duplicate/incomplete domain fact");
+        assert_ne!(fact.status, ProofResolutionStatus::Exact, "{fact:#?}");
+        assert!(fact.target.is_none() && fact.edge_id.is_none());
+    }
+
+    for mutation in ["source_drift", "missing_dependency"] {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(
+            project.path(),
+            &mut store,
+            &[
+                (
+                    "src/App/Caller.php",
+                    "<?php\nnamespace App;\nfunction target() {}\nfunction caller() { target(); }\n",
+                ),
+                (
+                    "src/App/Sibling.php",
+                    "<?php\nnamespace App;\nfunction unrelated() {}\n",
+                ),
+            ],
+        )?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        let sibling = store
+            .get_files()?
+            .into_iter()
+            .find(|file| file.path.ends_with("Sibling.php"))
+            .expect("PHP namespace sibling");
+        if mutation == "source_drift" {
+            store.get_connection().execute(
+                "UPDATE file SET content_hash = ?1 WHERE id = ?2",
+                ("0".repeat(64), sibling.id),
+            )?;
+            assert!(
+                store
+                    .validate_proof_resolution_publication(&publication(1))
+                    .is_err()
+            );
+        } else {
+            let receipt = store
+                .get_proof_resolution_publication()?
+                .expect("PHP proof publication");
+            let mut facts = store.get_proof_resolution_facts()?;
+            let fact = facts
+                .iter_mut()
+                .find(|fact| {
+                    fact.provenance.language_adapter == "php"
+                        && fact.callsite.raw_target == "target"
+                })
+                .expect("PHP exact target fact");
+            fact.provenance
+                .dependency_file_hashes
+                .retain(|dependency| dependency.file_id != FileId(sibling.id));
+            *fact = seal_call_resolution_fact(fact.clone())?;
+            let projection = ProofResolutionProjection {
+                adapter_roster: receipt.adapter_roster,
+                funnel: build_proof_resolution_funnel(&facts),
+                facts,
+            };
+            assert!(
+                store
+                    .replace_proof_resolution_projection(&publication(2), &projection)
+                    .is_err()
+            );
+        }
+    }
+    Ok(())
+}
+
+#[test]
 fn java_and_kotlin_exact_facts_reject_resealed_raw_call_mutation() -> anyhow::Result<()> {
     for (language, path, source) in [
         (

--- a/crates/codestory-indexer/tests/proof_resolution.rs
+++ b/crates/codestory-indexer/tests/proof_resolution.rs
@@ -1400,6 +1400,74 @@ fn ruby_complete_domain_closes_duplicates_reopening_and_relative_imports() -> an
             );
         }
     }
+
+    for mutation in ["source_drift", "missing_dependency"] {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(
+            project.path(),
+            &mut store,
+            &[
+                (
+                    "lib/worker.rb",
+                    "class Worker\n  def imported_target\n  end\nend\n",
+                ),
+                (
+                    "lib/caller.rb",
+                    "require_relative \"worker\"\ndef caller\n  Worker.new.imported_target\nend\n",
+                ),
+                (
+                    "lib/unrelated.rb",
+                    "def unrelated_target\nend\ndef unrelated_caller\n  unrelated_target\nend\n",
+                ),
+            ],
+        )?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        store.validate_proof_resolution_publication(&publication(1))?;
+        let unrelated = store
+            .get_files()?
+            .into_iter()
+            .find(|file| file.path.ends_with("unrelated.rb"))
+            .expect("Ruby governed-domain sibling");
+        if mutation == "source_drift" {
+            store.get_connection().execute(
+                "UPDATE file SET content_hash = ?1 WHERE id = ?2",
+                ("0".repeat(64), unrelated.id),
+            )?;
+            assert!(
+                store
+                    .validate_proof_resolution_publication(&publication(1))
+                    .is_err()
+            );
+        } else {
+            let receipt = store
+                .get_proof_resolution_publication()?
+                .expect("Ruby proof publication");
+            let mut facts = store.get_proof_resolution_facts()?;
+            let fact = facts
+                .iter_mut()
+                .find(|fact| {
+                    fact.provenance.language_adapter == "ruby"
+                        && fact.callsite.raw_target == "imported_target"
+                        && fact.status == ProofResolutionStatus::Exact
+                })
+                .expect("Ruby exact require_relative fact");
+            fact.provenance
+                .dependency_file_hashes
+                .retain(|dependency| dependency.file_id != FileId(unrelated.id));
+            *fact = seal_call_resolution_fact(fact.clone())?;
+            let projection = ProofResolutionProjection {
+                adapter_roster: receipt.adapter_roster,
+                funnel: build_proof_resolution_funnel(&facts),
+                facts,
+            };
+            assert!(
+                store
+                    .replace_proof_resolution_projection(&publication(2), &projection)
+                    .is_err()
+            );
+        }
+    }
     Ok(())
 }
 
@@ -1513,6 +1581,42 @@ fn php_global_and_named_namespace_domains_are_complete_and_replay_bound() -> any
         assert!(fact.target.is_none() && fact.edge_id.is_none());
     }
 
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(
+        project.path(),
+        &mut store,
+        &[
+            (
+                "src/App/Caller.php",
+                concat!(
+                    "<?php\nnamespace App;\n",
+                    "class Worker { public function target() {} public function caller() { $this->target(); } }\n",
+                    "function construct() { (new Worker())->target(); }\n",
+                ),
+            ),
+            (
+                "src/App/Duplicate.php",
+                "<?php\nnamespace App;\nclass Worker { public function unrelated() {} }\n",
+            ),
+        ],
+    )?;
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    let duplicate_class_facts = store
+        .get_proof_resolution_facts()?
+        .into_iter()
+        .filter(|fact| {
+            fact.provenance.language_adapter == "php" && fact.callsite.raw_target == "target"
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(duplicate_class_facts.len(), 2, "{duplicate_class_facts:#?}");
+    assert!(duplicate_class_facts.iter().all(|fact| {
+        fact.status != ProofResolutionStatus::Exact
+            && fact.target.is_none()
+            && fact.edge_id.is_none()
+            && fact.evidence_chain.is_empty()
+    }));
+
     for mutation in ["source_drift", "missing_dependency"] {
         let project = tempfile::tempdir()?;
         let mut store = Store::new_in_memory()?;
@@ -1526,11 +1630,12 @@ fn php_global_and_named_namespace_domains_are_complete_and_replay_bound() -> any
                 ),
                 (
                     "src/App/Sibling.php",
-                    "<?php\nnamespace App;\nfunction unrelated() {}\n",
+                    "<?php\nnamespace App;\nfunction unrelated() {}\nfunction unrelated_caller() { unrelated(); }\n",
                 ),
             ],
         )?;
         rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        store.validate_proof_resolution_publication(&publication(1))?;
         let sibling = store
             .get_files()?
             .into_iter()
@@ -9024,7 +9129,7 @@ fn complete_projection_rejects_cache_schema_adapter_and_language_mismatch() -> a
             .expect_err("cache provenance mismatch must reject the complete projection");
         let message = error.to_string();
         assert!(
-            ["stale", "schema-v22", "adapter", "language"]
+            ["stale", "schema-v23", "adapter", "language"]
                 .iter()
                 .any(|needle| message.contains(needle)),
             "{mutation}: {error}"

--- a/crates/codestory-store/src/storage_impl/proof_resolution.rs
+++ b/crates/codestory-store/src/storage_impl/proof_resolution.rs
@@ -327,6 +327,7 @@ fn canonical_php_namespace_identity(name: &str) -> Option<String> {
     .then(|| components.join("."))
 }
 
+#[allow(clippy::type_complexity)]
 fn prepare_ruby_php_domain_closure(
     files: &[FileInfo],
     nodes: &HashMap<NodeId, Node>,
@@ -2541,10 +2542,8 @@ impl Storage {
                 .node_by_id
                 .get(&node_id)
                 .ok_or_else(|| proof_error("typed evidence references a missing graph node"))?;
-            if let Some(file_id) = node.file_node_id {
-                if !linear_language {
-                    required_dependency_ids.insert(FileId(file_id.0));
-                }
+            if !linear_language && let Some(file_id) = node.file_node_id {
+                required_dependency_ids.insert(FileId(file_id.0));
             }
         }
         if fact.status == ProofResolutionStatus::Exact && fact.provenance.language_adapter == "go" {
@@ -2587,9 +2586,11 @@ impl Storage {
                 )));
             }
         }
-        let observed_dependency_ids = (!linear_language)
-            .then(|| dependency_file_ids(fact))
-            .unwrap_or_default();
+        let observed_dependency_ids = if !linear_language {
+            dependency_file_ids(fact)
+        } else {
+            BTreeSet::new()
+        };
         if fact.status == ProofResolutionStatus::Exact
             && let Some(java_dependencies) =
                 java_same_package_dependency_ids(fact, &required_dependency_ids, context)?
@@ -2606,15 +2607,15 @@ impl Storage {
                 context,
             )?;
         }
-        if !linear_language {
-            if let Some(rust_dependencies) = rust_same_file_dependency_ids(
+        if !linear_language
+            && let Some(rust_dependencies) = rust_same_file_dependency_ids(
                 fact,
                 &required_dependency_ids,
                 &observed_dependency_ids,
                 context,
-            ) {
-                required_dependency_ids = rust_dependencies;
-            }
+            )
+        {
+            required_dependency_ids = rust_dependencies;
         }
         if !linear_language && observed_dependency_ids != required_dependency_ids {
             return Err(proof_error(format!(

--- a/crates/codestory-store/src/storage_impl/proof_resolution.rs
+++ b/crates/codestory-store/src/storage_impl/proof_resolution.rs
@@ -2206,6 +2206,15 @@ impl Storage {
                 context,
             )?;
         }
+        if fact.status == ProofResolutionStatus::Exact && fact.provenance.language_adapter == "ruby"
+        {
+            required_dependency_ids = context
+                .file_by_id
+                .values()
+                .filter(|file| file.indexed && file.complete && file.language == "ruby")
+                .map(|file| FileId(file.id))
+                .collect();
+        }
         if let Some(rust_dependencies) = rust_same_file_dependency_ids(
             fact,
             &required_dependency_ids,
@@ -2304,10 +2313,13 @@ impl Storage {
             .node_by_id
             .get(&raw_edge_target)
             .ok_or_else(|| proof_error("raw CALL placeholder node is missing"))?;
-        let direct_member_target = matches!(
+        let direct_member_target = (matches!(
             fact.callsite.callee_form,
             CalleeForm::ImplicitReceiver | CalleeForm::ExplicitReceiver | CalleeForm::NamedImport
-        ) && raw_edge_target == target
+        ) || matches!(
+            fact.provenance.language_adapter.as_str(),
+            "ruby" | "php"
+        )) && raw_edge_target == target
             && (matches!(raw_placeholder.kind, NodeKind::FUNCTION | NodeKind::METHOD)
                 || raw_placeholder.file_node_id != Some(NodeId(fact.callsite.file_id.0)));
         if !direct_member_target
@@ -2384,7 +2396,9 @@ impl Storage {
                     .get(import)
                     .ok_or_else(|| proof_error("static import binding is missing"))?;
                 if import_node.file_node_id != Some(NodeId(fact.callsite.file_id.0))
-                    || graph_leaf_name(&import_node.serialized_name) != fact.callsite.raw_target
+                    || (fact.provenance.language_adapter != "php"
+                        && graph_leaf_name(&import_node.serialized_name)
+                            != fact.callsite.raw_target)
                     || !(if context
                         .typescript_directory_marker_seen(NodeId(fact.callsite.file_id.0), *import)
                     {
@@ -3276,7 +3290,7 @@ fn graph_leaf_name(name: &str) -> &str {
 fn proof_import_node_kind_is_literal(language: &str, kind: NodeKind) -> bool {
     match language {
         "rust" => kind == NodeKind::MODULE,
-        "java" | "kotlin" | "javascript" | "typescript" | "tsx" | "python" => {
+        "java" | "kotlin" | "javascript" | "typescript" | "tsx" | "python" | "php" | "ruby" => {
             matches!(kind, NodeKind::MODULE | NodeKind::UNKNOWN)
         }
         _ => false,

--- a/crates/codestory-store/src/storage_impl/proof_resolution.rs
+++ b/crates/codestory-store/src/storage_impl/proof_resolution.rs
@@ -52,13 +52,28 @@ pub struct ProofResolutionPublication {
 pub fn seal_call_resolution_fact(
     mut fact: CallResolutionFact,
 ) -> Result<CallResolutionFact, StorageError> {
-    fact.provenance.dependency_file_hashes.sort();
-    if fact
-        .provenance
-        .dependency_file_hashes
-        .windows(2)
-        .any(|pair| pair[0].file_id == pair[1].file_id)
-    {
+    let linear_dependency_order =
+        matches!(fact.provenance.language_adapter.as_str(), "ruby" | "php");
+    if !linear_dependency_order {
+        fact.provenance.dependency_file_hashes.sort();
+    }
+    let unique_dependencies = if linear_dependency_order {
+        let mut members = HashSet::new();
+        fact.provenance
+            .dependency_file_hashes
+            .iter()
+            .all(|dependency| {
+                count_store_replay_work(1);
+                members.insert(dependency.file_id)
+            })
+    } else {
+        !fact
+            .provenance
+            .dependency_file_hashes
+            .windows(2)
+            .any(|pair| pair[0].file_id == pair[1].file_id)
+    };
+    if !unique_dependencies {
         return Err(proof_error(
             "dependency file hashes contain a duplicate file",
         ));
@@ -113,6 +128,24 @@ where
 }
 
 fn validate_fact_shape(fact: &CallResolutionFact, require_seal: bool) -> Result<(), StorageError> {
+    let linear_dependency_order =
+        matches!(fact.provenance.language_adapter.as_str(), "ruby" | "php");
+    let dependencies_are_canonical = if linear_dependency_order {
+        let mut members = HashSet::new();
+        fact.provenance
+            .dependency_file_hashes
+            .iter()
+            .all(|dependency| {
+                count_store_replay_work(1);
+                members.insert(dependency.file_id)
+            })
+    } else {
+        !fact
+            .provenance
+            .dependency_file_hashes
+            .windows(2)
+            .any(|pair| pair[0].file_id >= pair[1].file_id)
+    };
     if fact.callsite.file_id.0 == 0
         || fact.caller.0 == 0
         || !is_sha256(&fact.callsite.source_sha256)
@@ -143,11 +176,7 @@ fn validate_fact_shape(fact: &CallResolutionFact, require_seal: bool) -> Result<
             .dependency_file_hashes
             .iter()
             .any(|dependency| dependency.file_id.0 == 0 || !is_sha256(&dependency.source_sha256))
-        || fact
-            .provenance
-            .dependency_file_hashes
-            .windows(2)
-            .any(|pair| pair[0].file_id >= pair[1].file_id)
+        || !dependencies_are_canonical
     {
         return Err(proof_error(
             "dependency file hashes are empty, invalid, duplicate, or noncanonical",
@@ -268,10 +297,170 @@ struct ProofResolutionValidationContext {
     python_attestation_error_by_file: HashMap<i64, String>,
     java_package_identity_by_file: HashMap<i64, String>,
     java_dependency_ids_by_package: HashMap<String, BTreeSet<FileId>>,
+    ruby_dependency_file_ids: Vec<FileId>,
+    php_namespace_identity_by_file: HashMap<i64, PhpNamespaceIdentity>,
+    php_dependency_ids_by_namespace: HashMap<PhpNamespaceIdentity, Vec<FileId>>,
+    php_namespace_domain_invalid: bool,
     go_package_identity_by_file: HashMap<i64, GoPackageIdentity>,
     go_dependency_ids_by_package: HashMap<GoPackageIdentity, BTreeSet<FileId>>,
     go_attestation_error_by_file: HashMap<i64, String>,
     live_go_sources_authenticated: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum PhpNamespaceIdentity {
+    Global,
+    Named(String),
+}
+
+fn canonical_php_namespace_identity(name: &str) -> Option<String> {
+    let components = name.split('\\').collect::<Vec<_>>();
+    count_store_replay_work(components.len());
+    (!components.is_empty()
+        && components.iter().all(|component| {
+            let mut chars = component.chars();
+            chars
+                .next()
+                .is_some_and(|ch| ch == '_' || ch.is_ascii_alphabetic())
+                && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+        }))
+    .then(|| components.join("."))
+}
+
+fn prepare_ruby_php_domain_closure(
+    files: &[FileInfo],
+    nodes: &HashMap<NodeId, Node>,
+) -> (
+    Vec<FileId>,
+    HashMap<i64, PhpNamespaceIdentity>,
+    HashMap<PhpNamespaceIdentity, Vec<FileId>>,
+    bool,
+) {
+    let ruby_dependency_file_ids = files
+        .iter()
+        .filter(|file| file.indexed && file.language == "ruby")
+        .map(|file| {
+            count_store_replay_work(1);
+            FileId(file.id)
+        })
+        .collect::<Vec<_>>();
+    let php_file_ids = files
+        .iter()
+        .filter(|file| file.indexed && file.language == "php")
+        .map(|file| {
+            count_store_replay_work(1);
+            file.id
+        })
+        .collect::<HashSet<_>>();
+    let mut php_names_by_file = HashMap::<i64, Vec<String>>::new();
+    for node in nodes
+        .values()
+        .filter(|node| node.kind == NodeKind::NAMESPACE)
+    {
+        count_store_replay_work(1);
+        let Some(file_id) = node.file_node_id else {
+            continue;
+        };
+        if !php_file_ids.contains(&file_id.0) {
+            continue;
+        }
+        count_store_replay_work(1);
+        if let Some(name) = canonical_php_namespace_identity(&node.serialized_name) {
+            count_store_replay_work(1);
+            php_names_by_file.entry(file_id.0).or_default().push(name);
+        } else {
+            php_names_by_file
+                .entry(file_id.0)
+                .or_default()
+                .extend([String::new(), String::new()]);
+        }
+    }
+    let mut identity_by_file = HashMap::new();
+    let mut dependencies_by_namespace = HashMap::<PhpNamespaceIdentity, Vec<FileId>>::new();
+    let mut invalid = false;
+    for file in files
+        .iter()
+        .filter(|file| file.indexed && file.language == "php")
+    {
+        count_store_replay_work(1);
+        let names = php_names_by_file
+            .get(&file.id)
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        let identity = match names {
+            [] => PhpNamespaceIdentity::Global,
+            [name] if !name.is_empty() => PhpNamespaceIdentity::Named(name.clone()),
+            _ => {
+                invalid = true;
+                continue;
+            }
+        };
+        identity_by_file.insert(file.id, identity.clone());
+        dependencies_by_namespace
+            .entry(identity)
+            .or_default()
+            .push(FileId(file.id));
+        count_store_replay_work(2);
+    }
+    (
+        ruby_dependency_file_ids,
+        identity_by_file,
+        dependencies_by_namespace,
+        invalid,
+    )
+}
+
+fn ruby_php_dependency_ids(
+    fact: &CallResolutionFact,
+    context: &ProofResolutionValidationContext,
+) -> Result<Vec<FileId>, StorageError> {
+    let mut dependencies = Vec::new();
+    let mut members = HashSet::new();
+    let mut append = |file_id: FileId| {
+        count_store_replay_work(1);
+        if members.insert(file_id) {
+            dependencies.push(file_id);
+        }
+    };
+    append(fact.callsite.file_id);
+    if fact.provenance.language_adapter == "ruby" {
+        for file_id in &context.ruby_dependency_file_ids {
+            append(*file_id);
+        }
+        return Ok(dependencies);
+    }
+    if context.php_namespace_domain_invalid {
+        return Err(proof_error(
+            "PHP namespace domain contains an invalid identity",
+        ));
+    }
+    for file_id in std::iter::once(fact.callsite.file_id).chain(
+        fact.evidence_chain
+            .iter()
+            .flat_map(ResolutionEvidence::node_ids)
+            .chain(fact.target)
+            .filter_map(|node_id| {
+                context
+                    .node_by_id
+                    .get(&node_id)
+                    .and_then(|node| node.file_node_id)
+                    .map(|file| FileId(file.0))
+            }),
+    ) {
+        count_store_replay_work(1);
+        let identity = context
+            .php_namespace_identity_by_file
+            .get(&file_id.0)
+            .ok_or_else(|| proof_error("PHP dependency has no canonical namespace identity"))?;
+        let domain = context
+            .php_dependency_ids_by_namespace
+            .get(identity)
+            .ok_or_else(|| proof_error("PHP dependency namespace domain is missing"))?;
+        for dependency in domain {
+            append(*dependency);
+        }
+    }
+    Ok(dependencies)
 }
 
 fn prepare_rust_file_identity(
@@ -1248,6 +1437,10 @@ mod go_replay_complexity_tests {
             python_attestation_error_by_file: HashMap::new(),
             java_package_identity_by_file: HashMap::new(),
             java_dependency_ids_by_package: HashMap::new(),
+            ruby_dependency_file_ids: Vec::new(),
+            php_namespace_identity_by_file: HashMap::new(),
+            php_dependency_ids_by_namespace: HashMap::new(),
+            php_namespace_domain_invalid: false,
             go_package_identity_by_file,
             go_dependency_ids_by_package,
             go_attestation_error_by_file,
@@ -1415,6 +1608,10 @@ mod python_replay_complexity_tests {
             python_attestation_error_by_file,
             java_package_identity_by_file: HashMap::new(),
             java_dependency_ids_by_package: HashMap::new(),
+            ruby_dependency_file_ids: Vec::new(),
+            php_namespace_identity_by_file: HashMap::new(),
+            php_dependency_ids_by_namespace: HashMap::new(),
+            php_namespace_domain_invalid: false,
             go_package_identity_by_file: HashMap::new(),
             go_dependency_ids_by_package: HashMap::new(),
             go_attestation_error_by_file: HashMap::new(),
@@ -1451,6 +1648,166 @@ mod python_replay_complexity_tests {
             combined <= baseline * 2 + 128,
             "combined Python store replay grew superlinearly: {baseline} -> {combined}"
         );
+    }
+}
+
+#[cfg(test)]
+mod ruby_php_replay_complexity_tests {
+    use super::*;
+
+    fn measured_domain_replay_work(
+        language: &str,
+        file_count: usize,
+        fact_count: usize,
+        hostile_namespace: bool,
+    ) -> usize {
+        let temp = tempfile::tempdir().expect("Ruby/PHP replay tempdir");
+        let mut files = Vec::new();
+        let mut node_by_id = HashMap::new();
+        for index in 0..file_count {
+            let id = i64::try_from(index + 1).expect("file id");
+            files.push(FileInfo {
+                id,
+                path: temp.path().join(format!(
+                    "file_{index}.{}",
+                    if language == "ruby" { "rb" } else { "php" }
+                )),
+                language: language.to_owned(),
+                modification_time: 0,
+                indexed: true,
+                complete: true,
+                line_count: 1,
+                file_role: FileRole::Source,
+            });
+            if language == "php" {
+                let namespace = Node {
+                    id: NodeId(10_000 + id),
+                    kind: NodeKind::NAMESPACE,
+                    serialized_name: "App".to_owned(),
+                    file_node_id: Some(NodeId(id)),
+                    ..Default::default()
+                };
+                node_by_id.insert(namespace.id, namespace);
+                if hostile_namespace && index == file_count - 1 {
+                    let duplicate = Node {
+                        id: NodeId(20_000 + id),
+                        kind: NodeKind::NAMESPACE,
+                        serialized_name: "Other".to_owned(),
+                        file_node_id: Some(NodeId(id)),
+                        ..Default::default()
+                    };
+                    node_by_id.insert(duplicate.id, duplicate);
+                }
+            }
+        }
+        reset_store_replay_work();
+        let (
+            ruby_dependency_file_ids,
+            php_namespace_identity_by_file,
+            php_dependency_ids_by_namespace,
+            php_namespace_domain_invalid,
+        ) = prepare_ruby_php_domain_closure(&files, &node_by_id);
+        let file_by_id = files
+            .into_iter()
+            .map(|file| (file.id, file))
+            .collect::<HashMap<_, _>>();
+        let context = ProofResolutionValidationContext {
+            file_by_id,
+            file_content_hash_by_id: HashMap::new(),
+            rust_file_ids_by_path: HashMap::new(),
+            rust_root_count_by_directory: HashMap::new(),
+            node_by_id,
+            edges: Vec::new(),
+            edge_index_by_id: HashMap::new(),
+            ordinary_call_edge_indices: Vec::new(),
+            parsed_callsite_identity_by_edge: HashMap::new(),
+            import_relations: HashMap::new(),
+            typescript_directory_import_relations: HashMap::new(),
+            member_relations: HashMap::new(),
+            member_by_owner_and_name: HashMap::new(),
+            python_import_paths: HashMap::new(),
+            python_file_ids_by_path: HashMap::new(),
+            python_attestation_error_by_file: HashMap::new(),
+            java_package_identity_by_file: HashMap::new(),
+            java_dependency_ids_by_package: HashMap::new(),
+            ruby_dependency_file_ids,
+            php_namespace_identity_by_file,
+            php_dependency_ids_by_namespace,
+            php_namespace_domain_invalid,
+            go_package_identity_by_file: HashMap::new(),
+            go_dependency_ids_by_package: HashMap::new(),
+            go_attestation_error_by_file: HashMap::new(),
+            live_go_sources_authenticated: true,
+        };
+        let fact = CallResolutionFact {
+            fact_id: String::new(),
+            edge_id: Some(EdgeId(1)),
+            raw_edge_target: Some(NodeId(2)),
+            raw_callsite_identity: Some("1:1:1:2".to_owned()),
+            callsite: ExactCallsite {
+                file_id: FileId(1),
+                source_sha256: "0".repeat(64),
+                start_byte: 1,
+                end_byte_exclusive: 2,
+                line: 1,
+                column: 1,
+                callee_form: CalleeForm::Identifier,
+                raw_target: "target".to_owned(),
+            },
+            caller: NodeId(1),
+            target: None,
+            status: ProofResolutionStatus::Exact,
+            reason: ProofResolutionReason::ExactResolution,
+            evidence_chain: Vec::new(),
+            lookup_domain_complete: true,
+            provenance: ResolutionProvenance {
+                producer: INTERNAL_RESOLUTION_PRODUCER.to_owned(),
+                fact_schema_version: PROOF_RESOLUTION_FACT_SCHEMA_VERSION,
+                algorithm: EXACT_CALL_RESOLUTION_ALGORITHM.to_owned(),
+                language_adapter: language.to_owned(),
+                language_adapter_version: "reference-v2".to_owned(),
+                parser_fingerprint: "0".repeat(64),
+                dependency_file_hashes: Vec::new(),
+                evidence_sha256: String::new(),
+            },
+        };
+        for _ in 0..fact_count {
+            let result = ruby_php_dependency_ids(&fact, &context);
+            if hostile_namespace && language == "php" {
+                assert!(result.is_err());
+            } else {
+                assert_eq!(result.expect("closed domain").len(), file_count);
+            }
+        }
+        store_replay_work()
+    }
+
+    #[test]
+    fn ruby_php_file_domain_and_fact_replay_work_is_independently_linear() {
+        for language in ["ruby", "php"] {
+            let baseline = measured_domain_replay_work(language, 32, 32, false);
+            let more_files = measured_domain_replay_work(language, 64, 32, false);
+            let more_facts = measured_domain_replay_work(language, 32, 64, false);
+            let combined = measured_domain_replay_work(language, 64, 32, false);
+            let hostile = measured_domain_replay_work(language, 64, 32, true);
+            assert!(baseline > 0, "{language} replay work was not counted");
+            assert!(
+                more_files <= baseline * 2 + 128,
+                "{language} file preparation grew superlinearly: {baseline} -> {more_files}"
+            );
+            assert!(
+                more_facts <= baseline * 2 + 128,
+                "{language} fact replay grew superlinearly: {baseline} -> {more_facts}"
+            );
+            assert!(
+                combined <= baseline * 2 + 256,
+                "{language} combined replay grew superlinearly: {baseline} -> {combined}"
+            );
+            assert!(
+                hostile <= more_files + 128,
+                "{language} hostile domain work was not linear: {more_files} -> {hostile}"
+            );
+        }
     }
 }
 
@@ -1534,11 +1891,8 @@ impl ProofResolutionValidationContext {
         storage: &Storage,
         authenticate_live_go_sources: bool,
     ) -> Result<Self, StorageError> {
-        let file_by_id = storage
-            .get_files()?
-            .into_iter()
-            .map(|file| (file.id, file))
-            .collect();
+        let files = storage.get_files()?;
+        let file_by_id = files.iter().cloned().map(|file| (file.id, file)).collect();
         let (rust_file_ids_by_path, rust_root_count_by_directory) =
             prepare_rust_file_identity(&file_by_id);
         let python_file_ids_by_path = prepare_python_file_ids_by_path(&file_by_id);
@@ -1564,6 +1918,12 @@ impl ProofResolutionValidationContext {
             .collect();
         let (java_package_identity_by_file, java_dependency_ids_by_package) =
             prepare_java_package_closure(&file_by_id, &node_by_id);
+        let (
+            ruby_dependency_file_ids,
+            php_namespace_identity_by_file,
+            php_dependency_ids_by_namespace,
+            php_namespace_domain_invalid,
+        ) = prepare_ruby_php_domain_closure(&files, &node_by_id);
         let edges = storage.get_edges()?;
         let (ordinary_call_edge_indices, parsed_callsite_identity_by_edge) =
             prepare_call_edge_correlation_index(&edges, &node_by_id);
@@ -1736,6 +2096,10 @@ impl ProofResolutionValidationContext {
             python_attestation_error_by_file,
             java_package_identity_by_file,
             java_dependency_ids_by_package,
+            ruby_dependency_file_ids,
+            php_namespace_identity_by_file,
+            php_dependency_ids_by_namespace,
+            php_namespace_domain_invalid,
             go_package_identity_by_file,
             go_dependency_ids_by_package,
             go_attestation_error_by_file,
@@ -1911,7 +2275,7 @@ impl Storage {
         if edge_id.is_some() {
             sql.push_str(" WHERE edge_id = ?1 AND status = 'exact'");
         }
-        sql.push_str(" ORDER BY file_id, start_byte, end_byte_exclusive, fact_id");
+        sql.push_str(" ORDER BY rowid");
         let mut stmt = self.conn.prepare(&sql)?;
         let mut rows = match edge_id {
             Some(edge_id) => stmt.query(params![edge_id.0])?,
@@ -2148,7 +2512,12 @@ impl Storage {
             ));
         }
 
-        let mut required_dependency_ids = BTreeSet::from([fact.callsite.file_id]);
+        let linear_language = matches!(fact.provenance.language_adapter.as_str(), "ruby" | "php");
+        let mut required_dependency_ids = if linear_language {
+            BTreeSet::new()
+        } else {
+            BTreeSet::from([fact.callsite.file_id])
+        };
         let mut evidence_node_ids = fact
             .evidence_chain
             .iter()
@@ -2157,15 +2526,25 @@ impl Storage {
         if let Some(target) = fact.target {
             evidence_node_ids.push(target);
         }
-        evidence_node_ids.sort_unstable();
-        evidence_node_ids.dedup();
+        if linear_language {
+            let mut members = HashSet::new();
+            evidence_node_ids.retain(|node_id| {
+                count_store_replay_work(1);
+                members.insert(*node_id)
+            });
+        } else {
+            evidence_node_ids.sort_unstable();
+            evidence_node_ids.dedup();
+        }
         for node_id in evidence_node_ids {
             let node = context
                 .node_by_id
                 .get(&node_id)
                 .ok_or_else(|| proof_error("typed evidence references a missing graph node"))?;
             if let Some(file_id) = node.file_node_id {
-                required_dependency_ids.insert(FileId(file_id.0));
+                if !linear_language {
+                    required_dependency_ids.insert(FileId(file_id.0));
+                }
             }
         }
         if fact.status == ProofResolutionStatus::Exact && fact.provenance.language_adapter == "go" {
@@ -2189,7 +2568,28 @@ impl Storage {
                 )?
             };
         }
-        let observed_dependency_ids = dependency_file_ids(fact);
+        if linear_language {
+            let expected = if fact.status == ProofResolutionStatus::Exact {
+                ruby_php_dependency_ids(fact, context)?
+            } else {
+                vec![fact.callsite.file_id]
+            };
+            let observed = fact
+                .provenance
+                .dependency_file_hashes
+                .iter()
+                .map(|dependency| dependency.file_id)
+                .collect::<Vec<_>>();
+            count_store_replay_work(observed.len().saturating_add(expected.len()));
+            if observed != expected {
+                return Err(proof_error(format!(
+                    "dependency hashes do not exactly cover the Ruby/PHP governed domain: observed={observed:?} required={expected:?}"
+                )));
+            }
+        }
+        let observed_dependency_ids = (!linear_language)
+            .then(|| dependency_file_ids(fact))
+            .unwrap_or_default();
         if fact.status == ProofResolutionStatus::Exact
             && let Some(java_dependencies) =
                 java_same_package_dependency_ids(fact, &required_dependency_ids, context)?
@@ -2206,24 +2606,17 @@ impl Storage {
                 context,
             )?;
         }
-        if fact.status == ProofResolutionStatus::Exact && fact.provenance.language_adapter == "ruby"
-        {
-            required_dependency_ids = context
-                .file_by_id
-                .values()
-                .filter(|file| file.indexed && file.complete && file.language == "ruby")
-                .map(|file| FileId(file.id))
-                .collect();
+        if !linear_language {
+            if let Some(rust_dependencies) = rust_same_file_dependency_ids(
+                fact,
+                &required_dependency_ids,
+                &observed_dependency_ids,
+                context,
+            ) {
+                required_dependency_ids = rust_dependencies;
+            }
         }
-        if let Some(rust_dependencies) = rust_same_file_dependency_ids(
-            fact,
-            &required_dependency_ids,
-            &observed_dependency_ids,
-            context,
-        ) {
-            required_dependency_ids = rust_dependencies;
-        }
-        if observed_dependency_ids != required_dependency_ids {
+        if !linear_language && observed_dependency_ids != required_dependency_ids {
             return Err(proof_error(format!(
                 "dependency hashes do not exactly cover source, import, package, and target files for {}: observed={observed_dependency_ids:?} required={required_dependency_ids:?}",
                 fact.provenance.language_adapter
@@ -3017,7 +3410,20 @@ impl Storage {
                 "rows are immutable within an already receipted staged publication",
             ));
         }
-        let mut facts = projection.facts.clone();
+        let mut linear_facts = Vec::new();
+        let mut facts = projection
+            .facts
+            .iter()
+            .filter_map(|fact| {
+                if matches!(fact.provenance.language_adapter.as_str(), "ruby" | "php") {
+                    count_store_replay_work(1);
+                    linear_facts.push(fact.clone());
+                    None
+                } else {
+                    Some(fact.clone())
+                }
+            })
+            .collect::<Vec<_>>();
         facts.sort_by(|left, right| {
             (
                 left.callsite.file_id,
@@ -3032,11 +3438,15 @@ impl Storage {
                     right.fact_id.as_str(),
                 ))
         });
+        facts.extend(linear_facts);
         self.validate_facts_against_graph(&facts, true)?;
-        if facts.windows(2).any(|pair| {
-            pair[0].callsite.file_id == pair[1].callsite.file_id
-                && pair[0].callsite.start_byte == pair[1].callsite.start_byte
-                && pair[0].callsite.end_byte_exclusive == pair[1].callsite.end_byte_exclusive
+        let mut exact_callsites = HashSet::new();
+        if facts.iter().any(|fact| {
+            !exact_callsites.insert((
+                fact.callsite.file_id,
+                fact.callsite.start_byte,
+                fact.callsite.end_byte_exclusive,
+            ))
         }) {
             return Err(proof_error(
                 "more than one fact owns the same exact callsite",
@@ -3058,7 +3468,20 @@ impl Storage {
         let mut adapter_roster = projection.adapter_roster.clone();
         adapter_roster.sort();
         validate_adapter_roster(&facts, &adapter_roster)?;
-        let mut funnel = projection.funnel.clone();
+        let mut linear_funnel = Vec::new();
+        let mut funnel = projection
+            .funnel
+            .iter()
+            .filter_map(|row| {
+                if matches!(row.language.as_str(), "ruby" | "php") {
+                    count_store_replay_work(1);
+                    linear_funnel.push(row.clone());
+                    None
+                } else {
+                    Some(row.clone())
+                }
+            })
+            .collect::<Vec<_>>();
         funnel.sort_by(|left, right| {
             (
                 left.language.as_str(),
@@ -3071,6 +3494,7 @@ impl Storage {
                     right.evidence_kind.map(|kind| kind.as_str()),
                 ))
         });
+        funnel.extend(linear_funnel);
         if funnel.iter().any(|row| row.language.trim().is_empty()) {
             return Err(proof_error("funnel contains an empty language"));
         }
@@ -3466,15 +3890,23 @@ fn recompute_funnel(facts: &[CallResolutionFact]) -> Vec<ProofResolutionFunnelRo
         (String, Option<CalleeForm>, Option<ResolutionEvidenceKind>),
         ProofResolutionFunnelCounts,
     >::new();
+    let mut linear_rows = HashMap::<
+        (String, Option<CalleeForm>, Option<ResolutionEvidenceKind>),
+        ProofResolutionFunnelCounts,
+    >::new();
     for fact in facts {
         let evidence_kind = fact.evidence_chain.first().map(ResolutionEvidence::kind);
-        let counts = rows
-            .entry((
-                fact.provenance.language_adapter.clone(),
-                Some(fact.callsite.callee_form),
-                evidence_kind,
-            ))
-            .or_default();
+        let key = (
+            fact.provenance.language_adapter.clone(),
+            Some(fact.callsite.callee_form),
+            evidence_kind,
+        );
+        let counts = if matches!(fact.provenance.language_adapter.as_str(), "ruby" | "php") {
+            count_store_replay_work(1);
+            linear_rows.entry(key).or_default()
+        } else {
+            rows.entry(key).or_default()
+        };
         counts.syntax_calls += 1;
         counts.adapter_supported += u64::from(fact.status != ProofResolutionStatus::Unsupported);
         match fact.status {
@@ -3510,5 +3942,39 @@ fn recompute_funnel(facts: &[CallResolutionFact]) -> Vec<ProofResolutionFunnelRo
                 right.evidence_kind.map(|kind| kind.as_str()),
             ))
     });
+    for language in ["php", "ruby"] {
+        for callee_form in [
+            CalleeForm::Constructor,
+            CalleeForm::DynamicAccess,
+            CalleeForm::ExplicitReceiver,
+            CalleeForm::Identifier,
+            CalleeForm::ImplicitReceiver,
+            CalleeForm::NamedImport,
+            CalleeForm::QualifiedPath,
+        ] {
+            for evidence_kind in [
+                None,
+                Some(ResolutionEvidenceKind::ConstructorBinding),
+                Some(ResolutionEvidenceKind::ExplicitReceiverType),
+                Some(ResolutionEvidenceKind::ImplicitReceiver),
+                Some(ResolutionEvidenceKind::QualifiedPath),
+                Some(ResolutionEvidenceKind::SameFileDeclaration),
+                Some(ResolutionEvidenceKind::SamePackageDeclaration),
+                Some(ResolutionEvidenceKind::StaticImportBinding),
+            ] {
+                let key = (language.to_owned(), Some(callee_form), evidence_kind);
+                count_store_replay_work(1);
+                if let Some(counts) = linear_rows.remove(&key) {
+                    result.push(ProofResolutionFunnelRow {
+                        language: language.to_owned(),
+                        callee_form: Some(callee_form),
+                        evidence_kind,
+                        counts,
+                    });
+                }
+            }
+        }
+    }
+    debug_assert!(linear_rows.is_empty());
     result
 }


### PR DESCRIPTION
## Context

Closes #2073.
Refs #2023 and #2066.

This is the Ruby/PHP slice of the production-unreachable multilingual proof overlay. The supported/unsupported/hostile matrix was frozen before production changes at `6ac719cd`, and the accepted branch is frozen at `ab9e22b87b967d35119cdac3489ca316e9687586` on `dev/codestory-0.18@5fb498076c61247075c7898fa85a6f1ed557a949`.

## What changed

- Add exact Ruby resolution for the closed subset: unique same-file methods, `self`, direct constructor-bound receivers, and authenticated literal project-owned `require_relative` targets.
- Add exact PHP resolution for same-file and namespaced functions, exact `use` aliases, `$this`, direct construction, and concrete declared receiver types.
- Authenticate complete Ruby project and PHP global/named namespace domains during materialization and store replay.
- Default-deny Ruby executable declaration bodies and method-table mutation, including reopening, alias/undef, singleton classes, reflection, magic declarations, and call-shaped mutation families.
- Preserve parser order and use insertion-ordered membership paths with counted preparation, projection, and replay work.
- Isolate benchmark language/class cohorts so hostile Ruby global-domain poison cannot contaminate the supported cohort while every cohort still exercises a complete multi-file domain.
- Remove `ruby` and `php` from the temporary missing-adapter allowlist. Schema 32 and public route darkness remain unchanged.

## How to review

Start with the closed matrix in `crates/codestory-indexer/tests/proof_resolution.rs`. Then review the Ruby/PHP parser-domain producers in `crates/codestory-indexer/src/proof_resolution.rs`, the closed PHP namespace cache identity, and the matching replay reconstruction in `crates/codestory-store/src/storage_impl/proof_resolution.rs`.

The main trust questions are: whether any executable declaration domain can still authorize exact resolution; whether materialization and replay derive identical complete dependency domains; and whether every new path remains deterministic and linear.

## Verification

- `cargo test --locked -p codestory-indexer --test proof_resolution` — 159 passed
- `cargo test --locked -p codestory-bench --test multilingual_proof_contract` — 6 passed
- `cargo test --locked -p codestory-cli --test architecture_contracts` — 57 passed
- `cargo test --locked -p codestory-indexer --test fidelity_regression` — 8 passed
- `cargo test --locked -p codestory-indexer --test tictactoe_language_coverage` — 13 passed
- Ruby focused integration — 7 passed
- PHP focused integration — 5 passed
- Indexer/store linear-work contracts — 3 passed
- `cargo clippy --locked -p codestory-indexer -p codestory-store -p codestory-bench --all-targets -- -D warnings`
- package-scoped formatting check for the changed crates
- `git diff --check`

## Risk and non-claims

Ruby and PHP have large dynamic surfaces. Unsupported constructs remain canonical non-exact facts with no target, edge, or evidence, and exact facts require graph correlation plus complete authenticated domains. Ordinary navigation, retrieval, packet/context/search, runtime, CLI, plugin, Q2, schema, and public route registration are unchanged.
