### PR TITLE
Reuse retrieval components during incremental refresh

### DIFF
--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -389,7 +389,7 @@ fn append_index_members(markdown: &mut String, output: &IndexOutput<'_>) {
     }
 }
 
-fn append_index_phase_timings(markdown: &mut String, timings: &IndexingPhaseTimings) {
+pub(crate) fn append_index_phase_timings(markdown: &mut String, timings: &IndexingPhaseTimings) {
     let _ = writeln!(
         markdown,
         "timings_ms: parse={} flush={} resolve={} cleanup={} cache_refresh={}",

--- a/crates/codestory-cli/src/retrieval.rs
+++ b/crates/codestory-cli/src/retrieval.rs
@@ -1,10 +1,10 @@
 use anyhow::{Context, Result, bail};
-use codestory_contracts::api::IndexMode;
+use codestory_contracts::api::{IndexMode, IndexingPhaseTimings};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use codestory_runtime::{
-    FinalizeIndexOutcome, RetrievalIndexManifest, RetrievalStatusReport, RuntimeRetrievalConfig,
-    SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED,
+    FinalizeComponentWork, FinalizeIndexOutcome, FinalizePhaseTiming, RetrievalIndexManifest,
+    RetrievalStatusReport, RuntimeRetrievalConfig, SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED,
 };
 
 use crate::args::{
@@ -229,20 +229,27 @@ fn run_retrieval_index(cmd: RetrievalIndexCommand) -> Result<()> {
     let decision = runtime.resolve_refresh_decision_with_preflight(cmd.refresh)?;
     let refresh_mode = decision.effective_mode;
     ensure_retrieval_index_embedding_policy(&sidecar)?;
-    run_retrieval_index_refresh(&runtime, cmd.refresh, refresh_mode)?;
-    let outcome =
-        finalize_retrieval_index_for_sidecar_runtime(&runtime, &sidecar).or_else(|error| {
-            if !retrieval_index_should_retry_full_refresh(cmd.refresh, &error) {
-                return Err(error);
-            }
-            runtime
-                .index
-                .run_indexing_blocking(IndexMode::Full)
-                .map_err(map_api_error)?;
+    let mut core_phase_timings = run_retrieval_index_refresh(&runtime, cmd.refresh, refresh_mode)?;
+    let outcome = match finalize_retrieval_index_for_sidecar_runtime(&runtime, &sidecar) {
+        Ok(outcome) => outcome,
+        Err(error) if retrieval_index_should_retry_full_refresh(cmd.refresh, &error) => {
+            core_phase_timings = Some(
+                runtime
+                    .index
+                    .run_indexing_blocking(IndexMode::Full)
+                    .map_err(map_api_error)?,
+            );
             finalize_retrieval_index_for_sidecar_runtime(&runtime, &sidecar)
-                .context("retrieval index finalize after semantic-doc contract repair")
-        })?;
-    emit_retrieval_index(cmd.format, &outcome, cmd.output_file.as_deref())
+                .context("retrieval index finalize after semantic-doc contract repair")?
+        }
+        Err(error) => return Err(error),
+    };
+    emit_retrieval_index(
+        cmd.format,
+        &outcome,
+        core_phase_timings.as_ref(),
+        cmd.output_file.as_deref(),
+    )
 }
 
 fn ensure_retrieval_index_embedding_policy(sidecar: &RuntimeRetrievalConfig) -> Result<()> {
@@ -289,21 +296,19 @@ fn run_retrieval_index_refresh(
     runtime: &RuntimeContext,
     requested_refresh: RefreshMode,
     refresh_mode: Option<IndexMode>,
-) -> Result<()> {
+) -> Result<Option<IndexingPhaseTimings>> {
     let Some(mode) = refresh_mode else {
-        return Ok(());
+        return Ok(None);
     };
     runtime.open_project_summary()?;
-    runtime
+    match runtime
         .index
         .run_indexing_blocking(mode)
         .map_err(|error| map_api_error(annotate_refresh_error(error, requested_refresh, mode)))
-        .map(|_| ())
-        .or_else(|error| {
-            if !retrieval_index_should_retry_full_refresh(requested_refresh, &error) {
-                return Err(error);
-            }
-            runtime
+    {
+        Ok(timings) => Ok(Some(timings)),
+        Err(error) if retrieval_index_should_retry_full_refresh(requested_refresh, &error) => {
+            let timings = runtime
                 .index
                 .run_indexing_blocking(IndexMode::Full)
                 .map_err(|error| {
@@ -313,9 +318,11 @@ fn run_retrieval_index_refresh(
                         IndexMode::Full,
                     ))
                 })
-                .map(|_| ())
-                .context("retrieval index full refresh after semantic-doc contract repair")
-        })
+                .context("retrieval index full refresh after semantic-doc contract repair")?;
+            Ok(Some(timings))
+        }
+        Err(error) => Err(error),
+    }
 }
 
 pub(crate) fn finalize_retrieval_index_for_runtime(
@@ -381,21 +388,105 @@ struct RetrievalIndexOutput<'a> {
     scip_stubbed: bool,
     generation_retention_plan: &'a codestory_runtime::GenerationRetentionPlan,
     generation_retention: &'a codestory_runtime::GenerationRetentionApplyReport,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    core_phase_timings: Option<&'a IndexingPhaseTimings>,
+    retrieval_phase_timings: Vec<RetrievalPhaseTimingOutput<'a>>,
+    retrieval_component_work: Vec<RetrievalComponentWorkOutput<'a>>,
+}
+
+#[derive(serde::Serialize)]
+struct RetrievalPhaseTimingOutput<'a> {
+    phase: &'a str,
+    elapsed_ms: u64,
+}
+
+#[derive(serde::Serialize)]
+struct RetrievalComponentWorkOutput<'a> {
+    component: &'a str,
+    mode: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    retained: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    inserted: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    removed: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reordered: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    predecessor_bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    output_bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    attested_bytes: Option<u64>,
+}
+
+const RETRIEVAL_PHASE_ALLOWLIST: &[&str] = &[
+    "input fingerprint",
+    "lexical sidecar",
+    "incremental embedded vectors",
+    "embedded vectors",
+    "graph artifact",
+    "manifest write",
+    "unattributed",
+];
+
+const RETRIEVAL_COMPONENT_ALLOWLIST: &[&str] = &["lexical", "vectors", "graph"];
+const RETRIEVAL_COMPONENT_MODE_ALLOWLIST: &[&str] = &["reused", "copy_on_write", "complete"];
+
+fn safe_retrieval_phase_timings(
+    timings: &[FinalizePhaseTiming],
+) -> Vec<RetrievalPhaseTimingOutput<'_>> {
+    timings
+        .iter()
+        .filter(|timing| RETRIEVAL_PHASE_ALLOWLIST.contains(&timing.phase.as_str()))
+        .map(|timing| RetrievalPhaseTimingOutput {
+            phase: &timing.phase,
+            elapsed_ms: timing.elapsed_ms,
+        })
+        .collect()
+}
+
+fn safe_retrieval_component_work(
+    work: &[FinalizeComponentWork],
+) -> Vec<RetrievalComponentWorkOutput<'_>> {
+    work.iter()
+        .filter(|work| {
+            RETRIEVAL_COMPONENT_ALLOWLIST.contains(&work.component.as_str())
+                && RETRIEVAL_COMPONENT_MODE_ALLOWLIST.contains(&work.mode.as_str())
+        })
+        .map(|work| RetrievalComponentWorkOutput {
+            component: &work.component,
+            mode: &work.mode,
+            retained: work.retained,
+            inserted: work.inserted,
+            removed: work.removed,
+            reordered: work.reordered,
+            predecessor_bytes: work.predecessor_bytes,
+            output_bytes: work.output_bytes,
+            attested_bytes: work.attested_bytes,
+        })
+        .collect()
 }
 
 fn emit_retrieval_index(
     format: OutputFormat,
     outcome: &FinalizeIndexOutcome,
+    core_phase_timings: Option<&IndexingPhaseTimings>,
     output_file: Option<&std::path::Path>,
 ) -> Result<()> {
+    let retrieval_phase_timings = safe_retrieval_phase_timings(&outcome.phase_timings);
+    let retrieval_component_work = safe_retrieval_component_work(&outcome.component_work);
     let payload = RetrievalIndexOutput {
         manifest: &outcome.manifest,
         degraded_modes: &outcome.degraded_modes,
         scip_stubbed: outcome.scip_stubbed,
         generation_retention_plan: &outcome.generation_retention_plan,
         generation_retention: &outcome.generation_retention,
+        core_phase_timings,
+        retrieval_phase_timings,
+        retrieval_component_work,
     };
-    let markdown = format!(
+    let mut markdown = format!(
         "# Retrieval index\n\n- project_id: `{}`\n- lexical_version: `{}`\n- semantic_generation: `{}`\n- scip_revision: {:?}\n- degraded_modes: {:?}\n- retention_retained_bytes: {}\n- retention_reclaimable_bytes: {}\n- retention_removed_bytes: {}\n- retention_remaining_reclaimable_bytes: {}\n- retention_pruning_suppressed: {}\n",
         payload.manifest.project_id,
         payload.manifest.lexical_version,
@@ -408,6 +499,36 @@ fn emit_retrieval_index(
         payload.generation_retention.remaining_reclaimable_bytes,
         payload.generation_retention.pruning_suppressed,
     );
+    if let Some(timings) = core_phase_timings {
+        markdown.push_str("\n## Core indexing\n\n");
+        crate::output::append_index_phase_timings(&mut markdown, timings);
+    }
+    markdown.push_str("\n## Retrieval phases\n\n");
+    for timing in &payload.retrieval_phase_timings {
+        markdown.push_str(&format!("- {}: {} ms\n", timing.phase, timing.elapsed_ms));
+    }
+    markdown.push_str("\n## Retrieval component work\n\n");
+    for work in &payload.retrieval_component_work {
+        markdown.push_str(&format!(
+            "- {}: mode={}, retained={}, inserted={}, removed={}, reordered={}, predecessor_bytes={}, output_bytes={}, attested_bytes={}\n",
+            work.component,
+            work.mode,
+            work.retained
+                .map_or_else(|| "unknown".to_string(), |value| value.to_string()),
+            work.inserted
+                .map_or_else(|| "unknown".to_string(), |value| value.to_string()),
+            work.removed
+                .map_or_else(|| "unknown".to_string(), |value| value.to_string()),
+            work.reordered
+                .map_or_else(|| "unknown".to_string(), |value| value.to_string()),
+            work.predecessor_bytes
+                .map_or_else(|| "unknown".to_string(), |value| value.to_string()),
+            work.output_bytes
+                .map_or_else(|| "unknown".to_string(), |value| value.to_string()),
+            work.attested_bytes
+                .map_or_else(|| "unknown".to_string(), |value| value.to_string()),
+        ));
+    }
     emit(format, &payload, markdown, output_file)
 }
 
@@ -576,6 +697,61 @@ mod tests {
     use anyhow::anyhow;
     use std::fs;
     use tempfile::tempdir;
+
+    #[test]
+    fn retrieval_observability_exposes_only_aggregate_allowlisted_values() {
+        let phases = vec![
+            FinalizePhaseTiming {
+                phase: "lexical sidecar".into(),
+                elapsed_ms: 17,
+            },
+            FinalizePhaseTiming {
+                phase: "/private/source/path".into(),
+                elapsed_ms: 99,
+            },
+        ];
+        let work = vec![
+            FinalizeComponentWork {
+                component: "vectors".into(),
+                mode: "copy_on_write".into(),
+                retained: Some(41),
+                inserted: Some(2),
+                removed: Some(1),
+                reordered: Some(3),
+                predecessor_bytes: Some(1_024),
+                output_bytes: Some(1_100),
+                attested_bytes: Some(1_100),
+            },
+            FinalizeComponentWork {
+                component: "/private/component".into(),
+                mode: "complete".into(),
+                retained: None,
+                inserted: None,
+                removed: None,
+                reordered: None,
+                predecessor_bytes: None,
+                output_bytes: None,
+                attested_bytes: None,
+            },
+        ];
+
+        let safe_phases = safe_retrieval_phase_timings(&phases);
+        assert_eq!(safe_phases.len(), 1);
+        assert_eq!(safe_phases[0].phase, "lexical sidecar");
+        assert_eq!(safe_phases[0].elapsed_ms, 17);
+
+        let safe_work = safe_retrieval_component_work(&work);
+        assert_eq!(safe_work.len(), 1);
+        assert_eq!(safe_work[0].component, "vectors");
+        assert_eq!(safe_work[0].mode, "copy_on_write");
+        assert_eq!(safe_work[0].retained, Some(41));
+        assert_eq!(safe_work[0].inserted, Some(2));
+        assert_eq!(safe_work[0].removed, Some(1));
+        assert_eq!(safe_work[0].reordered, Some(3));
+        assert_eq!(safe_work[0].predecessor_bytes, Some(1_024));
+        assert_eq!(safe_work[0].output_bytes, Some(1_100));
+        assert_eq!(safe_work[0].attested_bytes, Some(1_100));
+    }
 
     struct LiveOperationFixture {
         _project: tempfile::TempDir,
@@ -1238,8 +1414,11 @@ mod tests {
             .resolve_refresh_decision_with_preflight(RefreshMode::Auto)
             .expect("resolve compatible auto refresh");
         assert_eq!(decision.effective_mode, Some(IndexMode::Incremental));
-        run_retrieval_index_refresh(&runtime, RefreshMode::Auto, decision.effective_mode)
-            .expect("run compatible incremental refresh");
+        let timings =
+            run_retrieval_index_refresh(&runtime, RefreshMode::Auto, decision.effective_mode)
+                .expect("run compatible incremental refresh")
+                .expect("executed core refresh must retain its phase timings");
+        assert!(timings.incremental_plan_probe.is_some());
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/copy_on_write.rs
+++ b/crates/codestory-retrieval/src/copy_on_write.rs
@@ -1,0 +1,119 @@
+use anyhow::{Context, Result, bail};
+use std::path::Path;
+
+/// Clone one immutable component into a distinct candidate file without
+/// copying its unchanged physical extents.
+///
+/// `Ok(false)` means the current filesystem/OS cannot provide a copy-on-write
+/// clone. Callers must fall back to their complete staged builder; a byte copy
+/// would preserve correctness but recreate the full-work defect this boundary
+/// exists to avoid.
+pub(crate) fn clone_file(source: &Path, destination: &Path) -> Result<bool> {
+    let source_metadata = std::fs::symlink_metadata(source)
+        .with_context(|| format!("inspect clone source {}", source.display()))?;
+    if !source_metadata.file_type().is_file() {
+        bail!("copy-on-write clone source is not a regular file");
+    }
+    if std::fs::symlink_metadata(destination).is_ok() {
+        bail!("copy-on-write clone destination already exists");
+    }
+
+    clone_file_platform(source, destination)
+}
+
+#[cfg(target_os = "macos")]
+fn clone_file_platform(source: &Path, destination: &Path) -> Result<bool> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let source = CString::new(source.as_os_str().as_bytes())
+        .context("copy-on-write clone source contains NUL")?;
+    let destination = CString::new(destination.as_os_str().as_bytes())
+        .context("copy-on-write clone destination contains NUL")?;
+    // SAFETY: both pointers come from live NUL-terminated C strings and the
+    // destination was proven absent above. `clonefile` creates a distinct file
+    // whose unchanged extents are shared copy-on-write by APFS.
+    let result = unsafe { libc::clonefile(source.as_ptr(), destination.as_ptr(), 0) };
+    if result == 0 {
+        return Ok(true);
+    }
+    let error = std::io::Error::last_os_error();
+    let _ = std::fs::remove_file(Path::new(std::ffi::OsStr::from_bytes(
+        destination.as_bytes(),
+    )));
+    match error.raw_os_error() {
+        Some(libc::ENOTSUP | libc::EXDEV | libc::EINVAL) => Ok(false),
+        _ => Err(error).context("clone immutable component with clonefile"),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn clone_file_platform(source: &Path, destination: &Path) -> Result<bool> {
+    use std::fs::OpenOptions;
+    use std::os::fd::AsRawFd;
+
+    // Linux's FICLONE ioctl is stable across the filesystems that implement
+    // reflinks. It either clones the complete file or leaves a candidate that
+    // we remove before reporting unsupported/failure.
+    const FICLONE: libc::c_ulong = 0x4004_9409;
+    let source = std::fs::File::open(source).context("open copy-on-write clone source")?;
+    let destination_file = OpenOptions::new()
+        .create_new(true)
+        .read(true)
+        .write(true)
+        .open(destination)
+        .context("create copy-on-write clone destination")?;
+    // SAFETY: both descriptors are valid regular files for the duration of the
+    // call and FICLONE does not retain their addresses.
+    let result = unsafe { libc::ioctl(destination_file.as_raw_fd(), FICLONE, source.as_raw_fd()) };
+    if result == 0 {
+        return Ok(true);
+    }
+    let error = std::io::Error::last_os_error();
+    drop(destination_file);
+    let _ = std::fs::remove_file(destination);
+    match error.raw_os_error() {
+        Some(libc::EOPNOTSUPP | libc::EXDEV | libc::ENOTTY | libc::EINVAL) => Ok(false),
+        _ => Err(error).context("clone immutable component with FICLONE"),
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+fn clone_file_platform(_source: &Path, _destination: &Path) -> Result<bool> {
+    Ok(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clone_is_distinct_and_copy_on_write_when_supported() {
+        let root = tempfile::TempDir::new().expect("tempdir");
+        let source = root.path().join("source");
+        let destination = root.path().join("destination");
+        std::fs::write(&source, b"immutable-source").expect("source");
+
+        if !clone_file(&source, &destination).expect("clone") {
+            return;
+        }
+        std::fs::write(&destination, b"candidate").expect("mutate candidate");
+
+        assert_eq!(std::fs::read(&source).unwrap(), b"immutable-source");
+        assert_eq!(std::fs::read(&destination).unwrap(), b"candidate");
+    }
+
+    #[test]
+    fn clone_refuses_an_existing_destination() {
+        let root = tempfile::TempDir::new().expect("tempdir");
+        let source = root.path().join("source");
+        let destination = root.path().join("destination");
+        std::fs::write(&source, b"source").expect("source");
+        std::fs::write(&destination, b"existing").expect("destination");
+
+        let error = clone_file(&source, &destination).expect_err("must refuse overwrite");
+
+        assert!(error.to_string().contains("destination already exists"));
+        assert_eq!(std::fs::read(&destination).unwrap(), b"existing");
+    }
+}

--- a/crates/codestory-retrieval/src/embedded_vector.rs
+++ b/crates/codestory-retrieval/src/embedded_vector.rs
@@ -17,7 +17,7 @@ use rusqlite::{Connection, OpenFlags, TransactionBehavior, params};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::cmp::Ordering;
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -27,8 +27,10 @@ const VECTOR_INDEX_SCHEMA_VERSION: i64 =
     crate::embedding_contract::EMBEDDING_VECTOR_SCHEMA_VERSION as i64;
 const VECTOR_INDEX_FILE: &str = "vectors.sqlite3";
 const VECTOR_GENERATION_MANIFEST_FILE: &str = "vector-generation-manifest.json";
-const VECTOR_GENERATION_MANIFEST_SCHEMA_VERSION: u32 = 1;
+const VECTOR_GENERATION_MANIFEST_SCHEMA_VERSION: u32 = 2;
+const VECTOR_COMPONENT_SCHEMA_VERSION: u32 = 2;
 const VECTOR_DIGEST_DOMAIN: &[u8] = b"codestory-vector-digest-v1\0";
+const VECTOR_COMPONENT_DIGEST_DOMAIN: &[u8] = b"codestory-vector-component-v2\0";
 const VECTOR_NORM_TOLERANCE: f64 = 1.0e-3;
 /// Minimum cosine supported by the source-backed development calibration.
 const DENSE_ABSTENTION_ABSOLUTE_FLOOR: f32 = 0.30;
@@ -77,6 +79,23 @@ pub(crate) struct AttestedSemanticPoint {
 pub(crate) struct ExpectedVectorAnchor {
     pub node_id: String,
     pub document_hash: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CurrentVectorAnchor {
+    pub node_id: String,
+    pub document_hash: String,
+    pub display_name: String,
+    pub file_path: Option<String>,
+    pub file_role: Option<FileRole>,
+    pub dense_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct IncrementalVectorWork {
+    pub retained: u64,
+    pub inserted: u64,
+    pub removed: u64,
 }
 
 pub(crate) struct AttestedVectorPublication<'a> {
@@ -252,12 +271,21 @@ pub(crate) fn producer_evidence_mismatches(
     expected.compatibility_with(observed).mismatches
 }
 
+fn vector_component_is_compatible(
+    expected: &EmbeddingVectorProducerEvidenceDto,
+    observed: &EmbeddingVectorProducerEvidenceDto,
+) -> Result<bool> {
+    Ok(vector_compatibility_identity(expected)? == vector_compatibility_identity(observed)?)
+}
+
 /// Content attestation returned before the candidate database is published.
 ///
-/// `vector_digest` is independent of SQLite layout and hashes canonical rows
-/// ordered by node id. `database_sha256` binds the exact SQLite bytes that are
-/// atomically renamed into the generation and is intended to be copied into
-/// the retrieval manifest.
+/// In the current component schema, `vector_digest`, `component_sha256`, and
+/// the legacy-named `database_sha256` all bind the canonical physical rows,
+/// independent of SQLite layout and publication identity. The generation and
+/// input hash remain a separate authenticated envelope. Schema-v1 manifests
+/// retain their historical whole-file `database_sha256` interpretation and
+/// are never admitted for copy-on-write reuse.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct VectorDatabaseAttestation {
     pub schema_version: i64,
@@ -270,6 +298,16 @@ pub(crate) struct VectorDatabaseAttestation {
     pub evidence_contract_identity: String,
     pub vector_digest: String,
     pub database_sha256: String,
+    #[serde(default = "legacy_vector_component_schema_version")]
+    pub component_schema_version: u32,
+    #[serde(default)]
+    pub component_sha256: String,
+    #[serde(default)]
+    pub database_size_bytes: u64,
+}
+
+const fn legacy_vector_component_schema_version() -> u32 {
+    1
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -300,6 +338,13 @@ impl VectorGenerationManifest {
         if vectors.evidence_contract_identity != compatibility_sha256 {
             bail!("vector attestation does not match producer evidence");
         }
+        if vectors.component_schema_version != VECTOR_COMPONENT_SCHEMA_VERSION
+            || vectors.component_sha256.len() != 64
+            || vectors.database_sha256 != vectors.component_sha256
+            || vectors.database_size_bytes == 0
+        {
+            bail!("vector attestation has incompatible physical component evidence");
+        }
         Ok(Self {
             schema_version: VECTOR_GENERATION_MANIFEST_SCHEMA_VERSION,
             evidence,
@@ -310,8 +355,28 @@ impl VectorGenerationManifest {
     }
 
     pub(crate) fn validate(&self) -> Result<()> {
-        if self.schema_version != VECTOR_GENERATION_MANIFEST_SCHEMA_VERSION {
+        if !matches!(
+            self.schema_version,
+            1 | VECTOR_GENERATION_MANIFEST_SCHEMA_VERSION
+        ) {
             bail!("unsupported vector generation manifest schema");
+        }
+        if self.schema_version == 1 {
+            if self.vectors.component_schema_version != 1
+                || !self.vectors.component_sha256.is_empty()
+            {
+                bail!("legacy vector manifest has incompatible component metadata");
+            }
+            let evidence_sha256 = hex_digest(Sha256::digest(
+                serde_json::to_vec(&self.evidence)
+                    .context("serialize legacy vector producer evidence")?,
+            ));
+            if evidence_sha256 != self.evidence_sha256
+                || vector_compatibility_identity(&self.evidence)? != self.compatibility_sha256
+            {
+                bail!("legacy vector generation manifest digest mismatch");
+            }
+            return Ok(());
         }
         let expected = Self::new(self.evidence.clone(), self.vectors.clone())?;
         if expected.evidence_sha256 != self.evidence_sha256 {
@@ -628,6 +693,100 @@ impl EmbeddedVectorIndex {
         )
     }
 
+    /// Reconcile a new immutable vector generation from one fully attested
+    /// predecessor without rewriting unchanged vector blobs.
+    ///
+    /// `Ok(None)` is the deliberate first-upgrade/corruption/filesystem
+    /// fallback: callers must use the complete staged builder. Once a clone is
+    /// established, cancellation or candidate construction failure is
+    /// returned rather than hidden behind a second build attempt.
+    pub(crate) fn try_build_incremental_with_cancel(
+        publication: AttestedVectorPublication<'_>,
+        previous_collection: &str,
+        expected_evidence: &EmbeddingVectorProducerEvidenceDto,
+        current_anchors: &[CurrentVectorAnchor],
+        before_publish: impl FnOnce() -> Result<()>,
+        produce_missing: impl FnOnce(
+            &[ExpectedVectorAnchor],
+            &mut dyn FnMut(AttestedSemanticPoint) -> Result<()>,
+        ) -> Result<()>,
+    ) -> Result<Option<(VectorDatabaseAttestation, IncrementalVectorWork)>> {
+        let expected_anchors = expected_anchor_map(publication.expected_anchors)?;
+        let current_anchors = current_vector_anchor_map(current_anchors, &expected_anchors)?;
+        let previous_manifest =
+            match Self::load_generation_manifest(publication.layout, previous_collection) {
+                Ok(manifest) => manifest,
+                Err(_) => return Ok(None),
+            };
+        if previous_manifest.schema_version != VECTOR_GENERATION_MANIFEST_SCHEMA_VERSION
+            || previous_manifest.vectors.component_schema_version != VECTOR_COMPONENT_SCHEMA_VERSION
+        {
+            return Ok(None);
+        }
+        if !vector_component_is_compatible(expected_evidence, &previous_manifest.evidence)? {
+            return Ok(None);
+        }
+        let previous_path = index_path(publication.layout, previous_collection);
+        let previous_anchors = match read_vector_anchor_map(&previous_path) {
+            Ok(anchors) => anchors,
+            Err(_) => return Ok(None),
+        };
+        if validate_database(
+            &previous_path,
+            &previous_manifest.vectors.generation,
+            &previous_manifest.vectors.input_hash,
+            publication.contract,
+            &previous_anchors,
+            Some(&previous_manifest.vectors),
+        )
+        .is_err()
+        {
+            return Ok(None);
+        }
+
+        let path = index_path(publication.layout, publication.collection);
+        let parent = path
+            .parent()
+            .context("embedded vector index has no parent")?;
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create embedded vector directory {}", parent.display()))?;
+        let (temp_path, reserved) =
+            codestory_workspace::atomic_file::create_unique_temp_file(&path, "vector-index")?;
+        drop(reserved);
+        std::fs::remove_file(&temp_path)
+            .with_context(|| format!("release vector clone reservation {}", temp_path.display()))?;
+        if !crate::copy_on_write::clone_file(&previous_path, &temp_path)? {
+            return Ok(None);
+        }
+
+        let result = (|| {
+            let work = reconcile_cloned_database(
+                &temp_path,
+                publication.generation,
+                publication.input_hash,
+                publication.contract,
+                &expected_anchors,
+                &current_anchors,
+                produce_missing,
+            )?;
+            let attestation = validate_database(
+                &temp_path,
+                publication.generation,
+                publication.input_hash,
+                publication.contract,
+                &expected_anchors,
+                None,
+            )?;
+            before_publish()?;
+            codestory_workspace::atomic_file::publish_existing_file_atomic(&temp_path, &path)?;
+            Ok((attestation, work))
+        })();
+        if result.is_err() {
+            let _ = std::fs::remove_file(&temp_path);
+        }
+        result.map(Some)
+    }
+
     /// Revalidate a published database against manifest-carried evidence.
     ///
     /// Readers should call this before admitting a candidate generation. The
@@ -721,12 +880,8 @@ impl EmbeddedVectorIndex {
         contract: &VectorEvidenceContract,
     ) -> Result<HashMap<(String, String), Vec<f32>>> {
         let manifest = Self::load_generation_manifest(layout, collection)?;
-        let mismatches = producer_evidence_mismatches(expected_evidence, &manifest.evidence);
-        if !mismatches.is_empty() {
-            bail!(
-                "reusable vector producer evidence is incompatible: {}",
-                mismatches.join(", ")
-            );
+        if !vector_component_is_compatible(expected_evidence, &manifest.evidence)? {
+            bail!("reusable vector producer evidence is incompatible");
         }
         let path = index_path(layout, collection);
         let connection = open_read_only(&path)?;
@@ -902,6 +1057,8 @@ struct DatabaseMetadata {
     producer_identity: String,
     evidence_contract_identity: String,
     vector_digest: String,
+    component_schema_version: u32,
+    component_sha256: String,
 }
 
 fn build_and_publish_database(
@@ -986,7 +1143,9 @@ fn write_database(
              point_count INTEGER NOT NULL,
              producer_identity TEXT NOT NULL,
              evidence_contract_identity TEXT NOT NULL,
-             vector_digest TEXT NOT NULL
+             vector_digest TEXT NOT NULL,
+             component_schema_version INTEGER NOT NULL,
+             component_sha256 TEXT NOT NULL
          );
          CREATE TABLE vectors (
              node_id TEXT PRIMARY KEY NOT NULL,
@@ -995,8 +1154,14 @@ fn write_database(
              file_path TEXT,
              file_role TEXT,
              dense_reason TEXT,
-             vector BLOB NOT NULL
-         ) WITHOUT ROWID;",
+             vector BLOB NOT NULL,
+             vector_sha256 TEXT NOT NULL
+         ) WITHOUT ROWID;
+         CREATE TRIGGER vectors_vector_update_guard
+         AFTER UPDATE OF vector ON vectors
+         BEGIN
+             UPDATE vectors SET vector_sha256 = 'invalid' WHERE node_id = NEW.node_id;
+         END;",
         )
         .with_context(|| format!("create embedded vector schema {}", path.display()))?;
     let transaction = connection
@@ -1007,8 +1172,9 @@ fn write_database(
         let mut insert = transaction
             .prepare(
                 "INSERT INTO vectors (
-                 node_id, document_hash, display_name, file_path, file_role, dense_reason, vector
-             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                 node_id, document_hash, display_name, file_path, file_role, dense_reason,
+                 vector, vector_sha256
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
             )
             .with_context(|| format!("prepare embedded vector insert {}", path.display()))?;
         let mut visit = |attested: AttestedSemanticPoint| -> Result<()> {
@@ -1039,6 +1205,8 @@ fn write_database(
             {
                 bail!("duplicate embedded vector anchor {}", point.node_id);
             }
+            let bytes = vector_bytes(&point.vector);
+            let vector_sha256 = hex_digest(Sha256::digest(&bytes));
             insert
                 .execute(params![
                     point.node_id,
@@ -1047,7 +1215,8 @@ fn write_database(
                     point.file_path,
                     point.file_role.map(|role| role.as_str()),
                     point.dense_reason,
-                    vector_bytes(&point.vector),
+                    bytes,
+                    vector_sha256,
                 ])
                 .with_context(|| format!("write embedded vector index {}", path.display()))?;
             Ok(())
@@ -1070,11 +1239,13 @@ fn write_database(
             missing
         );
     }
-    let vector_digest = canonical_vector_digest(&transaction, contract.embedding_dim)
-        .with_context(|| format!("digest embedded vector index {}", path.display()))?;
+    let vector_digest = canonical_vector_component_digest(&transaction)
+        .with_context(|| format!("digest embedded vector component {}", path.display()))?;
     transaction
         .execute(
-            "INSERT INTO metadata VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            "INSERT INTO metadata VALUES (
+                1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11
+             )",
             params![
                 VECTOR_INDEX_SCHEMA_VERSION,
                 generation,
@@ -1084,6 +1255,8 @@ fn write_database(
                 actual_anchors.len() as i64,
                 contract.producer_identity,
                 contract.evidence_contract_identity,
+                vector_digest,
+                VECTOR_COMPONENT_SCHEMA_VERSION,
                 vector_digest,
             ],
         )
@@ -1102,6 +1275,239 @@ fn write_database(
         .sync_all()
         .with_context(|| format!("sync embedded vector index {}", path.display()))?;
     Ok(actual_anchors)
+}
+
+fn current_vector_anchor_map(
+    current_anchors: &[CurrentVectorAnchor],
+    expected_anchors: &BTreeMap<String, String>,
+) -> Result<BTreeMap<String, CurrentVectorAnchor>> {
+    let mut current = BTreeMap::new();
+    for anchor in current_anchors {
+        if anchor.node_id.trim().is_empty() || anchor.document_hash.trim().is_empty() {
+            bail!("current embedded vector anchor identities must be non-empty");
+        }
+        if expected_anchors.get(&anchor.node_id) != Some(&anchor.document_hash) {
+            bail!(
+                "current embedded vector anchor {} does not match the expected publication",
+                anchor.node_id
+            );
+        }
+        if current
+            .insert(anchor.node_id.clone(), anchor.clone())
+            .is_some()
+        {
+            bail!(
+                "duplicate current embedded vector anchor {}",
+                anchor.node_id
+            );
+        }
+    }
+    if current.len() != expected_anchors.len() {
+        bail!(
+            "current embedded vector anchor coverage mismatch: expected {}, found {}",
+            expected_anchors.len(),
+            current.len()
+        );
+    }
+    Ok(current)
+}
+
+fn read_vector_anchor_map(path: &Path) -> Result<BTreeMap<String, String>> {
+    let connection = open_read_only(path)?;
+    let mut statement =
+        connection.prepare("SELECT node_id, document_hash FROM vectors ORDER BY node_id ASC")?;
+    let mut rows = statement.query([])?;
+    let mut anchors = BTreeMap::new();
+    while let Some(row) = rows.next()? {
+        let node_id = row.get::<_, String>(0)?;
+        let document_hash = row.get::<_, String>(1)?;
+        if anchors.insert(node_id.clone(), document_hash).is_some() {
+            bail!("duplicate embedded vector row {node_id}");
+        }
+    }
+    Ok(anchors)
+}
+
+fn reconcile_cloned_database(
+    path: &Path,
+    generation: &str,
+    input_hash: &str,
+    contract: &VectorEvidenceContract,
+    expected_anchors: &BTreeMap<String, String>,
+    current_anchors: &BTreeMap<String, CurrentVectorAnchor>,
+    produce_missing: impl FnOnce(
+        &[ExpectedVectorAnchor],
+        &mut dyn FnMut(AttestedSemanticPoint) -> Result<()>,
+    ) -> Result<()>,
+) -> Result<IncrementalVectorWork> {
+    let mut connection = Connection::open(sqlite_open_path(path))
+        .with_context(|| format!("open cloned embedded vector index {}", path.display()))?;
+    connection
+        .execute_batch("PRAGMA journal_mode=OFF; PRAGMA synchronous=FULL;")
+        .with_context(|| format!("configure cloned embedded vector index {}", path.display()))?;
+    validate_sqlite_quick_check(&connection).with_context(|| {
+        format!(
+            "quick-check cloned embedded vector index {}",
+            path.display()
+        )
+    })?;
+    let cloned_metadata = read_metadata(&connection)?;
+    if cloned_metadata.component_schema_version != VECTOR_COMPONENT_SCHEMA_VERSION
+        || cloned_metadata.component_sha256.is_empty()
+    {
+        bail!("cloned vector database does not support incremental reconciliation");
+    }
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .with_context(|| format!("begin cloned vector reconciliation {}", path.display()))?;
+
+    let existing = {
+        let mut statement = transaction.prepare(
+            "SELECT node_id, document_hash, display_name, file_path, file_role, dense_reason
+             FROM vectors ORDER BY node_id ASC",
+        )?;
+        let rows = statement.query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, Option<String>>(3)?,
+                row.get::<_, Option<String>>(4)?,
+                row.get::<_, Option<String>>(5)?,
+            ))
+        })?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()?
+    };
+    let removed = existing
+        .iter()
+        .filter(|(node_id, document_hash, ..)| expected_anchors.get(node_id) != Some(document_hash))
+        .count();
+    let retained = existing.len().saturating_sub(removed);
+    let retained_anchors = existing
+        .iter()
+        .filter(|(node_id, document_hash, ..)| expected_anchors.get(node_id) == Some(document_hash))
+        .map(|(node_id, document_hash, ..)| (node_id.as_str(), document_hash.as_str()))
+        .collect::<HashSet<_>>();
+
+    for (node_id, document_hash, ..) in &existing {
+        if expected_anchors.get(node_id) != Some(document_hash) {
+            transaction.execute("DELETE FROM vectors WHERE node_id = ?1", params![node_id])?;
+        }
+    }
+    for anchor in current_anchors.values() {
+        let changed = transaction.execute(
+            "UPDATE vectors
+             SET display_name = ?2, file_path = ?3, file_role = ?4, dense_reason = ?5
+             WHERE node_id = ?1 AND document_hash = ?6
+               AND (display_name IS NOT ?2 OR file_path IS NOT ?3
+                    OR file_role IS NOT ?4 OR dense_reason IS NOT ?5)",
+            params![
+                anchor.node_id,
+                anchor.display_name,
+                anchor.file_path,
+                anchor.file_role.map(|role| role.as_str()),
+                anchor.dense_reason,
+                anchor.document_hash,
+            ],
+        )?;
+        debug_assert!(changed <= 1);
+    }
+
+    let missing = expected_anchors
+        .iter()
+        .filter(|(node_id, document_hash)| {
+            !retained_anchors.contains(&(node_id.as_str(), document_hash.as_str()))
+        })
+        .map(|(node_id, document_hash)| ExpectedVectorAnchor {
+            node_id: node_id.clone(),
+            document_hash: document_hash.clone(),
+        })
+        .collect::<Vec<_>>();
+    let missing_map = expected_anchor_map(&missing)?;
+    let mut inserted = BTreeMap::new();
+    {
+        let mut insert = transaction.prepare(
+            "INSERT INTO vectors (
+                node_id, document_hash, display_name, file_path, file_role, dense_reason,
+                vector, vector_sha256
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        )?;
+        let mut visit = |attested: AttestedSemanticPoint| -> Result<()> {
+            let AttestedSemanticPoint {
+                point,
+                document_hash,
+            } = attested;
+            let expected_hash = missing_map
+                .get(&point.node_id)
+                .with_context(|| format!("unexpected incremental vector {}", point.node_id))?;
+            if expected_hash != &document_hash {
+                bail!(
+                    "incremental vector document hash mismatch for node {}",
+                    point.node_id
+                );
+            }
+            validate_vector(&point.node_id, &point.vector, contract.embedding_dim)?;
+            if inserted
+                .insert(point.node_id.clone(), document_hash.clone())
+                .is_some()
+            {
+                bail!("duplicate incremental embedded vector {}", point.node_id);
+            }
+            let bytes = vector_bytes(&point.vector);
+            let vector_sha256 = hex_digest(Sha256::digest(&bytes));
+            insert.execute(params![
+                point.node_id,
+                document_hash,
+                point.display_name,
+                point.file_path,
+                point.file_role.map(|role| role.as_str()),
+                point.dense_reason,
+                bytes,
+                vector_sha256,
+            ])?;
+            Ok(())
+        };
+        produce_missing(&missing, &mut visit)?;
+    }
+    if inserted != missing_map {
+        bail!(
+            "incremental embedded vector coverage mismatch: expected {}, found {}",
+            missing_map.len(),
+            inserted.len()
+        );
+    }
+
+    let vector_digest = canonical_vector_component_digest(&transaction)?;
+    transaction.execute("DELETE FROM metadata", [])?;
+    transaction.execute(
+        "INSERT INTO metadata VALUES (
+            1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11
+         )",
+        params![
+            VECTOR_INDEX_SCHEMA_VERSION,
+            generation,
+            input_hash,
+            contract.embedding_backend,
+            contract.embedding_dim as i64,
+            expected_anchors.len() as i64,
+            contract.producer_identity,
+            contract.evidence_contract_identity,
+            vector_digest,
+            VECTOR_COMPONENT_SCHEMA_VERSION,
+            vector_digest,
+        ],
+    )?;
+    transaction.commit()?;
+    drop(connection);
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(path)?
+        .sync_all()?;
+    Ok(IncrementalVectorWork {
+        retained: u64::try_from(retained).unwrap_or(u64::MAX),
+        inserted: u64::try_from(missing.len()).unwrap_or(u64::MAX),
+        removed: u64::try_from(removed).unwrap_or(u64::MAX),
+    })
 }
 
 pub(crate) fn validate_database(
@@ -1140,13 +1546,27 @@ pub(crate) fn validate_database(
             actual_count.max(0)
         );
     }
-    let (vector_digest, actual_anchors) =
-        validate_and_digest_vectors(&connection, contract.embedding_dim, expected_anchors)
-            .with_context(|| format!("validate embedded vector rows {}", path.display()))?;
+    let (vector_digest, actual_anchors, database_sha256, component_sha256) =
+        if metadata.component_schema_version == VECTOR_COMPONENT_SCHEMA_VERSION {
+            let (digest, count) =
+                validate_and_digest_vector_component(&connection, expected_anchors).with_context(
+                    || format!("validate embedded vector component {}", path.display()),
+                )?;
+            if digest != metadata.component_sha256 {
+                bail!("embedded vector physical component digest does not match metadata");
+            }
+            (digest.clone(), count, digest.clone(), digest)
+        } else if metadata.component_schema_version == 1 {
+            let (digest, count) =
+                validate_and_digest_vectors(&connection, contract.embedding_dim, expected_anchors)
+                    .with_context(|| format!("validate embedded vector rows {}", path.display()))?;
+            (digest, count, sha256_file(path)?, String::new())
+        } else {
+            bail!("unsupported embedded vector component schema");
+        };
     if actual_anchors != expected_anchors.len() || vector_digest != metadata.vector_digest {
         bail!("embedded vector canonical digest does not match metadata");
     }
-    let database_sha256 = sha256_file(path)?;
     let attestation = VectorDatabaseAttestation {
         schema_version: metadata.schema_version,
         generation: metadata.generation,
@@ -1158,6 +1578,15 @@ pub(crate) fn validate_database(
         evidence_contract_identity: metadata.evidence_contract_identity,
         vector_digest,
         database_sha256,
+        component_schema_version: metadata.component_schema_version,
+        component_sha256,
+        database_size_bytes: if metadata.component_schema_version == 1 {
+            0
+        } else {
+            std::fs::metadata(path)
+                .with_context(|| format!("inspect embedded vector database {}", path.display()))?
+                .len()
+        },
     };
     if let Some(expected) = expected_attestation
         && expected != &attestation
@@ -1193,6 +1622,11 @@ fn validate_health_database(
             "embedded vector count mismatch: expected {expected_points}, found {}",
             actual.max(0)
         );
+    }
+    if metadata.component_schema_version == VECTOR_COMPONENT_SCHEMA_VERSION
+        && canonical_vector_component_digest(&connection)? != metadata.component_sha256
+    {
+        bail!("embedded vector physical component digest mismatch");
     }
     Ok(actual as u64)
 }
@@ -1233,32 +1667,136 @@ fn read_metadata(connection: &Connection) -> Result<DatabaseMetadata> {
     if metadata_rows != 1 {
         bail!("embedded vector metadata must contain exactly one row");
     }
+    let has_component_metadata =
+        table_has_column(connection, "metadata", "component_schema_version")?
+            && table_has_column(connection, "metadata", "component_sha256")?;
+    let query = if has_component_metadata {
+        "SELECT schema_version, generation, input_hash, embedding_backend,
+                embedding_dim, point_count, producer_identity,
+                evidence_contract_identity, vector_digest,
+                component_schema_version, component_sha256
+         FROM metadata WHERE singleton = 1"
+    } else {
+        "SELECT schema_version, generation, input_hash, embedding_backend,
+                embedding_dim, point_count, producer_identity,
+                evidence_contract_identity, vector_digest, 1, ''
+         FROM metadata WHERE singleton = 1"
+    };
     connection
-        .query_row(
-            "SELECT schema_version, generation, input_hash, embedding_backend,
-                    embedding_dim, point_count, producer_identity,
-                    evidence_contract_identity, vector_digest
-             FROM metadata WHERE singleton = 1",
-            [],
-            |row| {
-                Ok(DatabaseMetadata {
-                    schema_version: row.get(0)?,
-                    generation: row.get(1)?,
-                    input_hash: row.get(2)?,
-                    embedding_backend: row.get(3)?,
-                    embedding_dim: row.get(4)?,
-                    point_count: row.get(5)?,
-                    producer_identity: row.get(6)?,
-                    evidence_contract_identity: row.get(7)?,
-                    vector_digest: row.get(8)?,
-                })
-            },
-        )
+        .query_row(query, [], |row| {
+            Ok(DatabaseMetadata {
+                schema_version: row.get(0)?,
+                generation: row.get(1)?,
+                input_hash: row.get(2)?,
+                embedding_backend: row.get(3)?,
+                embedding_dim: row.get(4)?,
+                point_count: row.get(5)?,
+                producer_identity: row.get(6)?,
+                evidence_contract_identity: row.get(7)?,
+                vector_digest: row.get(8)?,
+                component_schema_version: row.get(9)?,
+                component_sha256: row.get(10)?,
+            })
+        })
         .context("read the single embedded vector metadata row")
 }
 
-fn canonical_vector_digest(connection: &Connection, embedding_dim: usize) -> Result<String> {
-    digest_vector_rows(connection, embedding_dim, None).map(|(digest, _)| digest)
+fn table_has_column(connection: &Connection, table: &str, column: &str) -> Result<bool> {
+    let mut statement = connection.prepare(&format!("PRAGMA table_info({table})"))?;
+    let columns = statement.query_map([], |row| row.get::<_, String>(1))?;
+    for observed in columns {
+        if observed? == column {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn canonical_vector_component_digest(connection: &Connection) -> Result<String> {
+    digest_vector_component_rows(connection, None).map(|(digest, _)| digest)
+}
+
+fn validate_and_digest_vector_component(
+    connection: &Connection,
+    expected_anchors: &BTreeMap<String, String>,
+) -> Result<(String, usize)> {
+    digest_vector_component_rows(connection, Some(expected_anchors))
+}
+
+fn digest_vector_component_rows(
+    connection: &Connection,
+    expected_anchors: Option<&BTreeMap<String, String>>,
+) -> Result<(String, usize)> {
+    if !table_has_column(connection, "vectors", "vector_sha256")? {
+        bail!("embedded vector component is missing row digests");
+    }
+    let mut statement = connection.prepare(
+        "SELECT node_id, document_hash, display_name, file_path, file_role, dense_reason,
+                vector, vector_sha256
+         FROM vectors ORDER BY node_id ASC",
+    )?;
+    let mut rows = statement.query([])?;
+    let mut digest = Sha256::new();
+    digest.update(VECTOR_COMPONENT_DIGEST_DOMAIN);
+    let mut seen = BTreeSet::new();
+    while let Some(row) = rows.next()? {
+        let node_id = row.get::<_, String>(0)?;
+        let document_hash = row.get::<_, String>(1)?;
+        let display_name = row.get::<_, String>(2)?;
+        let file_path = row.get::<_, Option<String>>(3)?;
+        let file_role = row.get::<_, Option<String>>(4)?;
+        let dense_reason = row.get::<_, Option<String>>(5)?;
+        let vector = row.get::<_, Vec<u8>>(6)?;
+        let vector_sha256 = row.get::<_, String>(7)?;
+        if !seen.insert(node_id.clone()) {
+            bail!("duplicate embedded vector row {node_id}");
+        }
+        if node_id.trim().is_empty()
+            || document_hash.trim().is_empty()
+            || !is_sha256_hex(&vector_sha256)
+        {
+            bail!("embedded vector canonical digest row identities are invalid");
+        }
+        let observed_vector_sha256 = hex_digest(Sha256::digest(&vector));
+        if observed_vector_sha256 != vector_sha256 {
+            bail!("embedded vector blob digest mismatch for node {node_id}");
+        }
+        if let Some(expected_anchors) = expected_anchors
+            && expected_anchors.get(&node_id) != Some(&document_hash)
+        {
+            bail!("embedded vector document hash mismatch for node {node_id}");
+        }
+        hash_len_prefixed(&mut digest, node_id.as_bytes());
+        hash_len_prefixed(&mut digest, document_hash.as_bytes());
+        hash_len_prefixed(&mut digest, display_name.as_bytes());
+        hash_len_prefixed(
+            &mut digest,
+            file_path.as_deref().unwrap_or_default().as_bytes(),
+        );
+        hash_len_prefixed(
+            &mut digest,
+            file_role.as_deref().unwrap_or_default().as_bytes(),
+        );
+        hash_len_prefixed(
+            &mut digest,
+            dense_reason.as_deref().unwrap_or_default().as_bytes(),
+        );
+        hash_len_prefixed(&mut digest, vector_sha256.as_bytes());
+    }
+    if let Some(expected_anchors) = expected_anchors
+        && seen.len() != expected_anchors.len()
+    {
+        bail!(
+            "embedded vector component coverage mismatch: expected {}, found {}",
+            expected_anchors.len(),
+            seen.len()
+        );
+    }
+    Ok((hex_digest(digest.finalize()), seen.len()))
+}
+
+fn is_sha256_hex(value: &str) -> bool {
+    value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
 fn validate_and_digest_vectors(
@@ -1557,9 +2095,15 @@ fn search_database_batch_with_abstention(
             Ok(query_norm)
         })
         .collect::<Result<Vec<_>>>()?;
-    let mut statement = connection.prepare(
-        "SELECT node_id, display_name, file_path, file_role, dense_reason, vector FROM vectors",
-    )?;
+    let has_vector_hash = table_has_column(&connection, "vectors", "vector_sha256")?;
+    let query = if has_vector_hash {
+        "SELECT node_id, display_name, file_path, file_role, dense_reason, vector,
+                vector_sha256 FROM vectors"
+    } else {
+        "SELECT node_id, display_name, file_path, file_role, dense_reason, vector,
+                '' FROM vectors"
+    };
+    let mut statement = connection.prepare(query)?;
     let mut rows = statement.query([])?;
     let mut scored = queries
         .iter()
@@ -1570,6 +2114,12 @@ fn search_database_batch_with_abstention(
             bail!("embedded vector search cancelled");
         }
         let bytes: Vec<u8> = row.get(5)?;
+        let expected_vector_sha256 = row.get::<_, String>(6)?;
+        if !expected_vector_sha256.is_empty()
+            && hex_digest(Sha256::digest(&bytes)) != expected_vector_sha256
+        {
+            bail!("embedded vector row digest mismatch");
+        }
         let node_id = row.get::<_, String>(0)?;
         let display_name = row.get::<_, String>(1)?;
         let file_path = row.get::<_, Option<String>>(2)?;
@@ -1780,6 +2330,21 @@ mod tests {
                 document_hash: "document-2".into(),
             },
         ]
+    }
+
+    fn current_anchor(
+        node_id: &str,
+        document_hash: &str,
+        display_name: &str,
+    ) -> CurrentVectorAnchor {
+        CurrentVectorAnchor {
+            node_id: node_id.into(),
+            document_hash: document_hash.into(),
+            display_name: display_name.into(),
+            file_path: Some(format!("src/{node_id}.rs")),
+            file_role: Some(FileRole::Source),
+            dense_reason: Some("public_api".into()),
+        }
     }
 
     fn accelerated_device() -> EmbeddingDeviceReadiness {
@@ -2302,6 +2867,25 @@ mod tests {
         assert_eq!(attestation.vector_digest.len(), 64);
         assert_eq!(attestation.database_sha256.len(), 64);
         assert_eq!(attestation.producer_identity, "producer-v1");
+        let second_envelope = EmbeddedVectorIndex::build_attested_with_points(
+            &layout,
+            "codestory_attested_second_envelope",
+            "generation-v2",
+            "input-v2",
+            &contract,
+            &expected,
+            |visit| {
+                visit(attested_point("1", "document-1", vec![1.0, 0.0]))?;
+                visit(attested_point("2", "document-2", vec![0.0, 1.0]))
+            },
+        )
+        .expect("build same component under a second envelope");
+        assert_eq!(
+            attestation.component_sha256, second_envelope.component_sha256,
+            "physical component identity must not include the core-bound publication envelope"
+        );
+        assert_ne!(attestation.generation, second_envelope.generation);
+        assert_ne!(attestation.input_hash, second_envelope.input_hash);
         assert_eq!(
             EmbeddedVectorIndex::validate_published_attestation(
                 &layout,
@@ -2486,6 +3070,357 @@ mod tests {
             .expect_err("invalid vector must fail");
             assert!(format!("{error:#}").contains(expected_message));
         }
+    }
+
+    #[test]
+    fn incremental_generation_reconciles_same_count_changes_without_rewriting_predecessor() {
+        let root = tempdir().expect("tempdir");
+        let layout = layout(root.path());
+        let device = accelerated_device();
+        let identity = accelerated_identity();
+        let evidence = build_vector_producer_evidence(
+            &device,
+            Some(&identity),
+            crate::embeddings::RETRIEVAL_EMBEDDING_DIM as u32,
+            EmbeddingVectorPublicationIdentityDto {
+                core_generation_id: "core-v2".into(),
+                core_run_id: "run-v2".into(),
+                retrieval_generation: "generation-v2".into(),
+                retrieval_input_hash: "input-v2".into(),
+                semantic_generation: "current".into(),
+            },
+        );
+        let contract = VectorEvidenceContract::new(
+            "backend",
+            2,
+            "producer-v1",
+            vector_compatibility_identity(&evidence).expect("compatibility"),
+        );
+        let previous_expected = vec![
+            ExpectedVectorAnchor {
+                node_id: "1".into(),
+                document_hash: "document-1".into(),
+            },
+            ExpectedVectorAnchor {
+                node_id: "2".into(),
+                document_hash: "document-2".into(),
+            },
+        ];
+        let previous_attestation = EmbeddedVectorIndex::build_attested_with_points(
+            &layout,
+            "previous",
+            "generation-v1",
+            "input-v1",
+            &contract,
+            &previous_expected,
+            |visit| {
+                visit(attested_point("1", "document-1", vec![1.0, 0.0]))?;
+                visit(attested_point("2", "document-2", vec![0.0, 1.0]))
+            },
+        )
+        .expect("build predecessor");
+        let mut previous_evidence = evidence.clone();
+        previous_evidence.publication = EmbeddingVectorPublicationIdentityDto {
+            core_generation_id: "core-v1".into(),
+            core_run_id: "run-v1".into(),
+            retrieval_generation: "generation-v1".into(),
+            retrieval_input_hash: "input-v1".into(),
+            semantic_generation: "previous".into(),
+        };
+        let previous_manifest =
+            VectorGenerationManifest::new(previous_evidence, previous_attestation)
+                .expect("predecessor manifest");
+        EmbeddedVectorIndex::publish_generation_manifest(&layout, "previous", &previous_manifest)
+            .expect("publish predecessor manifest");
+        let previous_bytes = std::fs::read(index_path(&layout, "previous")).expect("predecessor");
+
+        let current_expected = vec![
+            ExpectedVectorAnchor {
+                node_id: "1".into(),
+                document_hash: "document-1".into(),
+            },
+            ExpectedVectorAnchor {
+                node_id: "3".into(),
+                document_hash: "document-3".into(),
+            },
+        ];
+        let outcome = EmbeddedVectorIndex::try_build_incremental_with_cancel(
+            AttestedVectorPublication {
+                layout: &layout,
+                collection: "current",
+                generation: "generation-v2",
+                input_hash: "input-v2",
+                contract: &contract,
+                expected_anchors: &current_expected,
+            },
+            "previous",
+            &evidence,
+            &[
+                current_anchor("1", "document-1", "renamed display metadata"),
+                current_anchor("3", "document-3", "symbol_3"),
+            ],
+            || Ok(()),
+            |missing, visit| {
+                assert_eq!(missing.len(), 1);
+                assert_eq!(missing[0].node_id, "3");
+                visit(attested_point("3", "document-3", vec![0.0, 1.0]))
+            },
+        )
+        .expect("incremental build");
+        let Some((attestation, work)) = outcome else {
+            return;
+        };
+
+        assert_eq!(work.retained, 1);
+        assert_eq!(work.inserted, 1);
+        assert_eq!(work.removed, 1);
+        assert_eq!(attestation.point_count, 2);
+        assert_eq!(
+            std::fs::read(index_path(&layout, "previous")).expect("predecessor after build"),
+            previous_bytes
+        );
+        let connection = open_read_only(&index_path(&layout, "current")).expect("current db");
+        let retained_metadata: String = connection
+            .query_row(
+                "SELECT display_name FROM vectors WHERE node_id = '1'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("retained metadata");
+        assert_eq!(retained_metadata, "renamed display metadata");
+        let removed_count: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM vectors WHERE node_id = '2'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("removed row");
+        assert_eq!(removed_count, 0);
+    }
+
+    #[test]
+    fn incremental_vector_cancellation_leaves_no_candidate_publication() {
+        let root = tempdir().expect("tempdir");
+        let layout = layout(root.path());
+        let evidence = build_vector_producer_evidence(
+            &accelerated_device(),
+            Some(&accelerated_identity()),
+            crate::embeddings::RETRIEVAL_EMBEDDING_DIM as u32,
+            EmbeddingVectorPublicationIdentityDto {
+                core_generation_id: "core-v1".into(),
+                core_run_id: "run-v1".into(),
+                retrieval_generation: "generation-v1".into(),
+                retrieval_input_hash: "input-v1".into(),
+                semantic_generation: "previous".into(),
+            },
+        );
+        let contract = VectorEvidenceContract::new(
+            "backend",
+            2,
+            "producer-v1",
+            vector_compatibility_identity(&evidence).expect("compatibility"),
+        );
+        let expected = expected_anchors();
+        let previous_attestation = EmbeddedVectorIndex::build_attested_with_points(
+            &layout,
+            "previous",
+            "generation-v1",
+            "input-v1",
+            &contract,
+            &expected,
+            |visit| {
+                visit(attested_point("1", "document-1", vec![1.0, 0.0]))?;
+                visit(attested_point("2", "document-2", vec![0.0, 1.0]))
+            },
+        )
+        .expect("build predecessor");
+        let manifest = VectorGenerationManifest::new(evidence.clone(), previous_attestation)
+            .expect("manifest");
+        EmbeddedVectorIndex::publish_generation_manifest(&layout, "previous", &manifest)
+            .expect("publish predecessor manifest");
+
+        let result = EmbeddedVectorIndex::try_build_incremental_with_cancel(
+            AttestedVectorPublication {
+                layout: &layout,
+                collection: "cancelled",
+                generation: "generation-v2",
+                input_hash: "input-v2",
+                contract: &contract,
+                expected_anchors: &expected,
+            },
+            "previous",
+            &evidence,
+            &[
+                current_anchor("1", "document-1", "symbol_1"),
+                current_anchor("2", "document-2", "symbol_2"),
+            ],
+            || bail!("simulated incremental cancellation"),
+            |missing, _| {
+                assert!(missing.is_empty());
+                Ok(())
+            },
+        );
+        match result {
+            Ok(None) => {}
+            Err(error) => {
+                assert!(format!("{error:#}").contains("simulated incremental cancellation"))
+            }
+            Ok(Some(_)) => panic!("cancelled vector candidate was published"),
+        }
+        assert!(!index_path(&layout, "cancelled").exists());
+    }
+
+    #[test]
+    fn corrupt_vector_predecessor_requests_complete_fallback_without_a_candidate() {
+        let root = tempdir().expect("tempdir");
+        let layout = layout(root.path());
+        let evidence = build_vector_producer_evidence(
+            &accelerated_device(),
+            Some(&accelerated_identity()),
+            crate::embeddings::RETRIEVAL_EMBEDDING_DIM as u32,
+            EmbeddingVectorPublicationIdentityDto {
+                core_generation_id: "core-v1".into(),
+                core_run_id: "run-v1".into(),
+                retrieval_generation: "generation-v1".into(),
+                retrieval_input_hash: "input-v1".into(),
+                semantic_generation: "previous".into(),
+            },
+        );
+        let contract = VectorEvidenceContract::new(
+            "backend",
+            2,
+            "producer-v1",
+            vector_compatibility_identity(&evidence).expect("compatibility"),
+        );
+        let expected = expected_anchors();
+        let attestation = EmbeddedVectorIndex::build_attested_with_points(
+            &layout,
+            "previous",
+            "generation-v1",
+            "input-v1",
+            &contract,
+            &expected,
+            |visit| {
+                visit(attested_point("1", "document-1", vec![1.0, 0.0]))?;
+                visit(attested_point("2", "document-2", vec![0.0, 1.0]))
+            },
+        )
+        .expect("build predecessor");
+        let manifest =
+            VectorGenerationManifest::new(evidence.clone(), attestation).expect("manifest");
+        EmbeddedVectorIndex::publish_generation_manifest(&layout, "previous", &manifest)
+            .expect("publish manifest");
+        let connection = Connection::open(index_path(&layout, "previous")).expect("open vector db");
+        connection
+            .execute("DROP TRIGGER vectors_vector_update_guard", [])
+            .expect("remove mutation guard");
+        connection
+            .execute(
+                "UPDATE vectors SET vector = X'0000000000000000' WHERE node_id = '1'",
+                [],
+            )
+            .expect("corrupt vector row");
+        drop(connection);
+
+        let outcome = EmbeddedVectorIndex::try_build_incremental_with_cancel(
+            AttestedVectorPublication {
+                layout: &layout,
+                collection: "current",
+                generation: "generation-v2",
+                input_hash: "input-v2",
+                contract: &contract,
+                expected_anchors: &expected,
+            },
+            "previous",
+            &evidence,
+            &[
+                current_anchor("1", "document-1", "symbol_1"),
+                current_anchor("2", "document-2", "symbol_2"),
+            ],
+            || Ok(()),
+            |_, _| panic!("corrupt predecessor must not enter differential production"),
+        )
+        .expect("fallback decision");
+
+        assert!(outcome.is_none());
+        assert!(!index_path(&layout, "current").exists());
+    }
+
+    #[test]
+    fn legacy_vector_manifest_requests_complete_fallback_before_clone() {
+        let root = tempdir().expect("tempdir");
+        let layout = layout(root.path());
+        let evidence = build_vector_producer_evidence(
+            &accelerated_device(),
+            Some(&accelerated_identity()),
+            crate::embeddings::RETRIEVAL_EMBEDDING_DIM as u32,
+            EmbeddingVectorPublicationIdentityDto {
+                core_generation_id: "core-v1".into(),
+                core_run_id: "run-v1".into(),
+                retrieval_generation: "generation-v1".into(),
+                retrieval_input_hash: "input-v1".into(),
+                semantic_generation: "previous".into(),
+            },
+        );
+        let contract = VectorEvidenceContract::new(
+            "backend",
+            2,
+            "producer-v1",
+            vector_compatibility_identity(&evidence).expect("compatibility"),
+        );
+        let expected = expected_anchors();
+        let attestation = EmbeddedVectorIndex::build_attested_with_points(
+            &layout,
+            "previous",
+            "generation-v1",
+            "input-v1",
+            &contract,
+            &expected,
+            |visit| {
+                visit(attested_point("1", "document-1", vec![1.0, 0.0]))?;
+                visit(attested_point("2", "document-2", vec![0.0, 1.0]))
+            },
+        )
+        .expect("build predecessor");
+        let mut manifest =
+            VectorGenerationManifest::new(evidence.clone(), attestation).expect("manifest");
+        manifest.schema_version = 1;
+        manifest.vectors.component_schema_version = 1;
+        manifest.vectors.component_sha256.clear();
+        std::fs::create_dir_all(
+            generation_manifest_path(&layout, "previous")
+                .parent()
+                .expect("manifest parent"),
+        )
+        .expect("manifest parent");
+        std::fs::write(
+            generation_manifest_path(&layout, "previous"),
+            serde_json::to_vec(&manifest).expect("legacy manifest JSON"),
+        )
+        .expect("legacy manifest");
+
+        let outcome = EmbeddedVectorIndex::try_build_incremental_with_cancel(
+            AttestedVectorPublication {
+                layout: &layout,
+                collection: "current",
+                generation: "generation-v2",
+                input_hash: "input-v2",
+                contract: &contract,
+                expected_anchors: &expected,
+            },
+            "previous",
+            &evidence,
+            &[
+                current_anchor("1", "document-1", "symbol_1"),
+                current_anchor("2", "document-2", "symbol_2"),
+            ],
+            || Ok(()),
+            |_, _| panic!("legacy predecessor must not enter differential production"),
+        )
+        .expect("fallback decision");
+
+        assert!(outcome.is_none());
+        assert!(!index_path(&layout, "current").exists());
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/health.rs
+++ b/crates/codestory-retrieval/src/health.rs
@@ -513,9 +513,7 @@ fn has_real_scip_artifact(project_dir: &Path, generation: &str) -> bool {
     else {
         return false;
     };
-    project_dir
-        .join(crate::scip_index::SCIP_SYMBOLS_FILE)
-        .is_file()
+    crate::scip_index::scip_symbols_component_path(project_dir).is_file()
         // `index.scip` is parsed and bound to this generation's revision.
         // Existence alone let a corrupt-but-present marker publish clean.
         && crate::scip_index::parse_scip_index_marker(project_dir, &revision).is_ok()

--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -1,8 +1,8 @@
 use crate::config::{SidecarLayout, SidecarRuntimeConfig, dir_size_bytes};
 use crate::embedded_vector::{
-    AttestedSemanticPoint, EmbeddedVectorIndex, ExpectedVectorAnchor, SemanticPoint,
-    VectorEvidenceContract, VectorGenerationManifest, build_vector_producer_evidence,
-    producer_evidence_mismatches, vector_compatibility_identity,
+    AttestedSemanticPoint, CurrentVectorAnchor, EmbeddedVectorIndex, ExpectedVectorAnchor,
+    SemanticPoint, VectorEvidenceContract, VectorGenerationManifest,
+    build_vector_producer_evidence, producer_evidence_mismatches, vector_compatibility_identity,
     vector_producer_compatibility_identity,
 };
 use crate::generation::{
@@ -11,8 +11,9 @@ use crate::generation::{
 };
 use crate::health::probe_sidecar_health_for_runtime;
 use crate::lexical_index::{
-    LEXICAL_INDEX_VERSION, LexicalInputFingerprint, build_lexical_shard,
-    finish_lexical_input_for_store, lexical_source_input,
+    LEXICAL_INDEX_VERSION, LexicalInputFingerprint, PreparedLexicalInput,
+    build_prepared_lexical_shard, finish_lexical_input_for_store, lexical_source_input,
+    prepare_lexical_input_for_store,
 };
 use crate::retention::{
     FsGenerationRemover, GLOBAL_GENERATION_GC_LOCK_SCOPE, GenerationRetentionApplyReport,
@@ -21,7 +22,7 @@ use crate::retention::{
     scan_retention_protection, write_retention_marker,
 };
 use crate::scip_index::{
-    SCIP_PRECISE_SEMANTIC_IMPORT_DIR, emit_scip_artifacts_from_store,
+    SCIP_PRECISE_SEMANTIC_IMPORT_DIR, emit_scip_artifacts_from_store_incremental,
     import_precise_semantic_scip_artifact,
 };
 use anyhow::{Context, Result, bail};
@@ -41,9 +42,34 @@ use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
-#[cfg(any(not(feature = "test-support"), test))]
 use std::time::{Duration, Instant};
 use tracing::{info, warn};
+
+thread_local! {
+    static FINALIZE_PHASE_TIMINGS: std::cell::RefCell<Option<(Instant, Vec<FinalizePhaseTiming>)>> =
+        const { std::cell::RefCell::new(None) };
+    static FINALIZE_COMPONENT_WORK: std::cell::RefCell<Vec<FinalizeComponentWork>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FinalizePhaseTiming {
+    pub phase: String,
+    pub elapsed_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FinalizeComponentWork {
+    pub component: String,
+    pub mode: String,
+    pub retained: Option<u64>,
+    pub inserted: Option<u64>,
+    pub removed: Option<u64>,
+    pub reordered: Option<u64>,
+    pub predecessor_bytes: Option<u64>,
+    pub output_bytes: Option<u64>,
+    pub attested_bytes: Option<u64>,
+}
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct FinalizeIndexOutcome {
@@ -53,6 +79,100 @@ pub struct FinalizeIndexOutcome {
     pub scip_stubbed: bool,
     pub generation_retention_plan: GenerationRetentionPlan,
     pub generation_retention: GenerationRetentionApplyReport,
+    #[serde(skip)]
+    pub phase_timings: Vec<FinalizePhaseTiming>,
+    #[serde(skip)]
+    pub component_work: Vec<FinalizeComponentWork>,
+}
+
+fn begin_finalize_phase_timings() {
+    FINALIZE_PHASE_TIMINGS.with(|state| {
+        *state.borrow_mut() = Some((Instant::now(), Vec::new()));
+    });
+    FINALIZE_COMPONENT_WORK.with(|state| state.borrow_mut().clear());
+}
+
+fn record_finalize_component_work(
+    component: &'static str,
+    mode: &'static str,
+    retained: Option<u64>,
+    inserted: Option<u64>,
+    removed: Option<u64>,
+) {
+    FINALIZE_COMPONENT_WORK.with(|state| {
+        state.borrow_mut().push(FinalizeComponentWork {
+            component: component.to_string(),
+            mode: mode.to_string(),
+            retained,
+            inserted,
+            removed,
+            reordered: None,
+            predecessor_bytes: None,
+            output_bytes: None,
+            attested_bytes: None,
+        });
+    });
+}
+
+fn record_finalize_component_details(
+    component: &'static str,
+    reordered: Option<u64>,
+    predecessor_bytes: Option<u64>,
+    output_bytes: Option<u64>,
+    attested_bytes: Option<u64>,
+) {
+    FINALIZE_COMPONENT_WORK.with(|state| {
+        if let Some(work) = state
+            .borrow_mut()
+            .iter_mut()
+            .rev()
+            .find(|work| work.component == component)
+        {
+            work.reordered = reordered;
+            work.predecessor_bytes = predecessor_bytes;
+            work.output_bytes = output_bytes;
+            work.attested_bytes = attested_bytes;
+        }
+    });
+}
+
+fn component_size(path: &Path) -> Option<u64> {
+    std::fs::metadata(path).ok().map(|metadata| metadata.len())
+}
+
+fn finish_finalize_component_work() -> Vec<FinalizeComponentWork> {
+    FINALIZE_COMPONENT_WORK.with(|state| std::mem::take(&mut *state.borrow_mut()))
+}
+
+fn record_finalize_phase_timing(phase: &'static str, elapsed: Duration) {
+    let elapsed_ms = u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX);
+    FINALIZE_PHASE_TIMINGS.with(|state| {
+        if let Some((_, timings)) = state.borrow_mut().as_mut() {
+            timings.push(FinalizePhaseTiming {
+                phase: phase.to_string(),
+                elapsed_ms,
+            });
+        }
+    });
+    info!(phase, elapsed_ms, "retrieval finalization phase completed");
+}
+
+fn finish_finalize_phase_timings() -> Vec<FinalizePhaseTiming> {
+    FINALIZE_PHASE_TIMINGS.with(|state| {
+        let Some((started, mut timings)) = state.borrow_mut().take() else {
+            return Vec::new();
+        };
+        let total_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+        let attributed = timings
+            .iter()
+            .map(|timing| timing.elapsed_ms)
+            .fold(0_u64, u64::saturating_add);
+        timings.push(FinalizePhaseTiming {
+            phase: "unattributed".to_string(),
+            elapsed_ms: total_ms.saturating_sub(attributed),
+        });
+        timings
+    })
 }
 
 /// Typed signal that source-derived retrieval input drifted during preparation.
@@ -542,6 +662,7 @@ pub fn finalize_index_for_runtime_with_progress_and_cancel(
     cancelled: &AtomicBool,
     mut progress: impl FnMut(&'static str),
 ) -> Result<FinalizeIndexOutcome> {
+    begin_finalize_phase_timings();
     ensure_retrieval_index_not_cancelled(cancelled, "preflight")?;
     let layout = runtime.layout.clone();
     let project_identity = runtime.validated_project_identity(project_root)?;
@@ -582,6 +703,7 @@ pub fn finalize_index_for_runtime_with_progress_and_cancel(
         u32::try_from(embedding_dim).context("negative embedding dimension")?,
     )?;
 
+    let fingerprint_started = Instant::now();
     let storage = Store::open(storage_path).context("open storage for retrieval sidecar input")?;
     let lexical_source =
         lexical_source_input(project_root, storage_path).context("hash lexical source input")?;
@@ -593,16 +715,20 @@ pub fn finalize_index_for_runtime_with_progress_and_cancel(
         dimension: embedding_dim,
         producer_compatibility_identity: &producer_compatibility_identity,
     };
-    let sidecar_input = compute_sidecar_input_fingerprint_with_lexical_source(
+    let prepared_lexical =
+        prepare_lexical_input_for_store(lexical_source, project_root, input_snapshot.storage())
+            .context("prepare pinned lexical input")?;
+    let sidecar_input = compute_sidecar_input_fingerprint_with_lexical_fingerprint(
         input_snapshot.storage(),
         project_root,
         &project_id,
         &embedding_contract,
-        lexical_source,
+        prepared_lexical.fingerprint.clone(),
     )?;
     input_snapshot
         .finish()
         .context("finish coherent sidecar input snapshot")?;
+    record_finalize_phase_timing("input fingerprint", fingerprint_started.elapsed());
     let previous_manifest = storage
         .get_retrieval_index_manifest(&project_id)
         .context("load previous retrieval_index_manifest")?;
@@ -682,14 +808,61 @@ pub fn finalize_index_for_runtime_with_progress_and_cancel(
             };
             let semantic_point_count = semantic_ready_point_count(&previous_semantic);
             if unchanged_generation_is_reusable(&status, semantic_point_count) {
+                record_finalize_component_work(
+                    "lexical",
+                    "reused",
+                    Some(prepared_lexical.document_count()),
+                    Some(0),
+                    Some(0),
+                );
+                record_finalize_component_work(
+                    "vectors",
+                    "reused",
+                    semantic_point_count,
+                    Some(0),
+                    Some(0),
+                );
+                let vector_bytes = component_size(&crate::embedded_vector::index_path(
+                    &layout,
+                    &previous.semantic_generation,
+                ));
+                record_finalize_component_details(
+                    "vectors",
+                    None,
+                    None,
+                    vector_bytes,
+                    vector_bytes,
+                );
+                record_finalize_component_work("graph", "reused", None, Some(0), Some(0));
                 let mut manifest = previous.clone();
                 if let Some(generation) = manifest.sidecar_generation.clone() {
                     let scip_dir = layout.scip_project_dir(&generation);
+                    let lexical_bytes = component_size(
+                        &crate::lexical_index::shard_dir_for(&layout.lexical_data_dir, &generation)
+                            .join(crate::lexical_index::LEXICAL_INDEX_FILE),
+                    );
+                    record_finalize_component_details(
+                        "lexical",
+                        None,
+                        None,
+                        lexical_bytes,
+                        lexical_bytes,
+                    );
+                    let graph_bytes =
+                        component_size(&crate::scip_index::scip_symbols_component_path(&scip_dir));
+                    record_finalize_component_details(
+                        "graph",
+                        Some(0),
+                        None,
+                        graph_bytes,
+                        graph_bytes,
+                    );
                     if update_precise_semantic_import_status(&scip_dir, &generation, &mut manifest)?
                     {
                         return persist_finalized_manifest(
                             project_root,
                             storage_path,
+                            &prepared_lexical,
                             &retention_context,
                             cancelled,
                             &sidecar_input,
@@ -711,6 +884,7 @@ pub fn finalize_index_for_runtime_with_progress_and_cancel(
                 return persist_finalized_manifest(
                     project_root,
                     storage_path,
+                    &prepared_lexical,
                     &retention_context,
                     cancelled,
                     &sidecar_input,
@@ -776,16 +950,14 @@ pub fn finalize_index_for_runtime_with_progress_and_cancel(
 
     let lexical_outcome = with_finalize_progress(&mut progress, "lexical sidecar", || {
         ensure_lexical_generation(
-            project_root,
-            storage_path,
             &layout,
             &generation,
-            &LexicalInputFingerprint {
-                file_count: sidecar_input.lexical_file_count,
-                hash: sidecar_input.lexical_hash.clone(),
-                coverage: sidecar_input.lexical_coverage.clone(),
-            },
+            &prepared_lexical,
             &sidecar_input.hash,
+            previous_manifest
+                .as_ref()
+                .and_then(|manifest| manifest.sidecar_generation.as_deref()),
+            cancelled,
             lexical_ready,
         )
     })?;
@@ -806,6 +978,11 @@ pub fn finalize_index_for_runtime_with_progress_and_cancel(
             &scip_dir,
             &project_id,
             &generation,
+            previous_manifest
+                .as_ref()
+                .and_then(|manifest| manifest.sidecar_generation.as_deref())
+                .map(|previous| layout.scip_project_dir(previous)),
+            cancelled,
             scip_ready,
             &mut manifest,
         )
@@ -816,19 +993,19 @@ pub fn finalize_index_for_runtime_with_progress_and_cancel(
     manifest.scip_revision = read_scip_revision(&scip_dir).or(manifest.scip_revision);
     manifest.disk_bytes = sidecar_disk_bytes(&layout, &generation, &collection, &scip_dir);
 
-    with_finalize_progress(&mut progress, "manifest write", || {
-        persist_finalized_manifest(
-            project_root,
-            storage_path,
-            &retention_context,
-            cancelled,
-            &sidecar_input,
-            project_id,
-            manifest,
-            degraded_modes,
-            SidecarStubFlags { scip_stubbed },
-        )
-    })
+    progress("manifest write");
+    persist_finalized_manifest(
+        project_root,
+        storage_path,
+        &prepared_lexical,
+        &retention_context,
+        cancelled,
+        &sidecar_input,
+        project_id,
+        manifest,
+        degraded_modes,
+        SidecarStubFlags { scip_stubbed },
+    )
 }
 
 fn with_finalize_progress<T>(
@@ -837,32 +1014,103 @@ fn with_finalize_progress<T>(
     action: impl FnOnce() -> Result<T>,
 ) -> Result<T> {
     progress(phase);
-    action()
+    let started = Instant::now();
+    let result = action();
+    record_finalize_phase_timing(phase, started.elapsed());
+    result
 }
 
 fn ensure_lexical_generation(
-    project_root: &Path,
-    storage_path: &Path,
     layout: &SidecarLayout,
     generation: &str,
-    expected: &LexicalInputFingerprint,
+    expected: &PreparedLexicalInput,
     sidecar_input_hash: &str,
+    previous_generation: Option<&str>,
+    cancelled: &AtomicBool,
     mut lexical_ready: bool,
 ) -> Result<LexicalGenerationOutcome> {
+    let output_path = crate::lexical_index::shard_dir_for(&layout.lexical_data_dir, generation)
+        .join(crate::lexical_index::LEXICAL_INDEX_FILE);
     if lexical_ready {
         info!(sidecar_generation = %generation, "SQLite lexical shard reused");
+        record_finalize_component_work(
+            "lexical",
+            "reused",
+            Some(expected.document_count()),
+            Some(0),
+            Some(0),
+        );
+        let output_bytes = component_size(&output_path);
+        record_finalize_component_details("lexical", None, None, output_bytes, output_bytes);
     } else {
-        match build_lexical_shard(
-            project_root,
-            Some(storage_path),
+        match build_prepared_lexical_shard(
             &layout.lexical_data_dir,
             generation,
             expected,
             sidecar_input_hash,
+            previous_generation,
+            || ensure_retrieval_index_not_cancelled(cancelled, "lexical shard publication"),
         ) {
-            Ok(_) => {
+            Ok((_, work)) => {
                 lexical_ready = true;
-                info!(sidecar_generation = %generation, "SQLite lexical shard built");
+                if let Some(work) = work {
+                    record_finalize_component_work(
+                        "lexical",
+                        "copy_on_write",
+                        Some(work.retained),
+                        Some(work.inserted),
+                        Some(work.removed),
+                    );
+                    let predecessor_bytes = previous_generation.and_then(|previous| {
+                        component_size(
+                            &crate::lexical_index::shard_dir_for(
+                                &layout.lexical_data_dir,
+                                previous,
+                            )
+                            .join(crate::lexical_index::LEXICAL_INDEX_FILE),
+                        )
+                    });
+                    let output_bytes = component_size(&output_path);
+                    record_finalize_component_details(
+                        "lexical",
+                        None,
+                        predecessor_bytes,
+                        output_bytes,
+                        output_bytes,
+                    );
+                    info!(
+                        sidecar_generation = %generation,
+                        retained_document_count = work.retained,
+                        inserted_document_count = work.inserted,
+                        removed_document_count = work.removed,
+                        "SQLite lexical shard reconciled from immutable predecessor"
+                    );
+                } else {
+                    record_finalize_component_work(
+                        "lexical",
+                        "complete",
+                        Some(0),
+                        Some(expected.document_count()),
+                        Some(0),
+                    );
+                    let output_bytes = component_size(&output_path);
+                    record_finalize_component_details(
+                        "lexical",
+                        None,
+                        previous_generation.and_then(|previous| {
+                            component_size(
+                                &crate::lexical_index::shard_dir_for(
+                                    &layout.lexical_data_dir,
+                                    previous,
+                                )
+                                .join(crate::lexical_index::LEXICAL_INDEX_FILE),
+                            )
+                        }),
+                        output_bytes,
+                        output_bytes,
+                    );
+                    info!(sidecar_generation = %generation, "SQLite lexical shard built");
+                }
             }
             Err(error) => {
                 bail!("mandatory SQLite lexical shard build failed for {generation}: {error}")
@@ -873,8 +1121,8 @@ fn ensure_lexical_generation(
         || !crate::lexical_index::shard_matches_lexical_input(
             &layout.lexical_data_dir,
             generation,
-            expected.file_count,
-            &expected.hash,
+            expected.fingerprint.file_count,
+            &expected.fingerprint.hash,
             sidecar_input_hash,
         )
     {
@@ -964,6 +1212,20 @@ fn ensure_semantic_index(
             document_hash: anchor.document_hash.clone(),
         })
         .collect::<Vec<_>>();
+    let current_vector_anchors = anchors
+        .iter()
+        .map(|anchor| CurrentVectorAnchor {
+            node_id: anchor.node_id.0.to_string(),
+            document_hash: anchor.document_hash.clone(),
+            display_name: anchor
+                .qualified_name
+                .clone()
+                .unwrap_or_else(|| anchor.display_name.clone()),
+            file_path: anchor.file_path.clone(),
+            file_role: Some(anchor.file_role),
+            dense_reason: Some(anchor.selection_reason.clone()),
+        })
+        .collect::<Vec<_>>();
 
     let reusable_point_count = semantic_ready_points.and_then(|point_count| {
         let validation = (|| {
@@ -1003,12 +1265,112 @@ fn ensure_semantic_index(
     });
 
     let point_count = if let Some(point_count) = reusable_point_count {
+        record_finalize_component_work("vectors", "reused", Some(point_count), Some(0), Some(0));
+        let output_bytes = component_size(&crate::embedded_vector::index_path(
+            semantic.layout,
+            semantic.collection,
+        ));
+        record_finalize_component_details("vectors", None, None, output_bytes, output_bytes);
         info!(
             project_id = %project_id,
             sidecar_generation = %semantic.generation,
             point_count,
             "attested vector generation reused"
         );
+        point_count
+    } else if let Some((attestation, work)) = retention
+        .previous_manifest
+        .filter(|previous| previous.semantic_generation != semantic.collection)
+        .map(|previous| {
+            with_finalize_progress(progress, "incremental embedded vectors", || {
+                EmbeddedVectorIndex::try_build_incremental_with_cancel(
+                    crate::embedded_vector::AttestedVectorPublication {
+                        layout: semantic.layout,
+                        collection: semantic.collection,
+                        generation: semantic.generation,
+                        input_hash: semantic.input_hash,
+                        contract: &contract,
+                        expected_anchors: &expected_anchors,
+                    },
+                    &previous.semantic_generation,
+                    &evidence,
+                    &current_vector_anchors,
+                    || {
+                        ensure_retrieval_index_not_cancelled(
+                            cancelled,
+                            "incremental vector database publication",
+                        )
+                    },
+                    |missing, visit| {
+                        produce_missing_dense_anchors(
+                            &anchors,
+                            missing,
+                            retention.runtime,
+                            cancelled,
+                            visit,
+                        )
+                    },
+                )
+            })
+        })
+        .transpose()?
+        .flatten()
+    {
+        record_finalize_component_work(
+            "vectors",
+            "copy_on_write",
+            Some(work.retained),
+            Some(work.inserted),
+            Some(work.removed),
+        );
+        let predecessor_bytes = retention.previous_manifest.and_then(|previous| {
+            component_size(&crate::embedded_vector::index_path(
+                semantic.layout,
+                &previous.semantic_generation,
+            ))
+        });
+        let output_bytes = component_size(&crate::embedded_vector::index_path(
+            semantic.layout,
+            semantic.collection,
+        ));
+        record_finalize_component_details(
+            "vectors",
+            None,
+            predecessor_bytes,
+            output_bytes,
+            output_bytes,
+        );
+        info!(
+            project_id = %project_id,
+            sidecar_generation = %semantic.generation,
+            retained_point_count = work.retained,
+            embedded_point_count = work.inserted,
+            removed_point_count = work.removed,
+            "vector generation reconciled from immutable predecessor"
+        );
+        let point_count = attestation.point_count;
+        let generation_manifest =
+            VectorGenerationManifest::new(evidence.clone(), attestation.clone())?;
+        EmbeddedVectorIndex::publish_generation_manifest_with_cancel(
+            semantic.layout,
+            semantic.collection,
+            &generation_manifest,
+            || {
+                ensure_retrieval_index_not_cancelled(
+                    cancelled,
+                    "producer-evidence manifest publication",
+                )
+            },
+        )?;
+        EmbeddedVectorIndex::validate_published_attestation(
+            semantic.layout,
+            semantic.collection,
+            semantic.generation,
+            semantic.input_hash,
+            &contract,
+            &expected_anchors,
+            &attestation,
+        )?;
         point_count
     } else {
         let reusable_vectors = retention
@@ -1146,6 +1508,24 @@ fn ensure_semantic_index(
             )
         })?;
         let point_count = attestation.point_count;
+        record_finalize_component_work("vectors", "complete", Some(0), Some(point_count), Some(0));
+        let output_bytes = component_size(&crate::embedded_vector::index_path(
+            semantic.layout,
+            semantic.collection,
+        ));
+        let predecessor_bytes = retention.previous_manifest.and_then(|previous| {
+            component_size(&crate::embedded_vector::index_path(
+                semantic.layout,
+                &previous.semantic_generation,
+            ))
+        });
+        record_finalize_component_details(
+            "vectors",
+            None,
+            predecessor_bytes,
+            output_bytes,
+            output_bytes,
+        );
         let generation_manifest = VectorGenerationManifest::new(evidence, attestation.clone())?;
         EmbeddedVectorIndex::publish_generation_manifest_with_cancel(
             semantic.layout,
@@ -1187,6 +1567,73 @@ fn ensure_semantic_index(
     Ok(point_count)
 }
 
+fn produce_missing_dense_anchors(
+    anchors: &[DenseAnchorInput],
+    missing: &[ExpectedVectorAnchor],
+    runtime: &SidecarRuntimeConfig,
+    cancelled: &AtomicBool,
+    visit: &mut dyn FnMut(AttestedSemanticPoint) -> Result<()>,
+) -> Result<()> {
+    let anchors_by_node = anchors
+        .iter()
+        .map(|anchor| (anchor.node_id.0.to_string(), anchor))
+        .collect::<BTreeMap<_, _>>();
+    let missing_anchors = missing
+        .iter()
+        .map(|expected| {
+            let anchor = anchors_by_node
+                .get(&expected.node_id)
+                .with_context(|| format!("missing dense anchor {}", expected.node_id))?;
+            if anchor.document_hash != expected.document_hash {
+                bail!(
+                    "dense anchor document hash changed for {}",
+                    expected.node_id
+                );
+            }
+            Ok(*anchor)
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let client = crate::embeddings::ProductEmbeddingClient::new(runtime);
+    for batch in missing_anchors.chunks(runtime.retrieval.llm_doc_embed_batch_size.max(1)) {
+        ensure_retrieval_index_not_cancelled(cancelled, "incremental embedding batch")?;
+        let texts = batch
+            .iter()
+            .map(|anchor| anchor.text.clone())
+            .collect::<Vec<_>>();
+        let vectors = client
+            .embed_documents_with_control(&texts, None, &|| cancelled.load(Ordering::Acquire))
+            .context("embed changed dense anchor batch")?;
+        ensure_retrieval_index_not_cancelled(
+            cancelled,
+            "persisting an incremental embedding batch",
+        )?;
+        if vectors.len() != batch.len() {
+            bail!(
+                "embedding engine returned {} vectors for {} changed anchors",
+                vectors.len(),
+                batch.len()
+            );
+        }
+        for (anchor, vector) in batch.iter().zip(vectors) {
+            visit(AttestedSemanticPoint {
+                point: SemanticPoint {
+                    display_name: anchor
+                        .qualified_name
+                        .clone()
+                        .unwrap_or_else(|| anchor.display_name.clone()),
+                    node_id: anchor.node_id.0.to_string(),
+                    file_path: anchor.file_path.clone(),
+                    file_role: Some(anchor.file_role),
+                    dense_reason: Some(anchor.selection_reason.clone()),
+                    vector: normalize_vector(vector)?,
+                },
+                document_hash: anchor.document_hash.clone(),
+            })?;
+        }
+    }
+    Ok(())
+}
+
 fn normalize_vector(mut vector: Vec<f32>) -> Result<Vec<f32>> {
     if vector.is_empty() || vector.iter().any(|value| !value.is_finite()) {
         bail!("embedding engine returned an empty or non-finite vector");
@@ -1205,25 +1652,72 @@ fn normalize_vector(mut vector: Vec<f32>) -> Result<Vec<f32>> {
     Ok(vector)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn ensure_scip_artifacts(
     storage_path: &Path,
     scip_dir: &Path,
     project_id: &str,
     generation: &str,
+    previous_project_dir: Option<PathBuf>,
+    cancelled: &AtomicBool,
     scip_ready: bool,
     manifest: &mut RetrievalIndexManifest,
 ) -> Result<()> {
     if scip_ready {
         info!(project_id = %project_id, sidecar_generation = %generation, "SCIP graph artifacts reused");
+        record_finalize_component_work("graph", "reused", None, Some(0), Some(0));
+        let output_bytes =
+            component_size(&crate::scip_index::scip_symbols_component_path(scip_dir));
+        record_finalize_component_details("graph", Some(0), None, output_bytes, output_bytes);
         return Ok(());
     }
-    match emit_scip_artifacts_from_store(storage_path, scip_dir, generation) {
-        Ok(Some(revision)) => {
+    match emit_scip_artifacts_from_store_incremental(
+        storage_path,
+        scip_dir,
+        generation,
+        previous_project_dir.as_deref(),
+        || ensure_retrieval_index_not_cancelled(cancelled, "SCIP component publication"),
+    ) {
+        Ok(outcome) if outcome.revision.is_some() => {
+            record_finalize_component_work(
+                "graph",
+                if outcome.cloned {
+                    "copy_on_write"
+                } else {
+                    "complete"
+                },
+                Some(outcome.retained_records),
+                Some(outcome.inserted_records),
+                Some(outcome.removed_records),
+            );
+            let predecessor_bytes = previous_project_dir.as_deref().and_then(|previous| {
+                component_size(&crate::scip_index::scip_symbols_component_path(previous))
+            });
+            let output_bytes =
+                component_size(&crate::scip_index::scip_symbols_component_path(scip_dir));
+            record_finalize_component_details(
+                "graph",
+                Some(outcome.reordered_records),
+                predecessor_bytes,
+                output_bytes,
+                output_bytes,
+            );
+            let revision = outcome.revision.expect("matched present revision");
             manifest.scip_revision = Some(revision.clone());
-            info!(project_id = %project_id, sidecar_generation = %generation, %revision, "SCIP graph artifacts emitted from store");
+            info!(
+                project_id = %project_id,
+                sidecar_generation = %generation,
+                %revision,
+                retained_record_count = outcome.retained_records,
+                inserted_record_count = outcome.inserted_records,
+                removed_record_count = outcome.removed_records,
+                reordered_record_count = outcome.reordered_records,
+                cloned = outcome.cloned,
+                "SCIP graph artifacts emitted from store"
+            );
             Ok(())
         }
-        Ok(None) => {
+        Ok(_) => {
             bail!("mandatory SCIP graph artifacts unavailable for {project_id}");
         }
         Err(error) => {
@@ -1388,6 +1882,7 @@ fn with_embedding_publication_residency<T>(
 fn persist_finalized_manifest(
     project_root: &Path,
     storage_path: &Path,
+    prepared_lexical: &PreparedLexicalInput,
     retention_context: &GenerationRetentionContext<'_>,
     cancelled: &AtomicBool,
     sidecar_input: &SidecarInputFingerprint,
@@ -1396,6 +1891,7 @@ fn persist_finalized_manifest(
     degraded_modes: Vec<String>,
     stub_flags: SidecarStubFlags,
 ) -> Result<FinalizeIndexOutcome> {
+    let manifest_started = Instant::now();
     manifest.built_at_epoch_ms = Utc::now().timestamp_millis();
     manifest.degraded_modes_json =
         serde_json::to_string(&degraded_modes).unwrap_or_else(|_| "[]".into());
@@ -1414,20 +1910,21 @@ fn persist_finalized_manifest(
                 sidecar_input,
                 &manifest,
                 |storage| {
-                    let lexical_source = lexical_source_input(project_root, storage_path)
-                        .context("rescan lexical source at publication fence")?;
+                    prepared_lexical
+                        .revalidate_source_seals(project_root, storage_path)
+                        .context("revalidate lexical source identities at publication fence")?;
                     let embedding_contract = SidecarEmbeddingContract {
                         backend: &embedding_backend,
                         dimension: embedding_dim,
                         producer_compatibility_identity: &retention_context
                             .producer_compatibility_identity,
                     };
-                    let current_input = compute_sidecar_input_fingerprint_with_lexical_source(
+                    let current_input = compute_sidecar_input_fingerprint_with_lexical_fingerprint(
                         storage,
                         project_root,
                         &project_id,
                         &embedding_contract,
-                        lexical_source,
+                        prepared_lexical.fingerprint.clone(),
                     )?;
                     if let Some(reason) = manifest_unavailable_reason_for_runtime(
                         &project_id,
@@ -1544,6 +2041,7 @@ fn persist_finalized_manifest(
         "retrieval index manifest persisted"
     );
 
+    record_finalize_phase_timing("manifest write", manifest_started.elapsed());
     Ok(FinalizeIndexOutcome {
         project_id,
         manifest,
@@ -1551,6 +2049,8 @@ fn persist_finalized_manifest(
         scip_stubbed: stub_flags.scip_stubbed,
         generation_retention_plan,
         generation_retention,
+        phase_timings: finish_finalize_phase_timings(),
+        component_work: finish_finalize_component_work(),
     })
 }
 
@@ -2081,6 +2581,22 @@ fn compute_sidecar_input_fingerprint_with_lexical_source(
 ) -> Result<SidecarInputFingerprint> {
     let lexical = finish_lexical_input_for_store(lexical_source, project_root, storage)
         .context("hash lexical symbol input")?;
+    compute_sidecar_input_fingerprint_with_lexical_fingerprint(
+        storage,
+        project_root,
+        project_id,
+        embedding,
+        lexical,
+    )
+}
+
+fn compute_sidecar_input_fingerprint_with_lexical_fingerprint(
+    storage: &Store,
+    project_root: &Path,
+    project_id: &str,
+    embedding: &SidecarEmbeddingContract<'_>,
+    lexical: LexicalInputFingerprint,
+) -> Result<SidecarInputFingerprint> {
     let mut hasher = Sha256::new();
     let mut graph_hasher = Sha256::new();
     hash_part(&mut hasher, "codestory-sidecar-input-v10");
@@ -2322,6 +2838,27 @@ mod tests {
         serde_json::to_writer(&mut file, value).expect("write private control");
         file.write_all(b"\n").expect("terminate private control");
         file.sync_all().expect("sync private control");
+    }
+
+    #[test]
+    fn finalization_receipt_includes_manifest_time_and_component_bytes() {
+        begin_finalize_phase_timings();
+        record_finalize_phase_timing("input fingerprint", Duration::from_millis(2));
+        record_finalize_component_work("vectors", "copy_on_write", Some(4), Some(1), Some(1));
+        record_finalize_component_details("vectors", None, Some(1_024), Some(1_100), Some(1_100));
+        record_finalize_phase_timing("manifest write", Duration::from_millis(3));
+
+        let timings = finish_finalize_phase_timings();
+        let work = finish_finalize_component_work();
+
+        assert!(
+            timings
+                .iter()
+                .any(|timing| timing.phase == "manifest write" && timing.elapsed_ms == 3)
+        );
+        assert_eq!(work[0].predecessor_bytes, Some(1_024));
+        assert_eq!(work[0].output_bytes, Some(1_100));
+        assert_eq!(work[0].attested_bytes, Some(1_100));
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/lexical_index.rs
+++ b/crates/codestory-retrieval/src/lexical_index.rs
@@ -3,7 +3,7 @@
 use anyhow::{Context, Result, bail};
 use codestory_contracts::api::SearchTargetDto;
 use codestory_contracts::owned_artifacts::sqlite_file_with_sidecars;
-use codestory_contracts::validation_receipts::SealedReceiptCache;
+use codestory_contracts::validation_receipts::{ArtifactSeal, SealedReceiptCache};
 #[cfg(test)]
 use codestory_store::FileRole;
 use codestory_store::{SourcePolicyExclusionPolicyIdentity, Store, SymbolSearchDoc};
@@ -11,15 +11,18 @@ use codestory_workspace::paths::sqlite_open_path;
 use rusqlite::{Connection, OpenFlags, OptionalExtension, params};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 pub const LEXICAL_INDEX_VERSION: &str = "sqlite-fts5-v1";
 pub const LEXICAL_INDEX_FILE: &str = "lexical-index.sqlite3";
+#[cfg(any(test, feature = "test-support"))]
 const LEGACY_INDEX_FILE: &str = "lexical-index.jsonl";
+#[cfg(any(test, feature = "test-support"))]
 const LEGACY_META_FILE: &str = "shard-meta.json";
+#[cfg(any(test, feature = "test-support"))]
 const LEGACY_STUB_MARKER: &str = ".zoekt-stub";
 /// Default lexical source-file cap for scans without a pinned core publication.
 /// Product scans use the active cap recorded with that publication.
@@ -161,6 +164,37 @@ pub(crate) struct LexicalSourceInput {
     hasher: Sha256,
     file_count: u32,
     coverage: LexicalCoverage,
+    documents: Vec<LexicalDocument>,
+    source_seals: Vec<ArtifactSeal>,
+}
+
+pub(crate) struct PreparedLexicalInput {
+    pub fingerprint: LexicalInputFingerprint,
+    documents: Vec<LexicalDocument>,
+    source_seals: Vec<ArtifactSeal>,
+}
+
+impl PreparedLexicalInput {
+    pub(crate) fn document_count(&self) -> u64 {
+        u64::try_from(self.documents.len()).unwrap_or(u64::MAX)
+    }
+
+    pub(crate) fn revalidate_source_seals(
+        &self,
+        project_root: &Path,
+        storage_path: &Path,
+    ) -> Result<()> {
+        let observed = observe_lexical_source_seals(project_root, Some(storage_path))?;
+        if observed != self.source_seals {
+            bail!("lexical source identity changed after its single content inspection");
+        }
+        Ok(())
+    }
+}
+
+struct LexicalScanOutcome {
+    coverage: LexicalCoverage,
+    source_seals: Vec<ArtifactSeal>,
 }
 
 #[cfg(test)]
@@ -170,16 +204,15 @@ pub fn lexical_input_fingerprint(
 ) -> Result<LexicalInputFingerprint> {
     let mut hasher = lexical_documents_hasher();
     let mut file_count = 0_u32;
-    let coverage =
-        scan_lexical_documents(project_root, storage_path, storage_path, &mut |document| {
-            hash_lexical_document(&mut hasher, document);
-            file_count = file_count.saturating_add(1);
-            Ok(())
-        })?;
+    let scan = scan_lexical_documents(project_root, storage_path, storage_path, &mut |document| {
+        hash_lexical_document(&mut hasher, document);
+        file_count = file_count.saturating_add(1);
+        Ok(())
+    })?;
     Ok(LexicalInputFingerprint {
         file_count,
-        hash: finish_lexical_documents_hash(hasher, &coverage),
-        coverage,
+        hash: finish_lexical_documents_hash(hasher, &scan.coverage),
+        coverage: scan.coverage,
     })
 }
 
@@ -189,36 +222,53 @@ pub(crate) fn lexical_source_input(
 ) -> Result<LexicalSourceInput> {
     let mut hasher = lexical_documents_hasher();
     let mut file_count = 0_u32;
-    let coverage =
-        scan_lexical_documents(project_root, Some(storage_path), None, &mut |document| {
-            hash_lexical_document(&mut hasher, document);
-            file_count = file_count.saturating_add(1);
-            Ok(())
-        })?;
+    let mut documents = Vec::new();
+    let scan = scan_lexical_documents(project_root, Some(storage_path), None, &mut |document| {
+        hash_lexical_document(&mut hasher, document);
+        file_count = file_count.saturating_add(1);
+        documents.push(document.clone());
+        Ok(())
+    })?;
     Ok(LexicalSourceInput {
         hasher,
         file_count,
-        coverage,
+        coverage: scan.coverage,
+        documents,
+        source_seals: scan.source_seals,
     })
 }
 
 pub(crate) fn finish_lexical_input_for_store(
-    mut source: LexicalSourceInput,
+    source: LexicalSourceInput,
     project_root: &Path,
     storage: &Store,
 ) -> Result<LexicalInputFingerprint> {
+    Ok(prepare_lexical_input_for_store(source, project_root, storage)?.fingerprint)
+}
+
+pub(crate) fn prepare_lexical_input_for_store(
+    mut source: LexicalSourceInput,
+    project_root: &Path,
+    storage: &Store,
+) -> Result<PreparedLexicalInput> {
     scan_symbol_documents_from_store(project_root, storage, &mut |document| {
         hash_lexical_document(&mut source.hasher, document);
         source.file_count = source.file_count.saturating_add(1);
+        source.documents.push(document.clone());
         Ok(())
     })?;
-    Ok(LexicalInputFingerprint {
-        file_count: source.file_count,
-        hash: finish_lexical_documents_hash(source.hasher, &source.coverage),
-        coverage: source.coverage,
+    Ok(PreparedLexicalInput {
+        fingerprint: LexicalInputFingerprint {
+            file_count: source.file_count,
+            hash: finish_lexical_documents_hash(source.hasher, &source.coverage),
+            coverage: source.coverage,
+        },
+        documents: source.documents,
+        source_seals: source.source_seals,
     })
 }
 
+#[cfg(any(test, feature = "test-support"))]
 pub fn build_lexical_shard(
     project_root: &Path,
     storage_path: Option<&Path>,
@@ -240,7 +290,10 @@ pub fn build_lexical_shard(
             project_id,
             sidecar_input_hash,
             expected,
-            |visit| scan_lexical_documents(project_root, storage_path, storage_path, visit),
+            |visit| {
+                scan_lexical_documents(project_root, storage_path, storage_path, visit)
+                    .map(|scan| scan.coverage)
+            },
         )?;
         // The staged file is about to be renamed away, so its verdict is not
         // receiptable: seal the published identity, never the temporary one.
@@ -270,6 +323,95 @@ pub fn build_lexical_shard(
         }
     }
     Ok(rebuilt)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct IncrementalLexicalWork {
+    pub retained: u64,
+    pub inserted: u64,
+    pub removed: u64,
+}
+
+pub(crate) fn build_prepared_lexical_shard(
+    lexical_data_dir: &Path,
+    project_id: &str,
+    expected: &PreparedLexicalInput,
+    sidecar_input_hash: &str,
+    previous_project_id: Option<&str>,
+    before_publish: impl FnOnce() -> Result<()>,
+) -> Result<(LexicalInputFingerprint, Option<IncrementalLexicalWork>)> {
+    if prepared_lexical_fingerprint(&expected.documents, &expected.fingerprint.coverage)?
+        != expected.fingerprint
+    {
+        bail!("prepared lexical documents do not match their fingerprint");
+    }
+    let shard_dir = shard_dir_for(lexical_data_dir, project_id);
+    std::fs::create_dir_all(&shard_dir)?;
+    let index_path = shard_dir.join(LEXICAL_INDEX_FILE);
+    let (temp_path, reserved) =
+        codestory_workspace::atomic_file::create_unique_temp_file(&index_path, "lexical-index")?;
+    drop(reserved);
+
+    let result: Result<(LexicalInputFingerprint, Option<IncrementalLexicalWork>)> = (|| {
+        std::fs::remove_file(&temp_path)?;
+        let mut incremental = None;
+        if let Some(previous_project_id) = previous_project_id {
+            let previous_path =
+                shard_dir_for(lexical_data_dir, previous_project_id).join(LEXICAL_INDEX_FILE);
+            let predecessor_is_current = verify_lexical_database_contents(&previous_path)
+                .is_ok_and(|metadata| metadata.lexical_hash.len() == 64);
+            if predecessor_is_current
+                && crate::copy_on_write::clone_file(&previous_path, &temp_path)?
+            {
+                let permissions = std::fs::metadata(&temp_path)?.permissions();
+                make_file_owner_writable(&temp_path, &permissions)?;
+                incremental = Some(reconcile_cloned_lexical_database(
+                    &temp_path,
+                    project_id,
+                    sidecar_input_hash,
+                    &expected.fingerprint,
+                    &expected.documents,
+                )?);
+            }
+        }
+        if incremental.is_none() {
+            if temp_path.exists() {
+                std::fs::remove_file(&temp_path)?;
+            }
+            write_lexical_database(
+                &temp_path,
+                project_id,
+                sidecar_input_hash,
+                &expected.fingerprint,
+                |visit| {
+                    for document in &expected.documents {
+                        visit(document)?;
+                    }
+                    Ok(expected.fingerprint.coverage.clone())
+                },
+            )?;
+        }
+        let staged = verify_lexical_database_contents(&temp_path)?;
+        match_lexical_shard_expectations(
+            &staged,
+            project_id,
+            sidecar_input_hash,
+            Some((
+                expected.fingerprint.file_count,
+                expected.fingerprint.hash.as_str(),
+            )),
+        )?;
+        before_publish()?;
+        publish_immutable_lexical_database(&temp_path, &index_path)?;
+        Ok((expected.fingerprint.clone(), incremental))
+    })();
+    if result.is_err() {
+        if let Ok(metadata) = std::fs::metadata(&temp_path) {
+            let _ = make_file_owner_writable(&temp_path, &metadata.permissions());
+        }
+        let _ = std::fs::remove_file(&temp_path);
+    }
+    result
 }
 
 fn publish_immutable_lexical_database(temp_path: &Path, index_path: &Path) -> Result<()> {
@@ -971,7 +1113,7 @@ where
         "PRAGMA journal_mode = OFF;
          PRAGMA synchronous = FULL;
          PRAGMA temp_store = MEMORY;
-         PRAGMA user_version = 1;
+         PRAGMA user_version = 2;
          CREATE TABLE lexical_metadata (
              id INTEGER PRIMARY KEY CHECK (id = 1),
              version TEXT NOT NULL,
@@ -985,6 +1127,8 @@ where
          );
          CREATE TABLE lexical_documents (
              id INTEGER PRIMARY KEY,
+             document_key TEXT NOT NULL UNIQUE,
+             document_hash TEXT NOT NULL,
              path TEXT NOT NULL,
              content TEXT NOT NULL,
              source TEXT NOT NULL,
@@ -1000,8 +1144,9 @@ where
     let actual = {
         let mut insert_document = transaction.prepare(
             "INSERT INTO lexical_documents
-             (id, path, content, source, node_id, symbol_name, start_line)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+             (id, document_key, document_hash, path, content, source, node_id, symbol_name,
+              start_line)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
         )?;
         let mut insert_fts = transaction
             .prepare("INSERT INTO lexical_fts(rowid, path, content) VALUES (?1, ?2, ?3)")?;
@@ -1009,10 +1154,14 @@ where
             file_count = file_count
                 .checked_add(1)
                 .context("lexical document count overflow")?;
-            let id = i64::from(file_count);
+            let document_key = lexical_document_key(document)?;
+            let document_hash = lexical_document_hash(document);
+            let id = stable_lexical_document_id(&document_key);
             hash_lexical_document(&mut hasher, document);
             insert_document.execute(params![
                 id,
+                document_key,
+                document_hash,
                 document.path,
                 document.content,
                 document.source.provenance_label(),
@@ -1090,6 +1239,190 @@ where
     connection.execute_batch("PRAGMA optimize;")?;
     connection.close().map_err(|(_, error)| error)?;
     Ok(actual)
+}
+
+fn prepared_lexical_fingerprint(
+    documents: &[LexicalDocument],
+    coverage: &LexicalCoverage,
+) -> Result<LexicalInputFingerprint> {
+    let mut hasher = lexical_documents_hasher();
+    let mut keys = HashSet::new();
+    let mut ids = HashMap::new();
+    for document in documents {
+        let key = lexical_document_key(document)?;
+        if !keys.insert(key.clone()) {
+            bail!("duplicate prepared lexical document key");
+        }
+        let id = stable_lexical_document_id(&key);
+        if let Some(previous) = ids.insert(id, key.clone()) {
+            bail!("lexical document identity collision between {previous:?} and {key:?}");
+        }
+        hash_lexical_document(&mut hasher, document);
+    }
+    Ok(LexicalInputFingerprint {
+        file_count: u32::try_from(documents.len()).context("lexical document count overflow")?,
+        hash: finish_lexical_documents_hash(hasher, coverage),
+        coverage: coverage.clone(),
+    })
+}
+
+fn reconcile_cloned_lexical_database(
+    path: &Path,
+    project_id: &str,
+    sidecar_input_hash: &str,
+    expected: &LexicalInputFingerprint,
+    documents: &[LexicalDocument],
+) -> Result<IncrementalLexicalWork> {
+    let mut desired = BTreeMap::new();
+    let mut desired_ids = HashMap::new();
+    for document in documents {
+        let key = lexical_document_key(document)?;
+        let id = stable_lexical_document_id(&key);
+        if let Some(previous) = desired_ids.insert(id, key.clone()) {
+            bail!("lexical document identity collision between {previous:?} and {key:?}");
+        }
+        if desired
+            .insert(key.clone(), (id, lexical_document_hash(document), document))
+            .is_some()
+        {
+            bail!("duplicate prepared lexical document key {key:?}");
+        }
+    }
+
+    let mut connection = Connection::open(sqlite_open_path(path))?;
+    let schema_version: i32 = connection.query_row("PRAGMA user_version", [], |row| row.get(0))?;
+    if schema_version != 2 {
+        bail!("cloned lexical component does not support differential reconciliation");
+    }
+    connection.execute_batch(
+        "PRAGMA journal_mode = OFF;
+         PRAGMA synchronous = FULL;
+         DROP TRIGGER lexical_documents_no_insert;
+         DROP TRIGGER lexical_documents_no_update;
+         DROP TRIGGER lexical_documents_no_delete;
+         DROP TRIGGER lexical_metadata_no_insert;
+         DROP TRIGGER lexical_metadata_no_update;
+         DROP TRIGGER lexical_metadata_no_delete;",
+    )?;
+    let transaction = connection.transaction()?;
+    let existing = {
+        let mut statement = transaction.prepare(
+            "SELECT id, document_key, document_hash FROM lexical_documents
+             ORDER BY document_key",
+        )?;
+        statement
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?
+    };
+    let existing_by_key = existing
+        .iter()
+        .map(|(_, key, hash)| (key.as_str(), hash.as_str()))
+        .collect::<HashMap<_, _>>();
+    let desired_hash_by_key = desired
+        .iter()
+        .map(|(key, (_, hash, _))| (key.as_str(), hash.as_str()))
+        .collect::<HashMap<_, _>>();
+    let retained = existing
+        .iter()
+        .filter(|(_, key, hash)| desired_hash_by_key.get(key.as_str()) == Some(&hash.as_str()))
+        .count();
+    let removed = existing.len().saturating_sub(retained);
+    for (id, key, hash) in &existing {
+        if desired_hash_by_key.get(key.as_str()) != Some(&hash.as_str()) {
+            transaction.execute("DELETE FROM lexical_fts WHERE rowid = ?1", params![id])?;
+            transaction.execute("DELETE FROM lexical_documents WHERE id = ?1", params![id])?;
+        }
+    }
+    let missing = desired
+        .iter()
+        .filter(|(key, (_, hash, _))| existing_by_key.get(key.as_str()) != Some(&hash.as_str()))
+        .map(|(_, value)| (value.0, value.1.clone(), value.2))
+        .collect::<Vec<_>>();
+    {
+        let mut insert_document = transaction.prepare(
+            "INSERT INTO lexical_documents
+             (id, document_key, document_hash, path, content, source, node_id, symbol_name,
+              start_line)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+        )?;
+        let mut insert_fts = transaction
+            .prepare("INSERT INTO lexical_fts(rowid, path, content) VALUES (?1, ?2, ?3)")?;
+        for (id, hash, document) in &missing {
+            let key = lexical_document_key(document)?;
+            insert_document.execute(params![
+                id,
+                key,
+                hash,
+                document.path,
+                document.content,
+                document.source.provenance_label(),
+                document.node_id,
+                document.symbol_name,
+                document.start_line,
+            ])?;
+            insert_fts.execute(params![
+                id,
+                normalize_lexical_text(&document.path),
+                normalize_lexical_text(&document.content),
+            ])?;
+        }
+    }
+    transaction.execute("DELETE FROM lexical_metadata", [])?;
+    let coverage_json = serde_json::to_string(&expected.coverage)?;
+    transaction.execute(
+        "INSERT INTO lexical_metadata
+         (id, version, project_id, sidecar_input_hash, lexical_hash, file_count,
+          coverage_json, binding_sha256, indexed_at_epoch_ms)
+         VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        params![
+            LEXICAL_INDEX_VERSION,
+            project_id,
+            sidecar_input_hash,
+            expected.hash,
+            expected.file_count,
+            coverage_json,
+            metadata_binding(
+                project_id,
+                sidecar_input_hash,
+                &expected.hash,
+                expected.file_count,
+                &coverage_json,
+            ),
+            chrono::Utc::now().timestamp_millis(),
+        ],
+    )?;
+    transaction.execute_batch(
+        "CREATE TRIGGER lexical_documents_no_insert BEFORE INSERT ON lexical_documents
+         BEGIN SELECT RAISE(ABORT, 'immutable lexical generation'); END;
+         CREATE TRIGGER lexical_documents_no_update BEFORE UPDATE ON lexical_documents
+         BEGIN SELECT RAISE(ABORT, 'immutable lexical generation'); END;
+         CREATE TRIGGER lexical_documents_no_delete BEFORE DELETE ON lexical_documents
+         BEGIN SELECT RAISE(ABORT, 'immutable lexical generation'); END;
+         CREATE TRIGGER lexical_metadata_no_insert BEFORE INSERT ON lexical_metadata
+         BEGIN SELECT RAISE(ABORT, 'immutable lexical generation'); END;
+         CREATE TRIGGER lexical_metadata_no_update BEFORE UPDATE ON lexical_metadata
+         BEGIN SELECT RAISE(ABORT, 'immutable lexical generation'); END;
+         CREATE TRIGGER lexical_metadata_no_delete BEFORE DELETE ON lexical_metadata
+         BEGIN SELECT RAISE(ABORT, 'immutable lexical generation'); END;",
+    )?;
+    transaction.commit()?;
+    connection.execute_batch("PRAGMA optimize;")?;
+    connection.close().map_err(|(_, error)| error)?;
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(path)?
+        .sync_all()?;
+    Ok(IncrementalLexicalWork {
+        retained: u64::try_from(retained).unwrap_or(u64::MAX),
+        inserted: u64::try_from(missing.len()).unwrap_or(u64::MAX),
+        removed: u64::try_from(removed).unwrap_or(u64::MAX),
+    })
 }
 
 /// Deep-verify one immutable lexical shard, reusing a sealed receipt when the
@@ -1218,7 +1551,7 @@ fn read_open_database_metadata(
         bail!("lexical search cancelled");
     }
     let schema_version: i32 = connection.query_row("PRAGMA user_version", [], |row| row.get(0))?;
-    if schema_version != 1 {
+    if schema_version != 2 {
         bail!("lexical SQLite shard schema version is not current");
     }
     let required_tables: u32 = connection.query_row(
@@ -1338,7 +1671,7 @@ fn scan_lexical_documents(
     source_storage_path: Option<&Path>,
     symbol_storage_path: Option<&Path>,
     visit: &mut dyn FnMut(&LexicalDocument) -> Result<()>,
-) -> Result<LexicalCoverage> {
+) -> Result<LexicalScanOutcome> {
     let source_policy = lexical_source_policy(project_root, source_storage_path)?;
     let workspace = match source_storage_path {
         Some(storage_path) => {
@@ -1354,11 +1687,15 @@ fn scan_lexical_documents(
         .source_files()
         .context("discover canonical workspace files for lexical index")?;
     let mut coverage = LexicalCoverage::default();
+    let mut source_seals = Vec::new();
     for path in discovered {
         let relative = lexical_relative_path(project_root, &path);
         if source_policy.excluded_paths.contains(&relative) {
             continue;
         }
+        let before = ArtifactSeal::observe(&path)
+            .with_context(|| format!("seal lexical source before read {}", path.display()))?;
+        source_seals.push(before.clone());
         coverage.discovered_files = coverage.discovered_files.saturating_add(1);
         let metadata = match std::fs::metadata(&path) {
             Ok(metadata) => metadata,
@@ -1386,6 +1723,11 @@ fn scan_lexical_documents(
                 continue;
             }
         };
+        let after = ArtifactSeal::observe(&path)
+            .with_context(|| format!("seal lexical source after read {}", path.display()))?;
+        if after != before {
+            bail!("lexical source changed while reading {}", path.display());
+        }
         visit(&LexicalDocument {
             path: relative,
             content,
@@ -1397,7 +1739,41 @@ fn scan_lexical_documents(
         coverage.indexed_files = coverage.indexed_files.saturating_add(1);
     }
     scan_symbol_documents(project_root, symbol_storage_path, visit)?;
-    Ok(coverage)
+    Ok(LexicalScanOutcome {
+        coverage,
+        source_seals,
+    })
+}
+
+fn observe_lexical_source_seals(
+    project_root: &Path,
+    source_storage_path: Option<&Path>,
+) -> Result<Vec<ArtifactSeal>> {
+    let source_policy = lexical_source_policy(project_root, source_storage_path)?;
+    let workspace = match source_storage_path {
+        Some(storage_path) => {
+            codestory_workspace::WorkspaceManifest::open_with_storage_owned_exclusions(
+                project_root.to_path_buf(),
+                storage_path,
+            )
+        }
+        None => codestory_workspace::WorkspaceManifest::open(project_root.to_path_buf()),
+    }
+    .context("open workspace for lexical source fence")?;
+    workspace
+        .source_files()
+        .context("discover canonical workspace files for lexical source fence")?
+        .into_iter()
+        .filter(|path| {
+            !source_policy
+                .excluded_paths
+                .contains(&lexical_relative_path(project_root, path))
+        })
+        .map(|path| {
+            ArtifactSeal::observe(&path)
+                .with_context(|| format!("revalidate lexical source identity {}", path.display()))
+        })
+        .collect()
 }
 
 fn read_lexical_file_text_limited(path: &Path, max_bytes: u64) -> std::io::Result<Option<String>> {
@@ -1592,6 +1968,33 @@ fn hash_lexical_document(hasher: &mut Sha256, document: &LexicalDocument) {
         hasher.update([0]);
     }
     hasher.update(document.start_line.unwrap_or_default().to_le_bytes());
+}
+
+fn lexical_document_key(document: &LexicalDocument) -> Result<String> {
+    match document.source {
+        LexicalDocumentSource::LexicalSource => Ok(format!("source\0{}", document.path)),
+        LexicalDocumentSource::SymbolDoc | LexicalDocumentSource::ComponentReport => {
+            let node_id = document
+                .node_id
+                .as_deref()
+                .context("symbol lexical document is missing its node identity")?;
+            Ok(format!("{}\0{node_id}", document.source.provenance_label()))
+        }
+    }
+}
+
+fn lexical_document_hash(document: &LexicalDocument) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"codestory-lexical-document-v2\0");
+    hash_lexical_document(&mut hasher, document);
+    format!("{:x}", hasher.finalize())
+}
+
+fn stable_lexical_document_id(document_key: &str) -> i64 {
+    let bytes = Sha256::digest(document_key.as_bytes());
+    let mut prefix = [0_u8; 8];
+    prefix.copy_from_slice(&bytes[..8]);
+    i64::from_le_bytes(prefix) & i64::MAX
 }
 
 fn finish_lexical_documents_hash(mut hasher: Sha256, coverage: &LexicalCoverage) -> String {
@@ -2012,6 +2415,160 @@ mod tests {
         build_lexical_shard(project, None, data, generation, &fingerprint, input)
             .expect("build lexical shard");
         shard_dir_for(data, generation)
+    }
+
+    fn prepared_documents(documents: Vec<LexicalDocument>) -> PreparedLexicalInput {
+        let coverage = LexicalCoverage {
+            discovered_files: documents.len() as u32,
+            indexed_files: documents.len() as u32,
+            ..LexicalCoverage::default()
+        };
+        PreparedLexicalInput {
+            fingerprint: prepared_lexical_fingerprint(&documents, &coverage).expect("fingerprint"),
+            documents,
+            source_seals: Vec::new(),
+        }
+    }
+
+    fn source_document(path: &str, content: &str) -> LexicalDocument {
+        LexicalDocument {
+            path: path.into(),
+            content: content.into(),
+            source: LexicalDocumentSource::LexicalSource,
+            node_id: None,
+            symbol_name: None,
+            start_line: None,
+        }
+    }
+
+    #[test]
+    fn incremental_lexical_reconciliation_matches_a_clean_same_count_build() {
+        let root = TempDir::new().expect("tempdir");
+        let data = root.path().join("incremental");
+        let previous = prepared_documents(vec![
+            source_document("src/a.rs", "old alpha"),
+            source_document("src/b.rs", "removed beta"),
+            source_document("src/kept.rs", "unchanged epsilon"),
+        ]);
+        build_prepared_lexical_shard(&data, "previous", &previous, "input-v1", None, || Ok(()))
+            .expect("previous shard");
+        let current = prepared_documents(vec![
+            source_document("src/a.rs", "changed gamma"),
+            source_document("src/c.rs", "inserted delta"),
+            source_document("src/kept.rs", "unchanged epsilon"),
+        ]);
+        let (_, work) = build_prepared_lexical_shard(
+            &data,
+            "current",
+            &current,
+            "input-v2",
+            Some("previous"),
+            || Ok(()),
+        )
+        .expect("incremental shard");
+        let Some(work) = work else {
+            return;
+        };
+        assert_eq!(work.retained, 1);
+        assert_eq!(work.inserted, 2);
+        assert_eq!(work.removed, 2);
+
+        let clean_data = root.path().join("clean");
+        build_prepared_lexical_shard(
+            &clean_data,
+            "current",
+            &current,
+            "input-v2",
+            None,
+            || Ok(()),
+        )
+        .expect("clean shard");
+        for query in ["gamma", "delta", "beta", "epsilon"] {
+            let incremental_hits =
+                search_lexical_index(&shard_dir_for(&data, "current"), "input-v2", query, 8)
+                    .expect("incremental search");
+            let clean_hits =
+                search_lexical_index(&shard_dir_for(&clean_data, "current"), "input-v2", query, 8)
+                    .expect("clean search");
+            assert_eq!(
+                incremental_hits
+                    .iter()
+                    .map(|hit| (&hit.path, hit.source, hit.node_id.as_deref()))
+                    .collect::<Vec<_>>(),
+                clean_hits
+                    .iter()
+                    .map(|hit| (&hit.path, hit.source, hit.node_id.as_deref()))
+                    .collect::<Vec<_>>()
+            );
+        }
+    }
+
+    #[test]
+    fn cancelled_lexical_reconciliation_leaves_no_candidate_shard() {
+        let root = TempDir::new().expect("tempdir");
+        let data = root.path().join("data");
+        let previous = prepared_documents(vec![source_document("src/a.rs", "alpha")]);
+        build_prepared_lexical_shard(&data, "previous", &previous, "input-v1", None, || Ok(()))
+            .expect("previous shard");
+        let current = prepared_documents(vec![source_document("src/a.rs", "changed")]);
+
+        let error = build_prepared_lexical_shard(
+            &data,
+            "cancelled",
+            &current,
+            "input-v2",
+            Some("previous"),
+            || bail!("simulated lexical cancellation"),
+        )
+        .expect_err("cancelled lexical candidate must fail");
+
+        assert!(format!("{error:#}").contains("simulated lexical cancellation"));
+        assert!(
+            !shard_dir_for(&data, "cancelled")
+                .join(LEXICAL_INDEX_FILE)
+                .exists()
+        );
+        assert_eq!(
+            std::fs::read_dir(shard_dir_for(&data, "cancelled"))
+                .expect("cancelled shard directory")
+                .count(),
+            0,
+            "failed lexical staging must not leak a generation-local clone"
+        );
+    }
+
+    #[test]
+    fn corrupt_lexical_predecessor_falls_back_to_a_clean_candidate() {
+        let root = TempDir::new().expect("tempdir");
+        let data = root.path().join("data");
+        let previous = prepared_documents(vec![source_document("src/a.rs", "old")]);
+        build_prepared_lexical_shard(&data, "previous", &previous, "input-v1", None, || Ok(()))
+            .expect("previous shard");
+        let previous_path = shard_dir_for(&data, "previous").join(LEXICAL_INDEX_FILE);
+        let permissions = std::fs::metadata(&previous_path)
+            .expect("previous metadata")
+            .permissions();
+        make_file_owner_writable(&previous_path, &permissions).expect("make predecessor writable");
+        std::fs::write(&previous_path, b"not sqlite").expect("corrupt predecessor");
+        let current = prepared_documents(vec![source_document("src/a.rs", "current needle")]);
+
+        let (_, work) = build_prepared_lexical_shard(
+            &data,
+            "current",
+            &current,
+            "input-v2",
+            Some("previous"),
+            || Ok(()),
+        )
+        .expect("complete fallback");
+
+        assert!(work.is_none());
+        assert_eq!(
+            search_lexical_index(&shard_dir_for(&data, "current"), "input-v2", "needle", 8,)
+                .expect("search fallback candidate")
+                .len(),
+            1
+        );
     }
 
     fn publish_test_source_policy(
@@ -2723,7 +3280,7 @@ mod tests {
         .expect("lexical collection");
 
         assert_eq!(actual, expected);
-        assert!(coverage.complete());
+        assert!(coverage.coverage.complete());
     }
 
     #[test]
@@ -2852,9 +3409,9 @@ mod tests {
             source_paths,
             std::collections::BTreeSet::from(["src/widened.rs".to_string()])
         );
-        assert_eq!(coverage.discovered_files, 1);
-        assert_eq!(coverage.indexed_files, 1);
-        assert!(coverage.complete());
+        assert_eq!(coverage.coverage.discovered_files, 1);
+        assert_eq!(coverage.coverage.indexed_files, 1);
+        assert!(coverage.coverage.complete());
     }
 
     #[test]
@@ -2871,6 +3428,30 @@ mod tests {
         assert!(
             format!("{error:#}")
                 .contains("complete core publication for lexical source policy is missing")
+        );
+    }
+
+    #[test]
+    fn prepared_source_seals_detect_in_place_drift_without_a_second_content_scan() {
+        let project = TempDir::new().expect("project");
+        let source_path = project.path().join("lib.rs");
+        std::fs::write(&source_path, "fn before() {}\n").expect("source");
+        let storage_root = TempDir::new().expect("storage root");
+        let storage_path = storage_root.path().join("core.db");
+        let mut storage = Store::open(&storage_path).expect("core storage");
+        publish_test_source_policy(&mut storage, project.path(), MAX_FILE_BYTES, &[]);
+        let source = lexical_source_input(project.path(), &storage_path).expect("source input");
+        let prepared = prepare_lexical_input_for_store(source, project.path(), &storage)
+            .expect("prepared input");
+
+        std::fs::write(&source_path, "fn after_() {}\n").expect("rewrite same-size source");
+
+        let error = prepared
+            .revalidate_source_seals(project.path(), &storage_path)
+            .expect_err("in-place source rewrite must break the publication fence");
+        assert!(
+            format!("{error:#}").contains("source identity changed"),
+            "unexpected source-fence error: {error:#}"
         );
     }
 

--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -14,6 +14,7 @@ mod cache_clean;
 mod candidate;
 mod capabilities;
 mod config;
+mod copy_on_write;
 mod embedded_vector;
 mod embedding_contract;
 mod embedding_server_compat;
@@ -292,11 +293,11 @@ pub use health::{
     probe_infrastructure_health, probe_sidecar_health,
 };
 pub use index::{
-    FinalizeIndexOutcome, RetrievalIndexCancelled, SidecarInputChanged, finalize_index,
-    finalize_index_for_runtime, finalize_index_for_runtime_with_cancel,
-    finalize_index_for_runtime_with_progress, finalize_index_for_runtime_with_progress_and_cancel,
-    is_retrieval_index_cancelled, is_sidecar_input_changed, project_id_for_root,
-    sidecar_project_id_for_root,
+    FinalizeComponentWork, FinalizeIndexOutcome, FinalizePhaseTiming, RetrievalIndexCancelled,
+    SidecarInputChanged, finalize_index, finalize_index_for_runtime,
+    finalize_index_for_runtime_with_cancel, finalize_index_for_runtime_with_progress,
+    finalize_index_for_runtime_with_progress_and_cancel, is_retrieval_index_cancelled,
+    is_sidecar_input_changed, project_id_for_root, sidecar_project_id_for_root,
 };
 pub use inventory::{
     SidecarGcReport, SidecarInventoryReport, sidecar_gc_apply_with_storage,

--- a/crates/codestory-retrieval/src/scip_client.rs
+++ b/crates/codestory-retrieval/src/scip_client.rs
@@ -1,9 +1,9 @@
 use crate::candidate::{CandidateGraphDirection, CandidateGraphEvidence};
 use crate::config::SidecarLayout;
 use crate::scip_index::{
-    SCIP_GRAPH_PROJECTION_PROVENANCE, SCIP_STUB_MARKER_FILE, SCIP_SYMBOLS_FILE,
-    ScipAdjacencyDirection, ScipIndexMarkerError, ScipNormalizedSymbol, ScipSymbolRecord,
-    load_fresh_scip_query_view, parse_scip_index_marker,
+    SCIP_GRAPH_PROJECTION_PROVENANCE, SCIP_STUB_MARKER_FILE, ScipAdjacencyDirection,
+    ScipIndexMarkerError, ScipNormalizedSymbol, ScipSymbolRecord, load_fresh_scip_query_view,
+    parse_scip_index_marker, scip_symbols_component_path,
 };
 use codestory_contracts::graph::EdgeKind;
 use std::cmp::Ordering;
@@ -658,7 +658,7 @@ fn read_scip_revision(dir: &Path) -> Option<String> {
 }
 
 fn scip_artifact_status(project_dir: &Path, revision: &str, generation: &str) -> &'static str {
-    if !project_dir.join(SCIP_SYMBOLS_FILE).is_file()
+    if !scip_symbols_component_path(project_dir).is_file()
         || !project_dir.join("revision.txt").is_file()
         || project_dir.join(SCIP_STUB_MARKER_FILE).is_file()
     {
@@ -720,7 +720,7 @@ mod tests {
             proofs,
         };
         std::fs::write(
-            project_dir.join(SCIP_SYMBOLS_FILE),
+            scip_symbols_component_path(project_dir),
             serde_json::to_string_pretty(&index).expect("serialize"),
         )
         .expect("write symbols");

--- a/crates/codestory-retrieval/src/scip_index.rs
+++ b/crates/codestory-retrieval/src/scip_index.rs
@@ -4,6 +4,8 @@ use anyhow::{Context, Result, bail};
 use codestory_contracts::graph::{EdgeKind, NodeId, NodeKind};
 use codestory_contracts::validation_receipts::SealedReceiptCache;
 use codestory_store::Store;
+use codestory_workspace::paths::sqlite_open_path;
+use rusqlite::{Connection, params};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
@@ -12,6 +14,16 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 pub const SCIP_SYMBOLS_FILE: &str = "symbols.index.json";
+const SCIP_SYMBOLS_DATABASE_FILE: &str = "symbols.index.sqlite3";
+
+pub(crate) fn scip_symbols_component_path(project_dir: &Path) -> PathBuf {
+    let database = project_dir.join(SCIP_SYMBOLS_DATABASE_FILE);
+    if database.is_file() {
+        database
+    } else {
+        project_dir.join(SCIP_SYMBOLS_FILE)
+    }
+}
 pub const SCIP_INDEX_FILE: &str = "index.scip";
 pub const SCIP_PRECISE_SEMANTIC_IMPORT_DIR: &str = "precise-semantic-import";
 pub const SCIP_IMPORTED_PROOF_PROVENANCE: &str = "imported_scip_proof";
@@ -186,7 +198,7 @@ const SCIP_ADJACENCY_SEED_BATCH: usize = 512;
 /// neighbours, never adds one.
 const SCIP_MAX_REFERENCES_PER_SYMBOL: usize = 32;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ScipSymbolRecord {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub node_id: Option<String>,
@@ -439,7 +451,7 @@ impl fmt::Display for ScipArtifactDefect {
 
 impl std::error::Error for ScipArtifactDefect {}
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ScipSymbolsIndex {
     /// Retrieval generation this artifact was built for or admitted into.
     /// Legacy artifacts deserialize with an empty generation and are refused.
@@ -936,11 +948,36 @@ pub fn import_precise_semantic_scip_artifact(
 /// reference records for every validated graph adjacency between two emitted
 /// symbols, is stamped with `generation`, and is fully validated before it is
 /// written — an artifact that cannot validate is never published.
+#[cfg(any(test, feature = "test-support"))]
+#[allow(dead_code)]
 pub fn emit_scip_artifacts_from_store(
     storage_path: &Path,
     project_dir: &Path,
     generation: &str,
 ) -> Result<Option<String>> {
+    emit_scip_artifacts_from_store_incremental(storage_path, project_dir, generation, None, || {
+        Ok(())
+    })
+    .map(|outcome| outcome.revision)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ScipIncrementalOutcome {
+    pub revision: Option<String>,
+    pub retained_records: u64,
+    pub inserted_records: u64,
+    pub removed_records: u64,
+    pub reordered_records: u64,
+    pub cloned: bool,
+}
+
+pub(crate) fn emit_scip_artifacts_from_store_incremental(
+    storage_path: &Path,
+    project_dir: &Path,
+    generation: &str,
+    previous_project_dir: Option<&Path>,
+    mut before_publish: impl FnMut() -> Result<()>,
+) -> Result<ScipIncrementalOutcome> {
     if generation.trim().is_empty() {
         bail!("scip emit requires a non-empty retrieval generation");
     }
@@ -992,7 +1029,14 @@ pub fn emit_scip_artifacts_from_store(
     }
 
     if symbols.is_empty() {
-        return Ok(None);
+        return Ok(ScipIncrementalOutcome {
+            revision: None,
+            retained_records: 0,
+            inserted_records: 0,
+            removed_records: 0,
+            reordered_records: 0,
+            cloned: false,
+        });
     }
 
     let references = collect_reference_adjacency(&storage, &symbols)
@@ -1013,9 +1057,13 @@ pub fn emit_scip_artifacts_from_store(
     index
         .validate_records(generation)
         .context("validate scip artifact before publication")?;
-    let json = serde_json::to_string_pretty(&index).context("serialize scip symbols index")?;
-    std::fs::write(project_dir.join(SCIP_SYMBOLS_FILE), json)
-        .context("write symbols.index.json")?;
+    let work = publish_scip_component(
+        project_dir,
+        previous_project_dir,
+        &index,
+        &mut before_publish,
+    )?;
+    before_publish()?;
     std::fs::write(project_dir.join("revision.txt"), format!("{revision}\n"))
         .context("write scip revision")?;
     // Minimal marker so health treats graph lane as backed by a real artifact
@@ -1026,7 +1074,356 @@ pub fn emit_scip_artifacts_from_store(
     if stub.is_file() {
         std::fs::remove_file(stub).context("remove scip stub marker")?;
     }
-    Ok(Some(revision))
+    Ok(ScipIncrementalOutcome {
+        revision: Some(revision),
+        retained_records: work.retained,
+        inserted_records: work.inserted,
+        removed_records: work.removed,
+        reordered_records: work.reordered,
+        cloned: work.cloned,
+    })
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ScipComponentWork {
+    retained: u64,
+    inserted: u64,
+    removed: u64,
+    reordered: u64,
+    cloned: bool,
+}
+
+#[derive(Debug, Clone)]
+struct ScipComponentRow {
+    key: String,
+    kind: &'static str,
+    record_sha256: String,
+    record_json: String,
+    ordinal: u64,
+}
+
+fn publish_scip_component(
+    project_dir: &Path,
+    previous_project_dir: Option<&Path>,
+    index: &ScipSymbolsIndex,
+    before_publish: &mut dyn FnMut() -> Result<()>,
+) -> Result<ScipComponentWork> {
+    let rows = scip_component_rows(index)?;
+    let path = project_dir.join(SCIP_SYMBOLS_DATABASE_FILE);
+    let (temp_path, reserved) =
+        codestory_workspace::atomic_file::create_unique_temp_file(&path, "scip-symbols")?;
+    drop(reserved);
+    let result: Result<ScipComponentWork> = (|| {
+        std::fs::remove_file(&temp_path)?;
+        let mut cloned = false;
+        if let Some(previous_dir) = previous_project_dir {
+            let previous_path = previous_dir.join(SCIP_SYMBOLS_DATABASE_FILE);
+            if load_scip_symbols_database(&previous_path).is_ok()
+                && crate::copy_on_write::clone_file(&previous_path, &temp_path)?
+            {
+                cloned = true;
+            }
+        }
+        let work = if cloned {
+            reconcile_scip_component(&temp_path, index, &rows)?
+        } else {
+            write_scip_component(&temp_path, index, &rows)?
+        };
+        let observed = load_scip_symbols_database(&temp_path)?;
+        if &observed != index {
+            bail!("staged scip component differs from its pinned graph projection");
+        }
+        before_publish()?;
+        codestory_workspace::atomic_file::publish_existing_file_atomic(&temp_path, &path)?;
+        let legacy = project_dir.join(SCIP_SYMBOLS_FILE);
+        if legacy.is_file() {
+            std::fs::remove_file(legacy)?;
+        }
+        Ok(ScipComponentWork { cloned, ..work })
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temp_path);
+    }
+    result
+}
+
+fn scip_component_rows(index: &ScipSymbolsIndex) -> Result<Vec<ScipComponentRow>> {
+    let mut rows = Vec::with_capacity(index.symbols.len() + index.proofs.len());
+    let mut keys = BTreeMap::<String, String>::new();
+    for (ordinal, symbol) in index.symbols.iter().enumerate() {
+        let node_id = symbol
+            .node_id
+            .as_deref()
+            .context("graph-projection scip symbol is missing its node identity")?;
+        let record_json = serde_json::to_string(symbol)?;
+        let record_sha256 = sha256_text(&record_json);
+        let key = format!("symbol:{node_id}");
+        if keys.insert(key.clone(), record_sha256.clone()).is_some() {
+            bail!("duplicate graph-projection scip symbol identity");
+        }
+        rows.push(ScipComponentRow {
+            key,
+            kind: "symbol",
+            record_sha256,
+            record_json,
+            ordinal: ordinal as u64,
+        });
+    }
+    let mut proof_occurrences = HashMap::<String, u32>::new();
+    for (ordinal, proof) in index.proofs.iter().enumerate() {
+        let record_json = serde_json::to_string(proof)?;
+        let record_sha256 = sha256_text(&record_json);
+        let occurrence = proof_occurrences.entry(record_sha256.clone()).or_default();
+        let key = format!("proof:{record_sha256}:{occurrence}");
+        *occurrence = occurrence
+            .checked_add(1)
+            .context("scip proof occurrence overflow")?;
+        if let Some(previous_hash) = keys.insert(key.clone(), record_sha256.clone())
+            && previous_hash != record_sha256
+        {
+            bail!("scip component key collision");
+        }
+        rows.push(ScipComponentRow {
+            key,
+            kind: "proof",
+            record_sha256,
+            record_json,
+            ordinal: ordinal as u64,
+        });
+    }
+    rows.sort_by(|left, right| left.key.cmp(&right.key));
+    Ok(rows)
+}
+
+fn write_scip_component(
+    path: &Path,
+    index: &ScipSymbolsIndex,
+    rows: &[ScipComponentRow],
+) -> Result<ScipComponentWork> {
+    let mut connection = Connection::open(sqlite_open_path(path))?;
+    connection.execute_batch(
+        "PRAGMA journal_mode=OFF;
+         PRAGMA synchronous=FULL;
+         PRAGMA user_version=1;
+         CREATE TABLE metadata (
+             singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+             generation TEXT NOT NULL,
+             revision TEXT NOT NULL,
+             contract_json TEXT NOT NULL,
+             symbol_count INTEGER NOT NULL,
+             proof_count INTEGER NOT NULL,
+             component_sha256 TEXT NOT NULL
+         );
+         CREATE TABLE records (
+             record_key TEXT PRIMARY KEY NOT NULL,
+             kind TEXT NOT NULL,
+             record_sha256 TEXT NOT NULL,
+             record_json TEXT NOT NULL
+         ) WITHOUT ROWID;
+         CREATE TABLE record_order (
+             record_key TEXT PRIMARY KEY NOT NULL REFERENCES records(record_key),
+             ordinal INTEGER NOT NULL
+         ) WITHOUT ROWID;",
+    )?;
+    let transaction = connection.transaction()?;
+    {
+        let mut insert = transaction.prepare(
+            "INSERT INTO records(record_key, kind, record_sha256, record_json)
+             VALUES (?1, ?2, ?3, ?4)",
+        )?;
+        let mut insert_order =
+            transaction.prepare("INSERT INTO record_order(record_key, ordinal) VALUES (?1, ?2)")?;
+        for row in rows {
+            insert.execute(params![
+                row.key,
+                row.kind,
+                row.record_sha256,
+                row.record_json
+            ])?;
+            insert_order.execute(params![
+                row.key,
+                i64::try_from(row.ordinal).context("scip record ordinal overflow")?
+            ])?;
+        }
+    }
+    write_scip_component_metadata(&transaction, index)?;
+    transaction.commit()?;
+    drop(connection);
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(path)?
+        .sync_all()?;
+    Ok(ScipComponentWork {
+        retained: 0,
+        inserted: rows.len() as u64,
+        removed: 0,
+        reordered: 0,
+        cloned: false,
+    })
+}
+
+fn reconcile_scip_component(
+    path: &Path,
+    index: &ScipSymbolsIndex,
+    rows: &[ScipComponentRow],
+) -> Result<ScipComponentWork> {
+    let desired = rows
+        .iter()
+        .map(|row| (row.key.as_str(), row.record_sha256.as_str()))
+        .collect::<HashMap<_, _>>();
+    let mut connection = Connection::open(sqlite_open_path(path))?;
+    let schema: i32 = connection.query_row("PRAGMA user_version", [], |row| row.get(0))?;
+    if schema != 1 {
+        bail!("cloned scip component schema is not current");
+    }
+    connection.execute_batch("PRAGMA journal_mode=OFF; PRAGMA synchronous=FULL;")?;
+    let transaction = connection.transaction()?;
+    let existing = {
+        let mut statement = transaction.prepare(
+            "SELECT r.record_key, r.record_sha256, o.ordinal
+             FROM records r JOIN record_order o ON o.record_key = r.record_key
+             ORDER BY r.record_key",
+        )?;
+        statement
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, i64>(2)?,
+                ))
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?
+    };
+    let existing_map = existing
+        .iter()
+        .map(|(key, hash, _)| (key.as_str(), hash.as_str()))
+        .collect::<HashMap<_, _>>();
+    let retained = existing
+        .iter()
+        .filter(|(key, hash, _)| desired.get(key.as_str()) == Some(&hash.as_str()))
+        .count();
+    let retained_order = existing
+        .iter()
+        .filter(|(key, hash, _)| desired.get(key.as_str()) == Some(&hash.as_str()))
+        .map(|(key, _, ordinal)| (key.as_str(), *ordinal))
+        .collect::<HashMap<_, _>>();
+    for (key, hash, _) in &existing {
+        if desired.get(key.as_str()) != Some(&hash.as_str()) {
+            transaction.execute(
+                "DELETE FROM record_order WHERE record_key = ?1",
+                params![key],
+            )?;
+            transaction.execute("DELETE FROM records WHERE record_key = ?1", params![key])?;
+        }
+    }
+    let missing = rows
+        .iter()
+        .filter(|row| existing_map.get(row.key.as_str()) != Some(&row.record_sha256.as_str()))
+        .collect::<Vec<_>>();
+    {
+        let mut insert = transaction.prepare(
+            "INSERT INTO records(record_key, kind, record_sha256, record_json)
+             VALUES (?1, ?2, ?3, ?4)",
+        )?;
+        for row in &missing {
+            insert.execute(params![
+                row.key,
+                row.kind,
+                row.record_sha256,
+                row.record_json
+            ])?;
+        }
+    }
+    {
+        let mut insert_order = transaction.prepare(
+            "INSERT INTO record_order(record_key, ordinal) VALUES (?1, ?2)
+             ON CONFLICT(record_key) DO UPDATE SET ordinal = excluded.ordinal",
+        )?;
+        for row in rows.iter().filter(|row| {
+            retained_order.get(row.key.as_str())
+                != Some(&i64::try_from(row.ordinal).unwrap_or(i64::MAX))
+        }) {
+            insert_order.execute(params![
+                row.key,
+                i64::try_from(row.ordinal).context("scip record ordinal overflow")?
+            ])?;
+        }
+    }
+    transaction.execute("DELETE FROM metadata", [])?;
+    write_scip_component_metadata(&transaction, index)?;
+    transaction.commit()?;
+    drop(connection);
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(path)?
+        .sync_all()?;
+    Ok(ScipComponentWork {
+        retained: retained as u64,
+        inserted: missing.len() as u64,
+        removed: existing.len().saturating_sub(retained) as u64,
+        reordered: rows
+            .iter()
+            .filter(|row| {
+                retained_order.get(row.key.as_str())
+                    != Some(&i64::try_from(row.ordinal).unwrap_or(i64::MAX))
+            })
+            .count() as u64,
+        cloned: true,
+    })
+}
+
+fn write_scip_component_metadata(connection: &Connection, index: &ScipSymbolsIndex) -> Result<()> {
+    let component_sha256 = scip_component_digest(connection)?;
+    connection.execute(
+        "INSERT INTO metadata VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6)",
+        params![
+            index.generation,
+            index.revision,
+            serde_json::to_string(&index.contract)?,
+            i64::try_from(index.symbols.len()).context("scip symbol count overflow")?,
+            i64::try_from(index.proofs.len()).context("scip proof count overflow")?,
+            component_sha256,
+        ],
+    )?;
+    Ok(())
+}
+
+fn scip_component_digest(connection: &Connection) -> Result<String> {
+    let mut statement =
+        connection.prepare("SELECT record_key, record_sha256 FROM records ORDER BY record_key")?;
+    let mut rows = statement.query([])?;
+    let mut digest = Sha256::new();
+    digest.update(b"codestory-scip-component-v1\0");
+    while let Some(row) = rows.next()? {
+        let key = row.get::<_, String>(0)?;
+        let hash = row.get::<_, String>(1)?;
+        if hash.len() != 64 || !hash.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            bail!("scip component row digest is invalid");
+        }
+        digest.update((key.len() as u64).to_le_bytes());
+        digest.update(key.as_bytes());
+        digest.update(hash.as_bytes());
+    }
+    drop(rows);
+    drop(statement);
+    let mut order =
+        connection.prepare("SELECT record_key, ordinal FROM record_order ORDER BY record_key")?;
+    let mut rows = order.query([])?;
+    while let Some(row) = rows.next()? {
+        let key = row.get::<_, String>(0)?;
+        let ordinal = row.get::<_, i64>(1)?;
+        if ordinal < 0 {
+            bail!("scip component record ordinal is invalid");
+        }
+        digest.update((key.len() as u64).to_le_bytes());
+        digest.update(key.as_bytes());
+        digest.update(ordinal.to_le_bytes());
+    }
+    Ok(format!("{:x}", digest.finalize()))
+}
+
+fn sha256_text(value: &str) -> String {
+    format!("{:x}", Sha256::digest(value.as_bytes()))
 }
 
 fn scip_revision_for_symbols(
@@ -1182,6 +1579,10 @@ fn normalize_scip_path(path: &str) -> String {
 }
 
 pub fn load_scip_symbols(project_dir: &Path) -> Result<Option<ScipSymbolsIndex>> {
+    let database_path = project_dir.join(SCIP_SYMBOLS_DATABASE_FILE);
+    if database_path.is_file() {
+        return load_scip_symbols_database(&database_path).map(Some);
+    }
     let path = project_dir.join(SCIP_SYMBOLS_FILE);
     if !path.is_file() {
         return Ok(None);
@@ -1190,6 +1591,79 @@ pub fn load_scip_symbols(project_dir: &Path) -> Result<Option<ScipSymbolsIndex>>
     let parsed: ScipSymbolsIndex =
         serde_json::from_str(&body).context("parse scip symbols index json")?;
     Ok(Some(parsed))
+}
+
+fn load_scip_symbols_database(path: &Path) -> Result<ScipSymbolsIndex> {
+    let connection = Connection::open_with_flags(
+        sqlite_open_path(path),
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )?;
+    let schema: i32 = connection.query_row("PRAGMA user_version", [], |row| row.get(0))?;
+    if schema != 1 {
+        bail!("scip component schema is not current");
+    }
+    let check: String = connection.query_row("PRAGMA quick_check(1)", [], |row| row.get(0))?;
+    if check != "ok" {
+        bail!("scip component failed quick_check");
+    }
+    let (generation, revision, contract_json, symbol_count, proof_count, expected_digest) =
+        connection.query_row(
+            "SELECT generation, revision, contract_json, symbol_count, proof_count,
+                        component_sha256
+                 FROM metadata WHERE singleton = 1",
+            [],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get::<_, i64>(4)?,
+                    row.get::<_, String>(5)?,
+                ))
+            },
+        )?;
+    if scip_component_digest(&connection)? != expected_digest {
+        bail!("scip component digest mismatch");
+    }
+    let mut symbols = Vec::new();
+    let mut proofs = Vec::new();
+    let mut statement = connection.prepare(
+        "SELECT r.kind, r.record_sha256, r.record_json
+         FROM records r
+         JOIN record_order o ON o.record_key = r.record_key
+         ORDER BY CASE r.kind WHEN 'symbol' THEN 0 ELSE 1 END, o.ordinal",
+    )?;
+    let mut rows = statement.query([])?;
+    while let Some(row) = rows.next()? {
+        let kind = row.get::<_, String>(0)?;
+        let expected_hash = row.get::<_, String>(1)?;
+        let json = row.get::<_, String>(2)?;
+        if sha256_text(&json) != expected_hash {
+            bail!("scip component record digest mismatch");
+        }
+        match kind.as_str() {
+            "symbol" => symbols.push(serde_json::from_str(&json)?),
+            "proof" => proofs.push(serde_json::from_str(&json)?),
+            _ => bail!("scip component contains an unknown record kind"),
+        }
+    }
+    if i64::try_from(symbols.len()).unwrap_or(i64::MAX) != symbol_count
+        || i64::try_from(proofs.len()).unwrap_or(i64::MAX) != proof_count
+    {
+        bail!("scip component record cardinality mismatch");
+    }
+    let index = ScipSymbolsIndex {
+        generation,
+        revision,
+        contract: serde_json::from_str(&contract_json)?,
+        symbols,
+        proofs,
+    };
+    index
+        .validate_records(&index.generation)
+        .context("validate scip component records")?;
+    Ok(index)
 }
 
 pub(crate) fn load_fresh_scip_symbols(
@@ -1208,7 +1682,7 @@ pub(crate) fn load_fresh_scip_query_view(
     expected_revision: &str,
     generation: &str,
 ) -> Result<Option<Arc<ScipQueryView>>> {
-    let path = project_dir.join(SCIP_SYMBOLS_FILE);
+    let path = scip_symbols_component_path(project_dir);
     let revision_path = project_dir.join("revision.txt");
     let marker_path = project_dir.join(SCIP_INDEX_FILE);
     if !path.is_file() || !revision_path.is_file() || !marker_path.is_file() {
@@ -1253,6 +1727,176 @@ mod tests {
     use codestory_contracts::graph::{Edge, EdgeId, Node, NodeId, NodeKind, ResolutionCertainty};
     use codestory_store::{FileInfo, FileRole, SearchSymbolProjection};
     use tempfile::TempDir;
+
+    fn component_symbol(node_id: &str, path: &str, symbol: &str) -> ScipSymbolRecord {
+        ScipSymbolRecord {
+            node_id: Some(node_id.into()),
+            path: path.into(),
+            symbol: symbol.into(),
+            start_line: 1,
+            end_line: 1,
+        }
+    }
+
+    fn component_index(generation: &str, mut symbols: Vec<ScipSymbolRecord>) -> ScipSymbolsIndex {
+        symbols.sort_by(|left, right| left.node_id.cmp(&right.node_id));
+        let mut proofs = symbols
+            .iter()
+            .map(ScipProofRecord::definition)
+            .collect::<Vec<_>>();
+        proofs
+            .sort_by_key(|record| sha256_text(&serde_json::to_string(record).expect("proof json")));
+        let revision = scip_revision_for_symbols(&symbols, &[]);
+        ScipSymbolsIndex {
+            generation: generation.into(),
+            revision: revision.clone(),
+            contract: ScipProofAdapterContract::graph_projection(&revision),
+            symbols,
+            proofs,
+        }
+    }
+
+    #[test]
+    fn incremental_scip_component_matches_clean_add_change_delete_and_rename() {
+        let root = TempDir::new().expect("tempdir");
+        let previous_dir = root.path().join("previous");
+        let current_dir = root.path().join("current");
+        std::fs::create_dir_all(&previous_dir).expect("previous dir");
+        std::fs::create_dir_all(&current_dir).expect("current dir");
+        let previous = component_index(
+            "generation-v1",
+            vec![
+                component_symbol("1", "src/a.rs", "alpha"),
+                component_symbol("2", "src/b.rs", "beta"),
+                component_symbol("4", "src/kept.rs", "kept"),
+            ],
+        );
+        let previous_work = publish_scip_component(&previous_dir, None, &previous, &mut || Ok(()))
+            .expect("previous component");
+        assert!(!previous_work.cloned);
+
+        let current = component_index(
+            "generation-v2",
+            vec![
+                component_symbol("1", "src/a.rs", "alpha_changed"),
+                component_symbol("3", "src/renamed.rs", "beta"),
+                component_symbol("4", "src/kept.rs", "kept"),
+            ],
+        );
+        let work =
+            publish_scip_component(&current_dir, Some(&previous_dir), &current, &mut || Ok(()))
+                .expect("incremental component");
+        if !work.cloned {
+            return;
+        }
+        assert_eq!(work.retained, 2);
+        assert_eq!(work.inserted, 4);
+        assert_eq!(work.removed, 4);
+        assert_eq!(work.reordered, 4);
+        assert_eq!(
+            load_scip_symbols_database(&current_dir.join(SCIP_SYMBOLS_DATABASE_FILE))
+                .expect("current component"),
+            current
+        );
+    }
+
+    #[test]
+    fn identical_scip_records_do_not_rewrite_ordering_rows() {
+        let root = TempDir::new().expect("tempdir");
+        let previous_dir = root.path().join("previous");
+        let current_dir = root.path().join("current");
+        std::fs::create_dir_all(&previous_dir).expect("previous dir");
+        std::fs::create_dir_all(&current_dir).expect("current dir");
+        let previous = component_index(
+            "generation-v1",
+            vec![
+                component_symbol("1", "src/a.rs", "alpha"),
+                component_symbol("2", "src/b.rs", "beta"),
+            ],
+        );
+        publish_scip_component(&previous_dir, None, &previous, &mut || Ok(()))
+            .expect("previous component");
+        let mut current = previous.clone();
+        current.generation = "generation-v2".into();
+
+        let work =
+            publish_scip_component(&current_dir, Some(&previous_dir), &current, &mut || Ok(()))
+                .expect("incremental component");
+        if !work.cloned {
+            return;
+        }
+        assert_eq!(work.retained, 4);
+        assert_eq!(work.inserted, 0);
+        assert_eq!(work.removed, 0);
+        assert_eq!(work.reordered, 0);
+    }
+
+    #[test]
+    fn cancelled_scip_component_leaves_no_candidate_database() {
+        let root = TempDir::new().expect("tempdir");
+        let previous_dir = root.path().join("previous");
+        let cancelled_dir = root.path().join("cancelled");
+        std::fs::create_dir_all(&previous_dir).expect("previous dir");
+        std::fs::create_dir_all(&cancelled_dir).expect("cancelled dir");
+        let previous = component_index(
+            "generation-v1",
+            vec![component_symbol("1", "src/a.rs", "alpha")],
+        );
+        publish_scip_component(&previous_dir, None, &previous, &mut || Ok(()))
+            .expect("previous component");
+        let current = component_index(
+            "generation-v2",
+            vec![component_symbol("1", "src/a.rs", "changed")],
+        );
+
+        let error =
+            publish_scip_component(&cancelled_dir, Some(&previous_dir), &current, &mut || {
+                bail!("simulated SCIP cancellation")
+            })
+            .expect_err("cancelled SCIP component must fail");
+
+        assert!(format!("{error:#}").contains("simulated SCIP cancellation"));
+        assert!(!cancelled_dir.join(SCIP_SYMBOLS_DATABASE_FILE).exists());
+        assert_eq!(
+            std::fs::read_dir(&cancelled_dir)
+                .expect("cancelled SCIP directory")
+                .count(),
+            0,
+            "failed SCIP staging must not leak a generation-local clone"
+        );
+    }
+
+    #[test]
+    fn corrupt_scip_predecessor_falls_back_to_a_clean_component() {
+        let root = TempDir::new().expect("tempdir");
+        let previous_dir = root.path().join("previous");
+        let current_dir = root.path().join("current");
+        std::fs::create_dir_all(&previous_dir).expect("previous dir");
+        std::fs::create_dir_all(&current_dir).expect("current dir");
+        let previous = component_index(
+            "generation-v1",
+            vec![component_symbol("1", "src/a.rs", "old")],
+        );
+        publish_scip_component(&previous_dir, None, &previous, &mut || Ok(()))
+            .expect("previous component");
+        std::fs::write(previous_dir.join(SCIP_SYMBOLS_DATABASE_FILE), b"not sqlite")
+            .expect("corrupt predecessor");
+        let current = component_index(
+            "generation-v2",
+            vec![component_symbol("1", "src/a.rs", "current")],
+        );
+
+        let work =
+            publish_scip_component(&current_dir, Some(&previous_dir), &current, &mut || Ok(()))
+                .expect("complete fallback");
+
+        assert!(!work.cloned);
+        assert_eq!(
+            load_scip_symbols_database(&current_dir.join(SCIP_SYMBOLS_DATABASE_FILE))
+                .expect("load fallback component"),
+            current
+        );
+    }
 
     #[test]
     fn scip_emit_streams_canonical_pages_independent_of_legacy_projection() {

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -366,14 +366,15 @@ pub use repository_identity::{
     REPOSITORY_IDENTITY_SCHEMA_VERSION, RepositoryIdentityReport, inspect_repository_identity,
 };
 pub use retrieval_boundary::{
-    CacheCleanPlan, CacheCleanReport, FinalizeIndexOutcome, GenerationRetentionApplyReport,
-    GenerationRetentionPlan, ProcessOwnerState, ProcessStartProbe, QueryResult,
-    RetainedRollbackObservation, RetrievalIndexManifest, RetrievalProcessDefaults,
-    RetrievalRuntimeDefaults, RetrievalRuntimeOverrides, RetrievalStatusReport,
-    RollbackActivationError, RollbackActivationOutcome, RollbackActivationRefusal,
-    RuntimeRetrievalConfig, RuntimeRetrievalProfile, SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED,
-    SidecarGcReport, SidecarInventoryReport, apply_cache_clean,
-    ensure_product_embedding_backend_for_runtime, plan_cache_clean, retrieval_process_defaults,
+    CacheCleanPlan, CacheCleanReport, FinalizeComponentWork, FinalizeIndexOutcome,
+    FinalizePhaseTiming, GenerationRetentionApplyReport, GenerationRetentionPlan,
+    ProcessOwnerState, ProcessStartProbe, QueryResult, RetainedRollbackObservation,
+    RetrievalIndexManifest, RetrievalProcessDefaults, RetrievalRuntimeDefaults,
+    RetrievalRuntimeOverrides, RetrievalStatusReport, RollbackActivationError,
+    RollbackActivationOutcome, RollbackActivationRefusal, RuntimeRetrievalConfig,
+    RuntimeRetrievalProfile, SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED, SidecarGcReport,
+    SidecarInventoryReport, apply_cache_clean, ensure_product_embedding_backend_for_runtime,
+    plan_cache_clean, retrieval_process_defaults,
 };
 pub(crate) use search_runtime::SearchEngine;
 

--- a/crates/codestory-runtime/src/retrieval_boundary.rs
+++ b/crates/codestory-runtime/src/retrieval_boundary.rs
@@ -1,12 +1,12 @@
 use std::path::Path;
 
 pub use codestory_retrieval::{
-    CacheCleanPlan, CacheCleanReport, FinalizeIndexOutcome, GenerationRetentionApplyReport,
-    GenerationRetentionPlan, ProcessOwnerState, ProcessStartProbe, QueryResult,
-    RetainedRollbackObservation, RetrievalIndexManifest, RetrievalStatusReport,
-    RollbackActivationError, RollbackActivationOutcome, RollbackActivationRefusal,
-    SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED, SidecarGcReport, SidecarInventoryReport,
-    SidecarProcessDefaults as RetrievalProcessDefaults,
+    CacheCleanPlan, CacheCleanReport, FinalizeComponentWork, FinalizeIndexOutcome,
+    FinalizePhaseTiming, GenerationRetentionApplyReport, GenerationRetentionPlan,
+    ProcessOwnerState, ProcessStartProbe, QueryResult, RetainedRollbackObservation,
+    RetrievalIndexManifest, RetrievalStatusReport, RollbackActivationError,
+    RollbackActivationOutcome, RollbackActivationRefusal, SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED,
+    SidecarGcReport, SidecarInventoryReport, SidecarProcessDefaults as RetrievalProcessDefaults,
     SidecarRuntimeDefaults as RetrievalRuntimeDefaults,
     SidecarRuntimeOverrides as RetrievalRuntimeOverrides,
 };


### PR DESCRIPTION
## Context

Incremental core indexing already limits parser work to changed files, but retrieval derived a new physical generation from each core generation/run identity. That forced complete lexical, vector, and graph stores to be rebuilt on every incremental publication. Across the 18-repository product benchmark, incremental preparation was 88.05% of cold time on the discarded 0.18 candidate; Redis was effectively unchanged at 111.65s cold and 111.22s incremental.

Closes #2084
Refs #2066, #2023, #1973

## What changed

- separate reusable component compatibility from the publication-binding envelope;
- clone compatible SQLite components with native copy-on-write support and apply exact add/change/delete deltas;
- retain unchanged vector blobs directly instead of rewriting the complete vector database;
- update graph records and native ordering incrementally;
- reuse captured source inventory and hashes at the publication fence;
- expose retrieval phase and component accounting without leaking paths or document content;
- preserve atomic staging, corruption fallback, cancellation cleanup, and old-or-new publication behavior.

The ordinary graph, proof authority, packet/context/search DTOs, public routes, schema version, release version, and the 0.17 lane are unchanged.

## Consolidated adversarial review

One frozen trust-boundary review covered schema fallback, corruption, source drift, ordering, accounting, cleanup, and publication compatibility. Its complete correction batch is included here:

- schema-v1 vector stores fall back to a complete rebuild;
- vector blobs are rehashed during validation even if stored row digests were forged;
- source seals replace repeated live-source reads at finalization;
- identical graph ordering performs zero order writes;
- manifest timing and component byte accounting are complete;
- every staged failure removes temporary clones;
- physical vector compatibility ignores changing publication identities while final manifest validation remains publication-bound.

No further stylistic review round was added.

## Local verification

On commit `3c5907695c72639ba079611b2281267ad6f13cb3`:

- formatting check: passed;
- focused retrieval and CLI check: passed;
- focused warnings-as-errors lint: passed;
- retrieval library tests: 343 passed, 3 ignored;
- CLI retrieval observability contract: 1 passed;
- whitespace validation: passed;
- hostile tests cover legacy fallback, forged vector digest, in-place source drift, identical native ordering, staging cleanup, cancellation, timing, and component accounting.

## Performance evidence

The activation branch contains proof parser fixes not yet present on the 0.18 support base, so the repository-class probe used a disposable integration checkout combining exact activation source `ad845017705e478b7cf097ddfb78b0c14e38b4f8` with this support change. The support PR itself remains based on `dev/codestory-0.18`.

On an isolated Redis checkout and cache:

- cold: 113.45s;
- accepted incremental: 24.56s (21.65% of cold, a 78.35% reduction);
- retrieval work inside that incremental run: about 6.96s;
- lexical retained 32,867 documents with zero inserts/removals;
- vectors retained 22,269 rows with zero inserts/removals;
- graph retained 98,616 records with zero inserts/removals/reorders.

The remaining roughly 7.58s of core publication staging is separate from the retrieval full-rebuild defect and is not widened into this PR.

## Review focus

Please review the closed trust boundary: physical compatibility versus publication identity, exact delta classification, validation of reused bytes, native ordering, staged cleanup, and fail-closed fallback. This PR does not broaden language adapters or alter public proof semantics.


