### PR TITLE
add csharp swift dart exact resolution

### DIFF
--- a/crates/codestory-bench/src/bin/codestory_proof_availability/multilingual_contract.rs
+++ b/crates/codestory-bench/src/bin/codestory_proof_availability/multilingual_contract.rs
@@ -561,11 +561,7 @@ pub fn observe_multilingual_contract() -> Result<MultilingualObservation> {
     for dispatch in DISPATCHES {
         for ordinal in 0..24_u8 {
             let class = fixture_class(ordinal);
-            let relative = format!(
-                "languages/{}/{class:?}-{ordinal}.{}",
-                dispatch.language, dispatch.extension
-            )
-            .to_lowercase();
+            let relative = fixture_relative_path(dispatch, class, ordinal);
             planned.push(PlannedLanguageCase {
                 language: dispatch.language,
                 class,
@@ -846,7 +842,12 @@ fn initialize_fixture_repository(checkout: &Path) -> Result<()> {
 }
 
 fn fixture_relative_path(dispatch: &DispatchFixture, class: FixtureClass, ordinal: u8) -> PathBuf {
-    PathBuf::from(format!("fixtures/{class:?}-{ordinal}.{}", dispatch.extension).to_lowercase())
+    let cohort = format!("{class:?}_{ordinal}").to_lowercase();
+    match dispatch.language {
+        "swift" => PathBuf::from(format!("Sources/{cohort}/fixture.swift")),
+        "dart" => PathBuf::from(format!("lib/{cohort}.dart")),
+        _ => PathBuf::from(format!("fixtures/{cohort}.{}", dispatch.extension)),
+    }
 }
 
 fn fixture_symbol(language: &str, ordinal: u8) -> String {
@@ -873,47 +874,57 @@ fn observe_planned_language_cases(
                 .iter()
                 .filter(|fixture| fixture.language == dispatch.language && fixture.class == class)
                 .collect::<Vec<_>>();
-            let group_root =
-                tempfile::tempdir().context("create language-class fixture workspace")?;
-            let isolated = fixtures
-                .iter()
-                .map(|fixture| {
-                    let relative = fixture
-                        .path
-                        .strip_prefix(root)
-                        .context("fixture escaped multilingual workspace")?;
-                    Ok((
-                        *fixture,
-                        group_root.path().join(relative),
-                        fixture.source.clone(),
-                    ))
-                })
-                .collect::<Result<Vec<_>>>()?;
-            write_sources(
-                &isolated
+            let groups = if matches!(dispatch.language, "swift" | "dart") {
+                fixtures
+                    .into_iter()
+                    .map(|fixture| vec![fixture])
+                    .collect::<Vec<_>>()
+            } else {
+                vec![fixtures]
+            };
+            for fixtures in groups {
+                let group_root =
+                    tempfile::tempdir().context("create language-class fixture workspace")?;
+                let isolated = fixtures
                     .iter()
-                    .map(|(_, path, source)| (path.clone(), source.clone()))
-                    .collect::<Vec<_>>(),
-            )?;
-            let mut store = Store::new_in_memory()?;
-            index_paths(
-                group_root.path(),
-                &mut store,
-                isolated.iter().map(|(_, path, _)| path.clone()).collect(),
-            )?;
-            rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
-            for (fixture, path, _) in isolated {
-                cases.push(observe_case_from_store(
-                    &store,
-                    fixture.language,
-                    fixture.class,
-                    fixture.ordinal,
-                    &path,
-                    fixture.pinned_selector,
-                    adapter_roster.contains(fixture.language),
-                    fixture.materialized_commit.clone(),
-                    fixture.materialized_blob_sha256.clone(),
-                )?);
+                    .map(|fixture| {
+                        let relative = fixture
+                            .path
+                            .strip_prefix(root)
+                            .context("fixture escaped multilingual workspace")?;
+                        Ok((
+                            *fixture,
+                            group_root.path().join(relative),
+                            fixture.source.clone(),
+                        ))
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                write_sources(
+                    &isolated
+                        .iter()
+                        .map(|(_, path, source)| (path.clone(), source.clone()))
+                        .collect::<Vec<_>>(),
+                )?;
+                let mut store = Store::new_in_memory()?;
+                index_paths(
+                    group_root.path(),
+                    &mut store,
+                    isolated.iter().map(|(_, path, _)| path.clone()).collect(),
+                )?;
+                rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+                for (fixture, path, _) in isolated {
+                    cases.push(observe_case_from_store(
+                        &store,
+                        fixture.language,
+                        fixture.class,
+                        fixture.ordinal,
+                        &path,
+                        fixture.pinned_selector,
+                        adapter_roster.contains(fixture.language),
+                        fixture.materialized_commit.clone(),
+                        fixture.materialized_blob_sha256.clone(),
+                    )?);
+                }
             }
         }
     }

--- a/crates/codestory-bench/src/bin/codestory_proof_availability/multilingual_contract.rs
+++ b/crates/codestory-bench/src/bin/codestory_proof_availability/multilingual_contract.rs
@@ -30,7 +30,7 @@ pub const PUBLIC_PROOF_ROUTE_DARK: bool = true;
 /// Closed, temporary boundary for parser-backed languages without an installed
 /// proof adapter. The observed adapter roster is compared to this list in the
 /// contract test; this is not an expectation of a resolution result.
-pub const MISSING_ADAPTER_ALLOWLIST: &[&str] = &["csharp", "swift", "dart", "bash"];
+pub const MISSING_ADAPTER_ALLOWLIST: &[&str] = &["bash"];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FixtureClass {

--- a/crates/codestory-bench/tests/multilingual_proof_contract.rs
+++ b/crates/codestory-bench/tests/multilingual_proof_contract.rs
@@ -130,6 +130,29 @@ fn all_language_rows_are_real_parser_and_adapter_observations() -> anyhow::Resul
         observed_missing,
         MISSING_ADAPTER_ALLOWLIST.iter().copied().collect()
     );
+    assert_eq!(MISSING_ADAPTER_ALLOWLIST, &["bash"]);
+    for case in &observation.cases {
+        let components = case
+            .path
+            .components()
+            .filter_map(|component| component.as_os_str().to_str())
+            .collect::<Vec<_>>();
+        match case.language {
+            "swift" => assert!(
+                components
+                    .iter()
+                    .any(|component| matches!(*component, "Source" | "Sources")),
+                "Swift benchmark cohort escaped its authenticated source layout: {}",
+                case.path.display()
+            ),
+            "dart" => assert!(
+                components.contains(&"lib"),
+                "Dart benchmark cohort escaped lib: {}",
+                case.path.display()
+            ),
+            _ => {}
+        }
+    }
     Ok(())
 }
 

--- a/crates/codestory-indexer/src/cache.rs
+++ b/crates/codestory-indexer/src/cache.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::path::{Component, Path, PathBuf};
 
 // Versioned with proof-input semantics so older parser artifacts fail closed.
-const INDEX_ARTIFACT_CACHE_VERSION: u32 = 25;
+const INDEX_ARTIFACT_CACHE_VERSION: u32 = 26;
 const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
 const FNV_PRIME: u64 = 0x00000100000001B3;
 
@@ -349,7 +349,7 @@ impl CachedIndexArtifact {
         resolution_file: Option<CachedResolutionFile>,
     ) -> Self {
         Self {
-            resolution_input_schema_version: 23,
+            resolution_input_schema_version: 24,
             files: index_result.files,
             nodes: index_result.nodes,
             edges: index_result.edges,

--- a/crates/codestory-indexer/src/cache.rs
+++ b/crates/codestory-indexer/src/cache.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::path::{Component, Path, PathBuf};
 
 // Versioned with proof-input semantics so older parser artifacts fail closed.
-const INDEX_ARTIFACT_CACHE_VERSION: u32 = 26;
+const INDEX_ARTIFACT_CACHE_VERSION: u32 = 27;
 const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
 const FNV_PRIME: u64 = 0x00000100000001B3;
 
@@ -312,12 +312,20 @@ pub(crate) struct CachedClassDeclaration {
     pub name: String,
     pub declaration: NodeId,
     pub methods: Vec<CachedClassMethod>,
+    #[serde(default)]
+    pub cross_module_visible: bool,
+    #[serde(default)]
+    pub runtime_closed: bool,
+    #[serde(default)]
+    pub super_name: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct CachedClassMethod {
     pub name: String,
     pub declaration: NodeId,
+    #[serde(default)]
+    pub cross_module_visible: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -349,7 +357,7 @@ impl CachedIndexArtifact {
         resolution_file: Option<CachedResolutionFile>,
     ) -> Self {
         Self {
-            resolution_input_schema_version: 24,
+            resolution_input_schema_version: 25,
             files: index_result.files,
             nodes: index_result.nodes,
             edges: index_result.edges,

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -15832,16 +15832,45 @@ fn index_file_with_resolution_inputs(
             };
             let nid = NodeId(generate_id(&canonical_seed));
             graph_to_node_id.insert(node_id, nid);
-            let effective_access = access_kind.or_else(|| {
-                infer_access_from_source(
-                    language_config.language_name,
-                    &tree,
-                    source,
-                    &line_offsets,
-                    start_line,
+            let effective_access = if language_config.language_name == "swift"
+                && matches!(
                     kind,
+                    NodeKind::STRUCT
+                        | NodeKind::CLASS
+                        | NodeKind::ENUM
+                        | NodeKind::FUNCTION
+                        | NodeKind::METHOD
                 )
-            });
+                && matches!(
+                    canonical_role,
+                    CanonicalNodeRole::Definition
+                        | CanonicalNodeRole::Declaration
+                        | CanonicalNodeRole::ForwardDeclaration
+                ) {
+                Some(
+                    if proof_resolution::swift_declaration_cross_module_visible_at(
+                        &tree,
+                        source,
+                        start_line,
+                        start_col_1,
+                    ) {
+                        AccessKind::Public
+                    } else {
+                        AccessKind::Default
+                    },
+                )
+            } else {
+                access_kind.or_else(|| {
+                    infer_access_from_source(
+                        language_config.language_name,
+                        &tree,
+                        source,
+                        &line_offsets,
+                        start_line,
+                        kind,
+                    )
+                })
+            };
 
             unique_nodes.insert(
                 nid,

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -16707,7 +16707,11 @@ mod proof_resolution_cache_tests {
                     methods: vec![CachedClassMethod {
                         name: "target".to_owned(),
                         declaration: old_method,
+                        cross_module_visible: false,
                     }],
+                    cross_module_visible: false,
+                    runtime_closed: false,
+                    super_name: None,
                 }],
                 direct_exports: vec![CachedDirectExport {
                     exported_name: "C".to_owned(),

--- a/crates/codestory-indexer/src/proof_resolution.rs
+++ b/crates/codestory-indexer/src/proof_resolution.rs
@@ -155,18 +155,24 @@ const C_ADAPTER_VERSION: &str = "reference-v2";
 const CPP_ADAPTER_VERSION: &str = "reference-v3";
 const RUBY_ADAPTER_VERSION: &str = "reference-v3";
 const PHP_ADAPTER_VERSION: &str = "reference-v2";
-const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 23;
+const CSHARP_ADAPTER_VERSION: &str = "reference-v1";
+const SWIFT_ADAPTER_VERSION: &str = "reference-v1";
+const DART_ADAPTER_VERSION: &str = "reference-v1";
+const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 24;
 const INSTALLED_ADAPTERS: &[(&str, &str)] = &[
     ("go", GO_ADAPTER_VERSION),
     ("javascript", ADAPTER_VERSION),
     ("c", C_ADAPTER_VERSION),
     ("cpp", CPP_ADAPTER_VERSION),
+    ("csharp", CSHARP_ADAPTER_VERSION),
+    ("dart", DART_ADAPTER_VERSION),
     ("java", JAVA_ADAPTER_VERSION),
     ("kotlin", KOTLIN_ADAPTER_VERSION),
     ("python", PYTHON_ADAPTER_VERSION),
     ("php", PHP_ADAPTER_VERSION),
     ("ruby", RUBY_ADAPTER_VERSION),
     ("rust", RUST_ADAPTER_VERSION),
+    ("swift", SWIFT_ADAPTER_VERSION),
     ("tsx", TYPESCRIPT_ADAPTER_VERSION),
     ("typescript", TYPESCRIPT_ADAPTER_VERSION),
 ];
@@ -222,8 +228,9 @@ pub(crate) fn collect_call_resolution_inputs(
         (language == "go").then(|| GoResolutionIndex::build(tree, source, file_id, nodes));
     let python_index =
         (language == "python").then(|| PythonResolutionIndex::build(tree, source, file_id, nodes));
-    let java_kotlin_index = is_java_kotlin_language(language)
-        .then(|| JavaKotlinResolutionIndex::build(tree, source, language, file_id, nodes));
+    let java_kotlin_index = is_nominal_language(language).then(|| {
+        JavaKotlinResolutionIndex::build(tree, source, source_path, language, file_id, nodes)
+    });
     let c_cpp_index = is_c_cpp_language(language)
         .then(|| CCppResolutionIndex::build(tree, source, source_path, language, file_id, nodes));
     let ruby_index =
@@ -240,7 +247,11 @@ pub(crate) fn collect_call_resolution_inputs(
                 index.poisoned_export_names(),
             )
         } else if let Some(index) = &java_kotlin_index {
-            (Vec::new(), index.has_annotated_declaration, Vec::new())
+            (
+                Vec::new(),
+                index.has_annotated_declaration || index.domain_poisoned,
+                Vec::new(),
+            )
         } else if let Some(index) = &ruby_index {
             (index.direct_exports.clone(), index.poisoned, Vec::new())
         } else if let Some(index) = &php_index {
@@ -388,7 +399,11 @@ pub(crate) fn collect_call_resolution_inputs(
             emit_call(callee, form, raw_target, None);
         });
     }
-    if c_cpp_index.is_none() && ruby_index.is_none() && php_index.is_none() {
+    if c_cpp_index.is_none()
+        && ruby_index.is_none()
+        && php_index.is_none()
+        && !is_csharp_swift_dart_language(language)
+    {
         calls.sort_by_key(|input| (input.callsite.start_byte, input.callsite.end_byte_exclusive));
     } else {
         debug_assert!(calls.windows(2).all(|pair| {
@@ -484,6 +499,157 @@ fn is_javascript_language(language: &str) -> bool {
 
 fn is_java_kotlin_language(language: &str) -> bool {
     matches!(language, "java" | "kotlin")
+}
+
+fn is_csharp_swift_dart_language(language: &str) -> bool {
+    matches!(language, "csharp" | "swift" | "dart")
+}
+
+fn is_nominal_language(language: &str) -> bool {
+    is_java_kotlin_language(language) || is_csharp_swift_dart_language(language)
+}
+
+fn csd_source_domain(language: &str, source_path: &Path) -> Option<String> {
+    match language {
+        "csharp" => Some("csharp:global".to_string()),
+        "swift" => {
+            let components = source_path
+                .components()
+                .filter_map(|component| match component {
+                    Component::Normal(value) => value.to_str(),
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+            components
+                .windows(2)
+                .find_map(|pair| (pair[0] == "Sources").then(|| pair[1].to_string()))
+                .or_else(|| Some("swift:root".to_string()))
+        }
+        "dart" => {
+            let mut current = source_path.parent();
+            while let Some(directory) = current {
+                if directory.file_name().and_then(|name| name.to_str()) == Some("lib") {
+                    return Some("dart:lib".to_string());
+                }
+                current = directory.parent();
+            }
+            Some("dart:root".to_string())
+        }
+        _ => None,
+    }
+}
+
+fn swift_project_module(path: &Path) -> Option<&str> {
+    let mut components = path.components().filter_map(|component| match component {
+        Component::Normal(value) => value.to_str(),
+        _ => None,
+    });
+    while let Some(component) = components.next() {
+        if component == "Sources" {
+            return components
+                .next()
+                .filter(|module| java_kotlin_simple_identifier(module));
+        }
+    }
+    None
+}
+
+fn dart_literal_import_target_is_authenticated(
+    source_file: NodeId,
+    import: NodeId,
+    target_file: NodeId,
+    dependencies: &[FileId],
+    nodes: &HashMap<NodeId, &Node>,
+    files: &HashMap<i64, &codestory_store::FileInfo>,
+) -> bool {
+    let (Some(source), Some(target), Some(import_node)) = (
+        files.get(&source_file.0),
+        files.get(&target_file.0),
+        nodes.get(&import),
+    ) else {
+        return false;
+    };
+    let Some(uri) = quoted_literal(&import_node.serialized_name) else {
+        return false;
+    };
+    let relative = Path::new(uri);
+    let Some(source_directory) = source.path.parent() else {
+        return false;
+    };
+    let expected_path = source_directory.join(relative);
+    let exact_native_target = std::fs::symlink_metadata(&expected_path)
+        .ok()
+        .is_some_and(|metadata| !metadata.file_type().is_symlink() && metadata.is_file())
+        && workspace_path_identity(&expected_path).ok()
+            == workspace_path_identity(&target.path).ok();
+    let same_library = dart_library_root(&source.path)
+        .zip(dart_library_root(&target.path))
+        .is_some_and(|(source_root, target_root)| {
+            workspace_path_identity(source_root).ok() == workspace_path_identity(target_root).ok()
+        });
+    let source_library_identity =
+        dart_library_root(&source.path).and_then(|root| workspace_path_identity(root).ok());
+    let expected_dependencies = files
+        .values()
+        .filter(|file| {
+            file.indexed
+                && file.language == "dart"
+                && dart_library_root(&file.path).and_then(|root| workspace_path_identity(root).ok())
+                    == source_library_identity
+        })
+        .map(|file| FileId(file.id))
+        .collect::<HashSet<_>>();
+    import_node.kind == NodeKind::MODULE
+        && import_node.file_node_id == Some(source_file)
+        && relative
+            .extension()
+            .and_then(|extension| extension.to_str())
+            == Some("dart")
+        && relative
+            .components()
+            .all(|component| matches!(component, Component::Normal(_)))
+        && source_file != target_file
+        && target.language == "dart"
+        && target.indexed
+        && exact_native_target
+        && same_library
+        && source_library_identity.is_some()
+        && dependencies.iter().copied().collect::<HashSet<_>>() == expected_dependencies
+}
+
+fn generated_source_marker(source: &str) -> bool {
+    let prefix = source.get(..source.len().min(512)).unwrap_or(source);
+    let lowercase = prefix.to_ascii_lowercase();
+    lowercase.contains("generated code")
+        || lowercase.contains("@generated")
+        || lowercase.contains("<auto-generated")
+        || lowercase.contains("generatedcode(")
+}
+
+fn quoted_literal(surface: &str) -> Option<&str> {
+    let start = surface.find(['\'', '"'])?;
+    let quote = surface.as_bytes()[start] as char;
+    let rest = &surface[start + quote.len_utf8()..];
+    let end = rest.find(quote)?;
+    Some(&rest[..end])
+}
+
+fn import_alias(surface: &str) -> Option<String> {
+    let tail = surface.trim_end_matches(';').trim();
+    let (_, alias) = tail.rsplit_once(" as ")?;
+    java_kotlin_simple_identifier(alias.trim()).then(|| alias.trim().to_string())
+}
+
+fn import_show_names(surface: &str) -> Option<Vec<String>> {
+    let (_, shown) = surface.split_once(" show ")?;
+    let names = shown
+        .trim_end_matches(';')
+        .split(',')
+        .map(str::trim)
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    (!names.is_empty() && names.iter().all(|name| java_kotlin_simple_identifier(name)))
+        .then_some(names)
 }
 
 fn is_c_cpp_language(language: &str) -> bool {
@@ -3490,6 +3656,7 @@ enum JavaKotlinCallReceiver {
         owner_name: String,
         constructor: bool,
         receiver_name: Option<String>,
+        import_prefix: Option<String>,
     },
     Named {
         receiver_name: String,
@@ -3528,8 +3695,11 @@ struct JavaKotlinResolutionIndex<'tree> {
     callable_nodes: HashMap<(u32, String), Vec<NodeId>>,
     class_nodes: HashMap<(u32, String), Vec<NodeId>>,
     import_nodes: HashMap<u32, Vec<NodeId>>,
+    import_names: HashMap<NodeId, String>,
     imports_by_name: HashMap<String, Vec<JavaKotlinImportBinding>>,
     type_imports_by_name: HashMap<String, Vec<JavaKotlinImportBinding>>,
+    whole_module_imports: Vec<JavaKotlinImportBinding>,
+    prefixed_imports: HashMap<String, Vec<JavaKotlinImportBinding>>,
     owner_bindings: HashMap<(String, String), Vec<JavaKotlinLexicalBinding>>,
     rebound_receivers: HashSet<(usize, String)>,
     unsupported_type_names: HashSet<String>,
@@ -3540,12 +3710,14 @@ struct JavaKotlinResolutionIndex<'tree> {
     extension_methods: HashSet<String>,
     has_annotated_declaration: bool,
     has_delegation: bool,
+    domain_poisoned: bool,
 }
 
 impl<'tree> JavaKotlinResolutionIndex<'tree> {
     fn build(
         tree: &'tree Tree,
         source: &str,
+        source_path: &Path,
         language: &'tree str,
         file_id: NodeId,
         nodes: &[Node],
@@ -3553,6 +3725,7 @@ impl<'tree> JavaKotlinResolutionIndex<'tree> {
         let mut callable_nodes = HashMap::<(u32, String), Vec<NodeId>>::new();
         let mut class_nodes = HashMap::<(u32, String), Vec<NodeId>>::new();
         let mut import_nodes = HashMap::<u32, Vec<NodeId>>::new();
+        let mut import_names = HashMap::<NodeId, String>::new();
         for node in nodes
             .iter()
             .filter(|node| node.file_node_id == Some(file_id))
@@ -3570,18 +3743,25 @@ impl<'tree> JavaKotlinResolutionIndex<'tree> {
                         .or_default()
                         .push(node.id);
                 }
-                NodeKind::CLASS => {
+                NodeKind::CLASS | NodeKind::STRUCT => {
                     count_java_kotlin_resolution_work(1);
                     class_nodes.entry((line, name)).or_default().push(node.id);
                 }
                 NodeKind::MODULE | NodeKind::UNKNOWN => {
                     count_java_kotlin_resolution_work(1);
                     import_nodes.entry(line).or_default().push(node.id);
+                    import_names.insert(node.id, node.serialized_name.clone());
                 }
                 _ => {}
             }
         }
 
+        let nominal_source_poison = is_csharp_swift_dart_language(language)
+            && (generated_source_marker(source)
+                || language == "swift"
+                    && source
+                        .lines()
+                        .any(|line| line.trim_start().starts_with("extension ")));
         let mut result = Self {
             language,
             calls: Vec::new(),
@@ -3595,18 +3775,22 @@ impl<'tree> JavaKotlinResolutionIndex<'tree> {
             callable_nodes,
             class_nodes,
             import_nodes,
+            import_names,
             imports_by_name: HashMap::new(),
             type_imports_by_name: HashMap::new(),
+            whole_module_imports: Vec::new(),
+            prefixed_imports: HashMap::new(),
             owner_bindings: HashMap::new(),
             rebound_receivers: HashSet::new(),
             unsupported_type_names: HashSet::new(),
-            package_name: None,
+            package_name: csd_source_domain(language, source_path),
             wildcard_import: false,
             overloads: HashSet::new(),
             virtual_methods: HashSet::new(),
             extension_methods: HashSet::new(),
-            has_annotated_declaration: false,
+            has_annotated_declaration: nominal_source_poison,
             has_delegation: false,
+            domain_poisoned: nominal_source_poison,
         };
         let root = tree.root_node();
         JavaKotlinProducer::new(&mut result, source, root.id()).visit(
@@ -3620,21 +3804,25 @@ impl<'tree> JavaKotlinResolutionIndex<'tree> {
             },
         );
 
-        result
-            .calls
-            .sort_by_key(|call| (call.callee.start_byte(), call.callee.end_byte()));
+        if is_java_kotlin_language(language) {
+            result
+                .calls
+                .sort_by_key(|call| (call.callee.start_byte(), call.callee.end_byte()));
+        }
         for (index, call) in result.calls.iter().enumerate() {
             count_java_kotlin_resolution_work(1);
             result
                 .call_indices_by_span
                 .insert((call.callee.start_byte(), call.callee.end_byte()), index);
         }
-        result.declarations.sort_by(|left, right| {
-            left.name
-                .cmp(&right.name)
-                .then(left.declaration.cmp(&right.declaration))
-        });
-        result.classes.sort_by_key(|class| class.declaration);
+        if is_java_kotlin_language(language) {
+            result.declarations.sort_by(|left, right| {
+                left.name
+                    .cmp(&right.name)
+                    .then(left.declaration.cmp(&right.declaration))
+            });
+            result.classes.sort_by_key(|class| class.declaration);
+        }
         for (index, declaration) in result.declarations.iter().enumerate() {
             count_java_kotlin_resolution_work(1);
             result
@@ -3644,11 +3832,13 @@ impl<'tree> JavaKotlinResolutionIndex<'tree> {
                 .push(index);
         }
         for (index, class) in result.classes.iter_mut().enumerate() {
-            class.methods.sort_by(|left, right| {
-                left.name
-                    .cmp(&right.name)
-                    .then(left.declaration.cmp(&right.declaration))
-            });
+            if is_java_kotlin_language(language) {
+                class.methods.sort_by(|left, right| {
+                    left.name
+                        .cmp(&right.name)
+                        .then(left.declaration.cmp(&right.declaration))
+                });
+            }
             count_java_kotlin_resolution_work(2);
             result
                 .class_indices_by_name
@@ -3714,20 +3904,30 @@ impl<'tree> JavaKotlinResolutionIndex<'tree> {
             || self.extension_methods.contains(raw_target)
             || self.has_delegation
             || self.has_annotated_declaration
+            || self.domain_poisoned
         {
             return (Some(caller), CachedResolutionBinding::Unsupported);
         }
 
         if form == CalleeForm::Identifier {
             if call.identifier_shadowed {
-                return (Some(caller), CachedResolutionBinding::MissingBinding);
+                return (
+                    Some(caller),
+                    if is_csharp_swift_dart_language(self.language) {
+                        CachedResolutionBinding::Unsupported
+                    } else {
+                        CachedResolutionBinding::MissingBinding
+                    },
+                );
             }
             count_java_kotlin_resolution_work(1);
             if self.overloads.contains(&format!("overload:{raw_target}")) {
                 return (Some(caller), CachedResolutionBinding::Ambiguous);
             }
             count_java_kotlin_resolution_work(1);
-            if let Some(imports) = self.imports_by_name.get(raw_target) {
+            if !is_csharp_swift_dart_language(self.language)
+                && let Some(imports) = self.imports_by_name.get(raw_target)
+            {
                 return match imports.as_slice() {
                     [import] => (
                         Some(caller),
@@ -3747,6 +3947,59 @@ impl<'tree> JavaKotlinResolutionIndex<'tree> {
                 .get(raw_target)
                 .map(Vec::as_slice)
                 .unwrap_or_default();
+            if is_csharp_swift_dart_language(self.language) {
+                return match candidates {
+                    [_declaration] => (
+                        Some(caller),
+                        CachedResolutionBinding::JavaKotlinPackageFunction {
+                            package_name: self.package_name.clone().unwrap_or_default(),
+                            name: raw_target.to_string(),
+                        },
+                    ),
+                    [] if self.imports_by_name.contains_key(raw_target) => {
+                        match self.imports_by_name[raw_target].as_slice() {
+                            [import] => (
+                                Some(caller),
+                                CachedResolutionBinding::JavaKotlinImportedFunction {
+                                    package_name: import.package_name.clone(),
+                                    owner_name: None,
+                                    name: import.imported_name.clone(),
+                                    import: import.node,
+                                },
+                            ),
+                            _ => (Some(caller), CachedResolutionBinding::Ambiguous),
+                        }
+                    }
+                    [] if matches!(self.whole_module_imports.as_slice(), [_]) => {
+                        let import = &self.whole_module_imports[0];
+                        (
+                            Some(caller),
+                            CachedResolutionBinding::JavaKotlinImportedFunction {
+                                package_name: import.package_name.clone(),
+                                owner_name: None,
+                                name: raw_target.to_string(),
+                                import: import.node,
+                            },
+                        )
+                    }
+                    [] if !self.whole_module_imports.is_empty() => {
+                        (Some(caller), CachedResolutionBinding::Ambiguous)
+                    }
+                    [] if matches!(self.language, "csharp" | "swift")
+                        && self.package_name.is_some() =>
+                    {
+                        (
+                            Some(caller),
+                            CachedResolutionBinding::JavaKotlinPackageFunction {
+                                package_name: self.package_name.clone().unwrap_or_default(),
+                                name: raw_target.to_string(),
+                            },
+                        )
+                    }
+                    [] => (Some(caller), CachedResolutionBinding::MissingBinding),
+                    _ => (Some(caller), CachedResolutionBinding::Ambiguous),
+                };
+            }
             return match candidates {
                 [declaration] => (
                     Some(caller),
@@ -3755,13 +4008,17 @@ impl<'tree> JavaKotlinResolutionIndex<'tree> {
                         rust_glob_local_module: None,
                     },
                 ),
-                [] if self.language == "kotlin" && self.package_name.is_some() => (
-                    Some(caller),
-                    CachedResolutionBinding::JavaKotlinPackageFunction {
-                        package_name: self.package_name.clone().unwrap_or_default(),
-                        name: raw_target.to_string(),
-                    },
-                ),
+                [] if matches!(self.language, "kotlin" | "csharp" | "swift" | "dart")
+                    && self.package_name.is_some() =>
+                {
+                    (
+                        Some(caller),
+                        CachedResolutionBinding::JavaKotlinPackageFunction {
+                            package_name: self.package_name.clone().unwrap_or_default(),
+                            name: raw_target.to_string(),
+                        },
+                    )
+                }
                 [] => (Some(caller), CachedResolutionBinding::MissingBinding),
                 _ => (Some(caller), CachedResolutionBinding::Ambiguous),
             };
@@ -3784,12 +4041,51 @@ impl<'tree> JavaKotlinResolutionIndex<'tree> {
             }
         }
 
+        if self.language == "dart"
+            && let JavaKotlinCallReceiver::Named { receiver_name } = &call.receiver
+            && let Some(imports) = self.prefixed_imports.get(receiver_name)
+        {
+            count_java_kotlin_resolution_work(1);
+            return match imports.as_slice() {
+                [import] => (
+                    Some(caller),
+                    CachedResolutionBinding::JavaKotlinImportedFunction {
+                        package_name: import.package_name.clone(),
+                        owner_name: None,
+                        name: raw_target.to_string(),
+                        import: import.node,
+                    },
+                ),
+                _ => (Some(caller), CachedResolutionBinding::Ambiguous),
+            };
+        }
+
         let Some((owner_name, constructor)) = self.call_receiver_owner(call) else {
             return (Some(caller), CachedResolutionBinding::Unsupported);
         };
         count_java_kotlin_resolution_work(1);
         if self.unsupported_type_names.contains(&owner_name) {
             return (Some(caller), CachedResolutionBinding::Unsupported);
+        }
+        if let JavaKotlinCallReceiver::ExactType {
+            import_prefix: Some(prefix),
+            ..
+        } = &call.receiver
+        {
+            count_java_kotlin_resolution_work(1);
+            return match self.prefixed_imports.get(prefix).map(Vec::as_slice) {
+                Some([import]) => (
+                    Some(caller),
+                    CachedResolutionBinding::JavaKotlinImportedReceiver {
+                        package_name: import.package_name.clone(),
+                        owner_name,
+                        method_name: raw_target.to_string(),
+                        import: import.node,
+                        constructor,
+                    },
+                ),
+                _ => (Some(caller), CachedResolutionBinding::Ambiguous),
+            };
         }
         count_java_kotlin_resolution_work(1);
         if let Some(imports) = self.type_imports_by_name.get(&owner_name) {
@@ -3807,8 +4103,25 @@ impl<'tree> JavaKotlinResolutionIndex<'tree> {
                 _ => (Some(caller), CachedResolutionBinding::Ambiguous),
             };
         }
+        if matches!(self.language, "swift" | "dart") && !self.class_names.contains(&owner_name) {
+            count_java_kotlin_resolution_work(1);
+            return match self.whole_module_imports.as_slice() {
+                [import] => (
+                    Some(caller),
+                    CachedResolutionBinding::JavaKotlinImportedReceiver {
+                        package_name: import.package_name.clone(),
+                        owner_name,
+                        method_name: raw_target.to_string(),
+                        import: import.node,
+                        constructor,
+                    },
+                ),
+                [] => (Some(caller), CachedResolutionBinding::MissingBinding),
+                _ => (Some(caller), CachedResolutionBinding::Ambiguous),
+            };
+        }
         count_java_kotlin_resolution_work(1);
-        if self.language == "java"
+        if matches!(self.language, "java" | "csharp" | "swift" | "dart")
             && !self.class_names.contains(&owner_name)
             && let Some(package_name) = &self.package_name
         {
@@ -3859,6 +4172,17 @@ impl<'tree> JavaKotlinResolutionIndex<'tree> {
                 },
             );
         };
+        if is_csharp_swift_dart_language(self.language) {
+            return (
+                Some(caller),
+                CachedResolutionBinding::JavaKotlinPackageReceiver {
+                    package_name: self.package_name.clone().unwrap_or_default(),
+                    owner_name,
+                    method_name: raw_target.to_string(),
+                    constructor,
+                },
+            );
+        }
         if form == CalleeForm::ImplicitReceiver {
             return (
                 Some(caller),
@@ -3950,13 +4274,27 @@ impl<'index, 'tree> JavaKotlinProducer<'index, 'tree> {
         }
 
         let mut context = context;
-        if matches!(node.kind(), "interface_declaration" | "when_expression")
-            || self.index.language == "java" && node.kind() == "cast_expression"
+        if matches!(
+            node.kind(),
+            "interface_declaration"
+                | "protocol_declaration"
+                | "mixin_declaration"
+                | "extension_declaration"
+                | "when_expression"
+        ) || self.index.language == "java" && node.kind() == "cast_expression"
+            || self.index.language == "swift"
+                && matches!(node.kind(), "statements" | "directive")
+                && node_text(node, self.source).is_some_and(|surface| surface.contains("#if"))
         {
             context.unsupported = true;
+            if is_csharp_swift_dart_language(self.index.language) {
+                self.index.domain_poisoned = true;
+            }
         }
-        if node.kind() == "interface_declaration"
-            && let Some(name) = declaration_name(node, self.source)
+        if matches!(
+            node.kind(),
+            "interface_declaration" | "protocol_declaration" | "mixin_declaration"
+        ) && let Some(name) = declaration_name(node, self.source)
         {
             count_java_kotlin_resolution_work(1);
             self.index.unsupported_type_names.insert(name.to_string());
@@ -3993,12 +4331,16 @@ impl<'index, 'tree> JavaKotlinProducer<'index, 'tree> {
         let annotated = java_kotlin_declaration_has_annotation(node, self.source);
         let delegated = self.index.language == "kotlin"
             && java_kotlin_has_direct_child_kind(node, "delegation_specifiers");
-        let virtual_owner =
-            self.index.language == "java" && node.child_by_field_name("superclass").is_some();
+        let nominal_poison = csd_owner_is_unsupported(node, self.source, self.index.language);
+        let virtual_owner = self.index.language == "java"
+            && node.child_by_field_name("superclass").is_some()
+            || matches!(self.index.language, "swift" | "dart") && nominal_poison;
         self.index.has_annotated_declaration |= annotated;
         self.index.has_delegation |= delegated;
+        self.index.domain_poisoned |= nominal_poison;
         context.unsupported |= annotated
             || delegated
+            || nominal_poison
             || virtual_owner
             || node.child_by_field_name("type_parameters").is_some()
             || java_kotlin_has_direct_child_kind(node, "type_parameters");
@@ -4027,13 +4369,20 @@ impl<'index, 'tree> JavaKotlinProducer<'index, 'tree> {
         node: TsNode<'tree>,
         mut context: JavaKotlinWalkContext,
     ) -> JavaKotlinWalkContext {
-        let annotated = java_kotlin_declaration_has_annotation(node, self.source);
+        let declaration_node = nominal_callable_declaration(node, self.index.language);
+        let annotated = java_kotlin_declaration_has_annotation(declaration_node, self.source);
+        let unsupported_callable =
+            csd_callable_is_unsupported(declaration_node, self.source, self.index.language);
         self.index.has_annotated_declaration |= annotated;
+        self.index.domain_poisoned |= unsupported_callable;
         context.unsupported |= annotated
-            || node.child_by_field_name("type_parameters").is_some()
-            || java_kotlin_has_direct_child_kind(node, "type_parameters");
+            || unsupported_callable
+            || declaration_node
+                .child_by_field_name("type_parameters")
+                .is_some()
+            || java_kotlin_has_direct_child_kind(declaration_node, "type_parameters");
 
-        let Some(name) = declaration_name(node, self.source).map(str::to_string) else {
+        let Some(name) = declaration_name(declaration_node, self.source).map(str::to_string) else {
             context.caller = None;
             context.callable_id = Some(node.id());
             return context;
@@ -4054,7 +4403,9 @@ impl<'index, 'tree> JavaKotlinProducer<'index, 'tree> {
             self.index.extension_methods.insert(name.clone());
         }
 
-        let caller = self.index.map_callable_declaration(node, self.source);
+        let caller = self
+            .index
+            .map_callable_declaration(declaration_node, self.source);
         if let (Some(owner_index), Some(declaration)) = (context.owner_index, caller) {
             count_java_kotlin_resolution_work(1);
             self.index.classes[owner_index]
@@ -4065,11 +4416,16 @@ impl<'index, 'tree> JavaKotlinProducer<'index, 'tree> {
                 });
         }
         if let Some(declaration) = caller {
-            let same_file = if self.index.language == "kotlin" {
-                node.parent()
+            let same_file = if matches!(self.index.language, "kotlin" | "swift") {
+                declaration_node
+                    .parent()
                     .is_some_and(|parent| parent.id() == self.root_id)
+            } else if self.index.language == "dart" {
+                declaration_node
+                    .parent()
+                    .is_some_and(|parent| parent.kind() == "program")
             } else {
-                java_kotlin_java_method_is_static(node, self.source)
+                java_kotlin_java_method_is_static(declaration_node, self.source)
             };
             if same_file {
                 count_java_kotlin_resolution_work(1);
@@ -4083,29 +4439,75 @@ impl<'index, 'tree> JavaKotlinProducer<'index, 'tree> {
         }
         context.callable_id = Some(node.id());
         context.caller = caller;
+        if self.index.language == "dart" {
+            for (binding_name, binding) in dart_callable_bindings(declaration_node, self.source) {
+                self.insert_active(binding_name, binding);
+            }
+        }
         context
     }
 
     fn collect_package(&mut self, node: TsNode<'tree>) {
-        let expected = if self.index.language == "java" {
-            "package_declaration"
-        } else {
-            "package_header"
+        let expected = match self.index.language {
+            "java" => "package_declaration",
+            "kotlin" => "package_header",
+            "csharp" if node.kind() == "namespace_declaration" => "namespace_declaration",
+            "csharp" => "file_scoped_namespace_declaration",
+            _ => return,
         };
-        if node.kind() != expected || self.index.package_name.is_some() {
+        if node.kind() != expected {
             return;
         }
-        self.index.package_name = node_text(node, self.source)
-            .and_then(|surface| surface.trim().strip_prefix("package"))
-            .map(str::trim)
-            .map(|name| name.trim_end_matches(';').trim().to_string())
-            .filter(|name| !name.is_empty());
-        if self.index.package_name.is_some() {
-            count_java_kotlin_resolution_work(1);
+        let prefix = if self.index.language == "csharp" {
+            "namespace"
+        } else {
+            "package"
+        };
+        let parsed = if self.index.language == "csharp" {
+            node.child_by_field_name("name")
+                .and_then(|name| node_text(name, self.source))
+                .map(str::trim)
+                .map(str::to_string)
+                .filter(|name| !name.is_empty())
+        } else {
+            node_text(node, self.source)
+                .and_then(|surface| surface.trim().strip_prefix(prefix))
+                .map(str::trim)
+                .map(|name| name.trim_end_matches(';').trim().to_string())
+                .filter(|name| !name.is_empty())
+        };
+        count_java_kotlin_resolution_work(1);
+        if self.index.language == "csharp" {
+            match (&self.index.package_name, parsed) {
+                (Some(existing), Some(parsed)) if existing == &parsed => {}
+                (Some(existing), Some(parsed))
+                    if existing.starts_with("csharp:path:") || existing == "csharp:global" =>
+                {
+                    self.index.package_name = Some(parsed);
+                }
+                (_, Some(_)) => self.index.domain_poisoned = true,
+                _ => self.index.domain_poisoned = true,
+            }
+        } else if self.index.package_name.is_some() {
+            self.index.domain_poisoned = true;
+        } else {
+            self.index.package_name = parsed;
         }
     }
 
     fn collect_import(&mut self, node: TsNode<'tree>) {
+        if is_csharp_swift_dart_language(self.index.language) {
+            let expected = match self.index.language {
+                "csharp" => "using_directive",
+                "swift" => "import_declaration",
+                "dart" => "import_or_export",
+                _ => unreachable!("nominal import collector language"),
+            };
+            if node.kind() == expected {
+                self.collect_csd_import(node);
+            }
+            return;
+        }
         if !node.kind().contains("import") {
             return;
         }
@@ -4136,6 +4538,156 @@ impl<'index, 'tree> JavaKotlinProducer<'index, 'tree> {
                 .or_default()
                 .push(import);
         }
+    }
+
+    fn collect_csd_import(&mut self, node: TsNode<'tree>) {
+        let Some(surface) = node_text(node, self.source).map(str::trim) else {
+            self.index.domain_poisoned = true;
+            return;
+        };
+        let line = node.start_position().row as u32 + 1;
+        count_java_kotlin_resolution_work(1);
+        let Some(import_nodes) = self.index.import_nodes.get(&line).map(Vec::as_slice) else {
+            self.index.domain_poisoned = true;
+            return;
+        };
+        match self.index.language {
+            "csharp" => {
+                let Some(rest) = surface.trim_end_matches(';').trim().strip_prefix("using ") else {
+                    self.index.domain_poisoned = true;
+                    return;
+                };
+                let Some((alias, qualified)) = rest.split_once('=') else {
+                    self.index.domain_poisoned = true;
+                    return;
+                };
+                let alias = alias.trim();
+                let qualified = qualified.trim();
+                let Some((package_name, imported_name)) = qualified.rsplit_once('.') else {
+                    self.index.domain_poisoned = true;
+                    return;
+                };
+                if !java_kotlin_simple_identifier(alias)
+                    || !java_kotlin_simple_identifier(imported_name)
+                    || package_name.is_empty()
+                {
+                    self.index.domain_poisoned = true;
+                    return;
+                }
+                let matching_imports = import_nodes
+                    .iter()
+                    .filter(|candidate| {
+                        self.index
+                            .import_names
+                            .get(candidate)
+                            .is_some_and(|name| name == qualified)
+                    })
+                    .copied()
+                    .collect::<Vec<_>>();
+                let [import_node] = matching_imports.as_slice() else {
+                    self.index.domain_poisoned = true;
+                    return;
+                };
+                let binding = JavaKotlinImportBinding {
+                    package_name: package_name.to_string(),
+                    owner_name: None,
+                    imported_name: imported_name.to_string(),
+                    local_name: alias.to_string(),
+                    node: *import_node,
+                };
+                self.index
+                    .type_imports_by_name
+                    .entry(alias.to_string())
+                    .or_default()
+                    .push(binding);
+            }
+            "swift" => {
+                let [import_node] = import_nodes else {
+                    self.index.domain_poisoned = true;
+                    return;
+                };
+                if surface.contains(['.', ':']) {
+                    self.index.domain_poisoned = true;
+                    return;
+                }
+                let Some(module) = surface.strip_prefix("import ").map(str::trim) else {
+                    self.index.domain_poisoned = true;
+                    return;
+                };
+                if !java_kotlin_simple_identifier(module) {
+                    self.index.domain_poisoned = true;
+                    return;
+                }
+                self.index
+                    .whole_module_imports
+                    .push(JavaKotlinImportBinding {
+                        package_name: module.to_string(),
+                        owner_name: None,
+                        imported_name: "*".to_string(),
+                        local_name: "*".to_string(),
+                        node: *import_node,
+                    });
+            }
+            "dart" => {
+                let [import_node] = import_nodes else {
+                    self.index.domain_poisoned = true;
+                    return;
+                };
+                if surface.contains(" if ")
+                    || surface.contains(" deferred ")
+                    || surface.contains("dart:mirrors")
+                {
+                    self.index.wildcard_import = true;
+                    self.index.domain_poisoned = true;
+                    return;
+                }
+                let Some(uri) = quoted_literal(surface) else {
+                    self.index.domain_poisoned = true;
+                    return;
+                };
+                if uri.starts_with('/')
+                    || uri.contains(':')
+                    || uri.split('/').any(|component| component == "..")
+                {
+                    self.index.domain_poisoned = true;
+                    return;
+                }
+                let binding = JavaKotlinImportBinding {
+                    package_name: format!("dart:uri:{uri}"),
+                    owner_name: None,
+                    imported_name: "*".to_string(),
+                    local_name: "*".to_string(),
+                    node: *import_node,
+                };
+                if let Some(prefix) = import_alias(surface) {
+                    self.index
+                        .prefixed_imports
+                        .entry(prefix)
+                        .or_default()
+                        .push(binding);
+                } else if let Some(shown) = import_show_names(surface) {
+                    for name in shown {
+                        let mut named = binding.clone();
+                        named.imported_name = name.clone();
+                        named.local_name = name.clone();
+                        self.index
+                            .imports_by_name
+                            .entry(name.clone())
+                            .or_default()
+                            .push(named.clone());
+                        self.index
+                            .type_imports_by_name
+                            .entry(name)
+                            .or_default()
+                            .push(named);
+                    }
+                } else {
+                    self.index.whole_module_imports.push(binding);
+                }
+            }
+            _ => unreachable!("C#/Swift/Dart import collector language"),
+        }
+        count_java_kotlin_resolution_work(1);
     }
 
     fn parse_import(&self, node: TsNode<'tree>, surface: &str) -> Option<JavaKotlinImportBinding> {
@@ -4185,9 +4737,12 @@ impl<'index, 'tree> JavaKotlinProducer<'index, 'tree> {
     }
 
     fn collect_binding(&mut self, node: TsNode<'tree>, context: JavaKotlinWalkContext) {
-        let Some((name, binding)) =
+        let binding = if is_csharp_swift_dart_language(self.index.language) {
+            csd_lexical_binding(node, self.source, self.index.language)
+        } else {
             java_kotlin_lexical_binding(node, self.source, self.index.language)
-        else {
+        };
+        let Some((name, binding)) = binding else {
             return;
         };
         if context.callable_id.is_some() {
@@ -4210,7 +4765,10 @@ impl<'index, 'tree> JavaKotlinProducer<'index, 'tree> {
         let Some(callable_id) = context.callable_id else {
             return;
         };
-        let Some(left) = node.child_by_field_name("left") else {
+        let Some(left) = node
+            .child_by_field_name("left")
+            .or_else(|| node.named_child(0))
+        else {
             return;
         };
         let Some(name) = node_text(left, self.source)
@@ -4226,14 +4784,23 @@ impl<'index, 'tree> JavaKotlinProducer<'index, 'tree> {
     }
 
     fn collect_call(&mut self, node: TsNode<'tree>, context: JavaKotlinWalkContext) {
-        let call = if self.index.language == "java" {
-            java_call(node, self.source)
-        } else {
-            kotlin_call(node, self.source)
+        let call = match self.index.language {
+            "java" => java_call(node, self.source),
+            "kotlin" => kotlin_call(node, self.source),
+            "csharp" => csharp_call(node, self.source),
+            "swift" => swift_call(node, self.source),
+            "dart" => dart_call(node, self.source),
+            _ => None,
         };
         let Some((callee, form, raw_target)) = call else {
             return;
         };
+        if matches!(self.index.language, "swift" | "dart")
+            && form == CalleeForm::Identifier
+            && raw_target.chars().next().is_some_and(char::is_uppercase)
+        {
+            return;
+        }
         let owner_name = context
             .owner_index
             .map(|owner_index| self.index.classes[owner_index].name.clone());
@@ -4269,16 +4836,59 @@ impl<'index, 'tree> JavaKotlinProducer<'index, 'tree> {
         if form == CalleeForm::ImplicitReceiver {
             return JavaKotlinCallReceiver::Implicit;
         }
+        if self.index.language == "dart" {
+            let Some(receiver_surface) = dart_member_receiver_surface(callee, self.source) else {
+                return JavaKotlinCallReceiver::Blocked;
+            };
+            if let Some((owner_name, import_prefix)) = constructor_surface_owner(&receiver_surface)
+            {
+                return JavaKotlinCallReceiver::ExactType {
+                    owner_name,
+                    constructor: true,
+                    receiver_name: None,
+                    import_prefix,
+                };
+            }
+            let receiver_name = receiver_surface.trim_end_matches('?').trim();
+            if !java_kotlin_simple_identifier(receiver_name) {
+                return JavaKotlinCallReceiver::Blocked;
+            }
+            count_java_kotlin_resolution_work(1);
+            return match self
+                .active_bindings
+                .get(receiver_name)
+                .and_then(|bindings| bindings.last())
+            {
+                Some(JavaKotlinLexicalBinding::Receiver {
+                    owner_name,
+                    constructor,
+                }) => JavaKotlinCallReceiver::ExactType {
+                    owner_name: owner_name.clone(),
+                    constructor: *constructor,
+                    receiver_name: Some(receiver_name.to_string()),
+                    import_prefix: None,
+                },
+                Some(JavaKotlinLexicalBinding::Other) => JavaKotlinCallReceiver::Blocked,
+                None => JavaKotlinCallReceiver::Named {
+                    receiver_name: receiver_name.to_string(),
+                },
+            };
+        }
         let Some(receiver) = java_kotlin_member_receiver(callee, self.index.language) else {
             return JavaKotlinCallReceiver::Blocked;
         };
-        if let Some(owner_name) =
+        let direct_constructor = if is_csharp_swift_dart_language(self.index.language) {
+            csd_direct_constructor_type(receiver, self.source, self.index.language)
+        } else {
             java_kotlin_direct_constructor_type(receiver, self.source, self.index.language)
-        {
+                .map(|owner| (owner, None))
+        };
+        if let Some((owner_name, import_prefix)) = direct_constructor {
             return JavaKotlinCallReceiver::ExactType {
                 owner_name,
                 constructor: true,
                 receiver_name: None,
+                import_prefix,
             };
         }
         let Some(receiver_name) = node_text(receiver, self.source)
@@ -4301,6 +4911,7 @@ impl<'index, 'tree> JavaKotlinProducer<'index, 'tree> {
                 owner_name: owner_name.clone(),
                 constructor: *constructor,
                 receiver_name: Some(receiver_name.to_string()),
+                import_prefix: None,
             },
             Some(JavaKotlinLexicalBinding::Other) => JavaKotlinCallReceiver::Blocked,
             None if self.index.language == "java"
@@ -4310,6 +4921,7 @@ impl<'index, 'tree> JavaKotlinProducer<'index, 'tree> {
                     owner_name: receiver_name.to_string(),
                     constructor: false,
                     receiver_name: None,
+                    import_prefix: None,
                 }
             }
             None => JavaKotlinCallReceiver::Named {
@@ -4351,15 +4963,94 @@ impl<'index, 'tree> JavaKotlinProducer<'index, 'tree> {
 fn java_kotlin_callable_kind(language: &str, kind: &str) -> bool {
     matches!(
         (language, kind),
-        ("java", "method_declaration") | ("kotlin", "function_declaration")
+        ("java", "method_declaration")
+            | ("kotlin", "function_declaration")
+            | ("csharp", "method_declaration")
+            | ("swift", "function_declaration")
+            | ("dart", "function_body")
     )
 }
 
 fn java_kotlin_class_kind(language: &str, kind: &str) -> bool {
     matches!(
         (language, kind),
-        ("java", "class_declaration") | ("kotlin", "class_declaration")
+        ("java", "class_declaration")
+            | ("kotlin", "class_declaration")
+            | ("csharp", "class_declaration" | "struct_declaration")
+            | ("swift", "class_declaration")
+            | ("dart", "class_definition")
     )
+}
+
+fn nominal_callable_declaration<'tree>(node: TsNode<'tree>, language: &str) -> TsNode<'tree> {
+    if language != "dart" || node.kind() != "function_body" {
+        return node;
+    }
+    let Some(signature) = node.prev_named_sibling() else {
+        return node;
+    };
+    if signature.kind() == "function_signature" {
+        return signature;
+    }
+    if signature.kind() == "method_signature" {
+        let mut cursor = signature.walk();
+        if let Some(function) = signature
+            .named_children(&mut cursor)
+            .find(|child| child.kind() == "function_signature")
+        {
+            return function;
+        }
+    }
+    node
+}
+
+fn csd_owner_is_unsupported(node: TsNode<'_>, source: &str, language: &str) -> bool {
+    let header = node
+        .child_by_field_name("body")
+        .and_then(|body| source.get(node.start_byte()..body.start_byte()))
+        .or_else(|| node_text(node, source))
+        .unwrap_or_default();
+    match language {
+        "csharp" => header.split_whitespace().any(|word| word == "partial"),
+        "swift" => {
+            let header = header.trim_start();
+            header.starts_with("class ") || header.contains("@objc") || header.contains(" dynamic ")
+        }
+        "dart" => {
+            let header = header.trim_start();
+            !(header.starts_with("final class ") || header.starts_with("sealed class "))
+                || header.contains(" with ")
+                || header.contains(" implements ")
+        }
+        _ => false,
+    }
+}
+
+fn csd_callable_is_unsupported(node: TsNode<'_>, source: &str, language: &str) -> bool {
+    let Some(name) = node.child_by_field_name("name") else {
+        return is_csharp_swift_dart_language(language);
+    };
+    let header = source
+        .get(node.start_byte()..name.start_byte())
+        .unwrap_or_default();
+    match language {
+        "csharp" => {
+            header.split_whitespace().any(|word| {
+                matches!(
+                    word,
+                    "virtual" | "abstract" | "override" | "extern" | "partial"
+                )
+            }) || node_text(node, source).is_some_and(|surface| surface.contains("(this "))
+        }
+        "swift" => {
+            header.contains("@objc")
+                || header
+                    .split_whitespace()
+                    .any(|word| matches!(word, "dynamic" | "override" | "class" | "@objc"))
+        }
+        "dart" => header.contains('<') || header.contains("external"),
+        _ => false,
+    }
 }
 
 fn java_kotlin_simple_identifier(value: &str) -> bool {
@@ -4517,6 +5208,167 @@ fn java_kotlin_lexical_binding(
     Some((name, binding))
 }
 
+fn typed_binding_from_surface(surface: &str, language: &str) -> Option<(String, String, bool)> {
+    let before_initializer = surface.split('=').next()?.trim();
+    let constructor_type = surface.split_once('=').and_then(|(_, initializer)| {
+        let initializer = initializer.trim().trim_start_matches("new ").trim();
+        let (name, arguments) = initializer.split_once('(')?;
+        (arguments.contains(')')
+            && java_kotlin_simple_identifier(name)
+            && name.chars().next().is_some_and(char::is_uppercase))
+        .then(|| name.to_string())
+    });
+    let constructor = constructor_type.is_some();
+    if language == "swift" {
+        let (name, owner) = if let Some((left, right)) = before_initializer.split_once(':') {
+            (
+                left.split_whitespace().last()?.trim(),
+                right.trim().trim_end_matches('?').to_string(),
+            )
+        } else {
+            (
+                before_initializer.split_whitespace().last()?.trim(),
+                constructor_type?,
+            )
+        };
+        return (java_kotlin_simple_identifier(name) && java_kotlin_simple_identifier(&owner))
+            .then(|| (name.to_string(), owner, constructor));
+    }
+    let tokens = before_initializer
+        .split_whitespace()
+        .filter(|token| {
+            !matches!(
+                *token,
+                "final"
+                    | "const"
+                    | "var"
+                    | "required"
+                    | "readonly"
+                    | "private"
+                    | "public"
+                    | "protected"
+                    | "internal"
+                    | "static"
+            )
+        })
+        .collect::<Vec<_>>();
+    let name = tokens
+        .last()?
+        .trim_matches(|character: char| !character.is_alphanumeric() && character != '_');
+    let owner = tokens
+        .get(tokens.len().checked_sub(2).unwrap_or_default())
+        .filter(|_| tokens.len() >= 2)
+        .map(|owner| owner.trim_end_matches('?').to_string())
+        .or(constructor_type)?;
+    (java_kotlin_simple_identifier(name) && java_kotlin_simple_identifier(&owner))
+        .then(|| (name.to_string(), owner, constructor))
+}
+
+fn csd_lexical_binding(
+    node: TsNode<'_>,
+    source: &str,
+    language: &str,
+) -> Option<(String, JavaKotlinLexicalBinding)> {
+    let surface = match (language, node.kind()) {
+        ("csharp", "parameter") => node_text(node, source)?,
+        ("csharp", "variable_declarator") => {
+            node.parent().and_then(|parent| node_text(parent, source))?
+        }
+        ("swift", "parameter" | "property_declaration") => node_text(node, source)?,
+        ("dart", "declaration" | "local_variable_declaration") => node_text(node, source)?,
+        _ => return None,
+    };
+    let declared_name = match language {
+        "swift" => surface
+            .split([':', '='])
+            .next()
+            .and_then(|left| left.split_whitespace().last()),
+        "csharp" | "dart" => surface
+            .split('=')
+            .next()
+            .and_then(|left| left.split_whitespace().last())
+            .map(|name| {
+                name.trim_matches(|character: char| {
+                    !character.is_alphanumeric() && character != '_'
+                })
+            }),
+        _ => None,
+    }
+    .filter(|name| java_kotlin_simple_identifier(name))?
+    .to_string();
+    let Some((name, owner_name, constructor)) = typed_binding_from_surface(surface, language)
+    else {
+        count_java_kotlin_resolution_work(1);
+        return Some((declared_name, JavaKotlinLexicalBinding::Other));
+    };
+    if name != declared_name {
+        return Some((declared_name, JavaKotlinLexicalBinding::Other));
+    }
+    count_java_kotlin_resolution_work(2);
+    Some((
+        name,
+        if owner_name == "dynamic"
+            || owner_name == "var"
+            || owner_name.contains(['<', '>', '(', ')'])
+        {
+            JavaKotlinLexicalBinding::Other
+        } else {
+            JavaKotlinLexicalBinding::Receiver {
+                owner_name,
+                constructor,
+            }
+        },
+    ))
+}
+
+fn dart_callable_bindings(
+    signature: TsNode<'_>,
+    source: &str,
+) -> Vec<(String, JavaKotlinLexicalBinding)> {
+    let mut bindings = Vec::new();
+    let mut stack = vec![signature];
+    while let Some(node) = stack.pop() {
+        count_java_kotlin_resolution_work(1);
+        if node.kind() == "formal_parameter"
+            && let Some(surface) = node_text(node, source)
+        {
+            if let Some((name, owner_name, constructor)) =
+                typed_binding_from_surface(surface, "dart")
+            {
+                bindings.push((
+                    name,
+                    if owner_name == "dynamic" || owner_name == "Function" {
+                        JavaKotlinLexicalBinding::Other
+                    } else {
+                        JavaKotlinLexicalBinding::Receiver {
+                            owner_name,
+                            constructor,
+                        }
+                    },
+                ));
+            } else if let Some(name) = surface
+                .split('=')
+                .next()
+                .and_then(|left| left.split_whitespace().last())
+                .map(|name| {
+                    name.trim_matches(|character: char| {
+                        !character.is_alphanumeric() && character != '_'
+                    })
+                })
+                .filter(|name| java_kotlin_simple_identifier(name))
+            {
+                bindings.push((name.to_string(), JavaKotlinLexicalBinding::Other));
+            }
+        }
+        let mut cursor = node.walk();
+        let children = node.named_children(&mut cursor).collect::<Vec<_>>();
+        for child in children.into_iter().rev() {
+            stack.push(child);
+        }
+    }
+    bindings
+}
+
 fn java_call<'tree>(
     node: TsNode<'tree>,
     source: &str,
@@ -4530,6 +5382,179 @@ fn java_call<'tree>(
         Some(_) => CalleeForm::ExplicitReceiver,
     };
     Some((name, form, node_text(name, source)?.to_string()))
+}
+
+fn csharp_call<'tree>(
+    node: TsNode<'tree>,
+    source: &str,
+) -> Option<(TsNode<'tree>, CalleeForm, String)> {
+    (node.kind() == "invocation_expression").then_some(())?;
+    let function = node.child_by_field_name("function")?;
+    if function.kind() == "identifier" {
+        return Some((
+            function,
+            CalleeForm::Identifier,
+            node_text(function, source)?.to_string(),
+        ));
+    }
+    (function.kind() == "member_access_expression").then_some(())?;
+    let name = function.child_by_field_name("name")?;
+    let receiver = function.child_by_field_name("expression")?;
+    let form = if receiver.kind() == "this_expression" || node_text(receiver, source)? == "this" {
+        CalleeForm::ImplicitReceiver
+    } else {
+        CalleeForm::ExplicitReceiver
+    };
+    Some((name, form, node_text(name, source)?.to_string()))
+}
+
+fn swift_call<'tree>(
+    node: TsNode<'tree>,
+    source: &str,
+) -> Option<(TsNode<'tree>, CalleeForm, String)> {
+    (node.kind() == "call_expression").then_some(())?;
+    let function = node.named_child(0)?;
+    if function.kind() == "simple_identifier" {
+        return Some((
+            function,
+            CalleeForm::Identifier,
+            node_text(function, source)?.to_string(),
+        ));
+    }
+    (function.kind() == "navigation_expression").then_some(())?;
+    let receiver = function.named_child(0)?;
+    let suffix_index = u32::try_from(function.named_child_count().checked_sub(1)?).ok()?;
+    let suffix = function.named_child(suffix_index)?;
+    let member = first_descendant_named_kind(suffix, "simple_identifier")?;
+    let form = if receiver.kind() == "self_expression" {
+        CalleeForm::ImplicitReceiver
+    } else {
+        CalleeForm::ExplicitReceiver
+    };
+    Some((member, form, node_text(member, source)?.to_string()))
+}
+
+fn dart_call<'tree>(
+    node: TsNode<'tree>,
+    source: &str,
+) -> Option<(TsNode<'tree>, CalleeForm, String)> {
+    if node.kind() == "method_invocation" {
+        let function = node.child_by_field_name("function")?;
+        return (function.kind() == "identifier").then(|| {
+            (
+                function,
+                CalleeForm::Identifier,
+                node_text(function, source).unwrap_or_default().to_string(),
+            )
+        });
+    }
+    let mut cursor = node.walk();
+    let children = node.named_children(&mut cursor).collect::<Vec<_>>();
+    let mut found = None;
+    for pair in children.windows(2) {
+        if pair[0].kind() != "selector"
+            || pair[1].kind() != "selector"
+            || !node_contains_kind(pair[1], "argument_part")
+        {
+            continue;
+        }
+        let callee = first_descendant_named_kind(pair[0], "identifier")?;
+        let receiver = source.get(node.start_byte()..pair[0].start_byte())?.trim();
+        let form = if receiver == "this" {
+            CalleeForm::ImplicitReceiver
+        } else {
+            CalleeForm::ExplicitReceiver
+        };
+        found = Some((callee, form, node_text(callee, source)?.to_string()));
+    }
+    found
+}
+
+fn node_contains_kind(node: TsNode<'_>, kind: &str) -> bool {
+    if node.kind() == kind {
+        return true;
+    }
+    let mut stack = vec![node];
+    while let Some(current) = stack.pop() {
+        count_java_kotlin_resolution_work(1);
+        let mut cursor = current.walk();
+        for child in current.named_children(&mut cursor) {
+            if child.kind() == kind {
+                return true;
+            }
+            stack.push(child);
+        }
+    }
+    false
+}
+
+fn first_descendant_named_kind<'tree>(node: TsNode<'tree>, kind: &str) -> Option<TsNode<'tree>> {
+    if node.kind() == kind {
+        return Some(node);
+    }
+    let mut stack = vec![node];
+    while let Some(current) = stack.pop() {
+        count_java_kotlin_resolution_work(1);
+        let mut cursor = current.walk();
+        for child in current.named_children(&mut cursor) {
+            if child.kind() == kind {
+                return Some(child);
+            }
+            stack.push(child);
+        }
+    }
+    None
+}
+
+fn dart_member_receiver_surface(callee: TsNode<'_>, source: &str) -> Option<String> {
+    let selector = callee.parent()?.parent()?;
+    let expression = selector.parent()?;
+    source
+        .get(expression.start_byte()..selector.start_byte())
+        .map(str::trim)
+        .filter(|surface| !surface.is_empty())
+        .map(str::to_string)
+}
+
+fn constructor_surface_owner(surface: &str) -> Option<(String, Option<String>)> {
+    let surface = surface.trim().trim_end_matches('?').trim();
+    let callee = surface.strip_suffix("()")?.trim();
+    let (prefix, owner) = callee
+        .rsplit_once('.')
+        .map_or((None, callee), |(prefix, owner)| (Some(prefix), owner));
+    (java_kotlin_simple_identifier(owner)
+        && prefix.is_none_or(java_kotlin_simple_identifier)
+        && owner.chars().next().is_some_and(char::is_uppercase))
+    .then(|| (owner.to_string(), prefix.map(str::to_string)))
+}
+
+fn csd_direct_constructor_type(
+    node: TsNode<'_>,
+    source: &str,
+    language: &str,
+) -> Option<(String, Option<String>)> {
+    match language {
+        "csharp" => {
+            (node.kind() == "object_creation_expression").then_some(())?;
+            let owner = node
+                .child_by_field_name("type")
+                .and_then(|ty| java_kotlin_simple_type_name(ty, source))?;
+            Some((owner, None))
+        }
+        "swift" => {
+            (node.kind() == "call_expression").then_some(())?;
+            let callee = node.named_child(0)?;
+            let surface = node_text(callee, source)?;
+            let (prefix, owner) = surface
+                .rsplit_once('.')
+                .map_or((None, surface), |(prefix, owner)| (Some(prefix), owner));
+            (java_kotlin_simple_identifier(owner)
+                && prefix.is_none_or(java_kotlin_simple_identifier)
+                && owner.chars().next().is_some_and(char::is_uppercase))
+            .then(|| (owner.to_string(), prefix.map(str::to_string)))
+        }
+        _ => None,
+    }
 }
 
 fn kotlin_call<'tree>(
@@ -4571,12 +5596,16 @@ fn java_kotlin_member_receiver<'tree>(
     callee: TsNode<'tree>,
     language: &str,
 ) -> Option<TsNode<'tree>> {
-    let invocation = callee.parent()?;
-    if language == "java" {
-        return invocation.child_by_field_name("object");
+    let parent = callee.parent()?;
+    match language {
+        "java" => return parent.child_by_field_name("object"),
+        "csharp" => return parent.child_by_field_name("expression"),
+        "swift" => return parent.parent()?.named_child(0),
+        "dart" => return None,
+        _ => {}
     }
     count_java_kotlin_resolution_work(1);
-    invocation.named_child(0)
+    parent.named_child(0)
 }
 
 #[derive(Debug, Clone)]
@@ -11702,7 +12731,10 @@ pub fn rematerialize_proof_resolution_projection(
     let mut records = records
         .into_iter()
         .filter_map(|record| {
-            if matches!(record.file.language.as_str(), "ruby" | "php") {
+            if matches!(
+                record.file.language.as_str(),
+                "ruby" | "php" | "csharp" | "swift" | "dart"
+            ) {
                 count_ruby_php_resolution_work(1);
                 linear_records.push(record);
                 None
@@ -11730,7 +12762,10 @@ pub fn rematerialize_proof_resolution_projection(
         .iter()
         .flat_map(|record| record.calls.iter().cloned().map(move |call| (record, call)))
         .filter_map(|(record, call)| {
-            if matches!(record.file.language.as_str(), "ruby" | "php") {
+            if matches!(
+                record.file.language.as_str(),
+                "ruby" | "php" | "csharp" | "swift" | "dart"
+            ) {
                 count_ruby_php_resolution_work(1);
                 linear_inputs.push((record, call));
                 None
@@ -11755,7 +12790,10 @@ pub fn rematerialize_proof_resolution_projection(
     inputs.extend(linear_inputs);
     let mut callsite_members = HashSet::new();
     if inputs.iter().any(|(_, input)| {
-        if matches!(input.language.as_str(), "ruby" | "php") {
+        if matches!(
+            input.language.as_str(),
+            "ruby" | "php" | "csharp" | "swift" | "dart"
+        ) {
             count_ruby_php_resolution_work(1);
         }
         !callsite_members.insert((
@@ -11797,7 +12835,12 @@ pub fn rematerialize_proof_resolution_projection(
         &governed_by_id,
         &record_by_file_id,
     )?;
-    enforce_exact_evidence_corroboration(&mut claims, &node_by_id, &exact_evidence_validation);
+    enforce_exact_evidence_corroboration(
+        &mut claims,
+        &node_by_id,
+        &file_by_id,
+        &exact_evidence_validation,
+    );
     let exact_claim_indices = claims
         .iter()
         .enumerate()
@@ -12725,6 +13768,7 @@ fn typescript_directory_specifier(literal: &str) -> Option<&'static str> {
 
 struct ExactEvidenceValidationIndex {
     import_relations: HashMap<(NodeId, NodeId, NodeId), ProofRelationState>,
+    swift_module_import_relations: HashMap<(NodeId, NodeId), ProofRelationState>,
     typescript_directory_import_relations:
         HashMap<(NodeId, NodeId), TypescriptDirectoryImportState>,
     member_relations: HashMap<(NodeId, NodeId), ProofRelationState>,
@@ -12764,11 +13808,32 @@ fn python_raw_import_marker_is_admissible(edge: &Edge, nodes: &HashMap<NodeId, &
 impl ExactEvidenceValidationIndex {
     fn prepare(edges: &[Edge], nodes: &HashMap<NodeId, &Node>) -> Self {
         let mut import_relations = HashMap::<_, ProofRelationState>::new();
+        let mut swift_module_import_relations = HashMap::<_, ProofRelationState>::new();
         let mut typescript_directory_import_relations =
             HashMap::<_, TypescriptDirectoryImportState>::new();
         let mut member_relations = HashMap::<_, ProofRelationState>::new();
         let mut python_import_edges = HashMap::<NodeId, Vec<NodeId>>::new();
         for edge in edges {
+            if edge.kind == EdgeKind::IMPORT
+                && edge.source == edge.target
+                && let Some(file_id) = edge.file_node_id
+                && let Some(import) = nodes.get(&edge.source)
+                && import.kind == NodeKind::MODULE
+                && import.file_node_id == Some(file_id)
+            {
+                let state = swift_module_import_relations
+                    .entry((file_id, edge.source))
+                    .or_default();
+                if edge.effective_source() == edge.source
+                    && edge.effective_target() == edge.target
+                    && edge.resolved_target.is_none()
+                    && edge.candidate_targets.is_empty()
+                {
+                    state.admissible += 1;
+                } else {
+                    state.conflicting += 1;
+                }
+            }
             if edge.kind == EdgeKind::IMPORT
                 && let (Some(file_id), Some(target)) = (edge.file_node_id, edge.resolved_target)
             {
@@ -12917,6 +13982,7 @@ impl ExactEvidenceValidationIndex {
         }
         Self {
             import_relations,
+            swift_module_import_relations,
             typescript_directory_import_relations,
             member_relations,
             member_by_owner_and_name,
@@ -12928,6 +13994,12 @@ impl ExactEvidenceValidationIndex {
     fn has_import(&self, file: NodeId, import: NodeId, target: NodeId) -> bool {
         self.import_relations
             .get(&(file, import, target))
+            .is_some_and(ProofRelationState::is_unique)
+    }
+
+    fn has_swift_module_import(&self, file: NodeId, import: NodeId) -> bool {
+        self.swift_module_import_relations
+            .get(&(file, import))
             .is_some_and(ProofRelationState::is_unique)
     }
 
@@ -13021,6 +14093,7 @@ impl ExactEvidenceValidationIndex {
         &self,
         claim: &ResolvedSyntaxClaim,
         nodes: &HashMap<NodeId, &Node>,
+        files: &HashMap<i64, &codestory_store::FileInfo>,
     ) -> bool {
         let Some(target) = claim.target else {
             return false;
@@ -13073,8 +14146,10 @@ impl ExactEvidenceValidationIndex {
                 CalleeForm::Identifier,
                 [ResolutionEvidence::SamePackageDeclaration { declaration }],
             ) => {
-                matches!(claim.input.language.as_str(), "go" | "kotlin")
-                    && *declaration == target
+                matches!(
+                    claim.input.language.as_str(),
+                    "go" | "kotlin" | "csharp" | "swift" | "dart"
+                ) && *declaration == target
                     && target_node.file_node_id.is_some()
                     && target_node.file_node_id != Some(source_file)
             }
@@ -13094,6 +14169,14 @@ impl ExactEvidenceValidationIndex {
                             || matches!(
                                 &claim.input.binding,
                                 CachedResolutionBinding::JavaKotlinImportedFunction {
+                                    import: binding_import,
+                                    ..
+                                } if is_csharp_swift_dart_language(&claim.input.language)
+                                    && binding_import == import
+                            )
+                            || matches!(
+                                &claim.input.binding,
+                                CachedResolutionBinding::JavaKotlinImportedFunction {
                                     package_name,
                                     name,
                                     import: binding_import,
@@ -13109,6 +14192,17 @@ impl ExactEvidenceValidationIndex {
                             && target_node.qualified_name.as_deref().is_some_and(|name| {
                                 name.ends_with(&claim.input.callsite.raw_target)
                             })
+                    } else if claim.input.language == "dart" {
+                        target_node.file_node_id.is_some_and(|target_file| {
+                            dart_literal_import_target_is_authenticated(
+                                source_file,
+                                *import,
+                                target_file,
+                                &claim.exact_dependency_files,
+                                nodes,
+                                files,
+                            )
+                        })
                     } else if typescript_directory_import {
                         typescript_directory_import_is_correlated
                     } else if self.typescript_directory_marker_seen(source_file, *import) {
@@ -13197,8 +14291,10 @@ impl ExactEvidenceValidationIndex {
                     ResolutionEvidence::SamePackageDeclaration { declaration },
                 ],
             ) => {
-                claim.input.language == "go"
-                    && *declaration == target
+                matches!(
+                    claim.input.language.as_str(),
+                    "go" | "csharp" | "swift" | "dart"
+                ) && *declaration == target
                     && target_node.kind == NodeKind::METHOD
                     && target_node.file_node_id.is_some()
                     && nodes.get(owner).is_some_and(|owner_node| {
@@ -13321,7 +14417,9 @@ impl ExactEvidenceValidationIndex {
                     target,
                     target_node,
                     components,
+                    &claim.exact_dependency_files,
                     nodes,
+                    files,
                 ),
             (
                 CalleeForm::ExplicitReceiver,
@@ -13341,7 +14439,9 @@ impl ExactEvidenceValidationIndex {
                 target,
                 target_node,
                 components,
+                &claim.exact_dependency_files,
                 nodes,
+                files,
             ),
             (
                 CalleeForm::ExplicitReceiver,
@@ -13363,7 +14463,9 @@ impl ExactEvidenceValidationIndex {
                     target,
                     target_node,
                     &[],
+                    &claim.exact_dependency_files,
                     nodes,
+                    files,
                 )
             }
             (
@@ -13385,7 +14487,9 @@ impl ExactEvidenceValidationIndex {
                     target,
                     target_node,
                     &[],
+                    &claim.exact_dependency_files,
                     nodes,
+                    files,
                 ),
             (
                 CalleeForm::ExplicitReceiver,
@@ -13410,7 +14514,9 @@ impl ExactEvidenceValidationIndex {
                     target,
                     target_node,
                     components,
+                    &claim.exact_dependency_files,
                     nodes,
+                    files,
                 )
             }
             (
@@ -13512,9 +14618,25 @@ impl ExactEvidenceValidationIndex {
                     .iter()
                     .any(|dependency| dependency.0 == owner_file.0)
         } else if same_package {
-            language == "go"
-                && owner_node.file_node_id.is_some()
-                && target_node.file_node_id.is_some()
+            if is_csharp_swift_dart_language(language) {
+                nodes.get(&caller).is_some_and(|caller_node| {
+                    caller_node.file_node_id == Some(source_file)
+                        && matches!(caller_node.kind, NodeKind::FUNCTION | NodeKind::METHOD)
+                }) && owner_node.file_node_id.is_some()
+                    && owner_node.file_node_id == target_node.file_node_id
+                    && domain_dependencies
+                        .iter()
+                        .any(|dependency| dependency.0 == source_file.0)
+                    && owner_node.file_node_id.is_some_and(|owner_file| {
+                        domain_dependencies
+                            .iter()
+                            .any(|dependency| dependency.0 == owner_file.0)
+                    })
+            } else {
+                language == "go"
+                    && owner_node.file_node_id.is_some()
+                    && target_node.file_node_id.is_some()
+            }
         } else if language == "go" {
             owner_node.file_node_id.is_some() && target_node.file_node_id.is_some()
         } else {
@@ -13545,7 +14667,9 @@ impl ExactEvidenceValidationIndex {
         target: NodeId,
         target_node: &Node,
         components: &[NodeId],
+        domain_dependencies: &[FileId],
         nodes: &HashMap<NodeId, &Node>,
+        files: &HashMap<i64, &codestory_store::FileInfo>,
     ) -> bool {
         let java_kotlin_literal_import = matches!(language, "java" | "kotlin")
             && nodes.get(&import).is_some_and(|import_node| {
@@ -13565,6 +14689,49 @@ impl ExactEvidenceValidationIndex {
                 import,
                 &components[..components.len() - 2],
             );
+        let swift_module_import = language == "swift"
+            && components == [owner, target]
+            && nodes.get(&import).is_some_and(|import_node| {
+                import_node.kind == NodeKind::MODULE
+                    && import_node.file_node_id == Some(source_file)
+                    && self.has_swift_module_import(source_file, import)
+                    && nodes
+                        .get(&owner)
+                        .and_then(|owner_node| owner_node.file_node_id)
+                        .and_then(|file_id| files.get(&file_id.0))
+                        .and_then(|file| swift_project_module(&file.path))
+                        == Some(import_node.serialized_name.as_str())
+            })
+            && {
+                let dependency_set = domain_dependencies.iter().copied().collect::<HashSet<_>>();
+                let module = nodes
+                    .get(&import)
+                    .map(|import_node| import_node.serialized_name.as_str());
+                module.is_some_and(|module| {
+                    let expected = files
+                        .values()
+                        .filter(|file| {
+                            file.indexed
+                                && file.language == "swift"
+                                && swift_project_module(&file.path) == Some(module)
+                        })
+                        .map(|file| FileId(file.id))
+                        .collect::<HashSet<_>>();
+                    !expected.is_empty() && dependency_set == expected
+                })
+            };
+        let dart_literal_import = language == "dart"
+            && components == [owner, target]
+            && target_node.file_node_id.is_some_and(|target_file| {
+                dart_literal_import_target_is_authenticated(
+                    source_file,
+                    import,
+                    target_file,
+                    domain_dependencies,
+                    nodes,
+                    files,
+                )
+            });
         (if language == "python" {
             target_node.kind == NodeKind::FUNCTION && python_path
         } else {
@@ -13581,6 +14748,8 @@ impl ExactEvidenceValidationIndex {
             })
             && (python_path
                 || java_kotlin_literal_import
+                || swift_module_import
+                || dart_literal_import
                 || self.has_import(source_file, import, owner))
             && self.has_member(owner, target)
     }
@@ -13589,7 +14758,8 @@ impl ExactEvidenceValidationIndex {
 fn proof_import_node_kind_is_literal(language: &str, kind: NodeKind) -> bool {
     match language {
         "go" | "rust" => kind == NodeKind::MODULE,
-        "java" | "kotlin" | "javascript" | "typescript" | "tsx" | "python" | "php" | "ruby" => {
+        "java" | "kotlin" | "csharp" | "swift" | "dart" | "javascript" | "typescript" | "tsx"
+        | "python" | "php" | "ruby" => {
             matches!(kind, NodeKind::MODULE | NodeKind::UNKNOWN)
         }
         _ => false,
@@ -13599,6 +14769,7 @@ fn proof_import_node_kind_is_literal(language: &str, kind: NodeKind) -> bool {
 fn enforce_exact_evidence_corroboration(
     claims: &mut [ResolvedSyntaxClaim],
     nodes: &HashMap<NodeId, &Node>,
+    files: &HashMap<i64, &codestory_store::FileInfo>,
     validation: &ExactEvidenceValidationIndex,
 ) {
     for claim in claims
@@ -13670,7 +14841,7 @@ fn enforce_exact_evidence_corroboration(
                 *evidence_components = components;
             }
         }
-        if !validation.claim_has_literal_corroboration(claim, nodes) {
+        if !validation.claim_has_literal_corroboration(claim, nodes, files) {
             claim.status = ProofResolutionStatus::IncompleteDomain;
             claim.reason = ProofResolutionReason::LookupDomainIncomplete;
             claim.target = None;
@@ -14635,6 +15806,122 @@ enum JavaKotlinImportResolution {
     Incomplete,
 }
 
+fn dart_library_root(path: &Path) -> Option<&Path> {
+    let mut current = path.parent();
+    while let Some(directory) = current {
+        if directory.file_name().and_then(|name| name.to_str()) == Some("lib") {
+            return Some(directory);
+        }
+        current = directory.parent();
+    }
+    None
+}
+
+fn resolve_dart_literal_import(
+    projection: &JavaKotlinProjectionIndex,
+    records: &HashMap<WorkspacePathIdentity, &ResolutionCacheRecord>,
+    source_record: &ResolutionCacheRecord,
+    encoded_uri: &str,
+    owner_name: Option<&str>,
+    imported_name: &str,
+) -> JavaKotlinImportResolution {
+    let Some(uri) = encoded_uri.strip_prefix("dart:uri:") else {
+        return JavaKotlinImportResolution::Incomplete;
+    };
+    let relative = Path::new(uri);
+    if relative
+        .extension()
+        .and_then(|extension| extension.to_str())
+        != Some("dart")
+        || relative
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return JavaKotlinImportResolution::Incomplete;
+    }
+    let Some(source_directory) = source_record.path.parent() else {
+        return JavaKotlinImportResolution::Incomplete;
+    };
+    let target_path = source_directory.join(relative);
+    if !matches!(
+        std::fs::symlink_metadata(&target_path),
+        Ok(metadata) if !metadata.file_type().is_symlink() && metadata.is_file()
+    ) {
+        return JavaKotlinImportResolution::Incomplete;
+    }
+    let (Some(source_library), Some(target_library)) = (
+        dart_library_root(&source_record.path),
+        dart_library_root(&target_path),
+    ) else {
+        return JavaKotlinImportResolution::Incomplete;
+    };
+    if workspace_path_identity(source_library).ok() != workspace_path_identity(target_library).ok()
+    {
+        return JavaKotlinImportResolution::Incomplete;
+    }
+    let Ok(target_identity) = workspace_path_identity(&target_path) else {
+        return JavaKotlinImportResolution::Incomplete;
+    };
+    let Some(target_record) = records.get(&target_identity).copied() else {
+        return JavaKotlinImportResolution::Incomplete;
+    };
+    if target_record.file.language != "dart"
+        || !target_record.file.complete
+        || !target_record.file.lookup_input_complete
+        || target_record.file.export_poison_all
+        || target_record.file.file_id == source_record.file.file_id
+    {
+        return JavaKotlinImportResolution::Incomplete;
+    }
+    let Some(domain) = projection
+        .domains
+        .get(&("dart".to_string(), "dart:lib".to_string()))
+        .filter(|domain| domain.complete && !domain.poisoned)
+    else {
+        return JavaKotlinImportResolution::Incomplete;
+    };
+    let file_id = FileId(target_record.file.file_id.0);
+    let candidates = if let Some(owner_name) = owner_name {
+        let owners = target_record
+            .file
+            .classes
+            .iter()
+            .filter(|class| class.name == owner_name)
+            .collect::<Vec<_>>();
+        let [owner] = owners.as_slice() else {
+            return if owners.is_empty() {
+                JavaKotlinImportResolution::Missing
+            } else {
+                JavaKotlinImportResolution::Ambiguous
+            };
+        };
+        owner
+            .methods
+            .iter()
+            .filter(|method| method.name == imported_name)
+            .map(|method| (owner.declaration, method.declaration))
+            .collect::<Vec<_>>()
+    } else {
+        target_record
+            .file
+            .top_level_declarations
+            .iter()
+            .filter(|declaration| declaration.name == imported_name)
+            .map(|declaration| (declaration.declaration, declaration.declaration))
+            .collect::<Vec<_>>()
+    };
+    match candidates.as_slice() {
+        [(owner, declaration)] => JavaKotlinImportResolution::Exact {
+            owner: *owner,
+            declaration: *declaration,
+            file_id,
+            dependencies: domain.dependencies.clone(),
+        },
+        [] => JavaKotlinImportResolution::Missing,
+        _ => JavaKotlinImportResolution::Ambiguous,
+    }
+}
+
 impl JavaKotlinProjectionIndex {
     fn prepare(records: &[ResolutionCacheRecord]) -> Self {
         let mut domains = HashMap::<(String, String), JavaKotlinImportDomain>::new();
@@ -14760,7 +16047,7 @@ impl JavaKotlinProjectionIndex {
         }
         for record in records
             .iter()
-            .filter(|record| is_java_kotlin_language(&record.file.language))
+            .filter(|record| is_nominal_language(&record.file.language))
         {
             let Some(package_name) = record.file.java_kotlin_package.as_ref() else {
                 continue;
@@ -14791,6 +16078,13 @@ impl JavaKotlinProjectionIndex {
                     });
             }
             for class in &record.file.classes {
+                domain.classes.entry(class.name.clone()).or_default().push(
+                    JavaKotlinImportCandidate {
+                        owner: class.declaration,
+                        declaration: class.declaration,
+                        file_id,
+                    },
+                );
                 for method in &class.methods {
                     domain
                         .declarations
@@ -14804,12 +16098,14 @@ impl JavaKotlinProjectionIndex {
                 }
             }
         }
-        for domain in domains.values_mut() {
-            domain.dependencies.sort();
-            domain.dependencies.dedup();
-            for candidates in domain.declarations.values_mut() {
-                candidates.sort_by_key(|candidate| candidate.declaration);
-                candidates.dedup_by(|left, right| left.declaration == right.declaration);
+        for ((language, _), domain) in &mut domains {
+            if is_java_kotlin_language(language) {
+                domain.dependencies.sort();
+                domain.dependencies.dedup();
+                for candidates in domain.declarations.values_mut() {
+                    candidates.sort_by_key(|candidate| candidate.declaration);
+                    candidates.dedup_by(|left, right| left.declaration == right.declaration);
+                }
             }
         }
         Self {
@@ -14837,7 +16133,20 @@ impl JavaKotlinProjectionIndex {
         else {
             return JavaKotlinImportResolution::Missing;
         };
-        Self::resolve_domain(domain, owner_name, imported_name)
+        let resolution = Self::resolve_domain(domain, owner_name, imported_name);
+        let (Some(owner_name), JavaKotlinImportResolution::Exact { owner, .. }) =
+            (owner_name, &resolution)
+        else {
+            return resolution;
+        };
+        if matches!(
+            domain.classes.get(owner_name).map(Vec::as_slice),
+            Some([candidate]) if candidate.owner == *owner
+        ) {
+            resolution
+        } else {
+            JavaKotlinImportResolution::Ambiguous
+        }
     }
 
     fn resolve_php(
@@ -16176,6 +17485,15 @@ fn resolve_syntax_claim(
             import,
         } => match if input.language == "php" {
             java_kotlin_index.resolve_php_named(package_name, owner_name.as_deref(), name)
+        } else if input.language == "dart" {
+            resolve_dart_literal_import(
+                java_kotlin_index,
+                records,
+                source_record,
+                package_name,
+                owner_name.as_deref(),
+                name,
+            )
         } else {
             java_kotlin_index.resolve(&input.language, package_name, owner_name.as_deref(), name)
         } {
@@ -16231,14 +17549,22 @@ fn resolve_syntax_claim(
                 status = ProofResolutionStatus::Exact;
                 reason = ProofResolutionReason::ExactResolution;
                 target = Some(declaration);
-                if *constructor {
-                    evidence_chain
-                        .push(ResolutionEvidence::ConstructorBinding { constructor: owner });
+                if input.callsite.callee_form == CalleeForm::ImplicitReceiver {
+                    evidence_chain.push(ResolutionEvidence::ImplicitReceiver { owner });
+                } else {
+                    if *constructor {
+                        evidence_chain
+                            .push(ResolutionEvidence::ConstructorBinding { constructor: owner });
+                    }
+                    evidence_chain.push(ResolutionEvidence::ExplicitReceiverType {
+                        receiver_type: owner,
+                    });
                 }
-                evidence_chain.push(ResolutionEvidence::ExplicitReceiverType {
-                    receiver_type: owner,
+                evidence_chain.push(if file_id == input.callsite.file_id {
+                    ResolutionEvidence::SameFileDeclaration { declaration }
+                } else {
+                    ResolutionEvidence::SamePackageDeclaration { declaration }
                 });
-                evidence_chain.push(ResolutionEvidence::SamePackageDeclaration { declaration });
                 exact_node_file_expectations.push((owner, file_id));
                 exact_node_file_expectations.push((declaration, file_id));
                 dependencies.push(input.callsite.file_id);
@@ -16265,6 +17591,15 @@ fn resolve_syntax_claim(
             constructor,
         } => match if input.language == "php" {
             java_kotlin_index.resolve_php_named(package_name, Some(owner_name), method_name)
+        } else if input.language == "dart" {
+            resolve_dart_literal_import(
+                java_kotlin_index,
+                records,
+                source_record,
+                package_name,
+                Some(owner_name),
+                method_name,
+            )
         } else {
             java_kotlin_index.resolve(&input.language, package_name, Some(owner_name), method_name)
         } {
@@ -16808,7 +18143,10 @@ fn seal_resolved_claim(
         None
     };
     let input = &claim.input;
-    let linear_dependency_order = matches!(input.language.as_str(), "ruby" | "php");
+    let linear_dependency_order = matches!(
+        input.language.as_str(),
+        "ruby" | "php" | "csharp" | "swift" | "dart"
+    );
     let mut dependency_ids = Vec::new();
     let mut dependency_members = HashSet::new();
     let mut push_dependency = |file_id: NodeId| {
@@ -16892,8 +18230,15 @@ pub fn build_funnel(facts: &[CallResolutionFact]) -> Vec<ProofResolutionFunnelRo
             Some(fact.callsite.callee_form),
             evidence_kind,
         );
-        let counts = if matches!(fact.provenance.language_adapter.as_str(), "ruby" | "php") {
-            count_ruby_php_resolution_work(1);
+        let counts = if matches!(
+            fact.provenance.language_adapter.as_str(),
+            "ruby" | "php" | "csharp" | "swift" | "dart"
+        ) {
+            if is_csharp_swift_dart_language(&fact.provenance.language_adapter) {
+                count_java_kotlin_resolution_work(1);
+            } else {
+                count_ruby_php_resolution_work(1);
+            }
             linear_rows.entry(key).or_default()
         } else {
             rows.entry(key).or_default()
@@ -16933,7 +18278,7 @@ pub fn build_funnel(facts: &[CallResolutionFact]) -> Vec<ProofResolutionFunnelRo
                 right.evidence_kind.map(|kind| kind.as_str()),
             ))
     });
-    for language in ["php", "ruby"] {
+    for language in ["csharp", "dart", "php", "ruby", "swift"] {
         for callee_form in [
             CalleeForm::Constructor,
             CalleeForm::DynamicAccess,
@@ -16954,7 +18299,11 @@ pub fn build_funnel(facts: &[CallResolutionFact]) -> Vec<ProofResolutionFunnelRo
                 Some(ResolutionEvidenceKind::StaticImportBinding),
             ] {
                 let key = (language.to_owned(), Some(callee_form), evidence_kind);
-                count_ruby_php_resolution_work(1);
+                if is_csharp_swift_dart_language(language) {
+                    count_java_kotlin_resolution_work(1);
+                } else {
+                    count_ruby_php_resolution_work(1);
+                }
                 if let Some(counts) = linear_rows.remove(&key) {
                     result.push(ProofResolutionFunnelRow {
                         language: language.to_owned(),
@@ -17732,10 +19081,22 @@ mod java_kotlin_complexity_tests {
 
     fn measured_work(language: &str, source: &str) -> usize {
         let mut parser = Parser::new();
-        let grammar = if language == "java" {
-            tree_sitter_java::LANGUAGE.into()
-        } else {
-            tree_sitter_kotlin_ng::LANGUAGE.into()
+        let (grammar, path) = match language {
+            "java" => (tree_sitter_java::LANGUAGE.into(), Path::new("Exact.java")),
+            "kotlin" => (
+                tree_sitter_kotlin_ng::LANGUAGE.into(),
+                Path::new("Exact.kt"),
+            ),
+            "csharp" => (tree_sitter_c_sharp::LANGUAGE.into(), Path::new("Exact.cs")),
+            "swift" => (
+                tree_sitter_swift::LANGUAGE.into(),
+                Path::new("Sources/App/Exact.swift"),
+            ),
+            "dart" => (
+                tree_sitter_dart_orchard::LANGUAGE.into(),
+                Path::new("lib/exact.dart"),
+            ),
+            _ => panic!("unsupported nominal test language {language}"),
         };
         parser.set_language(&grammar).expect("grammar must load");
         let tree = parser.parse(source, None).expect("source must parse");
@@ -17764,11 +19125,41 @@ mod java_kotlin_complexity_tests {
             next_id += 1;
         });
         reset_java_kotlin_resolution_work();
-        let index = JavaKotlinResolutionIndex::build(&tree, source, language, file_id, &nodes);
+        let index =
+            JavaKotlinResolutionIndex::build(&tree, source, path, language, file_id, &nodes);
         for call in &index.calls {
             let _ = index.resolve_syntax_claim(source, call.callee, call.form, &call.raw_target);
         }
         java_kotlin_resolution_work()
+    }
+
+    fn csd_source(language: &str, count: usize) -> String {
+        let mut source = match language {
+            "csharp" => String::from(
+                "public sealed class Worker { public void Run() {} }\npublic static class Calls {\n",
+            ),
+            "swift" => String::from("struct Worker { func run() {} }\n"),
+            "dart" => String::from("final class Worker { void run() {} }\n"),
+            _ => panic!("unsupported nominal test language {language}"),
+        };
+        for index in 0..count {
+            match language {
+                "csharp" => source.push_str(&format!(
+                    "public static void Caller{index}() {{ Worker receiver{index} = new Worker(); receiver{index}.Run(); }}\n"
+                )),
+                "swift" => source.push_str(&format!(
+                    "func caller{index}() {{ let receiver{index}: Worker = Worker(); receiver{index}.run() }}\n"
+                )),
+                "dart" => source.push_str(&format!(
+                    "void caller{index}() {{ Worker receiver{index} = Worker(); receiver{index}.run(); }}\n"
+                )),
+                _ => unreachable!(),
+            }
+        }
+        if language == "csharp" {
+            source.push_str("}\n");
+        }
+        source
     }
 
     fn source(language: &str, count: usize) -> String {
@@ -17808,6 +19199,22 @@ mod java_kotlin_complexity_tests {
         for language in ["java", "kotlin"] {
             let small = measured_work(language, &source(language, 64));
             let large = measured_work(language, &source(language, 128));
+            assert!(
+                small >= 64 * 8,
+                "{language} parser work was not fully counted: {small}"
+            );
+            assert!(
+                large <= small * 2 + 256,
+                "{language} parser/index work grew superlinearly: {small} -> {large}"
+            );
+        }
+    }
+
+    #[test]
+    fn csharp_swift_dart_parser_index_work_is_linear_for_doubled_receivers_and_callers() {
+        for language in ["csharp", "swift", "dart"] {
+            let small = measured_work(language, &csd_source(language, 64));
+            let large = measured_work(language, &csd_source(language, 128));
             assert!(
                 small >= 64 * 8,
                 "{language} parser work was not fully counted: {small}"

--- a/crates/codestory-indexer/src/proof_resolution.rs
+++ b/crates/codestory-indexer/src/proof_resolution.rs
@@ -24,17 +24,20 @@ use codestory_store::{
 use codestory_workspace::{WorkspacePathIdentity, workspace_path_identity};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Component, Path, PathBuf};
-use tree_sitter::{Node as TsNode, Tree};
+use tree_sitter::{Node as TsNode, Parser, Tree};
 
 #[cfg(test)]
 thread_local! {
     static RUST_RESOLUTION_WORK: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
     static GO_RESOLUTION_WORK: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
     static PYTHON_RESOLUTION_WORK: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
-    static JAVA_KOTLIN_RESOLUTION_WORK: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
     static C_CPP_RESOLUTION_WORK: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
     static RUBY_PHP_RESOLUTION_WORK: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
+
+#[cfg(test)]
+static JAVA_KOTLIN_RESOLUTION_WORK: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
 
 #[inline]
 fn count_rust_resolution_work(amount: usize) {
@@ -93,19 +96,19 @@ fn python_resolution_work() -> usize {
 #[inline]
 fn count_java_kotlin_resolution_work(amount: usize) {
     #[cfg(test)]
-    JAVA_KOTLIN_RESOLUTION_WORK.with(|work| work.set(work.get().saturating_add(amount)));
+    let _ = JAVA_KOTLIN_RESOLUTION_WORK.fetch_add(amount, std::sync::atomic::Ordering::Relaxed);
     #[cfg(not(test))]
     let _ = amount;
 }
 
 #[cfg(test)]
 fn reset_java_kotlin_resolution_work() {
-    JAVA_KOTLIN_RESOLUTION_WORK.with(|work| work.set(0));
+    JAVA_KOTLIN_RESOLUTION_WORK.store(0, std::sync::atomic::Ordering::Relaxed);
 }
 
 #[cfg(test)]
 fn java_kotlin_resolution_work() -> usize {
-    JAVA_KOTLIN_RESOLUTION_WORK.with(std::cell::Cell::get)
+    JAVA_KOTLIN_RESOLUTION_WORK.load(std::sync::atomic::Ordering::Relaxed)
 }
 
 #[inline]
@@ -155,10 +158,10 @@ const C_ADAPTER_VERSION: &str = "reference-v2";
 const CPP_ADAPTER_VERSION: &str = "reference-v3";
 const RUBY_ADAPTER_VERSION: &str = "reference-v3";
 const PHP_ADAPTER_VERSION: &str = "reference-v2";
-const CSHARP_ADAPTER_VERSION: &str = "reference-v1";
-const SWIFT_ADAPTER_VERSION: &str = "reference-v1";
-const DART_ADAPTER_VERSION: &str = "reference-v1";
-const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 24;
+const CSHARP_ADAPTER_VERSION: &str = "reference-v2";
+const SWIFT_ADAPTER_VERSION: &str = "reference-v2";
+const DART_ADAPTER_VERSION: &str = "reference-v2";
+const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 25;
 const INSTALLED_ADAPTERS: &[(&str, &str)] = &[
     ("go", GO_ADAPTER_VERSION),
     ("javascript", ADAPTER_VERSION),
@@ -512,30 +515,49 @@ fn is_nominal_language(language: &str) -> bool {
 fn csd_source_domain(language: &str, source_path: &Path) -> Option<String> {
     match language {
         "csharp" => Some("csharp:global".to_string()),
-        "swift" => {
-            let components = source_path
-                .components()
-                .filter_map(|component| match component {
-                    Component::Normal(value) => value.to_str(),
-                    _ => None,
-                })
-                .collect::<Vec<_>>();
-            components
-                .windows(2)
-                .find_map(|pair| (pair[0] == "Sources").then(|| pair[1].to_string()))
-                .or_else(|| Some("swift:root".to_string()))
-        }
-        "dart" => {
-            let mut current = source_path.parent();
-            while let Some(directory) = current {
-                if directory.file_name().and_then(|name| name.to_str()) == Some("lib") {
-                    return Some("dart:lib".to_string());
-                }
-                current = directory.parent();
-            }
-            Some("dart:root".to_string())
-        }
+        "swift" => swift_source_domain(source_path),
+        "dart" => dart_source_domain(source_path),
         _ => None,
+    }
+}
+
+fn path_normal_components(path: &Path) -> Vec<&str> {
+    path.components()
+        .filter_map(|component| match component {
+            Component::Normal(value) => value.to_str(),
+            _ => None,
+        })
+        .collect()
+}
+
+fn swift_source_domain(path: &Path) -> Option<String> {
+    let components = path_normal_components(path);
+    if let Some(module) = components
+        .windows(2)
+        .find_map(|pair| (pair[0] == "Sources").then_some(pair[1]))
+        .filter(|module| java_kotlin_simple_identifier(module))
+    {
+        return Some(format!("swift:Sources/{module}"));
+    }
+    components
+        .iter()
+        .any(|component| *component == "Source")
+        .then(|| "swift:Source".to_string())
+}
+
+fn dart_source_domain(path: &Path) -> Option<String> {
+    let components = path_normal_components(path);
+    let lib = components
+        .iter()
+        .rposition(|component| *component == "lib")?;
+    if lib >= 2 && matches!(components[lib - 2], "pkgs" | "packages") {
+        Some(format!(
+            "dart:{}/{}/lib",
+            components[lib - 2],
+            components[lib - 1]
+        ))
+    } else {
+        Some("dart:lib".to_string())
     }
 }
 
@@ -643,6 +665,18 @@ fn import_alias(surface: &str) -> Option<String> {
 fn import_show_names(surface: &str) -> Option<Vec<String>> {
     let (_, shown) = surface.split_once(" show ")?;
     let names = shown
+        .trim_end_matches(';')
+        .split(',')
+        .map(str::trim)
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    (!names.is_empty() && names.iter().all(|name| java_kotlin_simple_identifier(name)))
+        .then_some(names)
+}
+
+fn import_hide_names(surface: &str) -> Option<Vec<String>> {
+    let (_, hidden) = surface.split_once(" hide ")?;
+    let names = hidden
         .trim_end_matches(';')
         .split(',')
         .map(str::trim)
@@ -902,6 +936,9 @@ impl<'index, 'tree> RubyResolutionProducer<'index, 'tree> {
                     name: name.clone(),
                     declaration,
                     methods: Vec::new(),
+                    cross_module_visible: false,
+                    runtime_closed: false,
+                    super_name: None,
                 });
                 self.index.direct_exports.push(CachedDirectExport {
                     exported_name: name.clone(),
@@ -957,6 +994,7 @@ impl<'index, 'tree> RubyResolutionProducer<'index, 'tree> {
                         .push(CachedClassMethod {
                             name: name.clone(),
                             declaration,
+                            cross_module_visible: false,
                         });
                     count_ruby_php_resolution_work(1);
                     self.index
@@ -1579,6 +1617,9 @@ impl<'index, 'tree> PhpResolutionProducer<'index, 'tree> {
                     name: name.clone(),
                     declaration,
                     methods: Vec::new(),
+                    cross_module_visible: false,
+                    runtime_closed: false,
+                    super_name: None,
                 });
                 self.class_indices
                     .entry(name.clone())
@@ -1621,6 +1662,7 @@ impl<'index, 'tree> PhpResolutionProducer<'index, 'tree> {
                         .push(CachedClassMethod {
                             name: name.clone(),
                             declaration,
+                            cross_module_visible: false,
                         });
                     count_ruby_php_resolution_work(1);
                     self.index
@@ -2390,6 +2432,7 @@ impl<'tree> CCppResolutionIndex<'tree> {
                 self.classes[owner].methods.push(CachedClassMethod {
                     name,
                     declaration: target,
+                    cross_module_visible: false,
                 });
             } else {
                 self.declarations.push(CachedTopLevelDeclaration {
@@ -2817,6 +2860,9 @@ impl<'index, 'tree> CCppProducer<'index, 'tree> {
             name,
             declaration: *declaration,
             methods: Vec::new(),
+            cross_module_visible: false,
+            runtime_closed: false,
+            super_name: None,
         });
         self.index
             .class_namespace_paths
@@ -3646,6 +3692,17 @@ struct JavaKotlinImportBinding {
     imported_name: String,
     local_name: String,
     node: NodeId,
+    visible_names: Option<HashSet<String>>,
+    hidden_names: HashSet<String>,
+}
+
+impl JavaKotlinImportBinding {
+    fn allows(&self, name: &str) -> bool {
+        self.visible_names
+            .as_ref()
+            .is_none_or(|visible| visible.contains(name))
+            && !self.hidden_names.contains(name)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -3970,7 +4027,8 @@ impl<'tree> JavaKotlinResolutionIndex<'tree> {
                             _ => (Some(caller), CachedResolutionBinding::Ambiguous),
                         }
                     }
-                    [] if matches!(self.whole_module_imports.as_slice(), [_]) => {
+                    [] if matches!(self.whole_module_imports.as_slice(), [import] if import.allows(raw_target)) =>
+                    {
                         let import = &self.whole_module_imports[0];
                         (
                             Some(caller),
@@ -4047,7 +4105,7 @@ impl<'tree> JavaKotlinResolutionIndex<'tree> {
         {
             count_java_kotlin_resolution_work(1);
             return match imports.as_slice() {
-                [import] => (
+                [import] if import.allows(raw_target) => (
                     Some(caller),
                     CachedResolutionBinding::JavaKotlinImportedFunction {
                         package_name: import.package_name.clone(),
@@ -4074,7 +4132,7 @@ impl<'tree> JavaKotlinResolutionIndex<'tree> {
         {
             count_java_kotlin_resolution_work(1);
             return match self.prefixed_imports.get(prefix).map(Vec::as_slice) {
-                Some([import]) => (
+                Some([import]) if import.allows(&owner_name) => (
                     Some(caller),
                     CachedResolutionBinding::JavaKotlinImportedReceiver {
                         package_name: import.package_name.clone(),
@@ -4106,7 +4164,7 @@ impl<'tree> JavaKotlinResolutionIndex<'tree> {
         if matches!(self.language, "swift" | "dart") && !self.class_names.contains(&owner_name) {
             count_java_kotlin_resolution_work(1);
             return match self.whole_module_imports.as_slice() {
-                [import] => (
+                [import] if import.allows(&owner_name) => (
                     Some(caller),
                     CachedResolutionBinding::JavaKotlinImportedReceiver {
                         package_name: import.package_name.clone(),
@@ -4355,10 +4413,16 @@ impl<'index, 'tree> JavaKotlinProducer<'index, 'tree> {
         };
         count_java_kotlin_resolution_work(2);
         self.index.class_names.insert(name.clone());
+        let cross_module_visible = csd_cross_module_visible(node, self.source, self.index.language);
+        let runtime_closed = csd_runtime_closed(node, self.source, self.index.language);
+        let super_name = csd_super_name(node, self.source, self.index.language);
         self.index.classes.push(CachedClassDeclaration {
             name,
             declaration,
             methods: Vec::new(),
+            cross_module_visible,
+            runtime_closed,
+            super_name,
         });
         context.owner_index = Some(self.index.classes.len() - 1);
         context
@@ -4413,6 +4477,11 @@ impl<'index, 'tree> JavaKotlinProducer<'index, 'tree> {
                 .push(CachedClassMethod {
                     name: name.clone(),
                     declaration,
+                    cross_module_visible: csd_cross_module_visible(
+                        declaration_node,
+                        self.source,
+                        self.index.language,
+                    ),
                 });
         }
         if let Some(declaration) = caller {
@@ -4433,7 +4502,11 @@ impl<'index, 'tree> JavaKotlinProducer<'index, 'tree> {
                     name,
                     declaration,
                     module_path: Vec::new(),
-                    cross_module_visible: false,
+                    cross_module_visible: csd_cross_module_visible(
+                        declaration_node,
+                        self.source,
+                        self.index.language,
+                    ),
                 });
             }
         }
@@ -4483,7 +4556,7 @@ impl<'index, 'tree> JavaKotlinProducer<'index, 'tree> {
                 (Some(existing), Some(parsed))
                     if existing.starts_with("csharp:path:") || existing == "csharp:global" =>
                 {
-                    self.index.package_name = Some(parsed);
+                    self.index.package_name = Some(format!("csharp:{parsed}"));
                 }
                 (_, Some(_)) => self.index.domain_poisoned = true,
                 _ => self.index.domain_poisoned = true,
@@ -4589,11 +4662,13 @@ impl<'index, 'tree> JavaKotlinProducer<'index, 'tree> {
                     return;
                 };
                 let binding = JavaKotlinImportBinding {
-                    package_name: package_name.to_string(),
+                    package_name: format!("csharp:{package_name}"),
                     owner_name: None,
                     imported_name: imported_name.to_string(),
                     local_name: alias.to_string(),
                     node: *import_node,
+                    visible_names: None,
+                    hidden_names: HashSet::new(),
                 };
                 self.index
                     .type_imports_by_name
@@ -4621,11 +4696,13 @@ impl<'index, 'tree> JavaKotlinProducer<'index, 'tree> {
                 self.index
                     .whole_module_imports
                     .push(JavaKotlinImportBinding {
-                        package_name: module.to_string(),
+                        package_name: format!("swift:Sources/{module}"),
                         owner_name: None,
                         imported_name: "*".to_string(),
                         local_name: "*".to_string(),
                         node: *import_node,
+                        visible_names: None,
+                        hidden_names: HashSet::new(),
                     });
             }
             "dart" => {
@@ -4658,6 +4735,12 @@ impl<'index, 'tree> JavaKotlinProducer<'index, 'tree> {
                     imported_name: "*".to_string(),
                     local_name: "*".to_string(),
                     node: *import_node,
+                    visible_names: import_show_names(surface)
+                        .map(|names| names.into_iter().collect()),
+                    hidden_names: import_hide_names(surface)
+                        .unwrap_or_default()
+                        .into_iter()
+                        .collect(),
                 };
                 if let Some(prefix) = import_alias(surface) {
                     self.index
@@ -4733,6 +4816,8 @@ impl<'index, 'tree> JavaKotlinProducer<'index, 'tree> {
             imported_name,
             local_name,
             node: *node_id,
+            visible_names: None,
+            hidden_names: HashSet::new(),
         })
     }
 
@@ -5018,12 +5103,60 @@ fn csd_owner_is_unsupported(node: TsNode<'_>, source: &str, language: &str) -> b
         }
         "dart" => {
             let header = header.trim_start();
-            !(header.starts_with("final class ") || header.starts_with("sealed class "))
+            header.starts_with("abstract ")
+                || header.starts_with("interface ")
+                || header.starts_with("abstract interface ")
+                || header.starts_with("mixin ")
                 || header.contains(" with ")
                 || header.contains(" implements ")
         }
         _ => false,
     }
+}
+
+fn csd_declaration_header<'a>(node: TsNode<'_>, source: &'a str) -> &'a str {
+    node.child_by_field_name("body")
+        .and_then(|body| source.get(node.start_byte()..body.start_byte()))
+        .or_else(|| node_text(node, source))
+        .unwrap_or_default()
+}
+
+fn csd_cross_module_visible(node: TsNode<'_>, source: &str, language: &str) -> bool {
+    if language != "swift" {
+        return true;
+    }
+    csd_declaration_header(node, source)
+        .split(|character: char| !character.is_alphanumeric() && character != '_')
+        .any(|token| matches!(token, "public" | "open"))
+}
+
+fn csd_runtime_closed(node: TsNode<'_>, source: &str, language: &str) -> bool {
+    let header = csd_declaration_header(node, source).trim_start();
+    match language {
+        "csharp" => header.split_whitespace().any(|token| token == "sealed"),
+        "swift" => header.starts_with("struct ") || header.starts_with("enum "),
+        "dart" => header.starts_with("final class ") || header.starts_with("sealed class "),
+        _ => false,
+    }
+}
+
+fn csd_super_name(node: TsNode<'_>, source: &str, language: &str) -> Option<String> {
+    if language != "dart" {
+        return None;
+    }
+    let header = csd_declaration_header(node, source);
+    let mut tokens = header.split(|character: char| {
+        character.is_whitespace() || matches!(character, '{' | '(' | ')' | '<' | '>' | ',')
+    });
+    while let Some(token) = tokens.next() {
+        if token == "extends" {
+            return tokens
+                .find(|candidate| !candidate.is_empty())
+                .filter(|candidate| java_kotlin_simple_identifier(candidate))
+                .map(str::to_string);
+        }
+    }
+    None
 }
 
 fn csd_callable_is_unsupported(node: TsNode<'_>, source: &str, language: &str) -> bool {
@@ -7396,6 +7529,7 @@ impl<'tree> PythonResolutionIndex<'tree> {
                         methods.push(CachedClassMethod {
                             name: method_name.to_string(),
                             declaration,
+                            cross_module_visible: false,
                         });
                     }
                 }
@@ -7404,6 +7538,9 @@ impl<'tree> PythonResolutionIndex<'tree> {
                 name: name.clone(),
                 declaration: owner,
                 methods,
+                cross_module_visible: false,
+                runtime_closed: false,
+                super_name: None,
             };
             self.classes_by_name
                 .entry(name.clone())
@@ -8854,6 +8991,9 @@ impl<'tree> JavascriptResolutionIndex<'tree> {
                         name: name.clone(),
                         declaration: owner,
                         methods,
+                        cross_module_visible: false,
+                        runtime_closed: false,
+                        super_name: None,
                     });
                 }
                 JavascriptBindingKind::Class { owner }
@@ -9927,6 +10067,7 @@ fn javascript_class_methods(
         methods.push(CachedClassMethod {
             name: name.to_string(),
             declaration: *declaration,
+            cross_module_visible: false,
         });
     }
     methods.sort_by(|left, right| {
@@ -12544,6 +12685,20 @@ pub fn rematerialize_proof_resolution_projection(
         .iter()
         .map(|node| (node.id, node))
         .collect::<HashMap<_, _>>();
+    let mut csd_nodes_by_file = HashMap::<i64, Vec<Node>>::new();
+    for node in nodes.iter().filter(|node| {
+        node.file_node_id.is_some_and(|file_id| {
+            file_by_id
+                .get(&file_id.0)
+                .is_some_and(|file| is_csharp_swift_dart_language(&file.language))
+        })
+    }) {
+        count_java_kotlin_resolution_work(1);
+        csd_nodes_by_file
+            .entry(node.file_node_id.expect("filtered CSD node has file").0)
+            .or_default()
+            .push(node.clone());
+    }
     let mut php_graph_names_by_file = HashMap::<i64, Vec<String>>::new();
     for node in nodes.iter().filter(|node| node.kind == NodeKind::NAMESPACE) {
         count_ruby_php_resolution_work(1);
@@ -12724,6 +12879,69 @@ pub fn rematerialize_proof_resolution_projection(
                 "proof resolution parser cache coverage is stale or hash-mismatched for {}",
                 indexed_file.path.display()
             ));
+        }
+        if is_csharp_swift_dart_language(&indexed_file.language) {
+            let source_bytes = std::fs::read(&indexed_file.path).with_context(|| {
+                format!(
+                    "proof resolution cannot authenticate semantic cache source {}",
+                    indexed_file.path.display()
+                )
+            })?;
+            if source_content_hash(&source_bytes) != *stored_hash {
+                return Err(anyhow!(
+                    "proof resolution semantic cache source drifted for {}",
+                    indexed_file.path.display()
+                ));
+            }
+            let source = std::str::from_utf8(&source_bytes).with_context(|| {
+                format!(
+                    "proof resolution semantic cache source is not UTF-8 for {}",
+                    indexed_file.path.display()
+                )
+            })?;
+            let extension = indexed_file
+                .path
+                .extension()
+                .and_then(|extension| extension.to_str())
+                .ok_or_else(|| anyhow!("proof resolution semantic cache path has no extension"))?;
+            let config = crate::get_language_for_ext(extension).ok_or_else(|| {
+                anyhow!(
+                    "proof resolution semantic cache has no parser for {}",
+                    indexed_file.path.display()
+                )
+            })?;
+            if config.language_name != indexed_file.language {
+                return Err(anyhow!(
+                    "proof resolution semantic cache parser language drifted for {}",
+                    indexed_file.path.display()
+                ));
+            }
+            let mut parser = Parser::new();
+            parser.set_language(&config.language).map_err(|error| {
+                anyhow!("proof resolution semantic cache parser failed: {error:?}")
+            })?;
+            let tree = parser
+                .parse(source, None)
+                .ok_or_else(|| anyhow!("proof resolution semantic cache source did not parse"))?;
+            let regenerated = collect_call_resolution_inputs(
+                &tree,
+                source,
+                &indexed_file.path,
+                &indexed_file.language,
+                &expected_parser_fingerprint,
+                NodeId(indexed_file.id),
+                csd_nodes_by_file
+                    .get(&indexed_file.id)
+                    .map(Vec::as_slice)
+                    .unwrap_or_default(),
+            );
+            if regenerated.file.as_ref() != Some(&record.file) || regenerated.calls != record.calls
+            {
+                return Err(anyhow!(
+                    "proof resolution semantic cache does not match authenticated source for {}",
+                    indexed_file.path.display()
+                ));
+            }
         }
         records.push(record);
     }
@@ -15781,6 +15999,9 @@ struct JavaKotlinImportDomain {
     dependency_members: HashSet<FileId>,
     declarations: HashMap<(Option<String>, String), Vec<JavaKotlinImportCandidate>>,
     classes: HashMap<String, Vec<JavaKotlinImportCandidate>>,
+    cross_module_visible_nodes: HashSet<NodeId>,
+    dart_runtime_closed_types: HashSet<String>,
+    dart_overridden_methods: HashSet<(String, String)>,
 }
 
 struct JavaKotlinProjectionIndex {
@@ -15824,6 +16045,7 @@ fn resolve_dart_literal_import(
     encoded_uri: &str,
     owner_name: Option<&str>,
     imported_name: &str,
+    direct_construction: bool,
 ) -> JavaKotlinImportResolution {
     let Some(uri) = encoded_uri.strip_prefix("dart:uri:") else {
         return JavaKotlinImportResolution::Incomplete;
@@ -15875,13 +16097,32 @@ fn resolve_dart_literal_import(
     }
     let Some(domain) = projection
         .domains
-        .get(&("dart".to_string(), "dart:lib".to_string()))
+        .get(&(
+            "dart".to_string(),
+            target_record
+                .file
+                .java_kotlin_package
+                .clone()
+                .unwrap_or_default(),
+        ))
         .filter(|domain| domain.complete && !domain.poisoned)
     else {
         return JavaKotlinImportResolution::Incomplete;
     };
     let file_id = FileId(target_record.file.file_id.0);
     let candidates = if let Some(owner_name) = owner_name {
+        if !projection.dart_dispatch_is_closed(
+            target_record
+                .file
+                .java_kotlin_package
+                .as_deref()
+                .unwrap_or_default(),
+            owner_name,
+            imported_name,
+            direct_construction,
+        ) {
+            return JavaKotlinImportResolution::Incomplete;
+        }
         let owners = target_record
             .file
             .classes
@@ -16076,6 +16317,11 @@ impl JavaKotlinProjectionIndex {
                         declaration: declaration.declaration,
                         file_id,
                     });
+                if declaration.cross_module_visible {
+                    domain
+                        .cross_module_visible_nodes
+                        .insert(declaration.declaration);
+                }
             }
             for class in &record.file.classes {
                 domain.classes.entry(class.name.clone()).or_default().push(
@@ -16085,6 +16331,12 @@ impl JavaKotlinProjectionIndex {
                         file_id,
                     },
                 );
+                if class.cross_module_visible {
+                    domain.cross_module_visible_nodes.insert(class.declaration);
+                }
+                if record.file.language == "dart" && class.runtime_closed {
+                    domain.dart_runtime_closed_types.insert(class.name.clone());
+                }
                 for method in &class.methods {
                     domain
                         .declarations
@@ -16095,6 +16347,16 @@ impl JavaKotlinProjectionIndex {
                             declaration: method.declaration,
                             file_id,
                         });
+                    if class.cross_module_visible && method.cross_module_visible {
+                        domain.cross_module_visible_nodes.insert(method.declaration);
+                    }
+                    if record.file.language == "dart"
+                        && let Some(super_name) = &class.super_name
+                    {
+                        domain
+                            .dart_overridden_methods
+                            .insert((super_name.clone(), method.name.clone()));
+                    }
                 }
             }
         }
@@ -16147,6 +16409,56 @@ impl JavaKotlinProjectionIndex {
         } else {
             JavaKotlinImportResolution::Ambiguous
         }
+    }
+
+    fn resolve_imported(
+        &self,
+        language: &str,
+        package_name: &str,
+        owner_name: Option<&str>,
+        imported_name: &str,
+    ) -> JavaKotlinImportResolution {
+        let resolution = self.resolve(language, package_name, owner_name, imported_name);
+        if language != "swift" {
+            return resolution;
+        }
+        let Some(domain) = self
+            .domains
+            .get(&(language.to_string(), package_name.to_string()))
+        else {
+            return JavaKotlinImportResolution::Missing;
+        };
+        match &resolution {
+            JavaKotlinImportResolution::Exact {
+                owner, declaration, ..
+            } if domain.cross_module_visible_nodes.contains(owner)
+                && domain.cross_module_visible_nodes.contains(declaration) =>
+            {
+                resolution
+            }
+            JavaKotlinImportResolution::Exact { .. } => JavaKotlinImportResolution::Missing,
+            _ => resolution,
+        }
+    }
+
+    fn dart_dispatch_is_closed(
+        &self,
+        package_name: &str,
+        owner_name: &str,
+        method_name: &str,
+        direct_construction: bool,
+    ) -> bool {
+        if direct_construction {
+            return true;
+        }
+        self.domains
+            .get(&("dart".to_string(), package_name.to_string()))
+            .is_some_and(|domain| {
+                domain.dart_runtime_closed_types.contains(owner_name)
+                    && !domain
+                        .dart_overridden_methods
+                        .contains(&(owner_name.to_string(), method_name.to_string()))
+            })
     }
 
     fn resolve_php(
@@ -17493,9 +17805,15 @@ fn resolve_syntax_claim(
                 package_name,
                 owner_name.as_deref(),
                 name,
+                true,
             )
         } else {
-            java_kotlin_index.resolve(&input.language, package_name, owner_name.as_deref(), name)
+            java_kotlin_index.resolve_imported(
+                &input.language,
+                package_name,
+                owner_name.as_deref(),
+                name,
+            )
         } {
             JavaKotlinImportResolution::Exact {
                 owner,
@@ -17546,6 +17864,27 @@ fn resolve_syntax_claim(
                 file_id,
                 mut dependencies,
             } => {
+                if input.language == "dart"
+                    && !java_kotlin_index.dart_dispatch_is_closed(
+                        package_name,
+                        owner_name,
+                        method_name,
+                        *constructor,
+                    )
+                {
+                    status = ProofResolutionStatus::Unsupported;
+                    reason = ProofResolutionReason::UnsupportedConstruct;
+                    return Ok(ResolvedSyntaxClaim {
+                        input,
+                        caller,
+                        target,
+                        status,
+                        reason,
+                        evidence_chain,
+                        exact_node_file_expectations,
+                        exact_dependency_files,
+                    });
+                }
                 status = ProofResolutionStatus::Exact;
                 reason = ProofResolutionReason::ExactResolution;
                 target = Some(declaration);
@@ -17599,9 +17938,15 @@ fn resolve_syntax_claim(
                 package_name,
                 Some(owner_name),
                 method_name,
+                *constructor,
             )
         } else {
-            java_kotlin_index.resolve(&input.language, package_name, Some(owner_name), method_name)
+            java_kotlin_index.resolve_imported(
+                &input.language,
+                package_name,
+                Some(owner_name),
+                method_name,
+            )
         } {
             JavaKotlinImportResolution::Exact {
                 owner,
@@ -19077,6 +19422,10 @@ mod c_cpp_complexity_tests {
 #[cfg(test)]
 mod java_kotlin_complexity_tests {
     use super::*;
+    use codestory_contracts::events::EventBus;
+    use codestory_store::{IndexPublicationMode, IndexPublicationRecord, Store};
+    use codestory_workspace::{BuildMode, RefreshInfo};
+    use std::fs;
     use tree_sitter::Parser;
 
     fn measured_work(language: &str, source: &str) -> usize {
@@ -19162,6 +19511,157 @@ mod java_kotlin_complexity_tests {
         source
     }
 
+    fn csd_pipeline_sources(language: &str, axis: &str, count: usize) -> Vec<(PathBuf, String)> {
+        let extension = match language {
+            "csharp" => "cs",
+            "swift" => "swift",
+            "dart" => "dart",
+            _ => unreachable!(),
+        };
+        if matches!(axis, "files" | "domains") {
+            return (0..count)
+                .map(|index| {
+                    let path = match (language, axis) {
+                        ("csharp", "domains") => {
+                            PathBuf::from(format!("src/Domain{index}/Exact.{extension}"))
+                        }
+                        ("swift", "domains") => {
+                            PathBuf::from(format!("Sources/Module{index}/Exact.{extension}"))
+                        }
+                        ("dart", "domains") => {
+                            PathBuf::from(format!("packages/package{index}/lib/exact.{extension}"))
+                        }
+                        ("csharp", _) => PathBuf::from(format!("src/App/Exact{index}.{extension}")),
+                        ("swift", _) => {
+                            PathBuf::from(format!("Sources/App/Exact{index}.{extension}"))
+                        }
+                        ("dart", _) => PathBuf::from(format!("lib/exact{index}.{extension}")),
+                        _ => unreachable!(),
+                    };
+                    let source = match language {
+                        "csharp" => format!(
+                            "namespace Domain{index}; public static class Calls{index} {{ public static void Target{index}() {{}} public static void Caller{index}() {{ Target{index}(); }} }}\n"
+                        ),
+                        "swift" => format!(
+                            "public func target{index}() {{}}\npublic func caller{index}() {{ target{index}() }}\n"
+                        ),
+                        "dart" => format!(
+                            "void target{index}() {{}}\nvoid caller{index}() {{ target{index}(); }}\n"
+                        ),
+                        _ => unreachable!(),
+                    };
+                    (path, source)
+                })
+                .collect();
+        }
+        let source = match axis {
+            "calls" | "repeated" => csd_source(language, count),
+            "declarations" => {
+                let mut source = csd_source(language, 1);
+                for index in 0..count {
+                    let declaration = match language {
+                        "csharp" => format!(
+                            "public sealed class Extra{index} {{ public void Run{index}() {{}} }}\n"
+                        ),
+                        "swift" => format!("struct Extra{index} {{ func run{index}() {{}} }}\n"),
+                        "dart" => {
+                            format!("final class Extra{index} {{ void run{index}() {{}} }}\n")
+                        }
+                        _ => unreachable!(),
+                    };
+                    source.push_str(&declaration);
+                }
+                source
+            }
+            "nested" => {
+                let mut source = csd_source(language, 1);
+                for index in 0..count {
+                    let owner = match language {
+                        "csharp" => format!(
+                            "public sealed class Owner{index} {{ public void Caller() {{ {{ Worker value = new Worker(); value.Run(); }} }} }}\n"
+                        ),
+                        "swift" => format!(
+                            "func owner{index}() {{ do {{ let value: Worker = Worker(); value.run() }} }}\n"
+                        ),
+                        "dart" => format!(
+                            "void owner{index}() {{ {{ final value = Worker(); value.run(); }} }}\n"
+                        ),
+                        _ => unreachable!(),
+                    };
+                    source.push_str(&owner);
+                }
+                source
+            }
+            "hostile" => {
+                let mut source = csd_source(language, 1);
+                for index in 0..count {
+                    let hostile = match language {
+                        "csharp" => format!("interface Hostile{index} {{ void Run(); }}\n"),
+                        "swift" => format!("protocol Hostile{index} {{ func run() }}\n"),
+                        "dart" => {
+                            format!("abstract interface class Hostile{index} {{ void run(); }}\n")
+                        }
+                        _ => unreachable!(),
+                    };
+                    source.push_str(&hostile);
+                }
+                source
+            }
+            _ => unreachable!(),
+        };
+        let path = match language {
+            "csharp" => PathBuf::from("src/App/Exact.cs"),
+            "swift" => PathBuf::from("Sources/App/Exact.swift"),
+            "dart" => PathBuf::from("lib/exact.dart"),
+            _ => unreachable!(),
+        };
+        vec![(path, source)]
+    }
+
+    fn measured_csd_pipeline_work(language: &str, axis: &str, count: usize) -> (usize, usize) {
+        let project = tempfile::tempdir().expect("temp project");
+        let sources = csd_pipeline_sources(language, axis, count);
+        let mut paths = Vec::new();
+        for (relative, source) in sources {
+            let path = project.path().join(relative);
+            fs::create_dir_all(path.parent().expect("source parent")).expect("create source dir");
+            fs::write(&path, source).expect("write source");
+            paths.push(path);
+        }
+        reset_java_kotlin_resolution_work();
+        codestory_store::reset_store_replay_work();
+        let mut store = Store::new_in_memory().expect("store");
+        crate::WorkspaceIndexer::new(project.path().to_path_buf())
+            .run_incremental(
+                &mut store,
+                &RefreshInfo {
+                    mode: BuildMode::Incremental,
+                    files_to_index: paths,
+                    files_to_remove: Vec::new(),
+                    existing_file_ids: HashMap::new(),
+                },
+                &EventBus::new(),
+                None,
+            )
+            .expect("index sources");
+        let publication = IndexPublicationRecord {
+            generation: 1,
+            generation_id: "linear-generation".to_string(),
+            run_id: "linear-run".to_string(),
+            mode: IndexPublicationMode::Full,
+            published_at_epoch_ms: 1,
+        };
+        rematerialize_proof_resolution_projection(&mut store, &publication)
+            .expect("rematerialize proof resolution");
+        store
+            .validate_proof_resolution_publication(&publication)
+            .expect("replay proof resolution");
+        (
+            java_kotlin_resolution_work(),
+            codestory_store::store_replay_work(),
+        )
+    }
+
     fn source(language: &str, count: usize) -> String {
         let mut source = if language == "java" {
             String::from("class Worker { void run() {} }\n")
@@ -19223,6 +19723,40 @@ mod java_kotlin_complexity_tests {
                 large <= small * 2 + 256,
                 "{language} parser/index work grew superlinearly: {small} -> {large}"
             );
+        }
+    }
+
+    #[test]
+    fn csharp_swift_dart_complete_pipeline_work_is_linear_for_each_growth_axis() {
+        for language in ["csharp", "swift", "dart"] {
+            for axis in [
+                "calls",
+                "files",
+                "declarations",
+                "domains",
+                "nested",
+                "repeated",
+                "hostile",
+            ] {
+                let small = measured_csd_pipeline_work(language, axis, 4);
+                let large = measured_csd_pipeline_work(language, axis, 8);
+                assert!(
+                    small.0 > 0 && small.1 > 0,
+                    "{language}/{axis} did not count the complete pipeline: {small:?}"
+                );
+                assert!(
+                    large.0 <= small.0 * 2 + 512,
+                    "{language}/{axis} index/projection work grew superlinearly: {small:?} -> {large:?}"
+                );
+                assert!(
+                    large.1 <= small.1 * 2 + 512,
+                    "{language}/{axis} store/replay work grew superlinearly: {small:?} -> {large:?}"
+                );
+                assert!(
+                    large.0 + large.1 <= (small.0 + small.1) * 2 + 1024,
+                    "{language}/{axis} total work grew superlinearly: {small:?} -> {large:?}"
+                );
+            }
         }
     }
 }
@@ -19474,7 +20008,11 @@ mod python_complexity_tests {
                     methods: vec![CachedClassMethod {
                         name: "run".to_owned(),
                         declaration: NodeId(30_000 + file_id),
+                        cross_module_visible: false,
                     }],
+                    cross_module_visible: false,
+                    runtime_closed: false,
+                    super_name: None,
                 }],
                 direct_exports: Vec::new(),
                 export_poison_all: false,

--- a/crates/codestory-indexer/src/proof_resolution.rs
+++ b/crates/codestory-indexer/src/proof_resolution.rs
@@ -5125,9 +5125,56 @@ fn csd_cross_module_visible(node: TsNode<'_>, source: &str, language: &str) -> b
     if language != "swift" {
         return true;
     }
-    csd_declaration_header(node, source)
-        .split(|character: char| !character.is_alphanumeric() && character != '_')
-        .any(|token| matches!(token, "public" | "open"))
+    swift_declaration_cross_module_visible(node, source)
+}
+
+fn swift_declaration_cross_module_visible(node: TsNode<'_>, source: &str) -> bool {
+    let mut cursor = node.walk();
+    let Some(modifiers) = node
+        .named_children(&mut cursor)
+        .find(|child| child.kind() == "modifiers")
+    else {
+        return false;
+    };
+    let mut cursor = modifiers.walk();
+    modifiers.named_children(&mut cursor).any(|modifier| {
+        modifier.kind() == "visibility_modifier"
+            && node_text(modifier, source)
+                .is_some_and(|text| matches!(text.trim(), "public" | "open"))
+    })
+}
+
+pub(crate) fn swift_declaration_cross_module_visible_at(
+    tree: &Tree,
+    source: &str,
+    line: u32,
+    column: u32,
+) -> bool {
+    let point = tree_sitter::Point {
+        row: line.saturating_sub(1) as usize,
+        column: column.saturating_sub(1) as usize,
+    };
+    let Some(mut node) = tree
+        .root_node()
+        .named_descendant_for_point_range(point, point)
+    else {
+        return false;
+    };
+    loop {
+        if matches!(
+            node.kind(),
+            "class_declaration"
+                | "protocol_declaration"
+                | "function_declaration"
+                | "property_declaration"
+        ) {
+            return swift_declaration_cross_module_visible(node, source);
+        }
+        let Some(parent) = node.parent() else {
+            return false;
+        };
+        node = parent;
+    }
 }
 
 fn csd_runtime_closed(node: TsNode<'_>, source: &str, language: &str) -> bool {
@@ -16002,6 +16049,9 @@ struct JavaKotlinImportDomain {
     cross_module_visible_nodes: HashSet<NodeId>,
     dart_runtime_closed_types: HashSet<String>,
     dart_overridden_methods: HashSet<(String, String)>,
+    dart_parent_candidates: HashMap<String, Vec<Option<String>>>,
+    dart_declared_methods: HashMap<String, Vec<String>>,
+    dart_ancestry_complete: bool,
 }
 
 struct JavaKotlinProjectionIndex {
@@ -16337,6 +16387,13 @@ impl JavaKotlinProjectionIndex {
                 if record.file.language == "dart" && class.runtime_closed {
                     domain.dart_runtime_closed_types.insert(class.name.clone());
                 }
+                if record.file.language == "dart" {
+                    domain
+                        .dart_parent_candidates
+                        .entry(class.name.clone())
+                        .or_default()
+                        .push(class.super_name.clone());
+                }
                 for method in &class.methods {
                     domain
                         .declarations
@@ -16350,12 +16407,12 @@ impl JavaKotlinProjectionIndex {
                     if class.cross_module_visible && method.cross_module_visible {
                         domain.cross_module_visible_nodes.insert(method.declaration);
                     }
-                    if record.file.language == "dart"
-                        && let Some(super_name) = &class.super_name
-                    {
+                    if record.file.language == "dart" {
                         domain
-                            .dart_overridden_methods
-                            .insert((super_name.clone(), method.name.clone()));
+                            .dart_declared_methods
+                            .entry(class.name.clone())
+                            .or_default()
+                            .push(method.name.clone());
                     }
                 }
             }
@@ -16367,6 +16424,47 @@ impl JavaKotlinProjectionIndex {
                 for candidates in domain.declarations.values_mut() {
                     candidates.sort_by_key(|candidate| candidate.declaration);
                     candidates.dedup_by(|left, right| left.declaration == right.declaration);
+                }
+            } else if language == "dart" {
+                domain.dart_ancestry_complete = true;
+                domain.dart_runtime_closed_types.retain(|name| {
+                    matches!(
+                        domain.dart_parent_candidates.get(name).map(Vec::as_slice),
+                        Some([_])
+                    )
+                });
+                for (subclass, methods) in &domain.dart_declared_methods {
+                    let mut current = subclass.as_str();
+                    let mut visited = HashSet::new();
+                    loop {
+                        if !visited.insert(current.to_string()) {
+                            domain.dart_ancestry_complete = false;
+                            break;
+                        }
+                        let Some([parent]) = domain
+                            .dart_parent_candidates
+                            .get(current)
+                            .map(Vec::as_slice)
+                        else {
+                            domain.dart_ancestry_complete = false;
+                            break;
+                        };
+                        let Some(parent) = parent.as_deref() else {
+                            break;
+                        };
+                        let Some([_]) =
+                            domain.dart_parent_candidates.get(parent).map(Vec::as_slice)
+                        else {
+                            domain.dart_ancestry_complete = false;
+                            break;
+                        };
+                        for method in methods {
+                            domain
+                                .dart_overridden_methods
+                                .insert((parent.to_string(), method.clone()));
+                        }
+                        current = parent;
+                    }
                 }
             }
         }
@@ -16448,16 +16546,15 @@ impl JavaKotlinProjectionIndex {
         method_name: &str,
         direct_construction: bool,
     ) -> bool {
-        if direct_construction {
-            return true;
-        }
         self.domains
             .get(&("dart".to_string(), package_name.to_string()))
             .is_some_and(|domain| {
-                domain.dart_runtime_closed_types.contains(owner_name)
-                    && !domain
-                        .dart_overridden_methods
-                        .contains(&(owner_name.to_string(), method_name.to_string()))
+                domain.dart_ancestry_complete
+                    && (direct_construction
+                        || (domain.dart_runtime_closed_types.contains(owner_name)
+                            && !domain
+                                .dart_overridden_methods
+                                .contains(&(owner_name.to_string(), method_name.to_string()))))
             })
     }
 

--- a/crates/codestory-indexer/src/proof_resolution.rs
+++ b/crates/codestory-indexer/src/proof_resolution.rs
@@ -540,8 +540,7 @@ fn swift_source_domain(path: &Path) -> Option<String> {
         return Some(format!("swift:Sources/{module}"));
     }
     components
-        .iter()
-        .any(|component| *component == "Source")
+        .contains(&"Source")
         .then(|| "swift:Source".to_string())
 }
 
@@ -5436,7 +5435,7 @@ fn typed_binding_from_surface(surface: &str, language: &str) -> Option<(String, 
         .last()?
         .trim_matches(|character: char| !character.is_alphanumeric() && character != '_');
     let owner = tokens
-        .get(tokens.len().checked_sub(2).unwrap_or_default())
+        .get(tokens.len().saturating_sub(2))
         .filter(|_| tokens.len() >= 2)
         .map(|owner| owner.trim_end_matches('?').to_string())
         .or(constructor_type)?;

--- a/crates/codestory-indexer/tests/proof_resolution.rs
+++ b/crates/codestory-indexer/tests/proof_resolution.rs
@@ -879,6 +879,613 @@ fn java_and_kotlin_closed_nonexact_matrix_never_proves() -> anyhow::Result<()> {
 }
 
 #[test]
+fn csharp_swift_and_dart_closed_exact_subset_emits_authenticated_exact_facts() -> anyhow::Result<()>
+{
+    let cases = [
+        (
+            "csharp_same_file",
+            "csharp",
+            vec![(
+                "src/Exact.cs",
+                concat!(
+                    "namespace App;\n",
+                    "sealed class Worker {\n",
+                    "  public void Target() {}\n",
+                    "  public void ThisCaller() { this.Target(); }\n",
+                    "}\n",
+                    "sealed class Holder {\n",
+                    "  private readonly Worker worker = new Worker();\n",
+                    "  public void FieldCaller() { worker.Target(); }\n",
+                    "}\n",
+                    "static class Calls {\n",
+                    "  public static void SameFileTarget() {}\n",
+                    "  public static void SameFileCaller() { SameFileTarget(); SameFileTarget(); }\n",
+                    "  public static void ConstructorCaller() { new Worker().Target(); }\n",
+                    "  public static void TypedLocalCaller() { Worker worker = new Worker(); worker.Target(); }\n",
+                    "  public static void TypedParameterCaller(Worker worker) { worker.Target(); }\n",
+                    "}\n",
+                ),
+            )],
+            vec![("SameFileTarget", 2), ("Target", 5)],
+        ),
+        (
+            "csharp_using_alias",
+            "csharp",
+            vec![
+                (
+                    "src/Lib/Worker.cs",
+                    "namespace Lib; public sealed class Worker { public void Target() {} }\n",
+                ),
+                (
+                    "src/App/Caller.cs",
+                    concat!(
+                        "using WorkerAlias = Lib.Worker;\n",
+                        "namespace App;\n",
+                        "static class Calls { public static void Caller(WorkerAlias worker) { worker.Target(); } }\n",
+                    ),
+                ),
+            ],
+            vec![("Target", 1)],
+        ),
+        (
+            "swift_same_file",
+            "swift",
+            vec![(
+                "Sources/App/Exact.swift",
+                concat!(
+                    "func sameFileTarget() {}\n",
+                    "func sameFileCaller() { sameFileTarget(); sameFileTarget() }\n",
+                    "struct Worker {\n",
+                    "  func target() {}\n",
+                    "  func selfCaller() { self.target() }\n",
+                    "}\n",
+                    "struct Holder {\n",
+                    "  let worker: Worker = Worker()\n",
+                    "  func propertyCaller() { worker.target() }\n",
+                    "}\n",
+                    "func constructorCaller() { Worker().target() }\n",
+                    "func typedLocalCaller() { let worker: Worker = Worker(); worker.target() }\n",
+                    "func typedParameterCaller(_ worker: Worker) { worker.target() }\n",
+                ),
+            )],
+            vec![("sameFileTarget", 2), ("target", 5)],
+        ),
+        (
+            "swift_project_module",
+            "swift",
+            vec![
+                (
+                    "Sources/WorkerModule/Worker.swift",
+                    "public struct Worker { public init() {} public func target() {} }\n",
+                ),
+                (
+                    "Sources/App/Caller.swift",
+                    "import WorkerModule\nfunc caller() { Worker().target() }\n",
+                ),
+            ],
+            vec![("target", 1)],
+        ),
+        (
+            "dart_same_library",
+            "dart",
+            vec![(
+                "lib/exact.dart",
+                concat!(
+                    "void sameFileTarget() {}\n",
+                    "void sameFileCaller() { sameFileTarget(); sameFileTarget(); }\n",
+                    "final class Worker {\n",
+                    "  void target() {}\n",
+                    "  void thisCaller() { this.target(); }\n",
+                    "}\n",
+                    "final class Holder {\n",
+                    "  final Worker worker = Worker();\n",
+                    "  void propertyCaller() { worker.target(); }\n",
+                    "}\n",
+                    "void constructorCaller() { Worker().target(); }\n",
+                    "void typedLocalCaller() { Worker worker = Worker(); worker.target(); }\n",
+                    "void typedParameterCaller(Worker worker) { worker.target(); }\n",
+                ),
+            )],
+            vec![("sameFileTarget", 2), ("target", 5)],
+        ),
+        (
+            "dart_exact_imports",
+            "dart",
+            vec![
+                (
+                    "lib/worker.dart",
+                    "void importedTarget() {}\nfinal class Worker { void target() {} }\n",
+                ),
+                (
+                    "lib/caller.dart",
+                    concat!(
+                        "import 'worker.dart' show importedTarget, Worker;\n",
+                        "void directCaller() { importedTarget(); Worker().target(); }\n",
+                    ),
+                ),
+                (
+                    "lib/prefixed.dart",
+                    concat!(
+                        "import 'worker.dart' as lib;\n",
+                        "void prefixedCaller() { lib.importedTarget(); lib.Worker().target(); }\n",
+                    ),
+                ),
+            ],
+            vec![("importedTarget", 2), ("target", 2)],
+        ),
+    ];
+
+    for (name, language, files, expected_targets) in cases {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(project.path(), &mut store, &files)?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        store.validate_proof_resolution_publication(&publication(1))?;
+        let facts = store
+            .get_proof_resolution_facts()?
+            .into_iter()
+            .filter(|fact| fact.provenance.language_adapter == language)
+            .collect::<Vec<_>>();
+        for (target, expected_count) in expected_targets {
+            let exact = facts
+                .iter()
+                .filter(|fact| fact.callsite.raw_target == target)
+                .filter(|fact| fact.status == ProofResolutionStatus::Exact)
+                .collect::<Vec<_>>();
+            assert_eq!(
+                exact.len(),
+                expected_count,
+                "{name} {target} did not emit the expected exact facts: {facts:#?}"
+            );
+            assert!(exact.iter().all(|fact| {
+                fact.edge_id.is_some()
+                    && fact.raw_edge_target.is_some()
+                    && fact.raw_callsite_identity.is_some()
+                    && fact.target.is_some()
+                    && !fact.evidence_chain.is_empty()
+                    && fact.provenance.evidence_sha256.len() == 64
+                    && !fact.provenance.dependency_file_hashes.is_empty()
+            }));
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn csharp_swift_and_dart_closed_hostile_matrix_never_proves() -> anyhow::Result<()> {
+    let cases = [
+        (
+            "csharp",
+            "dynamic_receiver",
+            "Hostile.cs",
+            "class Hostile { void Caller(dynamic value) { value.Target(); } }\n",
+            "Target",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "csharp",
+            "interface_dispatch",
+            "Hostile.cs",
+            "interface IWorker { void Target(); } class Hostile { void Caller(IWorker value) { value.Target(); } }\n",
+            "Target",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "csharp",
+            "virtual_dispatch",
+            "Hostile.cs",
+            "class Base { public virtual void Target() {} } sealed class Hostile { void Caller(Base value) { value.Target(); } }\n",
+            "Target",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "csharp",
+            "extension_method",
+            "Hostile.cs",
+            "sealed class Worker {} static class Extensions { public static void Target(this Worker value) {} } class Hostile { void Caller(Worker value) { value.Target(); } }\n",
+            "Target",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "csharp",
+            "generic_receiver",
+            "Hostile.cs",
+            "class Hostile { void Caller<T>(T value) { value.ToString(); } }\n",
+            "ToString",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "csharp",
+            "overload_ambiguity",
+            "Hostile.cs",
+            "class Hostile { static void Target(string value) {} static void Target(object value) {} void Caller() { Target(null); } }\n",
+            "Target",
+            ProofResolutionStatus::Ambiguous,
+        ),
+        (
+            "csharp",
+            "partial_type",
+            "Hostile.cs",
+            "partial class Hostile { void Target() {} void Caller() { this.Target(); } }\n",
+            "Target",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "csharp",
+            "generated_type",
+            "Hostile.cs",
+            "[System.CodeDom.Compiler.GeneratedCode(\"tool\", \"1\")] sealed class Hostile { void Target() {} void Caller() { this.Target(); } }\n",
+            "Target",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "csharp",
+            "callable_indirection",
+            "Hostile.cs",
+            "class Hostile { void Caller(System.Action call) { call(); } }\n",
+            "call",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "csharp",
+            "receiver_rebinding",
+            "Hostile.cs",
+            "sealed class Worker { public void Target() {} } class Hostile { void Caller() { Worker value = new Worker(); value = new Worker(); value.Target(); } }\n",
+            "Target",
+            ProofResolutionStatus::Ambiguous,
+        ),
+        (
+            "swift",
+            "protocol_dispatch",
+            "Hostile.swift",
+            "protocol Worker { func target() }\nfunc caller(_ value: any Worker) { value.target() }\n",
+            "target",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "swift",
+            "class_dispatch",
+            "Hostile.swift",
+            "class Worker { func target() {} }\nfunc caller(_ value: Worker) { value.target() }\n",
+            "target",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "swift",
+            "extension_method",
+            "Hostile.swift",
+            "struct Worker {}\nextension Worker { func target() {} }\nfunc caller(_ value: Worker) { value.target() }\n",
+            "target",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "swift",
+            "generic_receiver",
+            "Hostile.swift",
+            "func caller<T>(_ value: T) { String(describing: value) }\n",
+            "String",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "swift",
+            "overload_ambiguity",
+            "Hostile.swift",
+            "func target(_ value: Int) {}\nfunc target(_ value: String) {}\nfunc caller() { target(fatalError()) }\n",
+            "target",
+            ProofResolutionStatus::Ambiguous,
+        ),
+        (
+            "swift",
+            "objc_dispatch",
+            "Hostile.swift",
+            "@objc class Worker: NSObject { @objc dynamic func target() {} }\nfunc caller(_ value: Worker) { value.target() }\n",
+            "target",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "swift",
+            "callable_indirection",
+            "Hostile.swift",
+            "func caller(_ call: () -> Void) { call() }\n",
+            "call",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "swift",
+            "receiver_rebinding",
+            "Hostile.swift",
+            "struct Worker { func target() {} }\nfunc caller() { var value = Worker(); value = Worker(); value.target() }\n",
+            "target",
+            ProofResolutionStatus::Ambiguous,
+        ),
+        (
+            "swift",
+            "conditional_compilation",
+            "Hostile.swift",
+            "#if FEATURE\nfunc target() {}\n#endif\nfunc caller() { target() }\n",
+            "target",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "swift",
+            "generated_type",
+            "Hostile.swift",
+            "// @generated\nstruct Worker { func target() {} }\nfunc caller() { Worker().target() }\n",
+            "target",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "dart",
+            "dynamic_receiver",
+            "hostile.dart",
+            "void caller(dynamic value) { value.target(); }\n",
+            "target",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "dart",
+            "interface_dispatch",
+            "hostile.dart",
+            "abstract interface class Worker { void target(); }\nvoid caller(Worker value) { value.target(); }\n",
+            "target",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "dart",
+            "mixin_dispatch",
+            "hostile.dart",
+            "mixin WorkerMixin { void target() {} }\nclass Worker with WorkerMixin {}\nvoid caller(Worker value) { value.target(); }\n",
+            "target",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "dart",
+            "extension_method",
+            "hostile.dart",
+            "final class Worker {}\nextension WorkerExtension on Worker { void target() {} }\nvoid caller(Worker value) { value.target(); }\n",
+            "target",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "dart",
+            "generic_receiver",
+            "hostile.dart",
+            "void caller<T>(T value) { value.toString(); }\n",
+            "toString",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "dart",
+            "mirrors",
+            "hostile.dart",
+            "import 'dart:mirrors';\nfinal class Worker { void target() {} }\nvoid caller(Worker value) { value.target(); }\n",
+            "target",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "dart",
+            "callable_indirection",
+            "hostile.dart",
+            "void caller(void Function() call) { call(); }\n",
+            "call",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "dart",
+            "receiver_rebinding",
+            "hostile.dart",
+            "final class Worker { void target() {} }\nvoid caller() { Worker value = Worker(); value = Worker(); value.target(); }\n",
+            "target",
+            ProofResolutionStatus::Ambiguous,
+        ),
+        (
+            "dart",
+            "conditional_import",
+            "hostile.dart",
+            "import 'worker.dart' if (dart.library.io) 'io_worker.dart';\nvoid caller(Worker value) { value.target(); }\n",
+            "target",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "dart",
+            "deferred_import",
+            "hostile.dart",
+            "import 'worker.dart' deferred as lib;\nvoid caller() { lib.Worker().target(); }\n",
+            "target",
+            ProofResolutionStatus::Unsupported,
+        ),
+        (
+            "dart",
+            "generated_type",
+            "hostile.dart",
+            "// GENERATED CODE - DO NOT MODIFY BY HAND\nfinal class Worker { void target() {} }\nvoid caller() { Worker().target(); }\n",
+            "target",
+            ProofResolutionStatus::Unsupported,
+        ),
+    ];
+
+    for (language, name, path, source, target, expected) in cases {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(project.path(), &mut store, &[(path, source)])?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        let facts = store.get_proof_resolution_facts()?;
+        let fact = facts
+            .iter()
+            .find(|fact| {
+                fact.provenance.language_adapter == language && fact.callsite.raw_target == target
+            })
+            .unwrap_or_else(|| panic!("{language} {name} emitted no canonical fact: {facts:#?}"));
+        assert_eq!(fact.status, expected, "{language} {name}: {fact:#?}");
+        assert!(fact.reason.matches_status(fact.status), "{fact:#?}");
+        assert!(fact.target.is_none() && fact.edge_id.is_none(), "{fact:#?}");
+        assert!(fact.evidence_chain.is_empty(), "{fact:#?}");
+    }
+    Ok(())
+}
+
+#[test]
+fn csharp_swift_and_dart_complete_domains_are_replay_bound() -> anyhow::Result<()> {
+    let cases = [
+        (
+            "csharp",
+            vec![
+                (
+                    "src/Lib/Worker.cs",
+                    "namespace Lib; public sealed class Worker { public void Target() {} }\n",
+                ),
+                (
+                    "src/App/Caller.cs",
+                    "using WorkerAlias = Lib.Worker; namespace App; static class Calls { static void Caller(WorkerAlias worker) { worker.Target(); } }\n",
+                ),
+                (
+                    "src/Lib/Sibling.cs",
+                    "namespace Lib; public sealed class Sibling {}\n",
+                ),
+            ],
+            "Target",
+            "Sibling.cs",
+        ),
+        (
+            "swift",
+            vec![
+                (
+                    "Sources/WorkerModule/Worker.swift",
+                    "public struct Worker { public init() {} public func target() {} }\n",
+                ),
+                (
+                    "Sources/WorkerModule/Sibling.swift",
+                    "public struct Sibling {}\n",
+                ),
+                (
+                    "Sources/App/Caller.swift",
+                    "import WorkerModule\nfunc caller() { Worker().target() }\n",
+                ),
+            ],
+            "target",
+            "Sibling.swift",
+        ),
+        (
+            "dart",
+            vec![
+                (
+                    "lib/worker.dart",
+                    "final class Worker { void target() {} }\n",
+                ),
+                ("lib/sibling.dart", "final class Sibling {}\n"),
+                (
+                    "lib/caller.dart",
+                    "import 'worker.dart';\nvoid caller() { Worker().target(); }\n",
+                ),
+            ],
+            "target",
+            "sibling.dart",
+        ),
+    ];
+
+    for (language, files, target, sibling_name) in cases {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(project.path(), &mut store, &files)?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        store.validate_proof_resolution_publication(&publication(1))?;
+        let fact = store
+            .get_proof_resolution_facts()?
+            .into_iter()
+            .find(|fact| {
+                fact.provenance.language_adapter == language
+                    && fact.callsite.raw_target == target
+                    && fact.status == ProofResolutionStatus::Exact
+            })
+            .unwrap_or_else(|| panic!("missing {language} cross-file exact fact"));
+        let sibling = store
+            .get_files()?
+            .into_iter()
+            .find(|file| file.path.ends_with(sibling_name))
+            .expect("governed-domain sibling");
+        assert!(
+            fact.provenance
+                .dependency_file_hashes
+                .iter()
+                .any(|dependency| dependency.file_id == FileId(sibling.id)),
+            "{language} exact fact omitted its complete domain: {fact:#?}"
+        );
+        store.get_connection().execute(
+            "UPDATE file SET content_hash = ?1 WHERE id = ?2",
+            ("0".repeat(64), sibling.id),
+        )?;
+        store
+            .validate_proof_resolution_publication(&publication(1))
+            .expect_err("governed-domain source drift must reject replay");
+    }
+    Ok(())
+}
+
+#[test]
+fn csharp_swift_and_dart_incomplete_domains_never_emit_exact_facts() -> anyhow::Result<()> {
+    let cases = [
+        (
+            "csharp",
+            vec![
+                (
+                    "src/App/Caller.cs",
+                    "namespace App; static class Calls { static void Target() {} static void Caller() { Target(); } }\n",
+                ),
+                ("src/App/Broken.cs", "namespace App; class Broken {\n"),
+            ],
+            "Target",
+        ),
+        (
+            "swift",
+            vec![
+                (
+                    "Sources/App/Caller.swift",
+                    "func target() {}\nfunc caller() { target() }\n",
+                ),
+                ("Sources/App/Broken.swift", "struct Broken {\n"),
+            ],
+            "target",
+        ),
+        (
+            "dart",
+            vec![
+                (
+                    "lib/caller.dart",
+                    "void target() {}\nvoid caller() { target(); }\n",
+                ),
+                ("lib/broken.dart", "final class Broken {\n"),
+            ],
+            "target",
+        ),
+    ];
+
+    for (language, files, target) in cases {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(project.path(), &mut store, &files)?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        let facts = store.get_proof_resolution_facts()?;
+        let matching = facts
+            .iter()
+            .filter(|fact| {
+                fact.provenance.language_adapter == language && fact.callsite.raw_target == target
+            })
+            .collect::<Vec<_>>();
+        assert!(
+            !matching.is_empty(),
+            "missing {language} domain fact: {facts:#?}"
+        );
+        assert!(matching.iter().all(|fact| {
+            fact.status == ProofResolutionStatus::IncompleteDomain
+                && fact.target.is_none()
+                && fact.edge_id.is_none()
+                && fact.evidence_chain.is_empty()
+        }));
+    }
+    Ok(())
+}
+
+#[test]
 fn ruby_and_php_closed_exact_subset_emits_authenticated_exact_facts() -> anyhow::Result<()> {
     let cases = [
         (

--- a/crates/codestory-indexer/tests/proof_resolution.rs
+++ b/crates/codestory-indexer/tests/proof_resolution.rs
@@ -1674,7 +1674,8 @@ fn dart_exact_dispatch_requires_a_closed_same_library_override_domain() -> anyho
             let project = tempfile::tempdir()?;
             let mut store = Store::new_in_memory()?;
             index_files(project.path(), &mut store, &files)?;
-            rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+            rematerialize_proof_resolution_projection(&mut store, &publication(1))
+                .map_err(|error| anyhow::anyhow!("{name} reordered={reordered}: {error}"))?;
             let facts = store.get_proof_resolution_facts()?;
             let exact = facts.iter().any(|fact| {
                 fact.provenance.language_adapter == "dart"

--- a/crates/codestory-indexer/tests/proof_resolution.rs
+++ b/crates/codestory-indexer/tests/proof_resolution.rs
@@ -1583,6 +1583,110 @@ fn dart_exact_dispatch_requires_a_closed_same_library_override_domain() -> anyho
         });
         assert_eq!(exact, should_be_exact, "{name}: {facts:#?}");
     }
+
+    let ancestry_cases = [
+        (
+            "closed_without_override",
+            vec![
+                ("lib/a.dart", "final class A { void target() {} }\n"),
+                (
+                    "lib/b.dart",
+                    "import 'a.dart';\nfinal class B extends A {}\n",
+                ),
+                (
+                    "lib/c.dart",
+                    "import 'b.dart';\nfinal class C extends B {}\n",
+                ),
+                (
+                    "lib/caller.dart",
+                    "import 'a.dart';\nvoid caller(A receiver) { receiver.target(); }\n",
+                ),
+            ],
+            true,
+        ),
+        (
+            "transitive_override",
+            vec![
+                ("lib/a.dart", "final class A { void target() {} }\n"),
+                (
+                    "lib/b.dart",
+                    "import 'a.dart';\nfinal class B extends A {}\n",
+                ),
+                (
+                    "lib/c.dart",
+                    "import 'b.dart';\nfinal class C extends B { @override void target() {} }\n",
+                ),
+                (
+                    "lib/caller.dart",
+                    "import 'a.dart';\nvoid caller(A receiver) { receiver.target(); }\n",
+                ),
+            ],
+            false,
+        ),
+        (
+            "cyclic_ancestry",
+            vec![
+                (
+                    "lib/a.dart",
+                    "import 'c.dart';\nfinal class A extends C { void target() {} }\n",
+                ),
+                (
+                    "lib/c.dart",
+                    "import 'a.dart';\nfinal class C extends A {}\n",
+                ),
+                (
+                    "lib/caller.dart",
+                    "import 'a.dart';\nvoid caller(A receiver) { receiver.target(); }\n",
+                ),
+            ],
+            false,
+        ),
+        (
+            "ambiguous_parent",
+            vec![
+                ("lib/a.dart", "final class A { void target() {} }\n"),
+                (
+                    "lib/b_one.dart",
+                    "import 'a.dart';\nfinal class B extends A {}\n",
+                ),
+                (
+                    "lib/b_two.dart",
+                    "import 'a.dart';\nfinal class B extends A {}\n",
+                ),
+                (
+                    "lib/c.dart",
+                    "import 'b_one.dart';\nfinal class C extends B { @override void target() {} }\n",
+                ),
+                (
+                    "lib/caller.dart",
+                    "import 'a.dart';\nvoid caller(A receiver) { receiver.target(); }\n",
+                ),
+            ],
+            false,
+        ),
+    ];
+    for (name, files, should_be_exact) in ancestry_cases {
+        for reordered in [false, true] {
+            let mut files = files.clone();
+            if reordered {
+                files.reverse();
+            }
+            let project = tempfile::tempdir()?;
+            let mut store = Store::new_in_memory()?;
+            index_files(project.path(), &mut store, &files)?;
+            rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+            let facts = store.get_proof_resolution_facts()?;
+            let exact = facts.iter().any(|fact| {
+                fact.provenance.language_adapter == "dart"
+                    && fact.callsite.raw_target == "target"
+                    && fact.status == ProofResolutionStatus::Exact
+            });
+            assert_eq!(
+                exact, should_be_exact,
+                "{name} reordered={reordered} violated ancestry closure: {facts:#?}"
+            );
+        }
+    }
     Ok(())
 }
 
@@ -1636,6 +1740,52 @@ fn dart_combinators_and_swift_visibility_are_replay_authoritative() -> anyhow::R
                 .all(|fact| fact.status != ProofResolutionStatus::Exact),
             "{name} bypassed import/access visibility: {facts:#?}"
         );
+    }
+
+    for visibility in ["public", "open"] {
+        let comment_cases = [
+            (
+                "type",
+                format!("struct /* {visibility} */ Worker {{ public func target() {{}} }}\n"),
+                "func caller() { Worker().target() }\n",
+                "target",
+            ),
+            (
+                "member",
+                format!("public struct Worker {{ func /* {visibility} */ target() {{}} }}\n"),
+                "func caller() { Worker().target() }\n",
+                "target",
+            ),
+            (
+                "top_level",
+                format!("func /* {visibility} */ target() {{}}\n"),
+                "func caller() { target() }\n",
+                "target",
+            ),
+        ];
+        for (surface, declaration, caller, target) in comment_cases {
+            let project = tempfile::tempdir()?;
+            let mut store = Store::new_in_memory()?;
+            let caller = format!("import WorkerModule\n{caller}");
+            index_files(
+                project.path(),
+                &mut store,
+                &[
+                    ("Sources/WorkerModule/Worker.swift", declaration.as_str()),
+                    ("Sources/App/Caller.swift", caller.as_str()),
+                ],
+            )?;
+            rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+            let facts = store.get_proof_resolution_facts()?;
+            assert!(
+                facts.iter().all(|fact| {
+                    fact.provenance.language_adapter != "swift"
+                        || fact.callsite.raw_target != target
+                        || fact.status != ProofResolutionStatus::Exact
+                }),
+                "Swift {visibility} comment forged {surface} visibility: {facts:#?}"
+            );
+        }
     }
     Ok(())
 }

--- a/crates/codestory-indexer/tests/proof_resolution.rs
+++ b/crates/codestory-indexer/tests/proof_resolution.rs
@@ -639,7 +639,6 @@ fn java_and_kotlin_closed_exact_subset_emits_authenticated_exact_facts() -> anyh
             .into_iter()
             .filter(|fact| fact.provenance.language_adapter == language)
             .collect::<Vec<_>>();
-
         for (target, expected_count) in targets {
             let exact = facts
                 .iter()
@@ -956,7 +955,7 @@ fn csharp_swift_and_dart_closed_exact_subset_emits_authenticated_exact_facts() -
             vec![
                 (
                     "Sources/WorkerModule/Worker.swift",
-                    "public struct Worker { public init() {} public func target() {} }\n",
+                    "public struct Worker { public func target() {} }\n",
                 ),
                 (
                     "Sources/App/Caller.swift",
@@ -981,7 +980,7 @@ fn csharp_swift_and_dart_closed_exact_subset_emits_authenticated_exact_facts() -
                     "  final Worker worker = Worker();\n",
                     "  void propertyCaller() { worker.target(); }\n",
                     "}\n",
-                    "void constructorCaller() { Worker().target(); }\n",
+                    "void constructorCaller() { final worker = Worker(); worker.target(); }\n",
                     "void typedLocalCaller() { Worker worker = Worker(); worker.target(); }\n",
                     "void typedParameterCaller(Worker worker) { worker.target(); }\n",
                 ),
@@ -1000,18 +999,18 @@ fn csharp_swift_and_dart_closed_exact_subset_emits_authenticated_exact_facts() -
                     "lib/caller.dart",
                     concat!(
                         "import 'worker.dart' show importedTarget, Worker;\n",
-                        "void directCaller() { importedTarget(); Worker().target(); }\n",
+                        "void directCaller() { importedTarget(); final worker = Worker(); worker.target(); }\n",
                     ),
                 ),
                 (
                     "lib/prefixed.dart",
                     concat!(
                         "import 'worker.dart' as lib;\n",
-                        "void prefixedCaller() { lib.importedTarget(); lib.Worker().target(); }\n",
+                        "void prefixedCaller() { lib.importedTarget(); }\n",
                     ),
                 ),
             ],
-            vec![("importedTarget", 2), ("target", 2)],
+            vec![("importedTarget", 2), ("target", 1)],
         ),
     ];
 
@@ -1162,8 +1161,8 @@ fn csharp_swift_and_dart_closed_hostile_matrix_never_proves() -> anyhow::Result<
             "swift",
             "generic_receiver",
             "Hostile.swift",
-            "func caller<T>(_ value: T) { String(describing: value) }\n",
-            "String",
+            "func caller<T>(_ value: T) { value.target() }\n",
+            "target",
             ProofResolutionStatus::Unsupported,
         ),
         (
@@ -1304,23 +1303,34 @@ fn csharp_swift_and_dart_closed_hostile_matrix_never_proves() -> anyhow::Result<
         ),
     ];
 
+    let mut mismatches = Vec::new();
     for (language, name, path, source, target, expected) in cases {
         let project = tempfile::tempdir()?;
         let mut store = Store::new_in_memory()?;
         index_files(project.path(), &mut store, &[(path, source)])?;
         rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
         let facts = store.get_proof_resolution_facts()?;
-        let fact = facts
-            .iter()
-            .find(|fact| {
-                fact.provenance.language_adapter == language && fact.callsite.raw_target == target
-            })
-            .unwrap_or_else(|| panic!("{language} {name} emitted no canonical fact: {facts:#?}"));
-        assert_eq!(fact.status, expected, "{language} {name}: {fact:#?}");
-        assert!(fact.reason.matches_status(fact.status), "{fact:#?}");
-        assert!(fact.target.is_none() && fact.edge_id.is_none(), "{fact:#?}");
-        assert!(fact.evidence_chain.is_empty(), "{fact:#?}");
+        let fact = facts.iter().find(|fact| {
+            fact.provenance.language_adapter == language && fact.callsite.raw_target == target
+        });
+        let Some(fact) = fact else {
+            mismatches.push(format!(
+                "{language} {name}: emitted no canonical {target} fact: {facts:#?}"
+            ));
+            continue;
+        };
+        if fact.status != expected
+            || !fact.reason.matches_status(fact.status)
+            || fact.target.is_some()
+            || fact.edge_id.is_some()
+            || !fact.evidence_chain.is_empty()
+        {
+            mismatches.push(format!(
+                "{language} {name}: expected={expected:?} observed={fact:#?}"
+            ));
+        }
     }
+    assert!(mismatches.is_empty(), "{}", mismatches.join("\n"));
     Ok(())
 }
 
@@ -1351,7 +1361,7 @@ fn csharp_swift_and_dart_complete_domains_are_replay_bound() -> anyhow::Result<(
             vec![
                 (
                     "Sources/WorkerModule/Worker.swift",
-                    "public struct Worker { public init() {} public func target() {} }\n",
+                    "public struct Worker { public func target() {} }\n",
                 ),
                 (
                     "Sources/WorkerModule/Sibling.swift",
@@ -1375,7 +1385,7 @@ fn csharp_swift_and_dart_complete_domains_are_replay_bound() -> anyhow::Result<(
                 ("lib/sibling.dart", "final class Sibling {}\n"),
                 (
                     "lib/caller.dart",
-                    "import 'worker.dart';\nvoid caller() { Worker().target(); }\n",
+                    "import 'worker.dart';\nvoid caller() { final worker = Worker(); worker.target(); }\n",
                 ),
             ],
             "target",

--- a/crates/codestory-indexer/tests/proof_resolution.rs
+++ b/crates/codestory-indexer/tests/proof_resolution.rs
@@ -5,7 +5,8 @@ use codestory_contracts::proof_resolution::{
     ProofResolutionStatus, ResolutionEvidence, ResolutionEvidenceKind,
 };
 use codestory_indexer::{
-    WorkspaceIndexer, build_proof_resolution_funnel, rematerialize_proof_resolution_projection,
+    WorkspaceIndexer, build_proof_resolution_funnel, current_proof_resolution_adapter_roster,
+    rematerialize_proof_resolution_projection,
 };
 use codestory_store::{
     FileInfo, FileRole, IndexPublicationMode, IndexPublicationRecord, Store,
@@ -9952,7 +9953,10 @@ fn complete_projection_requires_cache_coverage_but_empty_and_unsupported_reposit
     let mut empty = Store::new_in_memory()?;
     let empty_receipt = rematerialize_proof_resolution_projection(&mut empty, &publication(1))?;
     assert_eq!(empty_receipt.fact_count, 0);
-    assert_eq!(empty_receipt.adapter_roster.len(), 12);
+    assert_eq!(
+        empty_receipt.adapter_roster,
+        current_proof_resolution_adapter_roster()
+    );
 
     let project = tempfile::tempdir()?;
     let mut unsupported = Store::new_in_memory()?;
@@ -9967,7 +9971,10 @@ fn complete_projection_requires_cache_coverage_but_empty_and_unsupported_reposit
     let unsupported_receipt =
         rematerialize_proof_resolution_projection(&mut unsupported, &publication(1))?;
     assert_eq!(unsupported_receipt.fact_count, 0);
-    assert_eq!(unsupported_receipt.adapter_roster.len(), 12);
+    assert_eq!(
+        unsupported_receipt.adapter_roster,
+        current_proof_resolution_adapter_roster()
+    );
 
     let governed_project = tempfile::tempdir()?;
     let mut governed = Store::new_in_memory()?;
@@ -10195,7 +10202,7 @@ fn complete_projection_rejects_cache_schema_adapter_and_language_mismatch() -> a
             .expect_err("cache provenance mismatch must reject the complete projection");
         let message = error.to_string();
         assert!(
-            ["stale", "schema-v23", "adapter", "language"]
+            ["stale", "schema-v25", "adapter", "language"]
                 .iter()
                 .any(|needle| message.contains(needle)),
             "{mutation}: {error}"
@@ -10615,7 +10622,7 @@ fn proof_resolution_roster_tracks_the_current_adapter_version() -> anyhow::Resul
             .map(|adapter| adapter.adapter_version.as_str()),
         Some("reference-v17")
     );
-    for language in ["java", "kotlin"] {
+    for language in ["java", "kotlin", "csharp", "swift", "dart"] {
         assert_eq!(
             receipt
                 .adapter_roster

--- a/crates/codestory-indexer/tests/proof_resolution.rs
+++ b/crates/codestory-indexer/tests/proof_resolution.rs
@@ -1627,10 +1627,13 @@ fn dart_combinators_and_swift_visibility_are_replay_authoritative() -> anyhow::R
         rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
         let facts = store.get_proof_resolution_facts()?;
         assert!(
-            facts.iter().filter(|fact| {
-                fact.provenance.language_adapter == language
-                    && fact.callsite.raw_target == target
-            }).all(|fact| fact.status != ProofResolutionStatus::Exact),
+            facts
+                .iter()
+                .filter(|fact| {
+                    fact.provenance.language_adapter == language
+                        && fact.callsite.raw_target == target
+                })
+                .all(|fact| fact.status != ProofResolutionStatus::Exact),
             "{name} bypassed import/access visibility: {facts:#?}"
         );
     }
@@ -1663,10 +1666,15 @@ fn csharp_swift_and_dart_cache_blob_semantics_are_not_self_authenticating() -> a
         )?;
         let mut artifact: serde_json::Value = serde_json::from_slice(&blob)?;
         match mutation {
-            "binding" => artifact["call_resolution_inputs"][0]["binding"]["kind"] = "unsupported".into(),
+            "binding" => {
+                artifact["call_resolution_inputs"][0]["binding"]["kind"] = "unsupported".into()
+            }
             "poison" => artifact["resolution_file"]["export_poison_all"] = true.into(),
             "domain" => artifact["resolution_file"]["java_kotlin_package"] = "ForgedModule".into(),
-            "import" => artifact["call_resolution_inputs"][0]["binding"]["package_name"] = "ForgedModule".into(),
+            "import" => {
+                artifact["call_resolution_inputs"][0]["binding"]["package_name"] =
+                    "ForgedModule".into()
+            }
             _ => unreachable!(),
         }
         store.get_connection().execute(

--- a/crates/codestory-indexer/tests/proof_resolution.rs
+++ b/crates/codestory-indexer/tests/proof_resolution.rs
@@ -1496,6 +1496,190 @@ fn csharp_swift_and_dart_incomplete_domains_never_emit_exact_facts() -> anyhow::
 }
 
 #[test]
+fn csharp_swift_and_dart_canonical_fixture_layouts_replay_exactly() -> anyhow::Result<()> {
+    let cases = [
+        (
+            "csharp",
+            "src/AutoMapper/Mapper.cs",
+            "namespace AutoMapper; public static class Mapper { public static void Map() {} public static void Caller() { Map(); } }\n",
+            "Map",
+        ),
+        (
+            "swift",
+            "Source/Session.swift",
+            "func request() {}\nfunc caller() { request() }\n",
+            "request",
+        ),
+        (
+            "dart",
+            "pkgs/http/lib/http.dart",
+            "void get() {}\nvoid caller() { get(); }\n",
+            "get",
+        ),
+    ];
+    for (language, path, source, target) in cases {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(project.path(), &mut store, &[(path, source)])?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        store.validate_proof_resolution_publication(&publication(1))?;
+        let facts = store.get_proof_resolution_facts()?;
+        assert!(
+            facts.iter().any(|fact| {
+                fact.provenance.language_adapter == language
+                    && fact.callsite.raw_target == target
+                    && fact.status == ProofResolutionStatus::Exact
+            }),
+            "{language} canonical fixture layout was not replay-exact: {facts:#?}"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn dart_exact_dispatch_requires_a_closed_same_library_override_domain() -> anyhow::Result<()> {
+    let cases = [
+        (
+            "subtype_override",
+            vec![
+                (
+                    "lib/worker.dart",
+                    "final class Worker { void target() {} }\nfinal class Derived extends Worker { @override void target() {} }\n",
+                ),
+                (
+                    "lib/caller.dart",
+                    "import 'worker.dart';\nvoid caller(Worker worker) { worker.target(); }\n",
+                ),
+            ],
+            false,
+        ),
+        (
+            "direct_exact_construction",
+            vec![(
+                "lib/caller.dart",
+                "class Worker { void target() {} }\nvoid caller() { final worker = Worker(); worker.target(); }\n",
+            )],
+            true,
+        ),
+        (
+            "externally_extensible_typed_parameter",
+            vec![(
+                "lib/caller.dart",
+                "class Worker { void target() {} }\nvoid caller(Worker worker) { worker.target(); }\n",
+            )],
+            false,
+        ),
+    ];
+    for (name, files, should_be_exact) in cases {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(project.path(), &mut store, &files)?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        let facts = store.get_proof_resolution_facts()?;
+        let exact = facts.iter().any(|fact| {
+            fact.provenance.language_adapter == "dart"
+                && fact.callsite.raw_target == "target"
+                && fact.status == ProofResolutionStatus::Exact
+        });
+        assert_eq!(exact, should_be_exact, "{name}: {facts:#?}");
+    }
+    Ok(())
+}
+
+#[test]
+fn dart_combinators_and_swift_visibility_are_replay_authoritative() -> anyhow::Result<()> {
+    let cases = [
+        (
+            "dart_hide",
+            "dart",
+            vec![
+                (
+                    "lib/worker.dart",
+                    "void hiddenTarget() {}\nfinal class Worker {}\n",
+                ),
+                (
+                    "lib/caller.dart",
+                    "import 'worker.dart' hide hiddenTarget;\nvoid caller() { hiddenTarget(); }\n",
+                ),
+            ],
+            "hiddenTarget",
+        ),
+        (
+            "swift_internal_member",
+            "swift",
+            vec![
+                (
+                    "Sources/WorkerModule/Worker.swift",
+                    "public struct Worker { func target() {} }\n",
+                ),
+                (
+                    "Sources/App/Caller.swift",
+                    "import WorkerModule\nfunc caller() { Worker().target() }\n",
+                ),
+            ],
+            "target",
+        ),
+    ];
+    for (name, language, files, target) in cases {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(project.path(), &mut store, &files)?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        let facts = store.get_proof_resolution_facts()?;
+        assert!(
+            facts.iter().filter(|fact| {
+                fact.provenance.language_adapter == language
+                    && fact.callsite.raw_target == target
+            }).all(|fact| fact.status != ProofResolutionStatus::Exact),
+            "{name} bypassed import/access visibility: {facts:#?}"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn csharp_swift_and_dart_cache_blob_semantics_are_not_self_authenticating() -> anyhow::Result<()> {
+    for mutation in ["binding", "poison", "domain", "import"] {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(
+            project.path(),
+            &mut store,
+            &[
+                (
+                    "Sources/WorkerModule/Worker.swift",
+                    "public struct Worker { public func target() {} }\n",
+                ),
+                (
+                    "Sources/App/Caller.swift",
+                    "import WorkerModule\nfunc caller() { Worker().target() }\n",
+                ),
+            ],
+        )?;
+        let (path, blob): (String, Vec<u8>) = store.get_connection().query_row(
+            "SELECT file_path, artifact_blob FROM index_artifact_cache WHERE file_path LIKE '%Caller.swift'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        let mut artifact: serde_json::Value = serde_json::from_slice(&blob)?;
+        match mutation {
+            "binding" => artifact["call_resolution_inputs"][0]["binding"]["kind"] = "unsupported".into(),
+            "poison" => artifact["resolution_file"]["export_poison_all"] = true.into(),
+            "domain" => artifact["resolution_file"]["java_kotlin_package"] = "ForgedModule".into(),
+            "import" => artifact["call_resolution_inputs"][0]["binding"]["package_name"] = "ForgedModule".into(),
+            _ => unreachable!(),
+        }
+        store.get_connection().execute(
+            "UPDATE index_artifact_cache SET artifact_blob = ?1 WHERE file_path = ?2",
+            (serde_json::to_vec(&artifact)?, path),
+        )?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))
+            .expect_err("CSD semantic cache BLOB mutation must fail closed");
+    }
+    Ok(())
+}
+
+#[test]
 fn ruby_and_php_closed_exact_subset_emits_authenticated_exact_facts() -> anyhow::Result<()> {
     let cases = [
         (

--- a/crates/codestory-indexer/tests/proof_resolution.rs
+++ b/crates/codestory-indexer/tests/proof_resolution.rs
@@ -1052,6 +1052,43 @@ fn csharp_swift_and_dart_closed_exact_subset_emits_authenticated_exact_facts() -
 }
 
 #[test]
+fn nonexact_narrow_graph_caller_span_does_not_block_publication() -> anyhow::Result<()> {
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(
+        project.path(),
+        &mut store,
+        &[(
+            "dart_tictactoe.dart",
+            include_str!("fixtures/tictactoe/dart_tictactoe.dart"),
+        )],
+    )?;
+    let navigation_edges = store.get_edges()?;
+
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    store.validate_proof_resolution_publication(&publication(1))?;
+
+    let facts = store
+        .get_proof_resolution_facts()?
+        .into_iter()
+        .filter(|fact| fact.provenance.language_adapter == "dart")
+        .filter(|fact| fact.callsite.raw_target == "print")
+        .filter(|fact| fact.callsite.line == 8)
+        .collect::<Vec<_>>();
+    assert_eq!(facts.len(), 1, "one parser callsite must own one fact");
+    let fact = &facts[0];
+    assert_eq!(fact.status, ProofResolutionStatus::Unsupported);
+    assert_eq!(fact.reason, ProofResolutionReason::UnsupportedConstruct);
+    assert!(fact.target.is_none());
+    assert!(fact.edge_id.is_none());
+    assert!(fact.raw_edge_target.is_none());
+    assert!(fact.raw_callsite_identity.is_none());
+    assert!(fact.evidence_chain.is_empty());
+    assert_eq!(store.get_edges()?, navigation_edges);
+    Ok(())
+}
+
+#[test]
 fn csharp_swift_and_dart_closed_hostile_matrix_never_proves() -> anyhow::Result<()> {
     let cases = [
         (

--- a/crates/codestory-store/src/lib.rs
+++ b/crates/codestory-store/src/lib.rs
@@ -52,6 +52,8 @@ pub use storage_impl::{
     UnownedProjectionRemovalSummary, seal_call_resolution_fact, stored_vector_encoding,
     structural_text_unit_digest,
 };
+#[cfg(debug_assertions)]
+pub use storage_impl::{reset_store_replay_work, store_replay_work};
 
 impl Store {
     /// Access stored file inventory used by workspace refresh planning.

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -48,6 +48,8 @@ use helpers::{
 
 pub use helpers::{StoredVectorEncoding, stored_vector_encoding};
 pub use proof_resolution::{ProofResolutionPublication, seal_call_resolution_fact};
+#[cfg(debug_assertions)]
+pub use proof_resolution::{reset_store_replay_work, store_replay_work};
 
 const SCHEMA_VERSION: u32 = 32;
 // Reserved outside the sequential migration range so a future real schema version cannot

--- a/crates/codestory-store/src/storage_impl/proof_resolution.rs
+++ b/crates/codestory-store/src/storage_impl/proof_resolution.rs
@@ -1039,8 +1039,7 @@ fn swift_source_domain(path: &Path) -> Option<String> {
         return Some(format!("swift:Sources/{module}"));
     }
     components
-        .iter()
-        .any(|component| *component == "Source")
+        .contains(&"Source")
         .then(|| "swift:Source".to_string())
 }
 

--- a/crates/codestory-store/src/storage_impl/proof_resolution.rs
+++ b/crates/codestory-store/src/storage_impl/proof_resolution.rs
@@ -13,27 +13,25 @@ const EVIDENCE_DIGEST_DOMAIN: &[u8] = b"codestory-proof-resolution-evidence-v1\0
 const FACT_ID_DOMAIN: &[u8] = b"codestory-proof-resolution-fact-id-v1\0";
 const PUBLICATION_DIGEST_DOMAIN: &[u8] = b"codestory-proof-resolution-publication-v1\0";
 
-#[cfg(test)]
-thread_local! {
-    static STORE_REPLAY_WORK: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
-}
+#[cfg(debug_assertions)]
+static STORE_REPLAY_WORK: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 
 #[inline]
 fn count_store_replay_work(amount: usize) {
-    #[cfg(test)]
-    STORE_REPLAY_WORK.with(|work| work.set(work.get().saturating_add(amount)));
-    #[cfg(not(test))]
+    #[cfg(debug_assertions)]
+    let _ = STORE_REPLAY_WORK.fetch_add(amount, std::sync::atomic::Ordering::Relaxed);
+    #[cfg(not(debug_assertions))]
     let _ = amount;
 }
 
-#[cfg(test)]
-fn reset_store_replay_work() {
-    STORE_REPLAY_WORK.with(|work| work.set(0));
+#[cfg(debug_assertions)]
+pub fn reset_store_replay_work() {
+    STORE_REPLAY_WORK.store(0, std::sync::atomic::Ordering::Relaxed);
 }
 
-#[cfg(test)]
-fn store_replay_work() -> usize {
-    STORE_REPLAY_WORK.with(std::cell::Cell::get)
+#[cfg(debug_assertions)]
+pub fn store_replay_work() -> usize {
+    STORE_REPLAY_WORK.load(std::sync::atomic::Ordering::Relaxed)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -293,6 +291,10 @@ struct ProofResolutionValidationContext {
     parsed_callsite_identity_by_edge: HashMap<EdgeId, CanonicalCallsiteIdentity>,
     import_relations: HashMap<(NodeId, NodeId, NodeId), ProofRelationState>,
     swift_module_import_relations: HashMap<(NodeId, NodeId), ProofRelationState>,
+    swift_public_node_ids: HashSet<NodeId>,
+    dart_import_visibility_by_node: HashMap<NodeId, DartImportVisibility>,
+    dart_runtime_closed_nodes: HashSet<NodeId>,
+    dart_overridden_owner_methods: HashSet<(NodeId, String)>,
     typescript_directory_import_relations:
         HashMap<(NodeId, NodeId), TypescriptDirectoryImportState>,
     member_relations: HashMap<(NodeId, NodeId), ProofRelationState>,
@@ -312,6 +314,12 @@ struct ProofResolutionValidationContext {
     go_dependency_ids_by_package: HashMap<GoPackageIdentity, BTreeSet<FileId>>,
     go_attestation_error_by_file: HashMap<i64, String>,
     live_go_sources_authenticated: bool,
+}
+
+#[derive(Default)]
+struct DartImportVisibility {
+    shown: Option<HashSet<String>>,
+    hidden: HashSet<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -818,10 +826,8 @@ fn prepare_csd_domain_closure(
                 Some([name]) => Some(format!("csharp:{name}")),
                 Some(_) => None,
             },
-            "swift" => swift_project_module(&file.path).map(|module| format!("swift:{module}")),
-            "dart" => dart_library_root(&file.path)
-                .and_then(|root| std::fs::canonicalize(root).ok())
-                .map(|root| format!("dart:{}", root.display())),
+            "swift" => swift_source_domain(&file.path),
+            "dart" => dart_source_domain(&file.path),
             _ => None,
         };
         let Some(identity) = identity else {
@@ -834,6 +840,180 @@ fn prepare_csd_domain_closure(
             .push(FileId(file.id));
     }
     (identity_by_file, dependency_ids_by_domain)
+}
+
+fn prepare_swift_public_nodes(
+    files: &[FileInfo],
+    hashes: &HashMap<i64, String>,
+    nodes: &HashMap<NodeId, Node>,
+) -> HashSet<NodeId> {
+    let mut lines_by_file = HashMap::<i64, Vec<String>>::new();
+    for file in files.iter().filter(|file| file.language == "swift") {
+        count_store_replay_work(1);
+        let Ok(bytes) = std::fs::read(&file.path) else {
+            continue;
+        };
+        if hashes.get(&file.id) != Some(&format!("{:x}", Sha256::digest(&bytes))) {
+            continue;
+        }
+        let Ok(source) = String::from_utf8(bytes) else {
+            continue;
+        };
+        lines_by_file.insert(file.id, source.lines().map(str::to_string).collect());
+    }
+    let mut public = HashSet::new();
+    for node in nodes.values() {
+        count_store_replay_work(1);
+        let Some((file, line)) = node.file_node_id.zip(node.start_line) else {
+            continue;
+        };
+        if lines_by_file
+            .get(&file.0)
+            .and_then(|lines| lines.get(line.saturating_sub(1) as usize))
+            .is_some_and(|line| {
+                line.split(|character: char| !character.is_alphanumeric() && character != '_')
+                    .any(|token| matches!(token, "public" | "open"))
+            })
+        {
+            public.insert(node.id);
+        }
+    }
+    public
+}
+
+fn prepare_dart_dispatch_closure(
+    files: &[FileInfo],
+    hashes: &HashMap<i64, String>,
+    nodes: &HashMap<NodeId, Node>,
+    domain_by_file: &HashMap<i64, String>,
+    member_by_owner_and_name: &HashMap<(NodeId, String), Option<NodeId>>,
+) -> (HashSet<NodeId>, HashSet<(NodeId, String)>) {
+    let mut lines_by_file = HashMap::<i64, Vec<String>>::new();
+    for file in files.iter().filter(|file| file.language == "dart") {
+        count_store_replay_work(1);
+        let Ok(bytes) = std::fs::read(&file.path) else {
+            continue;
+        };
+        if hashes.get(&file.id) != Some(&format!("{:x}", Sha256::digest(&bytes))) {
+            continue;
+        }
+        let Ok(source) = String::from_utf8(bytes) else {
+            continue;
+        };
+        lines_by_file.insert(file.id, source.lines().map(str::to_string).collect());
+    }
+    let mut class_by_domain_and_name = HashMap::<(String, String), Option<NodeId>>::new();
+    let mut closed = HashSet::new();
+    let mut super_by_class = Vec::<(NodeId, String, String)>::new();
+    for node in nodes.values().filter(|node| node.kind == NodeKind::CLASS) {
+        count_store_replay_work(1);
+        let Some(file) = node.file_node_id else {
+            continue;
+        };
+        let Some(domain) = domain_by_file.get(&file.0).cloned() else {
+            continue;
+        };
+        let Some(line) = node.start_line.and_then(|line| {
+            lines_by_file
+                .get(&file.0)
+                .and_then(|lines| lines.get(line.saturating_sub(1) as usize))
+        }) else {
+            continue;
+        };
+        let name = graph_leaf_name(&node.serialized_name).to_string();
+        class_by_domain_and_name
+            .entry((domain.clone(), name))
+            .and_modify(|entry| *entry = None)
+            .or_insert(Some(node.id));
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("final class ") || trimmed.starts_with("sealed class ") {
+            closed.insert(node.id);
+        }
+        let tokens = line
+            .split(|character: char| {
+                character.is_whitespace() || matches!(character, '{' | '(' | ')' | '<' | '>' | ',')
+            })
+            .collect::<Vec<_>>();
+        if let Some(index) = tokens.iter().position(|token| *token == "extends")
+            && let Some(super_name) = tokens[index + 1..].iter().find(|token| !token.is_empty())
+        {
+            super_by_class.push((node.id, domain, (*super_name).to_string()));
+        }
+    }
+    let unique_nodes = class_by_domain_and_name
+        .values()
+        .filter_map(|entry| *entry)
+        .collect::<HashSet<_>>();
+    closed.retain(|node| unique_nodes.contains(node));
+    let mut member_names_by_owner = HashMap::<NodeId, Vec<String>>::new();
+    for ((owner, name), member) in member_by_owner_and_name {
+        count_store_replay_work(1);
+        if member.is_some() {
+            member_names_by_owner
+                .entry(*owner)
+                .or_default()
+                .push(name.clone());
+        }
+    }
+    let mut overridden = HashSet::new();
+    for (subclass, domain, super_name) in super_by_class {
+        count_store_replay_work(1);
+        let Some(Some(owner)) = class_by_domain_and_name.get(&(domain, super_name)) else {
+            continue;
+        };
+        if let Some(names) = member_names_by_owner.get(&subclass) {
+            for name in names {
+                count_store_replay_work(1);
+                overridden.insert((*owner, name.clone()));
+            }
+        }
+    }
+    (closed, overridden)
+}
+
+fn path_normal_components(path: &Path) -> Vec<&str> {
+    path.components()
+        .filter_map(|component| match component {
+            std::path::Component::Normal(value) => value.to_str(),
+            _ => None,
+        })
+        .collect()
+}
+
+fn swift_source_domain(path: &Path) -> Option<String> {
+    let components = path_normal_components(path);
+    if let Some(module) = components
+        .windows(2)
+        .find_map(|pair| (pair[0] == "Sources").then_some(pair[1]))
+        .filter(|module| {
+            !module.is_empty()
+                && module
+                    .chars()
+                    .all(|character| character == '_' || character.is_alphanumeric())
+        })
+    {
+        return Some(format!("swift:Sources/{module}"));
+    }
+    components
+        .iter()
+        .any(|component| *component == "Source")
+        .then(|| "swift:Source".to_string())
+}
+
+fn dart_source_domain(path: &Path) -> Option<String> {
+    let components = path_normal_components(path);
+    let lib = components
+        .iter()
+        .rposition(|component| *component == "lib")?;
+    if lib >= 2 && matches!(components[lib - 2], "pkgs" | "packages") {
+        Some(format!(
+            "dart:{}/{}/lib",
+            components[lib - 2],
+            components[lib - 1]
+        ))
+    } else {
+        Some("dart:lib".to_string())
+    }
 }
 
 fn csd_dependency_ids(
@@ -1535,6 +1715,10 @@ mod go_replay_complexity_tests {
             parsed_callsite_identity_by_edge: HashMap::new(),
             import_relations: HashMap::new(),
             swift_module_import_relations: HashMap::new(),
+            swift_public_node_ids: HashSet::new(),
+            dart_import_visibility_by_node: HashMap::new(),
+            dart_runtime_closed_nodes: HashSet::new(),
+            dart_overridden_owner_methods: HashSet::new(),
             typescript_directory_import_relations: HashMap::new(),
             member_relations: HashMap::new(),
             member_by_owner_and_name: HashMap::new(),
@@ -1709,6 +1893,10 @@ mod python_replay_complexity_tests {
             parsed_callsite_identity_by_edge: HashMap::new(),
             import_relations: HashMap::new(),
             swift_module_import_relations: HashMap::new(),
+            swift_public_node_ids: HashSet::new(),
+            dart_import_visibility_by_node: HashMap::new(),
+            dart_runtime_closed_nodes: HashSet::new(),
+            dart_overridden_owner_methods: HashSet::new(),
             typescript_directory_import_relations: HashMap::new(),
             member_relations: HashMap::new(),
             member_by_owner_and_name: HashMap::new(),
@@ -1834,6 +2022,10 @@ mod ruby_php_replay_complexity_tests {
             parsed_callsite_identity_by_edge: HashMap::new(),
             import_relations: HashMap::new(),
             swift_module_import_relations: HashMap::new(),
+            swift_public_node_ids: HashSet::new(),
+            dart_import_visibility_by_node: HashMap::new(),
+            dart_runtime_closed_nodes: HashSet::new(),
+            dart_overridden_owner_methods: HashSet::new(),
             typescript_directory_import_relations: HashMap::new(),
             member_relations: HashMap::new(),
             member_by_owner_and_name: HashMap::new(),
@@ -2034,6 +2226,27 @@ impl ProofResolutionValidationContext {
             prepare_java_package_closure(&file_by_id, &node_by_id);
         let (csd_domain_identity_by_file, csd_dependency_ids_by_domain) =
             prepare_csd_domain_closure(&files, &node_by_id);
+        let swift_public_node_ids =
+            prepare_swift_public_nodes(&files, &file_content_hash_by_id, &node_by_id);
+        let mut dart_import_visibility_by_node = HashMap::new();
+        for node in node_by_id.values().filter(|node| {
+            node.file_node_id.is_some_and(|file| {
+                file_by_id
+                    .get(&file.0)
+                    .is_some_and(|file| file.language == "dart")
+            }) && node.kind == NodeKind::MODULE
+                && quoted_import_literal(&node.serialized_name).is_some()
+        }) {
+            count_store_replay_work(1);
+            dart_import_visibility_by_node.insert(
+                node.id,
+                DartImportVisibility {
+                    shown: dart_import_combinator_names(&node.serialized_name, "show"),
+                    hidden: dart_import_combinator_names(&node.serialized_name, "hide")
+                        .unwrap_or_default(),
+                },
+            );
+        }
         let (
             ruby_dependency_file_ids,
             php_namespace_identity_by_file,
@@ -2214,6 +2427,14 @@ impl ProofResolutionValidationContext {
                 .and_modify(|candidate| *candidate = None)
                 .or_insert(Some(member));
         }
+        let (dart_runtime_closed_nodes, dart_overridden_owner_methods) =
+            prepare_dart_dispatch_closure(
+                &files,
+                &file_content_hash_by_id,
+                &node_by_id,
+                &csd_domain_identity_by_file,
+                &member_by_owner_and_name,
+            );
         Ok(Self {
             file_by_id,
             file_content_hash_by_id,
@@ -2226,6 +2447,10 @@ impl ProofResolutionValidationContext {
             parsed_callsite_identity_by_edge,
             import_relations,
             swift_module_import_relations,
+            swift_public_node_ids,
+            dart_import_visibility_by_node,
+            dart_runtime_closed_nodes,
+            dart_overridden_owner_methods,
             typescript_directory_import_relations,
             member_relations,
             member_by_owner_and_name,
@@ -2839,6 +3064,33 @@ impl Storage {
         if target_node.file_node_id.is_none() {
             return Err(proof_error("exact target has no indexed dependency file"));
         }
+        if fact.provenance.language_adapter == "dart" {
+            let direct_construction = fact
+                .evidence_chain
+                .iter()
+                .any(|evidence| matches!(evidence, ResolutionEvidence::ConstructorBinding { .. }));
+            let receiver_owner = fact
+                .evidence_chain
+                .iter()
+                .find_map(|evidence| match evidence {
+                    ResolutionEvidence::ExplicitReceiverType { receiver_type } => {
+                        Some(*receiver_type)
+                    }
+                    ResolutionEvidence::ImplicitReceiver { owner } => Some(*owner),
+                    _ => None,
+                });
+            if let Some(owner) = receiver_owner
+                && !direct_construction
+                && (!context.dart_runtime_closed_nodes.contains(&owner)
+                    || context
+                        .dart_overridden_owner_methods
+                        .contains(&(owner, fact.callsite.raw_target.clone())))
+            {
+                return Err(proof_error(
+                    "Dart receiver dispatch is not closed by its complete library domain",
+                ));
+            }
+        }
         if fact.provenance.language_adapter == "go"
             && (!matches!(caller.kind, NodeKind::FUNCTION | NodeKind::METHOD)
                 || !matches!(target_node.kind, NodeKind::FUNCTION | NodeKind::METHOD))
@@ -2958,9 +3210,11 @@ impl Storage {
                     .get(import)
                     .ok_or_else(|| proof_error("static import binding is missing"))?;
                 if import_node.file_node_id != Some(NodeId(fact.callsite.file_id.0))
-                    || (!matches!(fact.provenance.language_adapter.as_str(), "php" | "dart")
-                        && graph_leaf_name(&import_node.serialized_name)
-                            != fact.callsite.raw_target)
+                    || (!matches!(
+                        fact.provenance.language_adapter.as_str(),
+                        "php" | "dart" | "swift"
+                    ) && graph_leaf_name(&import_node.serialized_name)
+                        != fact.callsite.raw_target)
                     || !(if context
                         .typescript_directory_marker_seen(NodeId(fact.callsite.file_id.0), *import)
                     {
@@ -2982,6 +3236,16 @@ impl Storage {
                                 target_file,
                             )
                         })
+                    } else if fact.provenance.language_adapter == "swift" {
+                        context.has_swift_module_import(NodeId(fact.callsite.file_id.0), *import)
+                            && context.swift_public_node_ids.contains(&target)
+                            && target_node.file_node_id.is_some_and(|target_file| {
+                                context
+                                    .file_by_id
+                                    .get(&target_file.0)
+                                    .and_then(|file| swift_project_module(&file.path))
+                                    == Some(import_node.serialized_name.as_str())
+                            })
                     } else {
                         context.has_import(NodeId(fact.callsite.file_id.0), *import, target)
                     })
@@ -3460,6 +3724,8 @@ impl Storage {
             && components.is_some_and(|components| components == [owner, target])
             && import_node.kind == NodeKind::MODULE
             && context.has_swift_module_import(source_file, import)
+            && context.swift_public_node_ids.contains(&owner)
+            && context.swift_public_node_ids.contains(&target)
             && owner_node
                 .file_node_id
                 .and_then(|file_id| context.file_by_id.get(&file_id.0))
@@ -3962,6 +4228,25 @@ fn quoted_import_literal(surface: &str) -> Option<&str> {
     Some(&rest[..rest.find(quote)?])
 }
 
+fn dart_import_combinator_names(surface: &str, keyword: &str) -> Option<HashSet<String>> {
+    let marker = format!(" {keyword} ");
+    let (_, tail) = surface.split_once(&marker)?;
+    let end = [" show ", " hide "]
+        .into_iter()
+        .filter_map(|next| tail.find(next))
+        .min()
+        .unwrap_or(tail.len());
+    Some(
+        tail[..end]
+            .trim_end_matches(';')
+            .split(',')
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+            .map(str::to_string)
+            .collect(),
+    )
+}
+
 fn dart_literal_import_target_is_authenticated(
     context: &ProofResolutionValidationContext,
     fact: &CallResolutionFact,
@@ -3976,6 +4261,22 @@ fn dart_literal_import_target_is_authenticated(
         return false;
     };
     let Some(uri) = quoted_import_literal(&import_node.serialized_name) else {
+        return false;
+    };
+    let imported_declaration = fact
+        .evidence_chain
+        .iter()
+        .find_map(|evidence| match evidence {
+            ResolutionEvidence::StaticImportBinding {
+                import: evidence_import,
+                declaration,
+            } if *evidence_import == import => Some(*declaration),
+            _ => None,
+        });
+    let Some(imported_name) = imported_declaration
+        .and_then(|declaration| context.node_by_id.get(&declaration))
+        .map(|node| graph_leaf_name(&node.serialized_name))
+    else {
         return false;
     };
     let relative = std::path::Path::new(uri);
@@ -4009,6 +4310,16 @@ fn dart_literal_import_target_is_authenticated(
             .components()
             .all(|component| matches!(component, std::path::Component::Normal(_)))
         && source.id != target.id
+        && context
+            .dart_import_visibility_by_node
+            .get(&import)
+            .is_some_and(|visibility| {
+                visibility
+                    .shown
+                    .as_ref()
+                    .is_none_or(|shown| shown.contains(imported_name))
+                    && !visibility.hidden.contains(imported_name)
+            })
         && target.language == "dart"
         && target.indexed
         && exact_native_target

--- a/crates/codestory-store/src/storage_impl/proof_resolution.rs
+++ b/crates/codestory-store/src/storage_impl/proof_resolution.rs
@@ -2947,13 +2947,18 @@ impl Storage {
             .node_by_id
             .get(&fact.caller)
             .ok_or_else(|| proof_error("caller node is missing"))?;
-        if caller.file_node_id != Some(NodeId(fact.callsite.file_id.0))
-            || caller
+        if caller.file_node_id != Some(NodeId(fact.callsite.file_id.0)) {
+            return Err(proof_error(
+                "caller node does not belong to the callsite file",
+            ));
+        }
+        if fact.status == ProofResolutionStatus::Exact
+            && (caller
                 .start_line
                 .is_some_and(|line| line > fact.callsite.line)
-            || caller
-                .end_line
-                .is_some_and(|line| line < fact.callsite.line)
+                || caller
+                    .end_line
+                    .is_some_and(|line| line < fact.callsite.line))
         {
             return Err(proof_error(
                 "caller containment does not match the exact callsite",

--- a/crates/codestory-store/src/storage_impl/proof_resolution.rs
+++ b/crates/codestory-store/src/storage_impl/proof_resolution.rs
@@ -14,24 +14,52 @@ const FACT_ID_DOMAIN: &[u8] = b"codestory-proof-resolution-fact-id-v1\0";
 const PUBLICATION_DIGEST_DOMAIN: &[u8] = b"codestory-proof-resolution-publication-v1\0";
 
 #[cfg(debug_assertions)]
-static STORE_REPLAY_WORK: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+thread_local! {
+    static STORE_REPLAY_WORK: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
 
 #[inline]
 fn count_store_replay_work(amount: usize) {
     #[cfg(debug_assertions)]
-    let _ = STORE_REPLAY_WORK.fetch_add(amount, std::sync::atomic::Ordering::Relaxed);
+    STORE_REPLAY_WORK.with(|work| work.set(work.get().saturating_add(amount)));
     #[cfg(not(debug_assertions))]
     let _ = amount;
 }
 
 #[cfg(debug_assertions)]
 pub fn reset_store_replay_work() {
-    STORE_REPLAY_WORK.store(0, std::sync::atomic::Ordering::Relaxed);
+    STORE_REPLAY_WORK.with(|work| work.set(0));
 }
 
 #[cfg(debug_assertions)]
 pub fn store_replay_work() -> usize {
-    STORE_REPLAY_WORK.load(std::sync::atomic::Ordering::Relaxed)
+    STORE_REPLAY_WORK.with(std::cell::Cell::get)
+}
+
+#[cfg(test)]
+#[test]
+fn replay_work_is_isolated_across_concurrent_go_ruby_and_csd_measurements() {
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(3));
+    let threads = [("go", 576), ("ruby", 222), ("csd", 901)]
+        .into_iter()
+        .map(|(language, expected)| {
+            let barrier = barrier.clone();
+            std::thread::spawn(move || {
+                reset_store_replay_work();
+                barrier.wait();
+                count_store_replay_work(expected);
+                barrier.wait();
+                assert_eq!(
+                    store_replay_work(),
+                    expected,
+                    "{language} observed another proof replay invocation's work"
+                );
+            })
+        })
+        .collect::<Vec<_>>();
+    for thread in threads {
+        thread.join().expect("counter isolation worker");
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/codestory-store/src/storage_impl/proof_resolution.rs
+++ b/crates/codestory-store/src/storage_impl/proof_resolution.rs
@@ -295,6 +295,7 @@ struct ProofResolutionValidationContext {
     dart_import_visibility_by_node: HashMap<NodeId, DartImportVisibility>,
     dart_runtime_closed_nodes: HashSet<NodeId>,
     dart_overridden_owner_methods: HashSet<(NodeId, String)>,
+    dart_ancestry_invalid_domains: HashSet<String>,
     typescript_directory_import_relations:
         HashMap<(NodeId, NodeId), TypescriptDirectoryImportState>,
     member_relations: HashMap<(NodeId, NodeId), ProofRelationState>,
@@ -843,42 +844,42 @@ fn prepare_csd_domain_closure(
 }
 
 fn prepare_swift_public_nodes(
+    storage: &Storage,
     files: &[FileInfo],
-    hashes: &HashMap<i64, String>,
     nodes: &HashMap<NodeId, Node>,
-) -> HashSet<NodeId> {
-    let mut lines_by_file = HashMap::<i64, Vec<String>>::new();
-    for file in files.iter().filter(|file| file.language == "swift") {
-        count_store_replay_work(1);
-        let Ok(bytes) = std::fs::read(&file.path) else {
-            continue;
-        };
-        if hashes.get(&file.id) != Some(&format!("{:x}", Sha256::digest(&bytes))) {
-            continue;
-        }
-        let Ok(source) = String::from_utf8(bytes) else {
-            continue;
-        };
-        lines_by_file.insert(file.id, source.lines().map(str::to_string).collect());
-    }
+) -> Result<HashSet<NodeId>, StorageError> {
+    let swift_file_ids = files
+        .iter()
+        .filter_map(|file| (file.language == "swift").then_some(file.id))
+        .collect::<HashSet<_>>();
+    let swift_node_ids = nodes
+        .values()
+        .filter_map(|node| {
+            count_store_replay_work(1);
+            node.file_node_id
+                .filter(|file| swift_file_ids.contains(&file.0))
+                .filter(|_| {
+                    matches!(
+                        node.kind,
+                        NodeKind::STRUCT
+                            | NodeKind::CLASS
+                            | NodeKind::ENUM
+                            | NodeKind::FUNCTION
+                            | NodeKind::METHOD
+                    )
+                })
+                .map(|_| node.id)
+        })
+        .collect::<Vec<_>>();
+    let access = storage.get_component_access_map_for_nodes(&swift_node_ids)?;
     let mut public = HashSet::new();
-    for node in nodes.values() {
+    for node_id in swift_node_ids {
         count_store_replay_work(1);
-        let Some((file, line)) = node.file_node_id.zip(node.start_line) else {
-            continue;
-        };
-        if lines_by_file
-            .get(&file.0)
-            .and_then(|lines| lines.get(line.saturating_sub(1) as usize))
-            .is_some_and(|line| {
-                line.split(|character: char| !character.is_alphanumeric() && character != '_')
-                    .any(|token| matches!(token, "public" | "open"))
-            })
-        {
-            public.insert(node.id);
+        if access.get(&node_id) == Some(&AccessKind::Public) {
+            public.insert(node_id);
         }
     }
-    public
+    Ok(public)
 }
 
 fn prepare_dart_dispatch_closure(
@@ -887,7 +888,7 @@ fn prepare_dart_dispatch_closure(
     nodes: &HashMap<NodeId, Node>,
     domain_by_file: &HashMap<i64, String>,
     member_by_owner_and_name: &HashMap<(NodeId, String), Option<NodeId>>,
-) -> (HashSet<NodeId>, HashSet<(NodeId, String)>) {
+) -> (HashSet<NodeId>, HashSet<(NodeId, String)>, HashSet<String>) {
     let mut lines_by_file = HashMap::<i64, Vec<String>>::new();
     for file in files.iter().filter(|file| file.language == "dart") {
         count_store_replay_work(1);
@@ -903,6 +904,8 @@ fn prepare_dart_dispatch_closure(
         lines_by_file.insert(file.id, source.lines().map(str::to_string).collect());
     }
     let mut class_by_domain_and_name = HashMap::<(String, String), Option<NodeId>>::new();
+    let mut class_identity_by_node = HashMap::<NodeId, (String, String)>::new();
+    let mut parent_by_class = HashMap::<NodeId, Option<String>>::new();
     let mut closed = HashSet::new();
     let mut super_by_class = Vec::<(NodeId, String, String)>::new();
     for node in nodes.values().filter(|node| node.kind == NodeKind::CLASS) {
@@ -920,7 +923,12 @@ fn prepare_dart_dispatch_closure(
         }) else {
             continue;
         };
+        let declaration_column = line.len().saturating_sub(line.trim_start().len()) as u32 + 1;
+        if node.start_col != Some(declaration_column) {
+            continue;
+        }
         let name = graph_leaf_name(&node.serialized_name).to_string();
+        class_identity_by_node.insert(node.id, (domain.clone(), name.clone()));
         class_by_domain_and_name
             .entry((domain.clone(), name))
             .and_modify(|entry| *entry = None)
@@ -934,10 +942,14 @@ fn prepare_dart_dispatch_closure(
                 character.is_whitespace() || matches!(character, '{' | '(' | ')' | '<' | '>' | ',')
             })
             .collect::<Vec<_>>();
-        if let Some(index) = tokens.iter().position(|token| *token == "extends")
-            && let Some(super_name) = tokens[index + 1..].iter().find(|token| !token.is_empty())
-        {
-            super_by_class.push((node.id, domain, (*super_name).to_string()));
+        let super_name = tokens
+            .iter()
+            .position(|token| *token == "extends")
+            .and_then(|index| tokens[index + 1..].iter().find(|token| !token.is_empty()))
+            .map(|name| (*name).to_string());
+        parent_by_class.insert(node.id, super_name.clone());
+        if let Some(super_name) = super_name {
+            super_by_class.push((node.id, domain, super_name));
         }
     }
     let unique_nodes = class_by_domain_and_name
@@ -956,19 +968,51 @@ fn prepare_dart_dispatch_closure(
         }
     }
     let mut overridden = HashSet::new();
-    for (subclass, domain, super_name) in super_by_class {
+    let mut invalid_domains = HashSet::new();
+    for (class, (domain, _)) in &class_identity_by_node {
+        let mut current = *class;
+        let mut visited = HashSet::new();
+        loop {
+            if !visited.insert(current) {
+                invalid_domains.insert(domain.clone());
+                break;
+            }
+            let Some(parent_name) = parent_by_class.get(&current).and_then(Option::as_deref) else {
+                break;
+            };
+            let Some(Some(parent)) =
+                class_by_domain_and_name.get(&(domain.clone(), parent_name.to_string()))
+            else {
+                invalid_domains.insert(domain.clone());
+                break;
+            };
+            current = *parent;
+        }
+    }
+    for (subclass, domain, _) in super_by_class {
         count_store_replay_work(1);
-        let Some(Some(owner)) = class_by_domain_and_name.get(&(domain, super_name)) else {
-            continue;
-        };
         if let Some(names) = member_names_by_owner.get(&subclass) {
-            for name in names {
-                count_store_replay_work(1);
-                overridden.insert((*owner, name.clone()));
+            let mut current = subclass;
+            let mut visited = HashSet::new();
+            while visited.insert(current) {
+                let Some(parent_name) = parent_by_class.get(&current).and_then(Option::as_deref)
+                else {
+                    break;
+                };
+                let Some(Some(owner)) =
+                    class_by_domain_and_name.get(&(domain.clone(), parent_name.to_string()))
+                else {
+                    break;
+                };
+                for name in names {
+                    count_store_replay_work(1);
+                    overridden.insert((*owner, name.clone()));
+                }
+                current = *owner;
             }
         }
     }
-    (closed, overridden)
+    (closed, overridden, invalid_domains)
 }
 
 fn path_normal_components(path: &Path) -> Vec<&str> {
@@ -1719,6 +1763,7 @@ mod go_replay_complexity_tests {
             dart_import_visibility_by_node: HashMap::new(),
             dart_runtime_closed_nodes: HashSet::new(),
             dart_overridden_owner_methods: HashSet::new(),
+            dart_ancestry_invalid_domains: HashSet::new(),
             typescript_directory_import_relations: HashMap::new(),
             member_relations: HashMap::new(),
             member_by_owner_and_name: HashMap::new(),
@@ -1897,6 +1942,7 @@ mod python_replay_complexity_tests {
             dart_import_visibility_by_node: HashMap::new(),
             dart_runtime_closed_nodes: HashSet::new(),
             dart_overridden_owner_methods: HashSet::new(),
+            dart_ancestry_invalid_domains: HashSet::new(),
             typescript_directory_import_relations: HashMap::new(),
             member_relations: HashMap::new(),
             member_by_owner_and_name: HashMap::new(),
@@ -2026,6 +2072,7 @@ mod ruby_php_replay_complexity_tests {
             dart_import_visibility_by_node: HashMap::new(),
             dart_runtime_closed_nodes: HashSet::new(),
             dart_overridden_owner_methods: HashSet::new(),
+            dart_ancestry_invalid_domains: HashSet::new(),
             typescript_directory_import_relations: HashMap::new(),
             member_relations: HashMap::new(),
             member_by_owner_and_name: HashMap::new(),
@@ -2226,8 +2273,7 @@ impl ProofResolutionValidationContext {
             prepare_java_package_closure(&file_by_id, &node_by_id);
         let (csd_domain_identity_by_file, csd_dependency_ids_by_domain) =
             prepare_csd_domain_closure(&files, &node_by_id);
-        let swift_public_node_ids =
-            prepare_swift_public_nodes(&files, &file_content_hash_by_id, &node_by_id);
+        let swift_public_node_ids = prepare_swift_public_nodes(storage, &files, &node_by_id)?;
         let mut dart_import_visibility_by_node = HashMap::new();
         for node in node_by_id.values().filter(|node| {
             node.file_node_id.is_some_and(|file| {
@@ -2427,14 +2473,17 @@ impl ProofResolutionValidationContext {
                 .and_modify(|candidate| *candidate = None)
                 .or_insert(Some(member));
         }
-        let (dart_runtime_closed_nodes, dart_overridden_owner_methods) =
-            prepare_dart_dispatch_closure(
-                &files,
-                &file_content_hash_by_id,
-                &node_by_id,
-                &csd_domain_identity_by_file,
-                &member_by_owner_and_name,
-            );
+        let (
+            dart_runtime_closed_nodes,
+            dart_overridden_owner_methods,
+            dart_ancestry_invalid_domains,
+        ) = prepare_dart_dispatch_closure(
+            &files,
+            &file_content_hash_by_id,
+            &node_by_id,
+            &csd_domain_identity_by_file,
+            &member_by_owner_and_name,
+        );
         Ok(Self {
             file_by_id,
             file_content_hash_by_id,
@@ -2451,6 +2500,7 @@ impl ProofResolutionValidationContext {
             dart_import_visibility_by_node,
             dart_runtime_closed_nodes,
             dart_overridden_owner_methods,
+            dart_ancestry_invalid_domains,
             typescript_directory_import_relations,
             member_relations,
             member_by_owner_and_name,
@@ -3079,16 +3129,24 @@ impl Storage {
                     ResolutionEvidence::ImplicitReceiver { owner } => Some(*owner),
                     _ => None,
                 });
-            if let Some(owner) = receiver_owner
-                && !direct_construction
-                && (!context.dart_runtime_closed_nodes.contains(&owner)
-                    || context
-                        .dart_overridden_owner_methods
-                        .contains(&(owner, fact.callsite.raw_target.clone())))
-            {
-                return Err(proof_error(
-                    "Dart receiver dispatch is not closed by its complete library domain",
-                ));
+            if let Some(owner) = receiver_owner {
+                let ancestry_invalid = context
+                    .node_by_id
+                    .get(&owner)
+                    .and_then(|node| node.file_node_id)
+                    .and_then(|file| context.csd_domain_identity_by_file.get(&file.0))
+                    .is_none_or(|domain| context.dart_ancestry_invalid_domains.contains(domain));
+                if ancestry_invalid
+                    || (!direct_construction
+                        && (!context.dart_runtime_closed_nodes.contains(&owner)
+                            || context
+                                .dart_overridden_owner_methods
+                                .contains(&(owner, fact.callsite.raw_target.clone()))))
+                {
+                    return Err(proof_error(
+                        "Dart receiver dispatch is not closed by its complete library domain",
+                    ));
+                }
             }
         }
         if fact.provenance.language_adapter == "go"

--- a/crates/codestory-store/src/storage_impl/proof_resolution.rs
+++ b/crates/codestory-store/src/storage_impl/proof_resolution.rs
@@ -52,8 +52,10 @@ pub struct ProofResolutionPublication {
 pub fn seal_call_resolution_fact(
     mut fact: CallResolutionFact,
 ) -> Result<CallResolutionFact, StorageError> {
-    let linear_dependency_order =
-        matches!(fact.provenance.language_adapter.as_str(), "ruby" | "php");
+    let linear_dependency_order = matches!(
+        fact.provenance.language_adapter.as_str(),
+        "ruby" | "php" | "csharp" | "swift" | "dart"
+    );
     if !linear_dependency_order {
         fact.provenance.dependency_file_hashes.sort();
     }
@@ -128,8 +130,10 @@ where
 }
 
 fn validate_fact_shape(fact: &CallResolutionFact, require_seal: bool) -> Result<(), StorageError> {
-    let linear_dependency_order =
-        matches!(fact.provenance.language_adapter.as_str(), "ruby" | "php");
+    let linear_dependency_order = matches!(
+        fact.provenance.language_adapter.as_str(),
+        "ruby" | "php" | "csharp" | "swift" | "dart"
+    );
     let dependencies_are_canonical = if linear_dependency_order {
         let mut members = HashSet::new();
         fact.provenance
@@ -288,6 +292,7 @@ struct ProofResolutionValidationContext {
     ordinary_call_edge_indices: Vec<usize>,
     parsed_callsite_identity_by_edge: HashMap<EdgeId, CanonicalCallsiteIdentity>,
     import_relations: HashMap<(NodeId, NodeId, NodeId), ProofRelationState>,
+    swift_module_import_relations: HashMap<(NodeId, NodeId), ProofRelationState>,
     typescript_directory_import_relations:
         HashMap<(NodeId, NodeId), TypescriptDirectoryImportState>,
     member_relations: HashMap<(NodeId, NodeId), ProofRelationState>,
@@ -297,6 +302,8 @@ struct ProofResolutionValidationContext {
     python_attestation_error_by_file: HashMap<i64, String>,
     java_package_identity_by_file: HashMap<i64, String>,
     java_dependency_ids_by_package: HashMap<String, BTreeSet<FileId>>,
+    csd_domain_identity_by_file: HashMap<i64, String>,
+    csd_dependency_ids_by_domain: HashMap<String, Vec<FileId>>,
     ruby_dependency_file_ids: Vec<FileId>,
     php_namespace_identity_by_file: HashMap<i64, PhpNamespaceIdentity>,
     php_dependency_ids_by_namespace: HashMap<PhpNamespaceIdentity, Vec<FileId>>,
@@ -766,6 +773,103 @@ fn prepare_java_package_closure(
             .insert(FileId(file_id));
     }
     (package_identity_by_file, dependency_ids_by_package)
+}
+
+fn prepare_csd_domain_closure(
+    files: &[FileInfo],
+    node_by_id: &HashMap<NodeId, Node>,
+) -> (HashMap<i64, String>, HashMap<String, Vec<FileId>>) {
+    let file_language_by_id = files
+        .iter()
+        .map(|file| (file.id, file.language.as_str()))
+        .collect::<HashMap<_, _>>();
+    let mut csharp_names = HashMap::<i64, Vec<String>>::new();
+    let mut csharp_members = HashMap::<i64, HashSet<String>>::new();
+    for node in node_by_id
+        .values()
+        .filter(|node| node.kind == NodeKind::NAMESPACE)
+    {
+        let Some(file_id) = node.file_node_id else {
+            continue;
+        };
+        if file_language_by_id.get(&file_id.0).copied() != Some("csharp")
+            || node.serialized_name.is_empty()
+        {
+            continue;
+        }
+        let members = csharp_members.entry(file_id.0).or_default();
+        if members.insert(node.serialized_name.clone()) {
+            csharp_names
+                .entry(file_id.0)
+                .or_default()
+                .push(node.serialized_name.clone());
+        }
+    }
+    let mut identity_by_file = HashMap::new();
+    let mut dependency_ids_by_domain = HashMap::<String, Vec<FileId>>::new();
+    for file in files
+        .iter()
+        .filter(|file| matches!(file.language.as_str(), "csharp" | "swift" | "dart"))
+    {
+        count_store_replay_work(1);
+        let identity = match file.language.as_str() {
+            "csharp" => match csharp_names.get(&file.id).map(Vec::as_slice) {
+                None | Some([]) => Some("csharp:global".to_string()),
+                Some([name]) => Some(format!("csharp:{name}")),
+                Some(_) => None,
+            },
+            "swift" => swift_project_module(&file.path).map(|module| format!("swift:{module}")),
+            "dart" => dart_library_root(&file.path)
+                .and_then(|root| std::fs::canonicalize(root).ok())
+                .map(|root| format!("dart:{}", root.display())),
+            _ => None,
+        };
+        let Some(identity) = identity else {
+            continue;
+        };
+        identity_by_file.insert(file.id, identity.clone());
+        dependency_ids_by_domain
+            .entry(identity)
+            .or_default()
+            .push(FileId(file.id));
+    }
+    (identity_by_file, dependency_ids_by_domain)
+}
+
+fn csd_dependency_ids(
+    fact: &CallResolutionFact,
+    context: &ProofResolutionValidationContext,
+) -> Result<Vec<FileId>, StorageError> {
+    let imported = fact
+        .evidence_chain
+        .iter()
+        .any(|evidence| matches!(evidence, ResolutionEvidence::StaticImportBinding { .. }));
+    let domain_file = if imported {
+        fact.target
+            .and_then(|target| context.node_by_id.get(&target))
+            .and_then(|target| target.file_node_id)
+            .map(|file| file.0)
+            .ok_or_else(|| proof_error("nominal import target has no governed domain file"))?
+    } else {
+        fact.callsite.file_id.0
+    };
+    let identity = context
+        .csd_domain_identity_by_file
+        .get(&domain_file)
+        .ok_or_else(|| proof_error("nominal exact fact has no authenticated domain identity"))?;
+    let domain = context
+        .csd_dependency_ids_by_domain
+        .get(identity)
+        .ok_or_else(|| proof_error("nominal exact fact has no complete dependency domain"))?;
+    let mut dependencies = Vec::with_capacity(domain.len().saturating_add(1));
+    let mut members = HashSet::new();
+    for file_id in std::iter::once(fact.callsite.file_id).chain(domain.iter().copied()) {
+        count_store_replay_work(1);
+        if members.insert(file_id) {
+            dependencies.push(file_id);
+        }
+    }
+    Ok(dependencies)
 }
 
 fn java_same_package_dependency_ids(
@@ -1430,6 +1534,7 @@ mod go_replay_complexity_tests {
             ordinary_call_edge_indices: Vec::new(),
             parsed_callsite_identity_by_edge: HashMap::new(),
             import_relations: HashMap::new(),
+            swift_module_import_relations: HashMap::new(),
             typescript_directory_import_relations: HashMap::new(),
             member_relations: HashMap::new(),
             member_by_owner_and_name: HashMap::new(),
@@ -1438,6 +1543,8 @@ mod go_replay_complexity_tests {
             python_attestation_error_by_file: HashMap::new(),
             java_package_identity_by_file: HashMap::new(),
             java_dependency_ids_by_package: HashMap::new(),
+            csd_domain_identity_by_file: HashMap::new(),
+            csd_dependency_ids_by_domain: HashMap::new(),
             ruby_dependency_file_ids: Vec::new(),
             php_namespace_identity_by_file: HashMap::new(),
             php_dependency_ids_by_namespace: HashMap::new(),
@@ -1601,6 +1708,7 @@ mod python_replay_complexity_tests {
             ordinary_call_edge_indices: Vec::new(),
             parsed_callsite_identity_by_edge: HashMap::new(),
             import_relations: HashMap::new(),
+            swift_module_import_relations: HashMap::new(),
             typescript_directory_import_relations: HashMap::new(),
             member_relations: HashMap::new(),
             member_by_owner_and_name: HashMap::new(),
@@ -1609,6 +1717,8 @@ mod python_replay_complexity_tests {
             python_attestation_error_by_file,
             java_package_identity_by_file: HashMap::new(),
             java_dependency_ids_by_package: HashMap::new(),
+            csd_domain_identity_by_file: HashMap::new(),
+            csd_dependency_ids_by_domain: HashMap::new(),
             ruby_dependency_file_ids: Vec::new(),
             php_namespace_identity_by_file: HashMap::new(),
             php_dependency_ids_by_namespace: HashMap::new(),
@@ -1723,6 +1833,7 @@ mod ruby_php_replay_complexity_tests {
             ordinary_call_edge_indices: Vec::new(),
             parsed_callsite_identity_by_edge: HashMap::new(),
             import_relations: HashMap::new(),
+            swift_module_import_relations: HashMap::new(),
             typescript_directory_import_relations: HashMap::new(),
             member_relations: HashMap::new(),
             member_by_owner_and_name: HashMap::new(),
@@ -1731,6 +1842,8 @@ mod ruby_php_replay_complexity_tests {
             python_attestation_error_by_file: HashMap::new(),
             java_package_identity_by_file: HashMap::new(),
             java_dependency_ids_by_package: HashMap::new(),
+            csd_domain_identity_by_file: HashMap::new(),
+            csd_dependency_ids_by_domain: HashMap::new(),
             ruby_dependency_file_ids,
             php_namespace_identity_by_file,
             php_dependency_ids_by_namespace,
@@ -1919,6 +2032,8 @@ impl ProofResolutionValidationContext {
             .collect();
         let (java_package_identity_by_file, java_dependency_ids_by_package) =
             prepare_java_package_closure(&file_by_id, &node_by_id);
+        let (csd_domain_identity_by_file, csd_dependency_ids_by_domain) =
+            prepare_csd_domain_closure(&files, &node_by_id);
         let (
             ruby_dependency_file_ids,
             php_namespace_identity_by_file,
@@ -1930,12 +2045,33 @@ impl ProofResolutionValidationContext {
             prepare_call_edge_correlation_index(&edges, &node_by_id);
         let mut edge_index_by_id = HashMap::with_capacity(edges.len());
         let mut import_relations = HashMap::<_, ProofRelationState>::new();
+        let mut swift_module_import_relations = HashMap::<_, ProofRelationState>::new();
         let mut typescript_directory_import_relations =
             HashMap::<_, TypescriptDirectoryImportState>::new();
         let mut member_relations = HashMap::<_, ProofRelationState>::new();
         let mut python_import_edges = HashMap::<NodeId, Vec<NodeId>>::new();
         for (index, edge) in edges.iter().enumerate() {
             edge_index_by_id.insert(edge.id, index);
+            if edge.kind == EdgeKind::IMPORT
+                && edge.source == edge.target
+                && let Some(file_id) = edge.file_node_id
+                && let Some(import) = node_by_id.get(&edge.source)
+                && import.kind == NodeKind::MODULE
+                && import.file_node_id == Some(file_id)
+            {
+                let state = swift_module_import_relations
+                    .entry((file_id, edge.source))
+                    .or_default();
+                if edge.effective_source() == edge.source
+                    && edge.effective_target() == edge.target
+                    && edge.resolved_target.is_none()
+                    && edge.candidate_targets.is_empty()
+                {
+                    state.admissible += 1;
+                } else {
+                    state.conflicting += 1;
+                }
+            }
             if edge.kind == EdgeKind::IMPORT
                 && let (Some(file_id), Some(target)) = (edge.file_node_id, edge.resolved_target)
             {
@@ -2089,6 +2225,7 @@ impl ProofResolutionValidationContext {
             ordinary_call_edge_indices,
             parsed_callsite_identity_by_edge,
             import_relations,
+            swift_module_import_relations,
             typescript_directory_import_relations,
             member_relations,
             member_by_owner_and_name,
@@ -2097,6 +2234,8 @@ impl ProofResolutionValidationContext {
             python_attestation_error_by_file,
             java_package_identity_by_file,
             java_dependency_ids_by_package,
+            csd_domain_identity_by_file,
+            csd_dependency_ids_by_domain,
             ruby_dependency_file_ids,
             php_namespace_identity_by_file,
             php_dependency_ids_by_namespace,
@@ -2111,6 +2250,12 @@ impl ProofResolutionValidationContext {
     fn has_import(&self, file: NodeId, import: NodeId, target: NodeId) -> bool {
         self.import_relations
             .get(&(file, import, target))
+            .is_some_and(ProofRelationState::is_unique)
+    }
+
+    fn has_swift_module_import(&self, file: NodeId, import: NodeId) -> bool {
+        self.swift_module_import_relations
+            .get(&(file, import))
             .is_some_and(ProofRelationState::is_unique)
     }
 
@@ -2513,7 +2658,12 @@ impl Storage {
             ));
         }
 
-        let linear_language = matches!(fact.provenance.language_adapter.as_str(), "ruby" | "php");
+        let csd_language = matches!(
+            fact.provenance.language_adapter.as_str(),
+            "csharp" | "swift" | "dart"
+        );
+        let linear_language =
+            matches!(fact.provenance.language_adapter.as_str(), "ruby" | "php") || csd_language;
         let mut required_dependency_ids = if linear_language {
             BTreeSet::new()
         } else {
@@ -2567,7 +2717,7 @@ impl Storage {
                 )?
             };
         }
-        if linear_language {
+        if linear_language && !csd_language {
             let expected = if fact.status == ProofResolutionStatus::Exact {
                 ruby_php_dependency_ids(fact, context)?
             } else {
@@ -2583,6 +2733,25 @@ impl Storage {
             if observed != expected {
                 return Err(proof_error(format!(
                     "dependency hashes do not exactly cover the Ruby/PHP governed domain: observed={observed:?} required={expected:?}"
+                )));
+            }
+        }
+        if csd_language {
+            let expected = if fact.status == ProofResolutionStatus::Exact {
+                csd_dependency_ids(fact, context)?
+            } else {
+                vec![fact.callsite.file_id]
+            };
+            let observed = fact
+                .provenance
+                .dependency_file_hashes
+                .iter()
+                .map(|dependency| dependency.file_id)
+                .collect::<Vec<_>>();
+            count_store_replay_work(observed.len().saturating_add(expected.len()));
+            if observed != expected {
+                return Err(proof_error(format!(
+                    "dependency hashes do not exactly cover the C#/Swift/Dart governed domain: observed={observed:?} required={expected:?}"
                 )));
             }
         }
@@ -2707,16 +2876,15 @@ impl Storage {
             .node_by_id
             .get(&raw_edge_target)
             .ok_or_else(|| proof_error("raw CALL placeholder node is missing"))?;
-        let direct_member_target = (matches!(
+        let direct_callable_target = (matches!(
             fact.callsite.callee_form,
             CalleeForm::ImplicitReceiver | CalleeForm::ExplicitReceiver | CalleeForm::NamedImport
         ) || matches!(
             fact.provenance.language_adapter.as_str(),
-            "ruby" | "php"
+            "ruby" | "php" | "csharp" | "swift" | "dart"
         )) && raw_edge_target == target
-            && (matches!(raw_placeholder.kind, NodeKind::FUNCTION | NodeKind::METHOD)
-                || raw_placeholder.file_node_id != Some(NodeId(fact.callsite.file_id.0)));
-        if !direct_member_target
+            && matches!(raw_placeholder.kind, NodeKind::FUNCTION | NodeKind::METHOD);
+        if !direct_callable_target
             && (raw_placeholder.file_node_id != Some(NodeId(fact.callsite.file_id.0))
                 || raw_placeholder.start_line != Some(fact.callsite.line))
             || graph_leaf_name(&raw_placeholder.serialized_name) != fact.callsite.raw_target
@@ -2790,7 +2958,7 @@ impl Storage {
                     .get(import)
                     .ok_or_else(|| proof_error("static import binding is missing"))?;
                 if import_node.file_node_id != Some(NodeId(fact.callsite.file_id.0))
-                    || (fact.provenance.language_adapter != "php"
+                    || (!matches!(fact.provenance.language_adapter.as_str(), "php" | "dart")
                         && graph_leaf_name(&import_node.serialized_name)
                             != fact.callsite.raw_target)
                     || !(if context
@@ -2805,6 +2973,15 @@ impl Storage {
                             .qualified_name
                             .as_deref()
                             .is_some_and(|name| name.ends_with(&fact.callsite.raw_target))
+                    } else if fact.provenance.language_adapter == "dart" {
+                        target_node.file_node_id.is_some_and(|target_file| {
+                            dart_literal_import_target_is_authenticated(
+                                context,
+                                fact,
+                                *import,
+                                target_file,
+                            )
+                        })
                     } else {
                         context.has_import(NodeId(fact.callsite.file_id.0), *import, target)
                     })
@@ -3279,6 +3456,35 @@ impl Storage {
                         owner,
                     )
             });
+        let swift_module_import = fact.provenance.language_adapter == "swift"
+            && components.is_some_and(|components| components == [owner, target])
+            && import_node.kind == NodeKind::MODULE
+            && context.has_swift_module_import(source_file, import)
+            && owner_node
+                .file_node_id
+                .and_then(|file_id| context.file_by_id.get(&file_id.0))
+                .and_then(|file| swift_project_module(&file.path))
+                == Some(import_node.serialized_name.as_str())
+            && {
+                let mut expected = context
+                    .file_by_id
+                    .values()
+                    .filter(|file| {
+                        file.indexed
+                            && file.language == "swift"
+                            && swift_project_module(&file.path)
+                                == Some(import_node.serialized_name.as_str())
+                    })
+                    .map(|file| FileId(file.id))
+                    .collect::<BTreeSet<_>>();
+                expected.insert(fact.callsite.file_id);
+                !expected.is_empty() && dependency_file_ids(fact) == expected
+            };
+        let dart_literal_import = fact.provenance.language_adapter == "dart"
+            && components.is_some_and(|components| components == [owner, target])
+            && target_node.file_node_id.is_some_and(|target_file| {
+                dart_literal_import_target_is_authenticated(context, fact, import, target_file)
+            });
         if import_node.file_node_id != Some(source_file)
             || !matches!(
                 owner_node.kind,
@@ -3287,6 +3493,8 @@ impl Storage {
             || owner_node.file_node_id != target_node.file_node_id
             || !(python_relative
                 || java_kotlin_literal_import
+                || swift_module_import
+                || dart_literal_import
                 || context.has_import(source_file, import, owner))
             || !context.has_member(owner, target)
         {
@@ -3416,7 +3624,10 @@ impl Storage {
             .facts
             .iter()
             .filter_map(|fact| {
-                if matches!(fact.provenance.language_adapter.as_str(), "ruby" | "php") {
+                if matches!(
+                    fact.provenance.language_adapter.as_str(),
+                    "ruby" | "php" | "csharp" | "swift" | "dart"
+                ) {
                     count_store_replay_work(1);
                     linear_facts.push(fact.clone());
                     None
@@ -3453,7 +3664,7 @@ impl Storage {
                 "more than one fact owns the same exact callsite",
             ));
         }
-        let mut exact_edges = BTreeSet::new();
+        let mut exact_edges = HashSet::new();
         for edge_id in facts
             .iter()
             .filter(|fact| fact.status == ProofResolutionStatus::Exact)
@@ -3474,7 +3685,10 @@ impl Storage {
             .funnel
             .iter()
             .filter_map(|row| {
-                if matches!(row.language.as_str(), "ruby" | "php") {
+                if matches!(
+                    row.language.as_str(),
+                    "ruby" | "php" | "csharp" | "swift" | "dart"
+                ) {
                     count_store_replay_work(1);
                     linear_funnel.push(row.clone());
                     None
@@ -3712,10 +3926,101 @@ fn graph_leaf_name(name: &str) -> &str {
         .unwrap_or(name)
 }
 
+fn swift_project_module(path: &std::path::Path) -> Option<&str> {
+    let mut components = path.components().filter_map(|component| match component {
+        std::path::Component::Normal(value) => value.to_str(),
+        _ => None,
+    });
+    while let Some(component) = components.next() {
+        if component == "Sources" {
+            return components.next().filter(|module| {
+                !module.is_empty()
+                    && module
+                        .chars()
+                        .all(|character| character == '_' || character.is_alphanumeric())
+            });
+        }
+    }
+    None
+}
+
+fn dart_library_root(path: &std::path::Path) -> Option<&std::path::Path> {
+    let mut current = path.parent();
+    while let Some(directory) = current {
+        if directory.file_name().and_then(|name| name.to_str()) == Some("lib") {
+            return Some(directory);
+        }
+        current = directory.parent();
+    }
+    None
+}
+
+fn quoted_import_literal(surface: &str) -> Option<&str> {
+    let start = surface.find(['\'', '"'])?;
+    let quote = surface.as_bytes()[start] as char;
+    let rest = &surface[start + quote.len_utf8()..];
+    Some(&rest[..rest.find(quote)?])
+}
+
+fn dart_literal_import_target_is_authenticated(
+    context: &ProofResolutionValidationContext,
+    fact: &CallResolutionFact,
+    import: NodeId,
+    target_file: NodeId,
+) -> bool {
+    let (Some(source), Some(target), Some(import_node)) = (
+        context.file_by_id.get(&fact.callsite.file_id.0),
+        context.file_by_id.get(&target_file.0),
+        context.node_by_id.get(&import),
+    ) else {
+        return false;
+    };
+    let Some(uri) = quoted_import_literal(&import_node.serialized_name) else {
+        return false;
+    };
+    let relative = std::path::Path::new(uri);
+    let Some(source_directory) = source.path.parent() else {
+        return false;
+    };
+    let expected_path = source_directory.join(relative);
+    let exact_native_target = std::fs::symlink_metadata(&expected_path)
+        .ok()
+        .is_some_and(|metadata| !metadata.file_type().is_symlink() && metadata.is_file())
+        && std::fs::canonicalize(&expected_path).ok() == std::fs::canonicalize(&target.path).ok();
+    let same_library = dart_library_root(&source.path)
+        .zip(dart_library_root(&target.path))
+        .is_some_and(|(source_root, target_root)| {
+            std::fs::canonicalize(source_root).ok() == std::fs::canonicalize(target_root).ok()
+        });
+    let expected_dependencies = csd_dependency_ids(fact, context).ok();
+    let observed_dependencies = fact
+        .provenance
+        .dependency_file_hashes
+        .iter()
+        .map(|dependency| dependency.file_id)
+        .collect::<Vec<_>>();
+    import_node.kind == NodeKind::MODULE
+        && import_node.file_node_id == Some(NodeId(fact.callsite.file_id.0))
+        && relative
+            .extension()
+            .and_then(|extension| extension.to_str())
+            == Some("dart")
+        && relative
+            .components()
+            .all(|component| matches!(component, std::path::Component::Normal(_)))
+        && source.id != target.id
+        && target.language == "dart"
+        && target.indexed
+        && exact_native_target
+        && same_library
+        && expected_dependencies.as_deref() == Some(observed_dependencies.as_slice())
+}
+
 fn proof_import_node_kind_is_literal(language: &str, kind: NodeKind) -> bool {
     match language {
         "rust" => kind == NodeKind::MODULE,
-        "java" | "kotlin" | "javascript" | "typescript" | "tsx" | "python" | "php" | "ruby" => {
+        "java" | "kotlin" | "csharp" | "swift" | "dart" | "javascript" | "typescript" | "tsx"
+        | "python" | "php" | "ruby" => {
             matches!(kind, NodeKind::MODULE | NodeKind::UNKNOWN)
         }
         _ => false,
@@ -3902,7 +4207,10 @@ fn recompute_funnel(facts: &[CallResolutionFact]) -> Vec<ProofResolutionFunnelRo
             Some(fact.callsite.callee_form),
             evidence_kind,
         );
-        let counts = if matches!(fact.provenance.language_adapter.as_str(), "ruby" | "php") {
+        let counts = if matches!(
+            fact.provenance.language_adapter.as_str(),
+            "ruby" | "php" | "csharp" | "swift" | "dart"
+        ) {
             count_store_replay_work(1);
             linear_rows.entry(key).or_default()
         } else {
@@ -3943,7 +4251,7 @@ fn recompute_funnel(facts: &[CallResolutionFact]) -> Vec<ProofResolutionFunnelRo
                 right.evidence_kind.map(|kind| kind.as_str()),
             ))
     });
-    for language in ["php", "ruby"] {
+    for language in ["csharp", "dart", "php", "ruby", "swift"] {
         for callee_form in [
             CalleeForm::Constructor,
             CalleeForm::DynamicAccess,

--- a/crates/codestory-store/tests/proof_resolution.rs
+++ b/crates/codestory-store/tests/proof_resolution.rs
@@ -1342,6 +1342,20 @@ fn exact_projection_rejects_digest_and_graph_mismatches_without_partial_rows() {
     assert!(error.to_string().contains("callsite identity"), "{error}");
     assert_eq!(store.proof_resolution_fact_count().unwrap(), 0);
 
+    store
+        .get_connection()
+        .execute("UPDATE node SET end_line = 1 WHERE id = 2", [])
+        .unwrap();
+    let caller_containment_mismatch = exact_fact(EdgeId(7));
+    let error = store
+        .replace_proof_resolution_projection(
+            &publication,
+            &projection(vec![caller_containment_mismatch]),
+        )
+        .expect_err("Exact caller containment mismatch must fail");
+    assert!(error.to_string().contains("caller containment"), "{error}");
+    assert_eq!(store.proof_resolution_fact_count().unwrap(), 0);
+
     let mut hash_mismatch = exact_fact(EdgeId(7));
     hash_mismatch.callsite.source_sha256 = "b".repeat(64);
     hash_mismatch.provenance.dependency_file_hashes[0].source_sha256 = "b".repeat(64);


### PR DESCRIPTION
## Context

CodeStory 0.18 must preserve exact proof across every parser-backed language without allowing navigation confidence to become proof authority. This support slice adds the closed C#, Swift, and Dart subset while keeping the public proof route dark.

## What changed

- adds C#, Swift, and Dart to the proof-adapter roster and shrinks the temporary missing-adapter allowlist to Bash
- resolves only the matrix's exact local/import/concrete-receiver/constructor cases
- closes Dart dispatch through the complete same-library ancestry domain
- derives Swift cross-module visibility from parser modifier nodes
- authenticates persistent semantic cache inputs by reparsing publication-bound source and comparing the typed projection
- validates projection/replay correlation and charges the complete preparation-to-publication pipeline to linear-work counters
- isolates debug work counters per thread so parallel tests measure only their invocation
- keeps non-exact facts from blocking ordinary publication when graph caller spans are narrower, while retaining strict caller-span rejection for Exact facts
- adds the frozen supported, unsupported, hostile, source-domain, cache-mutation, complexity, concurrency, and navigation-continuity contracts

No schema migration, graph replacement, retrieval consumer, production dispatcher, CLI command, MCP tool, or public catalog changes.

## How to review

The trust boundary is concentrated in:

- `crates/codestory-indexer/src/proof_resolution.rs`
- `crates/codestory-store/src/storage_impl/proof_resolution.rs`
- `crates/codestory-indexer/tests/proof_resolution.rs`
- `crates/codestory-store/tests/proof_resolution.rs`
- `crates/codestory-bench/tests/multilingual_proof_contract.rs`

Review exact admission, transitive Dart override closure, parser-derived Swift visibility, cache-source correlation, exact versus non-exact graph correlation, and the production-unreachability contract. The supported/unsupported matrix is frozen in the test fixtures.

## Verification

Exact head: `01225730aa430067f1d52013eca602bab8dee6f1`
Tree: `03b48b3f887a9ff521a38122f3b3250fb85847fa`

Local:

- proof-resolution binary: 168 passed
- multilingual proof contract: 6 passed, covering 384 matrix cases
- architecture contracts: 57 passed
- fidelity regression: 8 passed
- language coverage: 13 passed
- runtime search-scoring compatibility: 44 passed
- store package after parallel-counter fix: 292 passed
- store proof-resolution integration: 25 passed
- strict all-target clippy for indexer/store/bench: passed
- package formatting and diff checks: passed

Hosted on the exact head:

- Ubuntu draft source checks: passed
- deny rustdoc warnings: passed
- linux-contracts: passed
- linux-durability: passed
- closing issue contract: passed

## Risk and follow-up

Unsupported, dynamic, virtual, ambiguous, incomplete, or mutable constructs remain non-exact. Bash is the sole remaining parser dispatch on the temporary allowlist and is owned by #2075. Public activation remains blocked by #2066.

Closes #2074
Refs #2023
Refs #2066