### PR TITLE
add bash exact resolution and close adapter roster

### DIFF
--- a/crates/codestory-bench/src/bin/codestory_proof_availability/multilingual_contract.rs
+++ b/crates/codestory-bench/src/bin/codestory_proof_availability/multilingual_contract.rs
@@ -27,11 +27,6 @@ use std::process::Command;
 
 pub const PUBLIC_PROOF_ROUTE_DARK: bool = true;
 
-/// Closed, temporary boundary for parser-backed languages without an installed
-/// proof adapter. The observed adapter roster is compared to this list in the
-/// contract test; this is not an expectation of a resolution result.
-pub const MISSING_ADAPTER_ALLOWLIST: &[&str] = &["bash"];
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FixtureClass {
     Supported,

--- a/crates/codestory-bench/tests/multilingual_proof_contract.rs
+++ b/crates/codestory-bench/tests/multilingual_proof_contract.rs
@@ -6,8 +6,8 @@ use codestory_contracts::proof_resolution::{
     CalleeForm, ProofResolutionStatus, ResolutionEvidenceKind,
 };
 use multilingual_contract::{
-    FixtureClass, MISSING_ADAPTER_ALLOWLIST, ObservedDisposition, PUBLIC_PROOF_ROUTE_DARK,
-    dispatches, materialize_repository_source, materialized_projection_rejects_injected_fact,
+    FixtureClass, ObservedDisposition, PUBLIC_PROOF_ROUTE_DARK, dispatches,
+    materialize_repository_source, materialized_projection_rejects_injected_fact,
     observe_language_source, observe_language_source_after_call_edge_removal,
     observe_multilingual_contract, observe_structural_continuity, observe_structural_source,
     resolution_funnel, valid_callee_form,
@@ -105,19 +105,16 @@ fn all_language_rows_are_real_parser_and_adapter_observations() -> anyhow::Resul
             assert_eq!(selector, dispatch.pinned_selector);
             assert_eq!(selector.commit.len(), 40);
             assert!(!selector.path.is_empty() && !selector.selector.is_empty());
-            if positive.adapter_available {
-                assert!(
-                    positive.facts.iter().any(|fact| fact.proof_admitted),
-                    "{} positive fixture was not proven by its installed adapter",
-                    positive.path.display()
-                );
-            } else {
-                assert!(
-                    positive.facts.is_empty(),
-                    "{} is missing an adapter and must not fabricate proof facts",
-                    dispatch.language
-                );
-            }
+            assert!(
+                positive.adapter_available,
+                "{} has no installed exact-resolution adapter",
+                dispatch.language
+            );
+            assert!(
+                positive.facts.iter().any(|fact| fact.proof_admitted),
+                "{} positive fixture was not proven by its installed adapter",
+                positive.path.display()
+            );
         }
     }
 
@@ -126,11 +123,10 @@ fn all_language_rows_are_real_parser_and_adapter_observations() -> anyhow::Resul
         .filter(|dispatch| !observation.adapter_roster.contains(dispatch.language))
         .map(|dispatch| dispatch.language)
         .collect::<BTreeSet<_>>();
-    assert_eq!(
-        observed_missing,
-        MISSING_ADAPTER_ALLOWLIST.iter().copied().collect()
+    assert!(
+        observed_missing.is_empty(),
+        "every parser dispatch must have an installed exact-resolution adapter: {observed_missing:?}"
     );
-    assert_eq!(MISSING_ADAPTER_ALLOWLIST, &["bash"]);
     for case in &observation.cases {
         let components = case
             .path

--- a/crates/codestory-indexer/src/cache.rs
+++ b/crates/codestory-indexer/src/cache.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::path::{Component, Path, PathBuf};
 
 // Versioned with proof-input semantics so older parser artifacts fail closed.
-const INDEX_ARTIFACT_CACHE_VERSION: u32 = 27;
+const INDEX_ARTIFACT_CACHE_VERSION: u32 = 28;
 const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
 const FNV_PRIME: u64 = 0x00000100000001B3;
 
@@ -357,7 +357,7 @@ impl CachedIndexArtifact {
         resolution_file: Option<CachedResolutionFile>,
     ) -> Self {
         Self {
-            resolution_input_schema_version: 25,
+            resolution_input_schema_version: 26,
             files: index_result.files,
             nodes: index_result.nodes,
             edges: index_result.edges,

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -106,6 +106,8 @@ use cache::{
 };
 pub use cancellation::CancellationToken;
 use intermediate_storage::IntermediateStorage;
+#[cfg(debug_assertions)]
+pub use proof_resolution::{BashResolutionWork, bash_resolution_work, reset_bash_resolution_work};
 pub use proof_resolution::{
     build_funnel as build_proof_resolution_funnel, current_proof_resolution_adapter_roster,
     rematerialize_proof_resolution_projection,

--- a/crates/codestory-indexer/src/proof_resolution.rs
+++ b/crates/codestory-indexer/src/proof_resolution.rs
@@ -161,8 +161,10 @@ const PHP_ADAPTER_VERSION: &str = "reference-v2";
 const CSHARP_ADAPTER_VERSION: &str = "reference-v2";
 const SWIFT_ADAPTER_VERSION: &str = "reference-v2";
 const DART_ADAPTER_VERSION: &str = "reference-v2";
-const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 25;
+const BASH_ADAPTER_VERSION: &str = "reference-v1";
+const RESOLUTION_INPUT_SCHEMA_VERSION: u32 = 26;
 const INSTALLED_ADAPTERS: &[(&str, &str)] = &[
+    ("bash", BASH_ADAPTER_VERSION),
     ("go", GO_ADAPTER_VERSION),
     ("javascript", ADAPTER_VERSION),
     ("c", C_ADAPTER_VERSION),
@@ -240,6 +242,8 @@ pub(crate) fn collect_call_resolution_inputs(
         (language == "ruby").then(|| RubyResolutionIndex::build(tree, source, file_id, nodes));
     let php_index =
         (language == "php").then(|| PhpResolutionIndex::build(tree, source, file_id, nodes));
+    let bash_index =
+        (language == "bash").then(|| BashResolutionIndex::build(tree, source, file_id, nodes));
     let (direct_exports, export_poison_all, poisoned_export_names) =
         if let Some(index) = &javascript_index {
             index.collect_direct_exports(source)
@@ -281,6 +285,8 @@ pub(crate) fn collect_call_resolution_inputs(
         index.declarations.clone()
     } else if let Some(index) = &php_index {
         index.declarations.clone()
+    } else if let Some(index) = &bash_index {
+        index.declarations.clone()
     } else {
         Vec::new()
     };
@@ -317,6 +323,8 @@ pub(crate) fn collect_call_resolution_inputs(
             } else if let Some(index) = &ruby_index {
                 index.resolve_syntax_claim(callee, form, &raw_target)
             } else if let Some(index) = &php_index {
+                index.resolve_syntax_claim(callee, form, &raw_target)
+            } else if let Some(index) = &bash_index {
                 index.resolve_syntax_claim(callee, form, &raw_target)
             } else {
                 (None, CachedResolutionBinding::Unsupported)
@@ -397,6 +405,10 @@ pub(crate) fn collect_call_resolution_inputs(
         for call in &index.calls {
             emit_call(call.callee, call.form, call.raw_target.clone(), None);
         }
+    } else if let Some(index) = &bash_index {
+        for call in &index.calls {
+            emit_call(call.callee, call.form, call.raw_target.clone(), None);
+        }
     } else {
         collect_calls(tree.root_node(), source, &mut |callee, form, raw_target| {
             emit_call(callee, form, raw_target, None);
@@ -405,6 +417,7 @@ pub(crate) fn collect_call_resolution_inputs(
     if c_cpp_index.is_none()
         && ruby_index.is_none()
         && php_index.is_none()
+        && bash_index.is_none()
         && !is_csharp_swift_dart_language(language)
     {
         calls.sort_by_key(|input| (input.callsite.start_byte, input.callsite.end_byte_exclusive));
@@ -506,6 +519,10 @@ fn is_java_kotlin_language(language: &str) -> bool {
 
 fn is_csharp_swift_dart_language(language: &str) -> bool {
     matches!(language, "csharp" | "swift" | "dart")
+}
+
+fn semantic_cache_requires_source_reauthentication(language: &str) -> bool {
+    is_csharp_swift_dart_language(language) || language == "bash"
 }
 
 fn is_nominal_language(language: &str) -> bool {
@@ -773,6 +790,238 @@ fn unique_import_node(
         }
     }
     None
+}
+
+#[derive(Clone)]
+struct IndexedBashCall<'tree> {
+    callee: TsNode<'tree>,
+    form: CalleeForm,
+    raw_target: String,
+    caller: Option<NodeId>,
+    binding: CachedResolutionBinding,
+}
+
+#[derive(Clone, Copy)]
+struct BashDeclaration {
+    declaration: NodeId,
+    start_byte: usize,
+}
+
+struct BashResolutionIndex<'tree> {
+    calls: Vec<IndexedBashCall<'tree>>,
+    call_indices_by_span: HashMap<(usize, usize), usize>,
+    declarations: Vec<CachedTopLevelDeclaration>,
+}
+
+struct BashResolutionProducer<'a, 'tree> {
+    source: &'a str,
+    graph_functions: HashMap<(u32, String), Vec<NodeId>>,
+    calls: Vec<IndexedBashCall<'tree>>,
+    declarations: Vec<CachedTopLevelDeclaration>,
+    declarations_by_name: HashMap<String, Vec<BashDeclaration>>,
+    poisoned_definition_names: HashSet<String>,
+    source_domain_incomplete: bool,
+    dynamic_domain_unsupported: bool,
+}
+
+impl<'tree> BashResolutionIndex<'tree> {
+    fn build(tree: &'tree Tree, source: &str, file_id: NodeId, nodes: &[Node]) -> Self {
+        let mut graph_functions = HashMap::<(u32, String), Vec<NodeId>>::new();
+        for node in nodes
+            .iter()
+            .filter(|node| node.file_node_id == Some(file_id) && node.kind == NodeKind::FUNCTION)
+        {
+            count_ruby_php_resolution_work(1);
+            if let Some(line) = node.start_line {
+                graph_functions
+                    .entry((line, graph_leaf_name(&node.serialized_name).to_string()))
+                    .or_default()
+                    .push(node.id);
+                count_ruby_php_resolution_work(1);
+            }
+        }
+        let mut producer = BashResolutionProducer {
+            source,
+            graph_functions,
+            calls: Vec::new(),
+            declarations: Vec::new(),
+            declarations_by_name: HashMap::new(),
+            poisoned_definition_names: HashSet::new(),
+            source_domain_incomplete: false,
+            dynamic_domain_unsupported: false,
+        };
+        producer.visit(tree.root_node(), None, true);
+        producer.finish()
+    }
+
+    fn resolve_syntax_claim(
+        &self,
+        callee: TsNode<'tree>,
+        form: CalleeForm,
+        raw_target: &str,
+    ) -> (Option<NodeId>, CachedResolutionBinding) {
+        let Some(call) = self
+            .call_indices_by_span
+            .get(&(callee.start_byte(), callee.end_byte()))
+            .and_then(|index| self.calls.get(*index))
+        else {
+            return (None, CachedResolutionBinding::Unsupported);
+        };
+        if call.form != form || call.raw_target != raw_target {
+            return (call.caller, CachedResolutionBinding::Unsupported);
+        }
+        (call.caller, call.binding.clone())
+    }
+}
+
+impl<'a, 'tree> BashResolutionProducer<'a, 'tree> {
+    fn visit(&mut self, node: TsNode<'tree>, caller: Option<NodeId>, file_scope: bool) {
+        count_ruby_php_resolution_work(1);
+        let mut child_caller = caller;
+        if node.kind() == "function_definition" {
+            let name = node
+                .child_by_field_name("name")
+                .and_then(|name| node_text(name, self.source))
+                .map(str::to_string);
+            child_caller = name.as_deref().and_then(|name| {
+                self.unique_graph_function(node.start_position().row as u32 + 1, name)
+            });
+            if let Some(name) = name {
+                if file_scope {
+                    if let Some(declaration) = child_caller {
+                        self.declarations.push(CachedTopLevelDeclaration {
+                            name: name.clone(),
+                            declaration,
+                            module_path: Vec::new(),
+                            cross_module_visible: false,
+                        });
+                        count_ruby_php_resolution_work(1);
+                        self.declarations_by_name
+                            .entry(name)
+                            .or_default()
+                            .push(BashDeclaration {
+                                declaration,
+                                start_byte: node.start_byte(),
+                            });
+                        count_ruby_php_resolution_work(1);
+                    } else {
+                        self.poisoned_definition_names.insert(name);
+                        count_ruby_php_resolution_work(1);
+                    }
+                } else {
+                    self.poisoned_definition_names.insert(name);
+                    count_ruby_php_resolution_work(1);
+                }
+            }
+        } else if node.kind() == "command"
+            && let Some(callee) = bash_command_callee(node)
+            && let Some(raw_target) = node_text(callee, self.source).map(str::to_string)
+        {
+            let literal = bash_literal_command_name(callee, &raw_target);
+            if matches!(literal, Some("source" | ".")) {
+                self.source_domain_incomplete = true;
+            }
+            if matches!(literal, Some("alias" | "eval")) {
+                self.dynamic_domain_unsupported = true;
+            }
+            self.calls.push(IndexedBashCall {
+                callee,
+                form: if literal.is_some() {
+                    CalleeForm::Identifier
+                } else {
+                    CalleeForm::DynamicAccess
+                },
+                raw_target,
+                caller,
+                binding: CachedResolutionBinding::MissingBinding,
+            });
+            count_ruby_php_resolution_work(1);
+        }
+
+        let direct_program_child = node.kind() == "program";
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            self.visit(child, child_caller, direct_program_child);
+        }
+    }
+
+    fn unique_graph_function(&self, line: u32, name: &str) -> Option<NodeId> {
+        count_ruby_php_resolution_work(1);
+        let candidates = self
+            .graph_functions
+            .get(&(line, name.to_string()))
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        let [declaration] = candidates else {
+            return None;
+        };
+        Some(*declaration)
+    }
+
+    fn finish(mut self) -> BashResolutionIndex<'tree> {
+        for call in &mut self.calls {
+            count_ruby_php_resolution_work(1);
+            call.binding = if call.caller.is_none()
+                || call.form != CalleeForm::Identifier
+                || self.dynamic_domain_unsupported
+            {
+                CachedResolutionBinding::Unsupported
+            } else if self.source_domain_incomplete
+                || self.poisoned_definition_names.contains(&call.raw_target)
+            {
+                CachedResolutionBinding::IncompleteDomain
+            } else {
+                match self
+                    .declarations_by_name
+                    .get(&call.raw_target)
+                    .map(Vec::as_slice)
+                    .unwrap_or_default()
+                {
+                    [declaration] if declaration.start_byte < call.callee.start_byte() => {
+                        CachedResolutionBinding::SameFile {
+                            declaration: declaration.declaration,
+                            rust_glob_local_module: None,
+                        }
+                    }
+                    [_] => CachedResolutionBinding::IncompleteDomain,
+                    [] => CachedResolutionBinding::MissingBinding,
+                    _ => CachedResolutionBinding::Ambiguous,
+                }
+            };
+        }
+        debug_assert!(self.calls.windows(2).all(|pair| {
+            (pair[0].callee.start_byte(), pair[0].callee.end_byte())
+                <= (pair[1].callee.start_byte(), pair[1].callee.end_byte())
+        }));
+        let call_indices_by_span = self
+            .calls
+            .iter()
+            .enumerate()
+            .map(|(index, call)| {
+                count_ruby_php_resolution_work(1);
+                ((call.callee.start_byte(), call.callee.end_byte()), index)
+            })
+            .collect();
+        BashResolutionIndex {
+            calls: self.calls,
+            call_indices_by_span,
+            declarations: self.declarations,
+        }
+    }
+}
+
+fn bash_command_callee(command: TsNode<'_>) -> Option<TsNode<'_>> {
+    let name = command.child_by_field_name("name")?;
+    if name.kind() == "command_name" {
+        name.named_child(0).or(Some(name))
+    } else {
+        Some(name)
+    }
+}
+
+fn bash_literal_command_name<'a>(callee: TsNode<'_>, raw_target: &'a str) -> Option<&'a str> {
+    (callee.kind() == "word" && callee.named_child_count() == 0 && !raw_target.is_empty())
+        .then_some(raw_target)
 }
 
 struct RubyResolutionIndex<'tree> {
@@ -12736,7 +12985,7 @@ pub fn rematerialize_proof_resolution_projection(
         node.file_node_id.is_some_and(|file_id| {
             file_by_id
                 .get(&file_id.0)
-                .is_some_and(|file| is_csharp_swift_dart_language(&file.language))
+                .is_some_and(|file| semantic_cache_requires_source_reauthentication(&file.language))
         })
     }) {
         count_java_kotlin_resolution_work(1);
@@ -12926,7 +13175,7 @@ pub fn rematerialize_proof_resolution_projection(
                 indexed_file.path.display()
             ));
         }
-        if is_csharp_swift_dart_language(&indexed_file.language) {
+        if semantic_cache_requires_source_reauthentication(&indexed_file.language) {
             let source_bytes = std::fs::read(&indexed_file.path).with_context(|| {
                 format!(
                     "proof resolution cannot authenticate semantic cache source {}",
@@ -12997,7 +13246,7 @@ pub fn rematerialize_proof_resolution_projection(
         .filter_map(|record| {
             if matches!(
                 record.file.language.as_str(),
-                "ruby" | "php" | "csharp" | "swift" | "dart"
+                "bash" | "ruby" | "php" | "csharp" | "swift" | "dart"
             ) {
                 count_ruby_php_resolution_work(1);
                 linear_records.push(record);
@@ -13028,7 +13277,7 @@ pub fn rematerialize_proof_resolution_projection(
         .filter_map(|(record, call)| {
             if matches!(
                 record.file.language.as_str(),
-                "ruby" | "php" | "csharp" | "swift" | "dart"
+                "bash" | "ruby" | "php" | "csharp" | "swift" | "dart"
             ) {
                 count_ruby_php_resolution_work(1);
                 linear_inputs.push((record, call));
@@ -13056,7 +13305,7 @@ pub fn rematerialize_proof_resolution_projection(
     if inputs.iter().any(|(_, input)| {
         if matches!(
             input.language.as_str(),
-            "ruby" | "php" | "csharp" | "swift" | "dart"
+            "bash" | "ruby" | "php" | "csharp" | "swift" | "dart"
         ) {
             count_ruby_php_resolution_work(1);
         }
@@ -18586,7 +18835,7 @@ fn seal_resolved_claim(
     let input = &claim.input;
     let linear_dependency_order = matches!(
         input.language.as_str(),
-        "ruby" | "php" | "csharp" | "swift" | "dart"
+        "bash" | "ruby" | "php" | "csharp" | "swift" | "dart"
     );
     let mut dependency_ids = Vec::new();
     let mut dependency_members = HashSet::new();
@@ -18673,7 +18922,7 @@ pub fn build_funnel(facts: &[CallResolutionFact]) -> Vec<ProofResolutionFunnelRo
         );
         let counts = if matches!(
             fact.provenance.language_adapter.as_str(),
-            "ruby" | "php" | "csharp" | "swift" | "dart"
+            "bash" | "ruby" | "php" | "csharp" | "swift" | "dart"
         ) {
             if is_csharp_swift_dart_language(&fact.provenance.language_adapter) {
                 count_java_kotlin_resolution_work(1);
@@ -18719,7 +18968,7 @@ pub fn build_funnel(facts: &[CallResolutionFact]) -> Vec<ProofResolutionFunnelRo
                 right.evidence_kind.map(|kind| kind.as_str()),
             ))
     });
-    for language in ["csharp", "dart", "php", "ruby", "swift"] {
+    for language in ["bash", "csharp", "dart", "php", "ruby", "swift"] {
         for callee_form in [
             CalleeForm::Constructor,
             CalleeForm::DynamicAccess,
@@ -18931,6 +19180,71 @@ mod typescript_import_binding_tests {
             "typescript",
             Path::new("source.mts")
         ));
+    }
+}
+
+#[cfg(test)]
+mod bash_complexity_tests {
+    use super::*;
+    use tree_sitter::Parser;
+
+    fn source_work(functions: usize) -> usize {
+        let mut source = String::new();
+        let mut nodes = Vec::new();
+        for index in 0..functions {
+            let line = u32::try_from(index + 1).expect("Bash fixture line");
+            let name = format!("target_{index}");
+            source.push_str(&format!("{name}() {{ :; }}\n"));
+            nodes.push(Node {
+                id: NodeId(i64::try_from(index + 2).expect("Bash target id")),
+                kind: NodeKind::FUNCTION,
+                serialized_name: name,
+                file_node_id: Some(NodeId(1)),
+                start_line: Some(line),
+                ..Default::default()
+            });
+        }
+        let caller_line = u32::try_from(functions + 1).expect("Bash caller line");
+        source.push_str("caller() {");
+        for index in 0..functions {
+            source.push_str(&format!(" target_{index};"));
+        }
+        source.push_str(" }\n");
+        nodes.push(Node {
+            id: NodeId(i64::try_from(functions + 2).expect("Bash caller id")),
+            kind: NodeKind::FUNCTION,
+            serialized_name: "caller".to_string(),
+            file_node_id: Some(NodeId(1)),
+            start_line: Some(caller_line),
+            ..Default::default()
+        });
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_bash::LANGUAGE.into())
+            .expect("Bash grammar");
+        let tree = parser.parse(&source, None).expect("Bash source");
+        reset_ruby_php_resolution_work();
+        let index = BashResolutionIndex::build(&tree, &source, NodeId(1), &nodes);
+        assert_eq!(
+            index
+                .calls
+                .iter()
+                .filter(|call| call.raw_target.starts_with("target_"))
+                .count(),
+            functions
+        );
+        ruby_php_resolution_work()
+    }
+
+    #[test]
+    fn bash_parser_index_work_is_linear_for_doubled_declarations_and_calls() {
+        let small = source_work(128);
+        let large = source_work(256);
+        assert!(small > 0, "Bash work was not counted");
+        assert!(
+            large <= small.saturating_mul(2).saturating_add(32),
+            "Bash parser/index work grew superlinearly: {small} -> {large}"
+        );
     }
 }
 

--- a/crates/codestory-indexer/src/proof_resolution.rs
+++ b/crates/codestory-indexer/src/proof_resolution.rs
@@ -35,6 +35,63 @@ thread_local! {
     static RUBY_PHP_RESOLUTION_WORK: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
 
+#[cfg(debug_assertions)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct BashResolutionWork {
+    pub preparation: usize,
+    pub cache_reauthentication: usize,
+    pub projection: usize,
+    pub graph_correlation: usize,
+}
+
+#[cfg(debug_assertions)]
+thread_local! {
+    static BASH_RESOLUTION_WORK: std::cell::Cell<BashResolutionWork> = const {
+        std::cell::Cell::new(BashResolutionWork {
+            preparation: 0,
+            cache_reauthentication: 0,
+            projection: 0,
+            graph_correlation: 0,
+        })
+    };
+}
+
+#[derive(Clone, Copy)]
+enum BashResolutionPhase {
+    Preparation,
+    CacheReauthentication,
+    Projection,
+    GraphCorrelation,
+}
+
+#[inline]
+fn count_bash_resolution_work(phase: BashResolutionPhase, amount: usize) {
+    #[cfg(debug_assertions)]
+    BASH_RESOLUTION_WORK.with(|work| {
+        let mut value = work.get();
+        let slot = match phase {
+            BashResolutionPhase::Preparation => &mut value.preparation,
+            BashResolutionPhase::CacheReauthentication => &mut value.cache_reauthentication,
+            BashResolutionPhase::Projection => &mut value.projection,
+            BashResolutionPhase::GraphCorrelation => &mut value.graph_correlation,
+        };
+        *slot = slot.saturating_add(amount);
+        work.set(value);
+    });
+    #[cfg(not(debug_assertions))]
+    let _ = (phase, amount);
+}
+
+#[cfg(debug_assertions)]
+pub fn reset_bash_resolution_work() {
+    BASH_RESOLUTION_WORK.set(BashResolutionWork::default());
+}
+
+#[cfg(debug_assertions)]
+pub fn bash_resolution_work() -> BashResolutionWork {
+    BASH_RESOLUTION_WORK.get()
+}
+
 #[cfg(test)]
 static JAVA_KOTLIN_RESOLUTION_WORK: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
@@ -824,6 +881,13 @@ struct BashResolutionProducer<'a, 'tree> {
     dynamic_domain_unsupported: bool,
 }
 
+enum BashCommandEffect {
+    None,
+    IncompleteDomain,
+    Unsupported,
+    InvalidatesFunctions(Vec<String>),
+}
+
 impl<'tree> BashResolutionIndex<'tree> {
     fn build(tree: &'tree Tree, source: &str, file_id: NodeId, nodes: &[Node]) -> Self {
         let mut graph_functions = HashMap::<(u32, String), Vec<NodeId>>::new();
@@ -831,13 +895,13 @@ impl<'tree> BashResolutionIndex<'tree> {
             .iter()
             .filter(|node| node.file_node_id == Some(file_id) && node.kind == NodeKind::FUNCTION)
         {
-            count_ruby_php_resolution_work(1);
+            count_bash_resolution_work(BashResolutionPhase::Preparation, 1);
             if let Some(line) = node.start_line {
                 graph_functions
                     .entry((line, graph_leaf_name(&node.serialized_name).to_string()))
                     .or_default()
                     .push(node.id);
-                count_ruby_php_resolution_work(1);
+                count_bash_resolution_work(BashResolutionPhase::Preparation, 1);
             }
         }
         let mut producer = BashResolutionProducer {
@@ -876,7 +940,7 @@ impl<'tree> BashResolutionIndex<'tree> {
 
 impl<'a, 'tree> BashResolutionProducer<'a, 'tree> {
     fn visit(&mut self, node: TsNode<'tree>, caller: Option<NodeId>, file_scope: bool) {
-        count_ruby_php_resolution_work(1);
+        count_bash_resolution_work(BashResolutionPhase::Preparation, 1);
         let mut child_caller = caller;
         if node.kind() == "function_definition" {
             let name = node
@@ -895,7 +959,7 @@ impl<'a, 'tree> BashResolutionProducer<'a, 'tree> {
                             module_path: Vec::new(),
                             cross_module_visible: false,
                         });
-                        count_ruby_php_resolution_work(1);
+                        count_bash_resolution_work(BashResolutionPhase::Preparation, 1);
                         self.declarations_by_name
                             .entry(name)
                             .or_default()
@@ -903,27 +967,34 @@ impl<'a, 'tree> BashResolutionProducer<'a, 'tree> {
                                 declaration,
                                 start_byte: node.start_byte(),
                             });
-                        count_ruby_php_resolution_work(1);
+                        count_bash_resolution_work(BashResolutionPhase::Preparation, 1);
                     } else {
                         self.poisoned_definition_names.insert(name);
-                        count_ruby_php_resolution_work(1);
+                        count_bash_resolution_work(BashResolutionPhase::Preparation, 1);
                     }
                 } else {
                     self.poisoned_definition_names.insert(name);
-                    count_ruby_php_resolution_work(1);
+                    count_bash_resolution_work(BashResolutionPhase::Preparation, 1);
                 }
             }
-        } else if node.kind() == "command"
+        } else if matches!(node.kind(), "command" | "unset_command") {
+            match bash_command_effect(node, self.source) {
+                BashCommandEffect::None => {}
+                BashCommandEffect::IncompleteDomain => self.source_domain_incomplete = true,
+                BashCommandEffect::Unsupported => self.dynamic_domain_unsupported = true,
+                BashCommandEffect::InvalidatesFunctions(names) => {
+                    for name in names {
+                        count_bash_resolution_work(BashResolutionPhase::Preparation, 1);
+                        self.poisoned_definition_names.insert(name);
+                    }
+                }
+            }
+        }
+        if node.kind() == "command"
             && let Some(callee) = bash_command_callee(node)
             && let Some(raw_target) = node_text(callee, self.source).map(str::to_string)
         {
             let literal = bash_literal_command_name(callee, &raw_target);
-            if matches!(literal, Some("source" | ".")) {
-                self.source_domain_incomplete = true;
-            }
-            if matches!(literal, Some("alias" | "eval")) {
-                self.dynamic_domain_unsupported = true;
-            }
             self.calls.push(IndexedBashCall {
                 callee,
                 form: if literal.is_some() {
@@ -935,7 +1006,7 @@ impl<'a, 'tree> BashResolutionProducer<'a, 'tree> {
                 caller,
                 binding: CachedResolutionBinding::MissingBinding,
             });
-            count_ruby_php_resolution_work(1);
+            count_bash_resolution_work(BashResolutionPhase::Preparation, 1);
         }
 
         let direct_program_child = node.kind() == "program";
@@ -946,7 +1017,7 @@ impl<'a, 'tree> BashResolutionProducer<'a, 'tree> {
     }
 
     fn unique_graph_function(&self, line: u32, name: &str) -> Option<NodeId> {
-        count_ruby_php_resolution_work(1);
+        count_bash_resolution_work(BashResolutionPhase::Preparation, 1);
         let candidates = self
             .graph_functions
             .get(&(line, name.to_string()))
@@ -960,7 +1031,7 @@ impl<'a, 'tree> BashResolutionProducer<'a, 'tree> {
 
     fn finish(mut self) -> BashResolutionIndex<'tree> {
         for call in &mut self.calls {
-            count_ruby_php_resolution_work(1);
+            count_bash_resolution_work(BashResolutionPhase::Preparation, 1);
             call.binding = if call.caller.is_none()
                 || call.form != CalleeForm::Identifier
                 || self.dynamic_domain_unsupported
@@ -998,7 +1069,7 @@ impl<'a, 'tree> BashResolutionProducer<'a, 'tree> {
             .iter()
             .enumerate()
             .map(|(index, call)| {
-                count_ruby_php_resolution_work(1);
+                count_bash_resolution_work(BashResolutionPhase::Preparation, 1);
                 ((call.callee.start_byte(), call.callee.end_byte()), index)
             })
             .collect();
@@ -1022,6 +1093,120 @@ fn bash_command_callee(command: TsNode<'_>) -> Option<TsNode<'_>> {
 fn bash_literal_command_name<'a>(callee: TsNode<'_>, raw_target: &'a str) -> Option<&'a str> {
     (callee.kind() == "word" && callee.named_child_count() == 0 && !raw_target.is_empty())
         .then_some(raw_target)
+}
+
+fn bash_command_effect(command: TsNode<'_>, source: &str) -> BashCommandEffect {
+    if command.kind() == "unset_command" {
+        let mut cursor = command.walk();
+        let arguments = command.named_children(&mut cursor).collect::<Vec<_>>();
+        return bash_unset_effect(&arguments, source);
+    }
+    if command.kind() != "command" {
+        return BashCommandEffect::None;
+    }
+    let Some(callee) = bash_command_callee(command) else {
+        return BashCommandEffect::None;
+    };
+    let Some(mut effective) = bash_literal_node_text(callee, source) else {
+        return BashCommandEffect::None;
+    };
+    let mut cursor = command.walk();
+    let arguments = command
+        .children_by_field_name("argument", &mut cursor)
+        .collect::<Vec<_>>();
+    let mut argument_index = 0;
+    while matches!(effective, "builtin" | "command") {
+        let Some(argument) = arguments.get(argument_index).copied() else {
+            return BashCommandEffect::Unsupported;
+        };
+        let Some(next) = bash_literal_node_text(argument, source) else {
+            return BashCommandEffect::Unsupported;
+        };
+        argument_index += 1;
+        if next == "--" {
+            let Some(argument) = arguments.get(argument_index).copied() else {
+                return BashCommandEffect::Unsupported;
+            };
+            let Some(next_after_options) = bash_literal_node_text(argument, source) else {
+                return BashCommandEffect::Unsupported;
+            };
+            argument_index += 1;
+            effective = next_after_options;
+        } else if next.starts_with('-') {
+            return BashCommandEffect::Unsupported;
+        } else {
+            effective = next;
+        }
+        count_bash_resolution_work(BashResolutionPhase::Preparation, 1);
+    }
+    match effective {
+        "source" | "." => BashCommandEffect::IncompleteDomain,
+        "eval" | "alias" => BashCommandEffect::Unsupported,
+        "unset" => bash_unset_effect(&arguments[argument_index..], source),
+        _ => BashCommandEffect::None,
+    }
+}
+
+fn bash_unset_effect(arguments: &[TsNode<'_>], source: &str) -> BashCommandEffect {
+    let mut function_mode = false;
+    let mut names_started = false;
+    let mut names = Vec::new();
+    for argument in arguments {
+        count_bash_resolution_work(BashResolutionPhase::Preparation, 1);
+        let literal = bash_literal_node_text(*argument, source);
+        if !names_started {
+            match literal {
+                Some("--") => {
+                    names_started = true;
+                    continue;
+                }
+                Some("--function") => {
+                    function_mode = true;
+                    continue;
+                }
+                Some(option) if option.starts_with('-') && option.len() > 1 => {
+                    if option[1..]
+                        .chars()
+                        .all(|flag| matches!(flag, 'f' | 'v' | 'n'))
+                    {
+                        function_mode |= option[1..].contains('f');
+                        continue;
+                    }
+                    return BashCommandEffect::Unsupported;
+                }
+                _ => names_started = true,
+            }
+        }
+        if !function_mode {
+            continue;
+        }
+        let Some(name) = literal.filter(|name| bash_function_identifier(name)) else {
+            return BashCommandEffect::Unsupported;
+        };
+        names.push(name.to_owned());
+    }
+    if !function_mode {
+        BashCommandEffect::None
+    } else if names.is_empty() {
+        BashCommandEffect::Unsupported
+    } else {
+        BashCommandEffect::InvalidatesFunctions(names)
+    }
+}
+
+fn bash_literal_node_text<'a>(node: TsNode<'_>, source: &'a str) -> Option<&'a str> {
+    matches!(node.kind(), "word" | "variable_name")
+        .then(|| node_text(node, source))
+        .flatten()
+        .filter(|text| !text.is_empty())
+}
+
+fn bash_function_identifier(value: &str) -> bool {
+    let mut characters = value.chars();
+    characters
+        .next()
+        .is_some_and(|character| character == '_' || character.is_ascii_alphabetic())
+        && characters.all(|character| character == '_' || character.is_ascii_alphanumeric())
 }
 
 struct RubyResolutionIndex<'tree> {
@@ -12988,9 +13173,17 @@ pub fn rematerialize_proof_resolution_projection(
                 .is_some_and(|file| semantic_cache_requires_source_reauthentication(&file.language))
         })
     }) {
-        count_java_kotlin_resolution_work(1);
+        let file_id = node
+            .file_node_id
+            .expect("filtered semantic node has file")
+            .0;
+        if file_by_id[&file_id].language == "bash" {
+            count_bash_resolution_work(BashResolutionPhase::CacheReauthentication, 1);
+        } else {
+            count_java_kotlin_resolution_work(1);
+        }
         csd_nodes_by_file
-            .entry(node.file_node_id.expect("filtered CSD node has file").0)
+            .entry(file_id)
             .or_default()
             .push(node.clone());
     }
@@ -13182,6 +13375,12 @@ pub fn rematerialize_proof_resolution_projection(
                     indexed_file.path.display()
                 )
             })?;
+            if indexed_file.language == "bash" {
+                count_bash_resolution_work(
+                    BashResolutionPhase::CacheReauthentication,
+                    source_bytes.len().saturating_add(1),
+                );
+            }
             if source_content_hash(&source_bytes) != *stored_hash {
                 return Err(anyhow!(
                     "proof resolution semantic cache source drifted for {}",
@@ -13248,7 +13447,11 @@ pub fn rematerialize_proof_resolution_projection(
                 record.file.language.as_str(),
                 "bash" | "ruby" | "php" | "csharp" | "swift" | "dart"
             ) {
-                count_ruby_php_resolution_work(1);
+                if record.file.language == "bash" {
+                    count_bash_resolution_work(BashResolutionPhase::Projection, 1);
+                } else {
+                    count_ruby_php_resolution_work(1);
+                }
                 linear_records.push(record);
                 None
             } else {
@@ -13279,7 +13482,11 @@ pub fn rematerialize_proof_resolution_projection(
                 record.file.language.as_str(),
                 "bash" | "ruby" | "php" | "csharp" | "swift" | "dart"
             ) {
-                count_ruby_php_resolution_work(1);
+                if record.file.language == "bash" {
+                    count_bash_resolution_work(BashResolutionPhase::Projection, 1);
+                } else {
+                    count_ruby_php_resolution_work(1);
+                }
                 linear_inputs.push((record, call));
                 None
             } else {
@@ -13307,7 +13514,11 @@ pub fn rematerialize_proof_resolution_projection(
             input.language.as_str(),
             "bash" | "ruby" | "php" | "csharp" | "swift" | "dart"
         ) {
-            count_ruby_php_resolution_work(1);
+            if input.language == "bash" {
+                count_bash_resolution_work(BashResolutionPhase::Projection, 1);
+            } else {
+                count_ruby_php_resolution_work(1);
+            }
         }
         !callsite_members.insert((
             input.callsite.file_id,
@@ -13339,6 +13550,18 @@ pub fn rematerialize_proof_resolution_projection(
         .into_iter()
         .map(|(source_record, input)| resolve_syntax_claim(&claim_indexes, source_record, input))
         .collect::<Result<Vec<_>>>()?;
+    let bash_claim_count = claims
+        .iter()
+        .filter(|claim| claim.input.language == "bash")
+        .count();
+    if bash_claim_count > 0 {
+        count_bash_resolution_work(
+            BashResolutionPhase::GraphCorrelation,
+            bash_claim_count
+                .saturating_add(edges.len())
+                .saturating_add(1),
+        );
+    }
     enforce_go_exact_callable_ownership(&mut claims, &nodes);
     enforce_exact_dependency_eligibility(
         &mut claims,
@@ -13518,6 +13741,10 @@ pub fn rematerialize_proof_resolution_projection(
     }
     let mut facts = Vec::with_capacity(claims.len());
     for (claim_index, correlation) in claim_correlations.into_iter().enumerate() {
+        if claims[claim_index].input.language == "bash" {
+            count_bash_resolution_work(BashResolutionPhase::Projection, 1);
+            count_bash_resolution_work(BashResolutionPhase::GraphCorrelation, 1);
+        }
         facts.push(seal_resolved_claim(
             &file_content_hash_by_id,
             &node_by_id,
@@ -17388,6 +17615,9 @@ fn resolve_syntax_claim(
     source_record: &ResolutionCacheRecord,
     input: CachedCallResolutionInput,
 ) -> Result<ResolvedSyntaxClaim> {
+    if input.language == "bash" {
+        count_bash_resolution_work(BashResolutionPhase::Projection, 1);
+    }
     let files = indexes.files;
     let records = indexes.records;
     let rust_index = indexes.rust;
@@ -18843,7 +19073,9 @@ fn seal_resolved_claim(
         if dependency_members.insert(file_id) {
             dependency_ids.push(file_id);
         }
-        if linear_dependency_order {
+        if input.language == "bash" {
+            count_bash_resolution_work(BashResolutionPhase::Projection, 1);
+        } else if linear_dependency_order {
             count_ruby_php_resolution_work(1);
         }
     };
@@ -18924,7 +19156,9 @@ pub fn build_funnel(facts: &[CallResolutionFact]) -> Vec<ProofResolutionFunnelRo
             fact.provenance.language_adapter.as_str(),
             "bash" | "ruby" | "php" | "csharp" | "swift" | "dart"
         ) {
-            if is_csharp_swift_dart_language(&fact.provenance.language_adapter) {
+            if fact.provenance.language_adapter == "bash" {
+                count_bash_resolution_work(BashResolutionPhase::Projection, 1);
+            } else if is_csharp_swift_dart_language(&fact.provenance.language_adapter) {
                 count_java_kotlin_resolution_work(1);
             } else {
                 count_ruby_php_resolution_work(1);
@@ -18989,7 +19223,9 @@ pub fn build_funnel(facts: &[CallResolutionFact]) -> Vec<ProofResolutionFunnelRo
                 Some(ResolutionEvidenceKind::StaticImportBinding),
             ] {
                 let key = (language.to_owned(), Some(callee_form), evidence_kind);
-                if is_csharp_swift_dart_language(language) {
+                if language == "bash" {
+                    count_bash_resolution_work(BashResolutionPhase::Projection, 1);
+                } else if is_csharp_swift_dart_language(language) {
                     count_java_kotlin_resolution_work(1);
                 } else {
                     count_ruby_php_resolution_work(1);
@@ -19223,6 +19459,7 @@ mod bash_complexity_tests {
             .set_language(&tree_sitter_bash::LANGUAGE.into())
             .expect("Bash grammar");
         let tree = parser.parse(&source, None).expect("Bash source");
+        reset_bash_resolution_work();
         reset_ruby_php_resolution_work();
         let index = BashResolutionIndex::build(&tree, &source, NodeId(1), &nodes);
         assert_eq!(
@@ -19233,7 +19470,12 @@ mod bash_complexity_tests {
                 .count(),
             functions
         );
-        ruby_php_resolution_work()
+        assert_eq!(
+            ruby_php_resolution_work(),
+            0,
+            "Bash work leaked into the Ruby/PHP counter"
+        );
+        bash_resolution_work().preparation
     }
 
     #[test]

--- a/crates/codestory-indexer/tests/bash_proof_resolution.rs
+++ b/crates/codestory-indexer/tests/bash_proof_resolution.rs
@@ -282,7 +282,6 @@ fn bash_closed_unsupported_and_hostile_matrix_is_canonical_nonexact() -> anyhow:
 enum GraphMutation {
     Missing,
     Duplicate,
-    CandidateRetained,
     OpaqueIdentity,
     WrongLine,
     WrongSource,
@@ -293,7 +292,6 @@ fn bash_graph_correlation_hostile_matrix_never_authorizes_a_receipt() -> anyhow:
     for mutation in [
         GraphMutation::Missing,
         GraphMutation::Duplicate,
-        GraphMutation::CandidateRetained,
         GraphMutation::OpaqueIdentity,
         GraphMutation::WrongLine,
         GraphMutation::WrongSource,
@@ -321,12 +319,6 @@ fn bash_graph_correlation_hostile_matrix_never_authorizes_a_receipt() -> anyhow:
                 duplicate.id = EdgeId(edge.id.0.wrapping_add(1_000_000_000));
                 store.insert_edge(&duplicate)?;
             }
-            GraphMutation::CandidateRetained => {
-                store.get_connection().execute(
-                    "UPDATE edge SET candidate_target_node_ids = ?1 WHERE id = ?2",
-                    (format!("[{}]", edge.effective_target().0), edge.id.0),
-                )?;
-            }
             GraphMutation::OpaqueIdentity => {
                 store.get_connection().execute(
                     "UPDATE edge SET callsite_identity = 'opaque' WHERE id = ?1",
@@ -347,7 +339,20 @@ fn bash_graph_correlation_hostile_matrix_never_authorizes_a_receipt() -> anyhow:
             }
         }
 
-        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        if let Err(error) = rematerialize_proof_resolution_projection(&mut store, &publication(1)) {
+            assert!(
+                error.to_string().contains("CALL edge")
+                    || error.to_string().contains("correlation"),
+                "{mutation:?}: {error}"
+            );
+            assert_eq!(store.proof_resolution_fact_count()?, 0, "{mutation:?}");
+            assert_eq!(
+                store.get_proof_resolution_publication()?,
+                None,
+                "{mutation:?}"
+            );
+            continue;
+        }
         let facts = store
             .get_proof_resolution_facts()?
             .into_iter()

--- a/crates/codestory-indexer/tests/bash_proof_resolution.rs
+++ b/crates/codestory-indexer/tests/bash_proof_resolution.rs
@@ -301,6 +301,18 @@ fn bash_command_effect_matrix_closes_wrappers_unset_and_control_flow() -> anyhow
             reason: ProofResolutionReason::LookupDomainIncomplete,
         },
         Case {
+            name: "command_source",
+            source: "command source ./other.sh\ntarget() { :; }\ncaller() { target; }\n",
+            expected: ProofResolutionStatus::IncompleteDomain,
+            reason: ProofResolutionReason::LookupDomainIncomplete,
+        },
+        Case {
+            name: "builtin_dot",
+            source: "builtin . ./other.sh\ntarget() { :; }\ncaller() { target; }\n",
+            expected: ProofResolutionStatus::IncompleteDomain,
+            reason: ProofResolutionReason::LookupDomainIncomplete,
+        },
+        Case {
             name: "command_dot",
             source: "command . ./other.sh\ntarget() { :; }\ncaller() { target; }\n",
             expected: ProofResolutionStatus::IncompleteDomain,
@@ -309,6 +321,18 @@ fn bash_command_effect_matrix_closes_wrappers_unset_and_control_flow() -> anyhow
         Case {
             name: "builtin_eval",
             source: "target() { :; }\ncaller() { builtin eval 'target() { false; }'; target; }\n",
+            expected: ProofResolutionStatus::Unsupported,
+            reason: ProofResolutionReason::UnsupportedConstruct,
+        },
+        Case {
+            name: "command_eval",
+            source: "target() { :; }\ncaller() { command eval 'target() { false; }'; target; }\n",
+            expected: ProofResolutionStatus::Unsupported,
+            reason: ProofResolutionReason::UnsupportedConstruct,
+        },
+        Case {
+            name: "builtin_alias",
+            source: "builtin alias target='printf replaced'\ntarget() { :; }\ncaller() { target; }\n",
             expected: ProofResolutionStatus::Unsupported,
             reason: ProofResolutionReason::UnsupportedConstruct,
         },
@@ -343,6 +367,12 @@ fn bash_command_effect_matrix_closes_wrappers_unset_and_control_flow() -> anyhow
             reason: ProofResolutionReason::LookupDomainIncomplete,
         },
         Case {
+            name: "command_wrapped_literal_unset",
+            source: "target() { :; }\ncaller() { command unset --function target; target; }\n",
+            expected: ProofResolutionStatus::IncompleteDomain,
+            reason: ProofResolutionReason::LookupDomainIncomplete,
+        },
+        Case {
             name: "dynamic_unset_name",
             source: "target() { :; }\ncaller() { name=target; unset -f \"$name\"; target; }\n",
             expected: ProofResolutionStatus::Unsupported,
@@ -351,6 +381,12 @@ fn bash_command_effect_matrix_closes_wrappers_unset_and_control_flow() -> anyhow
         Case {
             name: "wrapped_dynamic_unset_name",
             source: "target() { :; }\ncaller() { name=target; command unset --function \"$name\"; target; }\n",
+            expected: ProofResolutionStatus::Unsupported,
+            reason: ProofResolutionReason::UnsupportedConstruct,
+        },
+        Case {
+            name: "builtin_wrapped_dynamic_unset_name",
+            source: "target() { :; }\ncaller() { name=target; builtin unset -f \"$name\"; target; }\n",
             expected: ProofResolutionStatus::Unsupported,
             reason: ProofResolutionReason::UnsupportedConstruct,
         },
@@ -389,9 +425,9 @@ fn bash_command_effect_matrix_closes_wrappers_unset_and_control_flow() -> anyhow
         let target = store
             .get_proof_resolution_facts()?
             .into_iter()
-            .filter(|fact| fact.provenance.language_adapter == "bash")
-            .filter(|fact| fact.callsite.raw_target == "target")
-            .last()
+            .rfind(|fact| {
+                fact.provenance.language_adapter == "bash" && fact.callsite.raw_target == "target"
+            })
             .unwrap_or_else(|| panic!("{} emitted no target call fact", case.name));
         assert_eq!(target.status, case.expected, "{}: {target:#?}", case.name);
         assert_eq!(target.reason, case.reason, "{}: {target:#?}", case.name);
@@ -412,7 +448,11 @@ fn bash_command_effect_matrix_closes_wrappers_unset_and_control_flow() -> anyhow
         } else {
             assert!(target.target.is_none(), "{}: {target:#?}", case.name);
             assert!(target.edge_id.is_none(), "{}: {target:#?}", case.name);
-            assert!(target.evidence_chain.is_empty(), "{}: {target:#?}", case.name);
+            assert!(
+                target.evidence_chain.is_empty(),
+                "{}: {target:#?}",
+                case.name
+            );
         }
     }
     Ok(())
@@ -572,9 +612,7 @@ fn bash_growth_sources(axis: BashGrowthAxis, size: usize) -> Vec<(String, String
             .map(|index| {
                 (
                     format!("proof_{index}.sh"),
-                    format!(
-                        "target_{index}() {{ :; }}\ncaller_{index}() {{ target_{index}; }}\n"
-                    ),
+                    format!("target_{index}() {{ :; }}\ncaller_{index}() {{ target_{index}; }}\n"),
                 )
             })
             .collect(),
@@ -661,7 +699,8 @@ fn bash_full_pipeline_work(
 }
 
 #[test]
-fn bash_full_proof_pipeline_work_is_phase_complete_and_linear_on_every_axis() -> anyhow::Result<()> {
+fn bash_full_proof_pipeline_work_is_phase_complete_and_linear_on_every_axis() -> anyhow::Result<()>
+{
     for axis in [
         BashGrowthAxis::Files,
         BashGrowthAxis::Declarations,

--- a/crates/codestory-indexer/tests/bash_proof_resolution.rs
+++ b/crates/codestory-indexer/tests/bash_proof_resolution.rs
@@ -3,8 +3,14 @@ use codestory_contracts::graph::{Edge, EdgeId, EdgeKind};
 use codestory_contracts::proof_resolution::{
     ProofResolutionReason, ProofResolutionStatus, ResolutionEvidence,
 };
-use codestory_indexer::{WorkspaceIndexer, rematerialize_proof_resolution_projection};
-use codestory_store::{IndexPublicationMode, IndexPublicationRecord, Store};
+use codestory_indexer::{
+    WorkspaceIndexer, bash_resolution_work, rematerialize_proof_resolution_projection,
+    reset_bash_resolution_work,
+};
+use codestory_store::{
+    IndexPublicationMode, IndexPublicationRecord, Store, bash_store_resolution_work,
+    reset_bash_store_resolution_work,
+};
 use codestory_workspace::{BuildMode, RefreshInfo};
 use std::collections::HashMap;
 use std::fs;
@@ -278,6 +284,140 @@ fn bash_closed_unsupported_and_hostile_matrix_is_canonical_nonexact() -> anyhow:
     Ok(())
 }
 
+#[test]
+fn bash_command_effect_matrix_closes_wrappers_unset_and_control_flow() -> anyhow::Result<()> {
+    struct Case {
+        name: &'static str,
+        source: &'static str,
+        expected: ProofResolutionStatus,
+        reason: ProofResolutionReason,
+    }
+
+    let cases = [
+        Case {
+            name: "builtin_source",
+            source: "builtin source ./other.sh\ntarget() { :; }\ncaller() { target; }\n",
+            expected: ProofResolutionStatus::IncompleteDomain,
+            reason: ProofResolutionReason::LookupDomainIncomplete,
+        },
+        Case {
+            name: "command_dot",
+            source: "command . ./other.sh\ntarget() { :; }\ncaller() { target; }\n",
+            expected: ProofResolutionStatus::IncompleteDomain,
+            reason: ProofResolutionReason::LookupDomainIncomplete,
+        },
+        Case {
+            name: "builtin_eval",
+            source: "target() { :; }\ncaller() { builtin eval 'target() { false; }'; target; }\n",
+            expected: ProofResolutionStatus::Unsupported,
+            reason: ProofResolutionReason::UnsupportedConstruct,
+        },
+        Case {
+            name: "command_alias",
+            source: "command alias target='printf replaced'\ntarget() { :; }\ncaller() { target; }\n",
+            expected: ProofResolutionStatus::Unsupported,
+            reason: ProofResolutionReason::UnsupportedConstruct,
+        },
+        Case {
+            name: "literal_unset_short_option",
+            source: "target() { :; }\ncaller() { unset -f target; target; }\n",
+            expected: ProofResolutionStatus::IncompleteDomain,
+            reason: ProofResolutionReason::LookupDomainIncomplete,
+        },
+        Case {
+            name: "literal_unset_long_option",
+            source: "target() { :; }\ncaller() { unset --function target; target; }\n",
+            expected: ProofResolutionStatus::IncompleteDomain,
+            reason: ProofResolutionReason::LookupDomainIncomplete,
+        },
+        Case {
+            name: "literal_unset_combined_option",
+            source: "target() { :; }\ncaller() { unset -fv -- target; target; }\n",
+            expected: ProofResolutionStatus::IncompleteDomain,
+            reason: ProofResolutionReason::LookupDomainIncomplete,
+        },
+        Case {
+            name: "wrapped_literal_unset",
+            source: "target() { :; }\ncaller() { builtin unset -f -- target; target; }\n",
+            expected: ProofResolutionStatus::IncompleteDomain,
+            reason: ProofResolutionReason::LookupDomainIncomplete,
+        },
+        Case {
+            name: "dynamic_unset_name",
+            source: "target() { :; }\ncaller() { name=target; unset -f \"$name\"; target; }\n",
+            expected: ProofResolutionStatus::Unsupported,
+            reason: ProofResolutionReason::UnsupportedConstruct,
+        },
+        Case {
+            name: "wrapped_dynamic_unset_name",
+            source: "target() { :; }\ncaller() { name=target; command unset --function \"$name\"; target; }\n",
+            expected: ProofResolutionStatus::Unsupported,
+            reason: ProofResolutionReason::UnsupportedConstruct,
+        },
+        Case {
+            name: "malformed_function_unset",
+            source: "target() { :; }\ncaller() { unset -f --; target; }\n",
+            expected: ProofResolutionStatus::Unsupported,
+            reason: ProofResolutionReason::UnsupportedConstruct,
+        },
+        Case {
+            name: "conditional_literal_unset",
+            source: "target() { :; }\ncaller() { if test -n \"$FLAG\"; then unset -f target; fi; target; }\n",
+            expected: ProofResolutionStatus::IncompleteDomain,
+            reason: ProofResolutionReason::LookupDomainIncomplete,
+        },
+        Case {
+            name: "literal_unset_other_function_control",
+            source: "target() { :; }\nunrelated() { :; }\ncaller() { unset -f unrelated; target; }\n",
+            expected: ProofResolutionStatus::Exact,
+            reason: ProofResolutionReason::ExactResolution,
+        },
+        Case {
+            name: "ordinary_variable_unset_control",
+            source: "target() { :; }\ncaller() { unset target_variable; target; }\n",
+            expected: ProofResolutionStatus::Exact,
+            reason: ProofResolutionReason::ExactResolution,
+        },
+    ];
+
+    for case in cases {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(project.path(), &mut store, &[("proof.sh", case.source)])?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        store.validate_proof_resolution_publication(&publication(1))?;
+        let target = store
+            .get_proof_resolution_facts()?
+            .into_iter()
+            .filter(|fact| fact.provenance.language_adapter == "bash")
+            .filter(|fact| fact.callsite.raw_target == "target")
+            .last()
+            .unwrap_or_else(|| panic!("{} emitted no target call fact", case.name));
+        assert_eq!(target.status, case.expected, "{}: {target:#?}", case.name);
+        assert_eq!(target.reason, case.reason, "{}: {target:#?}", case.name);
+        if case.expected == ProofResolutionStatus::Exact {
+            assert!(target.target.is_some(), "{}: {target:#?}", case.name);
+            assert!(target.edge_id.is_some(), "{}: {target:#?}", case.name);
+            assert!(
+                !target.evidence_chain.is_empty(),
+                "{}: {target:#?}",
+                case.name
+            );
+            assert_eq!(
+                store.get_exact_proof_resolution_fact_by_edge(target.edge_id.unwrap())?,
+                Some(target.clone()),
+                "{}: Exact effect-control receipt must replay",
+                case.name
+            );
+        } else {
+            assert!(target.target.is_none(), "{}: {target:#?}", case.name);
+            assert!(target.edge_id.is_none(), "{}: {target:#?}", case.name);
+            assert!(target.evidence_chain.is_empty(), "{}: {target:#?}", case.name);
+        }
+    }
+    Ok(())
+}
+
 #[derive(Clone, Copy, Debug)]
 enum GraphMutation {
     Missing,
@@ -413,5 +553,137 @@ fn bash_semantic_cache_is_reauthenticated_from_source_before_replay() -> anyhow:
     );
     assert_eq!(store.proof_resolution_fact_count()?, 0);
     assert_eq!(store.get_proof_resolution_publication()?, None);
+    Ok(())
+}
+
+#[derive(Clone, Copy, Debug)]
+enum BashGrowthAxis {
+    Files,
+    Declarations,
+    Calls,
+    RepeatedCallsites,
+    HostileEffects,
+    SourceTrivia,
+}
+
+fn bash_growth_sources(axis: BashGrowthAxis, size: usize) -> Vec<(String, String)> {
+    match axis {
+        BashGrowthAxis::Files => (0..size)
+            .map(|index| {
+                (
+                    format!("proof_{index}.sh"),
+                    format!(
+                        "target_{index}() {{ :; }}\ncaller_{index}() {{ target_{index}; }}\n"
+                    ),
+                )
+            })
+            .collect(),
+        BashGrowthAxis::Declarations => {
+            let mut source = String::new();
+            for index in 0..size {
+                source.push_str(&format!("target_{index}() {{ :; }}\n"));
+            }
+            source.push_str("caller() { target_0; }\n");
+            vec![("proof.sh".to_owned(), source)]
+        }
+        BashGrowthAxis::Calls => {
+            let mut source = String::new();
+            for index in 0..size {
+                source.push_str(&format!("target_{index}() {{ :; }}\n"));
+            }
+            source.push_str("caller() {");
+            for index in 0..size {
+                source.push_str(&format!(" target_{index};"));
+            }
+            source.push_str(" }\n");
+            vec![("proof.sh".to_owned(), source)]
+        }
+        BashGrowthAxis::RepeatedCallsites => {
+            let mut source = String::from("target() { :; }\ncaller() {");
+            for _ in 0..size {
+                source.push_str(" target;");
+            }
+            source.push_str(" }\n");
+            vec![("proof.sh".to_owned(), source)]
+        }
+        BashGrowthAxis::HostileEffects => {
+            let mut source = String::from("target() { :; }\ncaller() {\n");
+            for index in 0..size {
+                source.push_str(&format!("  unset -f missing_{index};\n"));
+            }
+            source.push_str("  target;\n}\n");
+            vec![("proof.sh".to_owned(), source)]
+        }
+        BashGrowthAxis::SourceTrivia => {
+            let mut source = String::from("target() { :; }\n");
+            for index in 0..size {
+                source.push_str(&format!("# inert parser-visible trivia {index}\n"));
+            }
+            source.push_str("caller() { target; }\n");
+            vec![("proof.sh".to_owned(), source)]
+        }
+    }
+}
+
+fn bash_full_pipeline_work(
+    axis: BashGrowthAxis,
+    size: usize,
+) -> anyhow::Result<([usize; 4], [usize; 4])> {
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    let sources = bash_growth_sources(axis, size);
+    let borrowed = sources
+        .iter()
+        .map(|(path, source)| (path.as_str(), source.as_str()))
+        .collect::<Vec<_>>();
+
+    reset_bash_resolution_work();
+    reset_bash_store_resolution_work();
+    index_files(project.path(), &mut store, &borrowed)?;
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    store.validate_proof_resolution_publication(&publication(1))?;
+    let indexer = bash_resolution_work();
+    let store = bash_store_resolution_work();
+    Ok((
+        [
+            indexer.preparation,
+            indexer.cache_reauthentication,
+            indexer.projection,
+            indexer.graph_correlation,
+        ],
+        [
+            store.sealing,
+            store.validation,
+            store.replay,
+            store.publication,
+        ],
+    ))
+}
+
+#[test]
+fn bash_full_proof_pipeline_work_is_phase_complete_and_linear_on_every_axis() -> anyhow::Result<()> {
+    for axis in [
+        BashGrowthAxis::Files,
+        BashGrowthAxis::Declarations,
+        BashGrowthAxis::Calls,
+        BashGrowthAxis::RepeatedCallsites,
+        BashGrowthAxis::HostileEffects,
+        BashGrowthAxis::SourceTrivia,
+    ] {
+        let (small_indexer, small_store) = bash_full_pipeline_work(axis, 8)?;
+        let (large_indexer, large_store) = bash_full_pipeline_work(axis, 16)?;
+        for (phase, (small, large)) in small_indexer
+            .into_iter()
+            .zip(large_indexer)
+            .chain(small_store.into_iter().zip(large_store))
+            .enumerate()
+        {
+            assert!(small > 0, "{axis:?} phase {phase} was not counted");
+            assert!(
+                large <= small.saturating_mul(2).saturating_add(64),
+                "{axis:?} phase {phase} grew superlinearly: {small} -> {large}"
+            );
+        }
+    }
     Ok(())
 }

--- a/crates/codestory-indexer/tests/bash_proof_resolution.rs
+++ b/crates/codestory-indexer/tests/bash_proof_resolution.rs
@@ -1,0 +1,412 @@
+use codestory_contracts::events::EventBus;
+use codestory_contracts::graph::{Edge, EdgeId, EdgeKind};
+use codestory_contracts::proof_resolution::{
+    ProofResolutionReason, ProofResolutionStatus, ResolutionEvidence,
+};
+use codestory_indexer::{WorkspaceIndexer, rematerialize_proof_resolution_projection};
+use codestory_store::{IndexPublicationMode, IndexPublicationRecord, Store};
+use codestory_workspace::{BuildMode, RefreshInfo};
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn publication(generation: u64) -> IndexPublicationRecord {
+    IndexPublicationRecord {
+        generation,
+        generation_id: format!("bash-generation-{generation}"),
+        run_id: format!("bash-run-{generation}"),
+        mode: IndexPublicationMode::Incremental,
+        published_at_epoch_ms: generation as i64,
+    }
+}
+
+fn index_files(
+    root: &Path,
+    store: &mut Store,
+    files: &[(&str, &str)],
+) -> anyhow::Result<Vec<PathBuf>> {
+    let mut paths = Vec::new();
+    for (relative, source) in files {
+        let path = root.join(relative);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(&path, source)?;
+        paths.push(path);
+    }
+    WorkspaceIndexer::new(root.to_path_buf()).run_incremental(
+        store,
+        &RefreshInfo {
+            mode: BuildMode::Incremental,
+            files_to_index: paths.clone(),
+            files_to_remove: Vec::new(),
+            existing_file_ids: HashMap::new(),
+        },
+        &EventBus::new(),
+        None,
+    )?;
+    Ok(paths)
+}
+
+#[test]
+fn bash_unique_prior_same_file_literal_calls_emit_exact_replayable_receipts() -> anyhow::Result<()>
+{
+    let cases = [
+        (
+            "posix_function",
+            "proof.sh",
+            "target() { return 0; }\ncaller() { target; }\n",
+            1,
+        ),
+        (
+            "function_keyword",
+            "proof.sh",
+            "function target { return 0; }\nfunction caller { target argument; }\n",
+            1,
+        ),
+        (
+            "companion_extension",
+            "proof.bash",
+            "target() { return 0; }\ncaller() { target; }\n",
+            1,
+        ),
+        (
+            "repeated_callsites",
+            "proof.sh",
+            "target() { return 0; }\ncaller() { target; target argument; }\n",
+            2,
+        ),
+    ];
+
+    for (name, path, source, expected_calls) in cases {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(project.path(), &mut store, &[(path, source)])?;
+        let edge_count_before = store
+            .get_edges()?
+            .iter()
+            .filter(|edge| edge.kind == EdgeKind::CALL)
+            .count();
+
+        let first = rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        store.validate_proof_resolution_publication(&publication(1))?;
+        let target_facts = store
+            .get_proof_resolution_facts()?
+            .into_iter()
+            .filter(|fact| fact.provenance.language_adapter == "bash")
+            .filter(|fact| fact.callsite.raw_target == "target")
+            .collect::<Vec<_>>();
+        assert_eq!(
+            target_facts.len(),
+            expected_calls,
+            "{name}: {target_facts:#?}"
+        );
+        let mut receipt_edges = std::collections::BTreeSet::new();
+        for fact in &target_facts {
+            assert_eq!(
+                fact.status,
+                ProofResolutionStatus::Exact,
+                "{name}: {fact:#?}"
+            );
+            assert_eq!(fact.reason, ProofResolutionReason::ExactResolution);
+            let target = fact.target.expect("Exact Bash target");
+            let edge_id = fact.edge_id.expect("Exact Bash edge");
+            assert!(fact.raw_edge_target.is_some());
+            assert!(fact.raw_callsite_identity.is_some());
+            assert!(fact.lookup_domain_complete);
+            assert!(matches!(
+                fact.evidence_chain.as_slice(),
+                [ResolutionEvidence::SameFileDeclaration { declaration }] if *declaration == target
+            ));
+            assert_eq!(fact.provenance.dependency_file_hashes.len(), 1);
+            assert_eq!(fact.provenance.evidence_sha256.len(), 64);
+            assert_eq!(
+                store.get_exact_proof_resolution_fact_by_edge(edge_id)?,
+                Some(fact.clone()),
+                "{name}: exact evidence must replay as the authoritative edge receipt"
+            );
+            assert!(receipt_edges.insert(edge_id), "{name}: receipt edge reused");
+        }
+        assert_eq!(
+            store
+                .get_edges()?
+                .iter()
+                .filter(|edge| edge.kind == EdgeKind::CALL)
+                .count(),
+            edge_count_before,
+            "{name}: proof projection changed the ordinary navigation edge set"
+        );
+        let second = rematerialize_proof_resolution_projection(&mut store, &publication(2))?;
+        assert_eq!(first.fact_count, second.fact_count, "{name}");
+        assert_eq!(first.fact_digest, second.fact_digest, "{name}");
+    }
+    Ok(())
+}
+
+#[test]
+fn bash_closed_unsupported_and_hostile_matrix_is_canonical_nonexact() -> anyhow::Result<()> {
+    struct Case {
+        name: &'static str,
+        source: &'static str,
+        probe: &'static str,
+        status: ProofResolutionStatus,
+        reason: ProofResolutionReason,
+    }
+
+    let cases = [
+        Case {
+            name: "literal_source",
+            source: "source ./other.sh\ntarget() { :; }\ncaller() { target; }\n",
+            probe: "target",
+            status: ProofResolutionStatus::IncompleteDomain,
+            reason: ProofResolutionReason::LookupDomainIncomplete,
+        },
+        Case {
+            name: "dot_source",
+            source: ". ./other.sh\ntarget() { :; }\ncaller() { target; }\n",
+            probe: "target",
+            status: ProofResolutionStatus::IncompleteDomain,
+            reason: ProofResolutionReason::LookupDomainIncomplete,
+        },
+        Case {
+            name: "alias",
+            source: "alias target='echo replaced'\ntarget() { :; }\ncaller() { target; }\n",
+            probe: "target",
+            status: ProofResolutionStatus::Unsupported,
+            reason: ProofResolutionReason::UnsupportedConstruct,
+        },
+        Case {
+            name: "eval",
+            source: "target() { :; }\ncaller() { eval 'target'; target; }\n",
+            probe: "target",
+            status: ProofResolutionStatus::Unsupported,
+            reason: ProofResolutionReason::UnsupportedConstruct,
+        },
+        Case {
+            name: "quoted_variable_command",
+            source: "target() { :; }\ncaller() { callback=target; \"$callback\"; }\n",
+            probe: "\"$callback\"",
+            status: ProofResolutionStatus::Unsupported,
+            reason: ProofResolutionReason::UnsupportedConstruct,
+        },
+        Case {
+            name: "expanded_variable_command",
+            source: "target() { :; }\ncaller() { callback=target; ${callback}; }\n",
+            probe: "${callback}",
+            status: ProofResolutionStatus::Unsupported,
+            reason: ProofResolutionReason::UnsupportedConstruct,
+        },
+        Case {
+            name: "target_producing_substitution",
+            source: "target() { :; }\ncaller() { $(printf target); }\n",
+            probe: "$(printf target)",
+            status: ProofResolutionStatus::Unsupported,
+            reason: ProofResolutionReason::UnsupportedConstruct,
+        },
+        Case {
+            name: "duplicate_definition",
+            source: "target() { :; }\ntarget() { false; }\ncaller() { target; }\n",
+            probe: "target",
+            status: ProofResolutionStatus::Ambiguous,
+            reason: ProofResolutionReason::MultipleBindings,
+        },
+        Case {
+            name: "conditional_definition",
+            source: "if test -n \"$FLAG\"; then target() { :; }; fi\ncaller() { target; }\n",
+            probe: "target",
+            status: ProofResolutionStatus::IncompleteDomain,
+            reason: ProofResolutionReason::LookupDomainIncomplete,
+        },
+        Case {
+            name: "external_path_command",
+            source: "caller() { codestory_external_fixture; }\n",
+            probe: "codestory_external_fixture",
+            status: ProofResolutionStatus::MissingBinding,
+            reason: ProofResolutionReason::MissingBinding,
+        },
+        Case {
+            name: "definition_after_callsite",
+            source: "caller() { target; }\ntarget() { :; }\n",
+            probe: "target",
+            status: ProofResolutionStatus::IncompleteDomain,
+            reason: ProofResolutionReason::LookupDomainIncomplete,
+        },
+        Case {
+            name: "parser_incomplete",
+            source: "target() { :; }\ncaller() { target;\n",
+            probe: "target",
+            status: ProofResolutionStatus::IncompleteDomain,
+            reason: ProofResolutionReason::LookupDomainIncomplete,
+        },
+    ];
+
+    for case in cases {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(project.path(), &mut store, &[("proof.sh", case.source)])?;
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        store.validate_proof_resolution_publication(&publication(1))?;
+        let facts = store
+            .get_proof_resolution_facts()?
+            .into_iter()
+            .filter(|fact| fact.provenance.language_adapter == "bash")
+            .collect::<Vec<_>>();
+        assert!(!facts.is_empty(), "{} emitted no Bash facts", case.name);
+        assert!(
+            facts
+                .iter()
+                .all(|fact| fact.status != ProofResolutionStatus::Exact),
+            "{} became proof-authoritative: {facts:#?}",
+            case.name
+        );
+        let probe = facts
+            .iter()
+            .find(|fact| fact.callsite.raw_target == case.probe)
+            .unwrap_or_else(|| panic!("{} missing probe {}: {facts:#?}", case.name, case.probe));
+        assert_eq!(probe.status, case.status, "{}: {probe:#?}", case.name);
+        assert_eq!(probe.reason, case.reason, "{}: {probe:#?}", case.name);
+        assert!(probe.target.is_none(), "{}: {probe:#?}", case.name);
+        assert!(probe.edge_id.is_none(), "{}: {probe:#?}", case.name);
+        assert!(probe.raw_edge_target.is_none(), "{}: {probe:#?}", case.name);
+        assert!(
+            probe.raw_callsite_identity.is_none(),
+            "{}: {probe:#?}",
+            case.name
+        );
+        assert!(probe.evidence_chain.is_empty(), "{}: {probe:#?}", case.name);
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy, Debug)]
+enum GraphMutation {
+    Missing,
+    Duplicate,
+    CandidateRetained,
+    OpaqueIdentity,
+    WrongLine,
+    WrongSource,
+}
+
+#[test]
+fn bash_graph_correlation_hostile_matrix_never_authorizes_a_receipt() -> anyhow::Result<()> {
+    for mutation in [
+        GraphMutation::Missing,
+        GraphMutation::Duplicate,
+        GraphMutation::CandidateRetained,
+        GraphMutation::OpaqueIdentity,
+        GraphMutation::WrongLine,
+        GraphMutation::WrongSource,
+    ] {
+        let project = tempfile::tempdir()?;
+        let mut store = Store::new_in_memory()?;
+        index_files(
+            project.path(),
+            &mut store,
+            &[("proof.sh", "target() { :; }\ncaller() { target; }\n")],
+        )?;
+        let edge = store
+            .get_edges()?
+            .into_iter()
+            .find(|edge| edge.kind == EdgeKind::CALL && edge.line == Some(2))
+            .expect("Bash target CALL edge");
+        match mutation {
+            GraphMutation::Missing => {
+                store
+                    .get_connection()
+                    .execute("DELETE FROM edge WHERE id = ?1", [edge.id.0])?;
+            }
+            GraphMutation::Duplicate => {
+                let mut duplicate: Edge = edge.clone();
+                duplicate.id = EdgeId(edge.id.0.wrapping_add(1_000_000_000));
+                store.insert_edge(&duplicate)?;
+            }
+            GraphMutation::CandidateRetained => {
+                store.get_connection().execute(
+                    "UPDATE edge SET candidate_target_node_ids = ?1 WHERE id = ?2",
+                    (format!("[{}]", edge.effective_target().0), edge.id.0),
+                )?;
+            }
+            GraphMutation::OpaqueIdentity => {
+                store.get_connection().execute(
+                    "UPDATE edge SET callsite_identity = 'opaque' WHERE id = ?1",
+                    [edge.id.0],
+                )?;
+            }
+            GraphMutation::WrongLine => {
+                store
+                    .get_connection()
+                    .execute("UPDATE edge SET line = 99 WHERE id = ?1", [edge.id.0])?;
+            }
+            GraphMutation::WrongSource => {
+                let file = edge.file_node_id.expect("Bash edge file");
+                store.get_connection().execute(
+                    "UPDATE edge SET source_node_id = ?1, resolved_source_node_id = NULL WHERE id = ?2",
+                    [file.0, edge.id.0],
+                )?;
+            }
+        }
+
+        rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+        let facts = store
+            .get_proof_resolution_facts()?
+            .into_iter()
+            .filter(|fact| fact.provenance.language_adapter == "bash")
+            .filter(|fact| fact.callsite.raw_target == "target")
+            .collect::<Vec<_>>();
+        assert_eq!(facts.len(), 1, "{mutation:?}: {facts:#?}");
+        assert_ne!(
+            facts[0].status,
+            ProofResolutionStatus::Exact,
+            "{mutation:?}: {:#?}",
+            facts[0]
+        );
+        assert!(facts[0].target.is_none(), "{mutation:?}: {:#?}", facts[0]);
+        assert!(facts[0].edge_id.is_none(), "{mutation:?}: {:#?}", facts[0]);
+        assert!(
+            facts[0].evidence_chain.is_empty(),
+            "{mutation:?}: {:#?}",
+            facts[0]
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn bash_semantic_cache_is_reauthenticated_from_source_before_replay() -> anyhow::Result<()> {
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(
+        project.path(),
+        &mut store,
+        &[("proof.sh", "target() { :; }\ncaller() { target; }\n")],
+    )?;
+    let blob = store.get_connection().query_row(
+        "SELECT artifact_blob FROM index_artifact_cache",
+        [],
+        |row| row.get::<_, Vec<u8>>(0),
+    )?;
+    let mut artifact: serde_json::Value = serde_json::from_slice(&blob)?;
+    let target_call = artifact["call_resolution_inputs"]
+        .as_array_mut()
+        .expect("Bash cache calls")
+        .iter_mut()
+        .find(|call| call["callsite"]["raw_target"] == "target")
+        .expect("cached target call");
+    target_call["binding"] = serde_json::json!({ "kind": "unsupported" });
+    store.get_connection().execute(
+        "UPDATE index_artifact_cache SET artifact_blob = ?1",
+        [serde_json::to_vec(&artifact)?],
+    )?;
+
+    let error = rematerialize_proof_resolution_projection(&mut store, &publication(1))
+        .expect_err("mutable Bash cache bytes cannot authenticate proof semantics");
+    assert!(
+        error.to_string().contains("semantic cache")
+            || error.to_string().contains("authenticated source"),
+        "{error}"
+    );
+    assert_eq!(store.proof_resolution_fact_count()?, 0);
+    assert_eq!(store.get_proof_resolution_publication()?, None);
+    Ok(())
+}

--- a/crates/codestory-indexer/tests/proof_resolution.rs
+++ b/crates/codestory-indexer/tests/proof_resolution.rs
@@ -10239,7 +10239,7 @@ fn complete_projection_rejects_cache_schema_adapter_and_language_mismatch() -> a
             .expect_err("cache provenance mismatch must reject the complete projection");
         let message = error.to_string();
         assert!(
-            ["stale", "schema-v25", "adapter", "language"]
+            ["stale", "schema-v26", "adapter", "language"]
                 .iter()
                 .any(|needle| message.contains(needle)),
             "{mutation}: {error}"

--- a/crates/codestory-store/src/lib.rs
+++ b/crates/codestory-store/src/lib.rs
@@ -53,7 +53,10 @@ pub use storage_impl::{
     structural_text_unit_digest,
 };
 #[cfg(debug_assertions)]
-pub use storage_impl::{reset_store_replay_work, store_replay_work};
+pub use storage_impl::{
+    BashStoreResolutionWork, bash_store_resolution_work, reset_bash_store_resolution_work,
+    reset_store_replay_work, store_replay_work,
+};
 
 impl Store {
     /// Access stored file inventory used by workspace refresh planning.

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -47,9 +47,12 @@ use helpers::{
 };
 
 pub use helpers::{StoredVectorEncoding, stored_vector_encoding};
-pub use proof_resolution::{ProofResolutionPublication, seal_call_resolution_fact};
 #[cfg(debug_assertions)]
-pub use proof_resolution::{reset_store_replay_work, store_replay_work};
+pub use proof_resolution::{
+    BashStoreResolutionWork, bash_store_resolution_work, reset_bash_store_resolution_work,
+    reset_store_replay_work, store_replay_work,
+};
+pub use proof_resolution::{ProofResolutionPublication, seal_call_resolution_fact};
 
 const SCHEMA_VERSION: u32 = 32;
 // Reserved outside the sequential migration range so a future real schema version cannot

--- a/crates/codestory-store/src/storage_impl/proof_resolution.rs
+++ b/crates/codestory-store/src/storage_impl/proof_resolution.rs
@@ -18,6 +18,63 @@ thread_local! {
     static STORE_REPLAY_WORK: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
 
+#[cfg(debug_assertions)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct BashStoreResolutionWork {
+    pub sealing: usize,
+    pub validation: usize,
+    pub replay: usize,
+    pub publication: usize,
+}
+
+#[cfg(debug_assertions)]
+thread_local! {
+    static BASH_STORE_RESOLUTION_WORK: std::cell::Cell<BashStoreResolutionWork> = const {
+        std::cell::Cell::new(BashStoreResolutionWork {
+            sealing: 0,
+            validation: 0,
+            replay: 0,
+            publication: 0,
+        })
+    };
+}
+
+#[derive(Clone, Copy)]
+enum BashStoreResolutionPhase {
+    Sealing,
+    Validation,
+    Replay,
+    Publication,
+}
+
+#[inline]
+fn count_bash_store_resolution_work(phase: BashStoreResolutionPhase, amount: usize) {
+    #[cfg(debug_assertions)]
+    BASH_STORE_RESOLUTION_WORK.with(|work| {
+        let mut value = work.get();
+        let slot = match phase {
+            BashStoreResolutionPhase::Sealing => &mut value.sealing,
+            BashStoreResolutionPhase::Validation => &mut value.validation,
+            BashStoreResolutionPhase::Replay => &mut value.replay,
+            BashStoreResolutionPhase::Publication => &mut value.publication,
+        };
+        *slot = slot.saturating_add(amount);
+        work.set(value);
+    });
+    #[cfg(not(debug_assertions))]
+    let _ = (phase, amount);
+}
+
+#[cfg(debug_assertions)]
+pub fn reset_bash_store_resolution_work() {
+    BASH_STORE_RESOLUTION_WORK.set(BashStoreResolutionWork::default());
+}
+
+#[cfg(debug_assertions)]
+pub fn bash_store_resolution_work() -> BashStoreResolutionWork {
+    BASH_STORE_RESOLUTION_WORK.get()
+}
+
 #[inline]
 fn count_store_replay_work(amount: usize) {
     #[cfg(debug_assertions)]
@@ -78,6 +135,10 @@ pub struct ProofResolutionPublication {
 pub fn seal_call_resolution_fact(
     mut fact: CallResolutionFact,
 ) -> Result<CallResolutionFact, StorageError> {
+    let bash_fact = fact.provenance.language_adapter == "bash";
+    if bash_fact {
+        count_bash_store_resolution_work(BashStoreResolutionPhase::Sealing, 1);
+    }
     let linear_dependency_order = matches!(
         fact.provenance.language_adapter.as_str(),
         "bash" | "ruby" | "php" | "csharp" | "swift" | "dart"
@@ -91,7 +152,11 @@ pub fn seal_call_resolution_fact(
             .dependency_file_hashes
             .iter()
             .all(|dependency| {
-                count_store_replay_work(1);
+                if bash_fact {
+                    count_bash_store_resolution_work(BashStoreResolutionPhase::Sealing, 1);
+                } else {
+                    count_store_replay_work(1);
+                }
                 members.insert(dependency.file_id)
             })
     } else {
@@ -156,6 +221,10 @@ where
 }
 
 fn validate_fact_shape(fact: &CallResolutionFact, require_seal: bool) -> Result<(), StorageError> {
+    let bash_fact = fact.provenance.language_adapter == "bash";
+    if bash_fact {
+        count_bash_store_resolution_work(BashStoreResolutionPhase::Sealing, 1);
+    }
     let linear_dependency_order = matches!(
         fact.provenance.language_adapter.as_str(),
         "bash" | "ruby" | "php" | "csharp" | "swift" | "dart"
@@ -166,7 +235,11 @@ fn validate_fact_shape(fact: &CallResolutionFact, require_seal: bool) -> Result<
             .dependency_file_hashes
             .iter()
             .all(|dependency| {
-                count_store_replay_work(1);
+                if bash_fact {
+                    count_bash_store_resolution_work(BashStoreResolutionPhase::Sealing, 1);
+                } else {
+                    count_store_replay_work(1);
+                }
                 members.insert(dependency.file_id)
             })
     } else {
@@ -2746,7 +2819,7 @@ impl Storage {
                 parse_canonical_json(&evidence_json, "evidence").map_err(proof_error)?;
             let dependency_file_hashes: Vec<DependencyFileHash> =
                 parse_canonical_json(&dependency_json, "dependency").map_err(proof_error)?;
-            facts.push(CallResolutionFact {
+            let fact = CallResolutionFact {
                 fact_id: row.get(0)?,
                 edge_id: row.get::<_, Option<i64>>(1)?.map(EdgeId),
                 raw_edge_target: row.get::<_, Option<i64>>(2)?.map(NodeId),
@@ -2789,7 +2862,17 @@ impl Storage {
                     dependency_file_hashes,
                     evidence_sha256: row.get(25)?,
                 },
-            });
+            };
+            if fact.provenance.language_adapter == "bash" {
+                count_bash_store_resolution_work(
+                    BashStoreResolutionPhase::Replay,
+                    fact.evidence_chain
+                        .len()
+                        .saturating_add(fact.provenance.dependency_file_hashes.len())
+                        .saturating_add(1),
+                );
+            }
+            facts.push(fact);
         }
         Ok(facts)
     }
@@ -2800,6 +2883,15 @@ impl Storage {
         authenticate_live_go_sources: bool,
     ) -> Result<(), StorageError> {
         for fact in facts {
+            if fact.provenance.language_adapter == "bash" {
+                count_bash_store_resolution_work(
+                    BashStoreResolutionPhase::Validation,
+                    fact.evidence_chain
+                        .len()
+                        .saturating_add(fact.provenance.dependency_file_hashes.len())
+                        .saturating_add(1),
+                );
+            }
             validate_fact_seal(fact)?;
         }
         let context =
@@ -3986,7 +4078,11 @@ impl Storage {
                     fact.provenance.language_adapter.as_str(),
                     "bash" | "ruby" | "php" | "csharp" | "swift" | "dart"
                 ) {
-                    count_store_replay_work(1);
+                    if fact.provenance.language_adapter == "bash" {
+                        count_bash_store_resolution_work(BashStoreResolutionPhase::Publication, 1);
+                    } else {
+                        count_store_replay_work(1);
+                    }
                     linear_facts.push(fact.clone());
                     None
                 } else {
@@ -4047,7 +4143,11 @@ impl Storage {
                     row.language.as_str(),
                     "bash" | "ruby" | "php" | "csharp" | "swift" | "dart"
                 ) {
-                    count_store_replay_work(1);
+                    if row.language == "bash" {
+                        count_bash_store_resolution_work(BashStoreResolutionPhase::Publication, 1);
+                    } else {
+                        count_store_replay_work(1);
+                    }
                     linear_funnel.push(row.clone());
                     None
                 } else {
@@ -4113,6 +4213,15 @@ impl Storage {
                  )",
             )?;
             for fact in &facts {
+                if fact.provenance.language_adapter == "bash" {
+                    count_bash_store_resolution_work(
+                        BashStoreResolutionPhase::Publication,
+                        fact.evidence_chain
+                            .len()
+                            .saturating_add(fact.provenance.dependency_file_hashes.len())
+                            .saturating_add(1),
+                    );
+                }
                 let evidence_json =
                     serde_json::to_string(&fact.evidence_chain).map_err(|error| {
                         proof_error(format!("failed to serialize typed evidence: {error}"))
@@ -4225,6 +4334,9 @@ impl Storage {
             ));
         }
         for fact in &facts {
+            if fact.provenance.language_adapter == "bash" {
+                count_bash_store_resolution_work(BashStoreResolutionPhase::Replay, 1);
+            }
             validate_fact_seal(fact)?;
         }
         Ok((manifest, facts))

--- a/crates/codestory-store/src/storage_impl/proof_resolution.rs
+++ b/crates/codestory-store/src/storage_impl/proof_resolution.rs
@@ -80,7 +80,7 @@ pub fn seal_call_resolution_fact(
 ) -> Result<CallResolutionFact, StorageError> {
     let linear_dependency_order = matches!(
         fact.provenance.language_adapter.as_str(),
-        "ruby" | "php" | "csharp" | "swift" | "dart"
+        "bash" | "ruby" | "php" | "csharp" | "swift" | "dart"
     );
     if !linear_dependency_order {
         fact.provenance.dependency_file_hashes.sort();
@@ -158,7 +158,7 @@ where
 fn validate_fact_shape(fact: &CallResolutionFact, require_seal: bool) -> Result<(), StorageError> {
     let linear_dependency_order = matches!(
         fact.provenance.language_adapter.as_str(),
-        "ruby" | "php" | "csharp" | "swift" | "dart"
+        "bash" | "ruby" | "php" | "csharp" | "swift" | "dart"
     );
     let dependencies_are_canonical = if linear_dependency_order {
         let mut members = HashSet::new();
@@ -2969,9 +2969,11 @@ impl Storage {
             fact.provenance.language_adapter.as_str(),
             "csharp" | "swift" | "dart"
         );
-        let linear_language =
+        let governed_domain_language =
             matches!(fact.provenance.language_adapter.as_str(), "ruby" | "php") || csd_language;
-        let mut required_dependency_ids = if linear_language {
+        let linear_language =
+            governed_domain_language || fact.provenance.language_adapter == "bash";
+        let mut required_dependency_ids = if governed_domain_language {
             BTreeSet::new()
         } else {
             BTreeSet::from([fact.callsite.file_id])
@@ -2999,7 +3001,7 @@ impl Storage {
                 .node_by_id
                 .get(&node_id)
                 .ok_or_else(|| proof_error("typed evidence references a missing graph node"))?;
-            if !linear_language && let Some(file_id) = node.file_node_id {
+            if !governed_domain_language && let Some(file_id) = node.file_node_id {
                 required_dependency_ids.insert(FileId(file_id.0));
             }
         }
@@ -3024,7 +3026,7 @@ impl Storage {
                 )?
             };
         }
-        if linear_language && !csd_language {
+        if governed_domain_language && !csd_language {
             let expected = if fact.status == ProofResolutionStatus::Exact {
                 ruby_php_dependency_ids(fact, context)?
             } else {
@@ -3062,7 +3064,7 @@ impl Storage {
                 )));
             }
         }
-        let observed_dependency_ids = if !linear_language {
+        let observed_dependency_ids = if !governed_domain_language {
             dependency_file_ids(fact)
         } else {
             BTreeSet::new()
@@ -3083,7 +3085,7 @@ impl Storage {
                 context,
             )?;
         }
-        if !linear_language
+        if !governed_domain_language
             && let Some(rust_dependencies) = rust_same_file_dependency_ids(
                 fact,
                 &required_dependency_ids,
@@ -3093,7 +3095,7 @@ impl Storage {
         {
             required_dependency_ids = rust_dependencies;
         }
-        if !linear_language && observed_dependency_ids != required_dependency_ids {
+        if !governed_domain_language && observed_dependency_ids != required_dependency_ids {
             return Err(proof_error(format!(
                 "dependency hashes do not exactly cover source, import, package, and target files for {}: observed={observed_dependency_ids:?} required={required_dependency_ids:?}",
                 fact.provenance.language_adapter
@@ -3982,7 +3984,7 @@ impl Storage {
             .filter_map(|fact| {
                 if matches!(
                     fact.provenance.language_adapter.as_str(),
-                    "ruby" | "php" | "csharp" | "swift" | "dart"
+                    "bash" | "ruby" | "php" | "csharp" | "swift" | "dart"
                 ) {
                     count_store_replay_work(1);
                     linear_facts.push(fact.clone());
@@ -4043,7 +4045,7 @@ impl Storage {
             .filter_map(|row| {
                 if matches!(
                     row.language.as_str(),
-                    "ruby" | "php" | "csharp" | "swift" | "dart"
+                    "bash" | "ruby" | "php" | "csharp" | "swift" | "dart"
                 ) {
                     count_store_replay_work(1);
                     linear_funnel.push(row.clone());
@@ -4610,7 +4612,7 @@ fn recompute_funnel(facts: &[CallResolutionFact]) -> Vec<ProofResolutionFunnelRo
         );
         let counts = if matches!(
             fact.provenance.language_adapter.as_str(),
-            "ruby" | "php" | "csharp" | "swift" | "dart"
+            "bash" | "ruby" | "php" | "csharp" | "swift" | "dart"
         ) {
             count_store_replay_work(1);
             linear_rows.entry(key).or_default()
@@ -4652,7 +4654,7 @@ fn recompute_funnel(facts: &[CallResolutionFact]) -> Vec<ProofResolutionFunnelRo
                 right.evidence_kind.map(|kind| kind.as_str()),
             ))
     });
-    for language in ["csharp", "dart", "php", "ruby", "swift"] {
+    for language in ["bash", "csharp", "dart", "php", "ruby", "swift"] {
         for callee_form in [
             CalleeForm::Constructor,
             CalleeForm::DynamicAccess,


### PR DESCRIPTION
## Context

This is the last dark language-adapter slice for CodeStory 0.18. It adds Bash's deliberately narrow exact subset, removes the temporary missing-adapter allowlist, and proves the proof-adapter roster matches all sixteen parser extraction dispatches.

## What changed

- adds exact Bash facts only for unique, prior, unconditional same-file functions called through direct literal names
- classifies sourced files, aliases, eval, indirect or variable calls, substitutions, duplicate/redefined/conditional/forward definitions, external commands, and incomplete domains as non-exact
- interprets parser-derived direct and `builtin`/`command` wrapped source, dot, eval, alias, and function-mode unset effects
- reauthenticates cached Bash inputs from publication-bound source before replay
- adds Bash-owned work accounting across preparation, cache reauthentication, projection, graph correlation, sealing, validation, replay, and publication
- removes the missing-adapter allowlist and makes the installed roster equal all sixteen parser dispatches
- preserves structural profiles, ordinary navigation edges, retrieval consumers, and public evidence surfaces

No schema migration, graph replacement, public command, MCP tool, packet/context/search change, or release change.

## How to review

The supported/unsupported and hostile matrix was committed before production changes. Review the Bash command-effect closure, exact graph/fact correlation, cache-source authentication, deterministic replay ordering, and eight-phase linear-work receipt. Dynamic shell behavior remains fail-closed rather than modeled.

## Verification

Exact head: `62308ea48a20b46d5375c2187a8a330e0d70990e`
Tree: `72c0641132163123e6d1f608c00e7e4d92c49699`

- Bash integration: 6 passed
- Bash parser complexity: 1 passed
- proof-resolution binary: 168 passed
- multilingual proof contract: 6 passed, covering 384 cases and all 16 dispatches
- architecture contracts: 57 passed
- store package in parallel: 292 passed
- fidelity regression: 8 passed
- language coverage: 13 passed
- strict all-target clippy for indexer/store/bench: passed
- package formatting and diff checks: passed

## Risk and follow-up

The adapter intentionally does not prove sourced, dynamic, external, conditional, redefined, or indirect shell calls. Public proof remains dark. The joined support head can now move to the final activation candidate owned by #2066.

Closes #2075
Refs #2023
Refs #2066