### PR TITLE
Reuse retrieval components across incremental refreshes

### DIFF
--- a/crates/codestory-retrieval/src/copy_on_write.rs
+++ b/crates/codestory-retrieval/src/copy_on_write.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 #[cfg(test)]
 thread_local! {
     static CLONE_DISABLED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    static PUBLICATION_DISABLED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
 #[cfg(test)]
@@ -16,6 +17,23 @@ pub(crate) fn with_clone_disabled<T>(action: impl FnOnce() -> T) -> T {
     }
 
     CLONE_DISABLED.with(|disabled| {
+        let restore = Restore(disabled.replace(true));
+        let result = action();
+        drop(restore);
+        result
+    })
+}
+
+#[cfg(test)]
+fn with_publication_disabled<T>(action: impl FnOnce() -> T) -> T {
+    struct Restore(bool);
+    impl Drop for Restore {
+        fn drop(&mut self) {
+            PUBLICATION_DISABLED.set(self.0);
+        }
+    }
+
+    PUBLICATION_DISABLED.with(|disabled| {
         let restore = Restore(disabled.replace(true));
         let result = action();
         drop(restore);
@@ -97,19 +115,13 @@ pub(crate) fn make_file_immutable(path: &Path) -> Result<()> {
     if !metadata.file_type().is_file() {
         bail!("immutable component is not a regular file");
     }
-    let mut permissions = metadata.permissions();
+    let permissions = immutable_permissions(metadata.permissions());
     if permissions.readonly() {
-        return Ok(());
+        std::fs::set_permissions(path, permissions)
+            .with_context(|| format!("make component immutable {}", path.display()))?;
+    } else {
+        bail!("component immutable permissions remained writable");
     }
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        permissions.set_mode(permissions.mode() & !0o222);
-    }
-    #[cfg(not(unix))]
-    permissions.set_readonly(true);
-    std::fs::set_permissions(path, permissions)
-        .with_context(|| format!("make component immutable {}", path.display()))?;
     if !std::fs::symlink_metadata(path)?.permissions().readonly() {
         bail!("component remained owner-writable after immutable publication");
     }
@@ -122,7 +134,81 @@ pub(crate) fn make_file_owner_writable(path: &Path) -> Result<()> {
     if !metadata.file_type().is_file() {
         bail!("staged component is not a regular file");
     }
-    let mut permissions = metadata.permissions();
+    let permissions = owner_writable_permissions(metadata.permissions());
+    std::fs::set_permissions(path, permissions)
+        .with_context(|| format!("make staged component owner-writable {}", path.display()))
+}
+
+pub(crate) fn publish_immutable_file_atomic(temp_path: &Path, destination: &Path) -> Result<()> {
+    make_file_immutable(temp_path)?;
+    let previous = match std::fs::symlink_metadata(destination) {
+        Ok(metadata) => {
+            if metadata.file_type().is_symlink() || !metadata.file_type().is_file() {
+                bail!("immutable component replacement destination is not a regular file");
+            }
+            let handle = open_permission_handle(destination)?;
+            handle
+                .set_permissions(owner_writable_permissions(metadata.permissions()))
+                .with_context(|| {
+                    format!(
+                        "temporarily permit immutable component replacement {}",
+                        destination.display()
+                    )
+                })?;
+            Some(handle)
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => return Err(error).context("inspect immutable component destination"),
+    };
+
+    #[cfg(test)]
+    let publication = if PUBLICATION_DISABLED.get() {
+        Err(anyhow::anyhow!(
+            "simulated immutable component publication failure"
+        ))
+    } else {
+        codestory_workspace::atomic_file::publish_existing_file_atomic(temp_path, destination)
+    };
+    #[cfg(not(test))]
+    let publication =
+        codestory_workspace::atomic_file::publish_existing_file_atomic(temp_path, destination);
+    let previous_restoration = previous.map_or(Ok(()), |handle| {
+        let permissions = handle.metadata()?.permissions();
+        handle
+            .set_permissions(immutable_permissions(permissions))
+            .context("restore replaced immutable component permissions")
+    });
+
+    match publication {
+        Ok(()) => {
+            previous_restoration?;
+            make_file_immutable(destination)
+        }
+        Err(error) => {
+            if let Err(restoration) = previous_restoration {
+                return Err(restoration).context(format!(
+                    "restore immutable destination after failed publication: {error:#}"
+                ));
+            }
+            let _ = make_file_immutable(destination);
+            let _ = make_file_owner_writable(temp_path);
+            Err(error)
+        }
+    }
+}
+
+fn immutable_permissions(mut permissions: std::fs::Permissions) -> std::fs::Permissions {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        permissions.set_mode(permissions.mode() & !0o222);
+    }
+    #[cfg(not(unix))]
+    permissions.set_readonly(true);
+    permissions
+}
+
+fn owner_writable_permissions(mut permissions: std::fs::Permissions) -> std::fs::Permissions {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
@@ -130,8 +216,29 @@ pub(crate) fn make_file_owner_writable(path: &Path) -> Result<()> {
     }
     #[cfg(not(unix))]
     permissions.set_readonly(false);
-    std::fs::set_permissions(path, permissions)
-        .with_context(|| format!("make staged component owner-writable {}", path.display()))
+    permissions
+}
+
+#[cfg(windows)]
+fn open_permission_handle(path: &Path) -> Result<std::fs::File> {
+    use std::os::windows::fs::OpenOptionsExt;
+
+    const FILE_SHARE_READ: u32 = 0x0000_0001;
+    const FILE_SHARE_WRITE: u32 = 0x0000_0002;
+    const FILE_SHARE_DELETE: u32 = 0x0000_0004;
+    const FILE_READ_ATTRIBUTES: u32 = 0x0000_0080;
+    const FILE_WRITE_ATTRIBUTES: u32 = 0x0000_0100;
+    std::fs::OpenOptions::new()
+        .access_mode(FILE_READ_ATTRIBUTES | FILE_WRITE_ATTRIBUTES)
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
+        .open(path)
+        .with_context(|| format!("open immutable component permissions {}", path.display()))
+}
+
+#[cfg(not(windows))]
+fn open_permission_handle(path: &Path) -> Result<std::fs::File> {
+    std::fs::File::open(path)
+        .with_context(|| format!("open immutable component permissions {}", path.display()))
 }
 
 #[cfg(target_os = "macos")]
@@ -247,6 +354,74 @@ mod tests {
         assert!(std::fs::metadata(&source).unwrap().permissions().readonly());
         assert!(
             std::fs::metadata(&destination)
+                .unwrap()
+                .permissions()
+                .readonly()
+        );
+    }
+
+    #[test]
+    fn immutable_publication_replaces_a_readonly_hard_link_without_mutating_its_predecessor() {
+        let root = tempfile::TempDir::new().expect("tempdir");
+        let predecessor = root.path().join("predecessor");
+        let current = root.path().join("current");
+        let staged = root.path().join("staged");
+        std::fs::write(&predecessor, b"old").expect("predecessor");
+        make_file_immutable(&predecessor).expect("immutable predecessor");
+        assert!(reference_file(&predecessor, &current).expect("current hard link"));
+        std::fs::write(&staged, b"new").expect("staged");
+
+        publish_immutable_file_atomic(&staged, &current).expect("replace readonly current");
+
+        assert_eq!(std::fs::read(&predecessor).unwrap(), b"old");
+        assert_eq!(std::fs::read(&current).unwrap(), b"new");
+        assert!(!codestory_workspace::same_workspace_path(
+            &predecessor,
+            &current
+        ));
+        assert!(
+            std::fs::metadata(&predecessor)
+                .unwrap()
+                .permissions()
+                .readonly()
+        );
+        assert!(
+            std::fs::metadata(&current)
+                .unwrap()
+                .permissions()
+                .readonly()
+        );
+    }
+
+    #[test]
+    fn failed_immutable_publication_restores_the_hard_linked_predecessor() {
+        let root = tempfile::TempDir::new().expect("tempdir");
+        let predecessor = root.path().join("predecessor");
+        let current = root.path().join("current");
+        let staged = root.path().join("staged");
+        std::fs::write(&predecessor, b"old").expect("predecessor");
+        make_file_immutable(&predecessor).expect("immutable predecessor");
+        assert!(reference_file(&predecessor, &current).expect("current hard link"));
+        std::fs::write(&staged, b"new").expect("staged");
+
+        let error = with_publication_disabled(|| publish_immutable_file_atomic(&staged, &current))
+            .expect_err("injected publication must fail");
+
+        assert!(error.to_string().contains("simulated immutable component"));
+        assert_eq!(std::fs::read(&predecessor).unwrap(), b"old");
+        assert_eq!(std::fs::read(&current).unwrap(), b"old");
+        assert!(codestory_workspace::same_workspace_path(
+            &predecessor,
+            &current
+        ));
+        assert!(
+            std::fs::metadata(&predecessor)
+                .unwrap()
+                .permissions()
+                .readonly()
+        );
+        assert!(
+            std::fs::metadata(&current)
                 .unwrap()
                 .permissions()
                 .readonly()

--- a/crates/codestory-retrieval/src/copy_on_write.rs
+++ b/crates/codestory-retrieval/src/copy_on_write.rs
@@ -1,6 +1,28 @@
 use anyhow::{Context, Result, bail};
 use std::path::Path;
 
+#[cfg(test)]
+thread_local! {
+    static CLONE_DISABLED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+#[cfg(test)]
+pub(crate) fn with_clone_disabled<T>(action: impl FnOnce() -> T) -> T {
+    struct Restore(bool);
+    impl Drop for Restore {
+        fn drop(&mut self) {
+            CLONE_DISABLED.set(self.0);
+        }
+    }
+
+    CLONE_DISABLED.with(|disabled| {
+        let restore = Restore(disabled.replace(true));
+        let result = action();
+        drop(restore);
+        result
+    })
+}
+
 /// Clone one immutable component into a distinct candidate file without
 /// copying its unchanged physical extents.
 ///
@@ -9,6 +31,10 @@ use std::path::Path;
 /// would preserve correctness but recreate the full-work defect this boundary
 /// exists to avoid.
 pub(crate) fn clone_file(source: &Path, destination: &Path) -> Result<bool> {
+    #[cfg(test)]
+    if CLONE_DISABLED.get() {
+        return Ok(false);
+    }
     let source_metadata = std::fs::symlink_metadata(source)
         .with_context(|| format!("inspect clone source {}", source.display()))?;
     if !source_metadata.file_type().is_file() {
@@ -19,6 +45,93 @@ pub(crate) fn clone_file(source: &Path, destination: &Path) -> Result<bool> {
     }
 
     clone_file_platform(source, destination)
+}
+
+/// Give another immutable generation a direct filesystem reference to the
+/// exact same component bytes.
+///
+/// A hard link is safe here because published components are immutable. It is
+/// also independent of reflink support: publication-only churn does not copy
+/// the file or open it for mutation. `Ok(false)` is a normal cross-device or
+/// unsupported-filesystem result; callers retain their COW/full fallback.
+pub(crate) fn reference_file(source: &Path, destination: &Path) -> Result<bool> {
+    let source_metadata = std::fs::symlink_metadata(source)
+        .with_context(|| format!("inspect component reference source {}", source.display()))?;
+    if !source_metadata.file_type().is_file() {
+        bail!("component reference source is not a regular file");
+    }
+    if !source_metadata.permissions().readonly() {
+        bail!("component reference source is not immutable");
+    }
+    if std::fs::symlink_metadata(destination).is_ok() {
+        bail!("component reference destination already exists");
+    }
+    match std::fs::hard_link(source, destination) {
+        Ok(()) => {
+            if !codestory_workspace::same_workspace_path(source, destination) {
+                let _ = std::fs::remove_file(destination);
+                bail!("component reference did not preserve native file identity");
+            }
+            Ok(true)
+        }
+        Err(error)
+            if matches!(
+                error.kind(),
+                std::io::ErrorKind::Unsupported | std::io::ErrorKind::PermissionDenied
+            ) || error.raw_os_error().is_some_and(|code| {
+                matches!(
+                    code,
+                    libc::EXDEV | libc::EPERM | libc::EOPNOTSUPP | libc::EINVAL
+                )
+            }) =>
+        {
+            Ok(false)
+        }
+        Err(error) => Err(error).context("reference immutable component with a hard link"),
+    }
+}
+
+pub(crate) fn make_file_immutable(path: &Path) -> Result<()> {
+    let metadata = std::fs::symlink_metadata(path)
+        .with_context(|| format!("inspect component permissions {}", path.display()))?;
+    if !metadata.file_type().is_file() {
+        bail!("immutable component is not a regular file");
+    }
+    let mut permissions = metadata.permissions();
+    if permissions.readonly() {
+        return Ok(());
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        permissions.set_mode(permissions.mode() & !0o222);
+    }
+    #[cfg(not(unix))]
+    permissions.set_readonly(true);
+    std::fs::set_permissions(path, permissions)
+        .with_context(|| format!("make component immutable {}", path.display()))?;
+    if !std::fs::symlink_metadata(path)?.permissions().readonly() {
+        bail!("component remained owner-writable after immutable publication");
+    }
+    Ok(())
+}
+
+pub(crate) fn make_file_owner_writable(path: &Path) -> Result<()> {
+    let metadata = std::fs::symlink_metadata(path)
+        .with_context(|| format!("inspect staged component permissions {}", path.display()))?;
+    if !metadata.file_type().is_file() {
+        bail!("staged component is not a regular file");
+    }
+    let mut permissions = metadata.permissions();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        permissions.set_mode(permissions.mode() | 0o200);
+    }
+    #[cfg(not(unix))]
+    permissions.set_readonly(false);
+    std::fs::set_permissions(path, permissions)
+        .with_context(|| format!("make staged component owner-writable {}", path.display()))
 }
 
 #[cfg(target_os = "macos")]
@@ -115,5 +228,28 @@ mod tests {
 
         assert!(error.to_string().contains("destination already exists"));
         assert_eq!(std::fs::read(&destination).unwrap(), b"existing");
+    }
+
+    #[test]
+    fn reference_reuses_the_exact_immutable_file_without_clone_support() {
+        let root = tempfile::TempDir::new().expect("tempdir");
+        let source = root.path().join("source");
+        let destination = root.path().join("destination");
+        std::fs::write(&source, b"immutable-source").expect("source");
+        make_file_immutable(&source).expect("immutable source");
+
+        assert!(with_clone_disabled(|| reference_file(&source, &destination)).expect("reference"));
+        assert_eq!(std::fs::read(&destination).unwrap(), b"immutable-source");
+        assert!(codestory_workspace::same_workspace_path(
+            &source,
+            &destination
+        ));
+        assert!(std::fs::metadata(&source).unwrap().permissions().readonly());
+        assert!(
+            std::fs::metadata(&destination)
+                .unwrap()
+                .permissions()
+                .readonly()
+        );
     }
 }

--- a/crates/codestory-retrieval/src/embedded_vector.rs
+++ b/crates/codestory-retrieval/src/embedded_vector.rs
@@ -96,6 +96,7 @@ pub(crate) struct IncrementalVectorWork {
     pub retained: u64,
     pub inserted: u64,
     pub removed: u64,
+    pub direct_reference: bool,
 }
 
 pub(crate) struct AttestedVectorPublication<'a> {
@@ -743,6 +744,12 @@ impl EmbeddedVectorIndex {
         {
             return Ok(None);
         }
+        crate::copy_on_write::make_file_immutable(&previous_path)?;
+
+        let previous_current_anchors = match read_current_vector_anchor_map(&previous_path) {
+            Ok(anchors) => anchors,
+            Err(_) => return Ok(None),
+        };
 
         let path = index_path(publication.layout, publication.collection);
         let parent = path
@@ -755,9 +762,35 @@ impl EmbeddedVectorIndex {
         drop(reserved);
         std::fs::remove_file(&temp_path)
             .with_context(|| format!("release vector clone reservation {}", temp_path.display()))?;
+        if previous_anchors == expected_anchors
+            && previous_current_anchors == current_anchors
+            && crate::copy_on_write::reference_file(&previous_path, &temp_path)?
+        {
+            let result = (|| {
+                let mut attestation = previous_manifest.vectors.clone();
+                attestation.generation = publication.generation.to_string();
+                attestation.input_hash = publication.input_hash.to_string();
+                before_publish()?;
+                codestory_workspace::atomic_file::publish_existing_file_atomic(&temp_path, &path)?;
+                Ok((
+                    attestation,
+                    IncrementalVectorWork {
+                        retained: u64::try_from(expected_anchors.len()).unwrap_or(u64::MAX),
+                        inserted: 0,
+                        removed: 0,
+                        direct_reference: true,
+                    },
+                ))
+            })();
+            if result.is_err() {
+                let _ = std::fs::remove_file(&temp_path);
+            }
+            return result.map(Some);
+        }
         if !crate::copy_on_write::clone_file(&previous_path, &temp_path)? {
             return Ok(None);
         }
+        crate::copy_on_write::make_file_owner_writable(&temp_path)?;
 
         let result = (|| {
             let work = reconcile_cloned_database(
@@ -779,6 +812,7 @@ impl EmbeddedVectorIndex {
             )?;
             before_publish()?;
             codestory_workspace::atomic_file::publish_existing_file_atomic(&temp_path, &path)?;
+            crate::copy_on_write::make_file_immutable(&path)?;
             Ok((attestation, work))
         })();
         if result.is_err() {
@@ -1107,6 +1141,7 @@ fn build_and_publish_database(
         )?;
         before_publish()?;
         codestory_workspace::atomic_file::publish_existing_file_atomic(&temp_path, &path)?;
+        crate::copy_on_write::make_file_immutable(&path)?;
         Ok(attestation)
     })();
     if result.is_err() {
@@ -1328,6 +1363,34 @@ fn read_vector_anchor_map(path: &Path) -> Result<BTreeMap<String, String>> {
     Ok(anchors)
 }
 
+fn read_current_vector_anchor_map(path: &Path) -> Result<BTreeMap<String, CurrentVectorAnchor>> {
+    let connection = open_read_only(path)?;
+    let mut statement = connection.prepare(
+        "SELECT node_id, document_hash, display_name, file_path, file_role, dense_reason
+         FROM vectors ORDER BY node_id ASC",
+    )?;
+    let mut rows = statement.query([])?;
+    let mut anchors = BTreeMap::new();
+    while let Some(row) = rows.next()? {
+        let node_id = row.get::<_, String>(0)?;
+        let file_role = row
+            .get::<_, Option<String>>(4)?
+            .map(|role| FileRole::from_db_value(&role));
+        let anchor = CurrentVectorAnchor {
+            node_id: node_id.clone(),
+            document_hash: row.get(1)?,
+            display_name: row.get(2)?,
+            file_path: row.get(3)?,
+            file_role,
+            dense_reason: row.get(5)?,
+        };
+        if anchors.insert(node_id.clone(), anchor).is_some() {
+            bail!("duplicate embedded vector row {node_id}");
+        }
+    }
+    Ok(anchors)
+}
+
 fn reconcile_cloned_database(
     path: &Path,
     generation: &str,
@@ -1507,6 +1570,7 @@ fn reconcile_cloned_database(
         retained: u64::try_from(retained).unwrap_or(u64::MAX),
         inserted: u64::try_from(missing.len()).unwrap_or(u64::MAX),
         removed: u64::try_from(removed).unwrap_or(u64::MAX),
+        direct_reference: false,
     })
 }
 
@@ -1524,9 +1588,14 @@ pub(crate) fn validate_database(
         .with_context(|| format!("quick-check embedded vector index {}", path.display()))?;
     let metadata = read_metadata(&connection)
         .with_context(|| format!("read embedded vector metadata {}", path.display()))?;
+    let physical_envelope_is_compatible =
+        if metadata.component_schema_version == VECTOR_COMPONENT_SCHEMA_VERSION {
+            !metadata.generation.trim().is_empty() && !metadata.input_hash.trim().is_empty()
+        } else {
+            metadata.generation == generation && metadata.input_hash == input_hash
+        };
     if metadata.schema_version != VECTOR_INDEX_SCHEMA_VERSION
-        || metadata.generation != generation
-        || metadata.input_hash != input_hash
+        || !physical_envelope_is_compatible
         || metadata.embedding_backend != contract.embedding_backend
         || metadata.embedding_dim != contract.embedding_dim as i64
         || metadata.point_count < 0
@@ -1569,8 +1638,16 @@ pub(crate) fn validate_database(
     }
     let attestation = VectorDatabaseAttestation {
         schema_version: metadata.schema_version,
-        generation: metadata.generation,
-        input_hash: metadata.input_hash,
+        generation: if metadata.component_schema_version == VECTOR_COMPONENT_SCHEMA_VERSION {
+            generation.to_string()
+        } else {
+            metadata.generation
+        },
+        input_hash: if metadata.component_schema_version == VECTOR_COMPONENT_SCHEMA_VERSION {
+            input_hash.to_string()
+        } else {
+            metadata.input_hash
+        },
         embedding_backend: metadata.embedding_backend,
         embedding_dim: metadata.embedding_dim as usize,
         point_count: metadata.point_count as u64,
@@ -1606,9 +1683,10 @@ fn validate_health_database(
 ) -> Result<u64> {
     let connection = open_read_only(path)?;
     let metadata = read_metadata(&connection)?;
+    let envelope_matches =
+        vector_publication_envelope_matches(path, &metadata, generation, input_hash)?;
     if metadata.schema_version != VECTOR_INDEX_SCHEMA_VERSION
-        || metadata.generation != generation
-        || metadata.input_hash != input_hash
+        || !envelope_matches
         || metadata.embedding_backend != embedding_backend
         || metadata.embedding_dim != embedding_dim as i64
         || metadata.point_count < 0
@@ -1623,12 +1701,53 @@ fn validate_health_database(
             actual.max(0)
         );
     }
-    if metadata.component_schema_version == VECTOR_COMPONENT_SCHEMA_VERSION
-        && canonical_vector_component_digest(&connection)? != metadata.component_sha256
-    {
-        bail!("embedded vector physical component digest mismatch");
+    if metadata.component_schema_version == VECTOR_COMPONENT_SCHEMA_VERSION {
+        let digest = canonical_vector_component_digest(&connection)?;
+        if digest != metadata.component_sha256 {
+            bail!("embedded vector physical component digest mismatch");
+        }
     }
     Ok(actual as u64)
+}
+
+fn vector_publication_envelope_matches(
+    path: &Path,
+    metadata: &DatabaseMetadata,
+    generation: &str,
+    input_hash: &str,
+) -> Result<bool> {
+    let manifest_path = path
+        .parent()
+        .context("embedded vector database has no generation directory")?
+        .join(VECTOR_GENERATION_MANIFEST_FILE);
+    match std::fs::symlink_metadata(&manifest_path) {
+        Ok(file_metadata) => {
+            if file_metadata.file_type().is_symlink() || !file_metadata.is_file() {
+                bail!("vector generation manifest is not a regular file");
+            }
+            let manifest: VectorGenerationManifest =
+                serde_json::from_slice(&std::fs::read(&manifest_path).with_context(|| {
+                    format!(
+                        "read vector generation manifest {}",
+                        manifest_path.display()
+                    )
+                })?)?;
+            manifest.validate()?;
+            Ok(metadata.point_count >= 0
+                && metadata.embedding_dim >= 0
+                && manifest.vectors.generation == generation
+                && manifest.vectors.input_hash == input_hash
+                && manifest.vectors.component_schema_version == metadata.component_schema_version
+                && manifest.vectors.component_sha256 == metadata.component_sha256
+                && manifest.vectors.embedding_backend == metadata.embedding_backend
+                && manifest.vectors.embedding_dim == metadata.embedding_dim as usize
+                && manifest.vectors.point_count == metadata.point_count as u64)
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            Ok(metadata.generation == generation && metadata.input_hash == input_hash)
+        }
+        Err(error) => Err(error).context("inspect vector generation manifest"),
+    }
 }
 
 fn expected_anchor_map(
@@ -2061,17 +2180,13 @@ fn search_database_batch_with_abstention(
         return Ok(vec![Vec::new(); queries.len()]);
     }
     let connection = open_read_only(path)?;
-    let (stored_generation, stored_hash, stored_dim): (String, String, i64) = connection
-        .query_row(
-            "SELECT generation, input_hash, embedding_dim FROM metadata",
-            [],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
-        )?;
-    if stored_generation != generation
-        || stored_hash != input_hash
+    let metadata = read_metadata(&connection)?;
+    if !vector_publication_envelope_matches(path, &metadata, generation, input_hash)?
+        || metadata.generation.trim().is_empty()
+        || metadata.input_hash.trim().is_empty()
         || queries
             .iter()
-            .any(|(query, limit)| *limit != 0 && stored_dim != query.len() as i64)
+            .any(|(query, limit)| *limit != 0 && metadata.embedding_dim != query.len() as i64)
     {
         bail!("embedded vector index publication identity changed");
     }
@@ -3196,6 +3311,166 @@ mod tests {
             )
             .expect("removed row");
         assert_eq!(removed_count, 0);
+        assert!(
+            std::fs::metadata(index_path(&layout, "previous"))
+                .expect("previous permissions")
+                .permissions()
+                .readonly()
+        );
+        assert!(
+            std::fs::metadata(index_path(&layout, "current"))
+                .expect("current permissions")
+                .permissions()
+                .readonly()
+        );
+    }
+
+    #[test]
+    fn publication_only_vector_churn_directly_references_the_component_without_clone() {
+        let root = tempdir().expect("tempdir");
+        let layout = layout(root.path());
+        let device = accelerated_device();
+        let identity = accelerated_identity();
+        let evidence = build_vector_producer_evidence(
+            &device,
+            Some(&identity),
+            crate::embeddings::RETRIEVAL_EMBEDDING_DIM as u32,
+            EmbeddingVectorPublicationIdentityDto {
+                core_generation_id: "core-v2".into(),
+                core_run_id: "run-v2".into(),
+                retrieval_generation: "generation-v2".into(),
+                retrieval_input_hash: "input-v2".into(),
+                semantic_generation: "current".into(),
+            },
+        );
+        let contract = VectorEvidenceContract::new(
+            "backend",
+            2,
+            "producer-v1",
+            vector_compatibility_identity(&evidence).expect("compatibility"),
+        );
+        let expected = expected_anchors();
+        let previous_attestation = EmbeddedVectorIndex::build_attested_with_points(
+            &layout,
+            "previous",
+            "generation-v1",
+            "input-v1",
+            &contract,
+            &expected,
+            |visit| {
+                visit(attested_point("1", "document-1", vec![1.0, 0.0]))?;
+                visit(attested_point("2", "document-2", vec![0.0, 1.0]))
+            },
+        )
+        .expect("build predecessor");
+        let mut previous_evidence = evidence.clone();
+        previous_evidence.publication = EmbeddingVectorPublicationIdentityDto {
+            core_generation_id: "core-v1".into(),
+            core_run_id: "run-v1".into(),
+            retrieval_generation: "generation-v1".into(),
+            retrieval_input_hash: "input-v1".into(),
+            semantic_generation: "previous".into(),
+        };
+        EmbeddedVectorIndex::publish_generation_manifest(
+            &layout,
+            "previous",
+            &VectorGenerationManifest::new(previous_evidence, previous_attestation)
+                .expect("predecessor manifest"),
+        )
+        .expect("publish predecessor manifest");
+        let previous_path = index_path(&layout, "previous");
+
+        let outcome = crate::copy_on_write::with_clone_disabled(|| {
+            EmbeddedVectorIndex::try_build_incremental_with_cancel(
+                AttestedVectorPublication {
+                    layout: &layout,
+                    collection: "current",
+                    generation: "generation-v2",
+                    input_hash: "input-v2",
+                    contract: &contract,
+                    expected_anchors: &expected,
+                },
+                "previous",
+                &evidence,
+                &[
+                    current_anchor("1", "document-1", "symbol_1"),
+                    current_anchor("2", "document-2", "symbol_2"),
+                ],
+                || Ok(()),
+                |_, _| panic!("publication-only reuse must not request vector production"),
+            )
+        })
+        .expect("publication-only vector build")
+        .expect("direct-reference outcome");
+        let (attestation, work) = outcome;
+        assert!(work.direct_reference);
+        assert_eq!(work.retained, 2);
+        assert_eq!(work.inserted, 0);
+        assert_eq!(work.removed, 0);
+        let current_path = index_path(&layout, "current");
+        assert_eq!(
+            codestory_workspace::workspace_path_identity(&previous_path)
+                .expect("previous identity"),
+            codestory_workspace::workspace_path_identity(&current_path).expect("current identity"),
+        );
+        assert_eq!(attestation.generation, "generation-v2");
+        assert_eq!(attestation.input_hash, "input-v2");
+        assert!(
+            std::fs::metadata(&previous_path)
+                .expect("previous permissions")
+                .permissions()
+                .readonly()
+        );
+        assert!(
+            std::fs::metadata(&current_path)
+                .expect("current permissions")
+                .permissions()
+                .readonly()
+        );
+        EmbeddedVectorIndex::validate_published_attestation(
+            &layout,
+            "current",
+            "generation-v2",
+            "input-v2",
+            &contract,
+            &expected,
+            &attestation,
+        )
+        .expect("validate current envelope over referenced vectors");
+        EmbeddedVectorIndex::publish_generation_manifest(
+            &layout,
+            "current",
+            &VectorGenerationManifest::new(evidence, attestation)
+                .expect("current generation manifest"),
+        )
+        .expect("publish current generation manifest");
+        search_database(
+            &current_path,
+            "generation-v2",
+            "input-v2",
+            &[1.0, 0.0],
+            1,
+            || false,
+        )
+        .expect("search current direct-reference envelope");
+        for (generation, input_hash) in [
+            ("wrong-generation", "input-v2"),
+            ("generation-v2", "wrong-input"),
+        ] {
+            let error = search_database(
+                &current_path,
+                generation,
+                input_hash,
+                &[1.0, 0.0],
+                1,
+                || false,
+            )
+            .expect_err("direct-reference search must reject the wrong envelope");
+            assert!(
+                format!("{error:#}").contains("publication identity changed"),
+                "unexpected error: {error:#}"
+            );
+        }
     }
 
     #[test]
@@ -3310,7 +3585,10 @@ mod tests {
             VectorGenerationManifest::new(evidence.clone(), attestation).expect("manifest");
         EmbeddedVectorIndex::publish_generation_manifest(&layout, "previous", &manifest)
             .expect("publish manifest");
-        let connection = Connection::open(index_path(&layout, "previous")).expect("open vector db");
+        let previous_path = index_path(&layout, "previous");
+        crate::copy_on_write::make_file_owner_writable(&previous_path)
+            .expect("authorize hostile corruption");
+        let connection = Connection::open(previous_path).expect("open vector db");
         connection
             .execute("DROP TRIGGER vectors_vector_update_guard", [])
             .expect("remove mutation guard");
@@ -3458,9 +3736,12 @@ mod tests {
             .is_err()
         );
 
+        let drift_path = index_path(&layout, "codestory_drift");
+        crate::copy_on_write::make_file_owner_writable(&drift_path)
+            .expect("make database writable for hostile drift injection");
         std::fs::OpenOptions::new()
             .append(true)
-            .open(index_path(&layout, "codestory_drift"))
+            .open(drift_path)
             .expect("open database for drift")
             .write_all(b"drift")
             .expect("append database drift");
@@ -3513,9 +3794,12 @@ mod tests {
         );
         validate().expect("admit complete reader generation");
 
+        let vector_path = index_path(&layout, &manifest.semantic_generation);
+        crate::copy_on_write::make_file_owner_writable(&vector_path)
+            .expect("make database writable for hostile byte drift injection");
         std::fs::OpenOptions::new()
             .append(true)
-            .open(index_path(&layout, &manifest.semantic_generation))
+            .open(&vector_path)
             .expect("open database for exact-byte drift")
             .write_all(b"byte-drift")
             .expect("append exact-byte drift");
@@ -3531,6 +3815,8 @@ mod tests {
             &identity,
             |_| {},
         );
+        crate::copy_on_write::make_file_owner_writable(&vector_path)
+            .expect("make database writable for hostile vector drift injection");
         let mut changed_vector = vec![0.0_f32; crate::embeddings::RETRIEVAL_EMBEDDING_DIM];
         changed_vector[1] = 1.0;
         Connection::open(index_path(&layout, &manifest.semantic_generation))
@@ -3552,6 +3838,8 @@ mod tests {
             &identity,
             |_| {},
         );
+        crate::copy_on_write::make_file_owner_writable(&vector_path)
+            .expect("make database writable for hostile document drift injection");
         Connection::open(index_path(&layout, &manifest.semantic_generation))
             .expect("open database for document drift")
             .execute(
@@ -3571,6 +3859,8 @@ mod tests {
             &identity,
             |_| {},
         );
+        crate::copy_on_write::make_file_owner_writable(&vector_path)
+            .expect("make database writable for hostile cardinality drift injection");
         Connection::open(index_path(&layout, &manifest.semantic_generation))
             .expect("open database for cardinality drift")
             .execute("DELETE FROM vectors WHERE node_id = '1'", [])

--- a/crates/codestory-retrieval/src/embedded_vector.rs
+++ b/crates/codestory-retrieval/src/embedded_vector.rs
@@ -771,7 +771,7 @@ impl EmbeddedVectorIndex {
                 attestation.generation = publication.generation.to_string();
                 attestation.input_hash = publication.input_hash.to_string();
                 before_publish()?;
-                codestory_workspace::atomic_file::publish_existing_file_atomic(&temp_path, &path)?;
+                crate::copy_on_write::publish_immutable_file_atomic(&temp_path, &path)?;
                 Ok((
                     attestation,
                     IncrementalVectorWork {
@@ -811,8 +811,7 @@ impl EmbeddedVectorIndex {
                 None,
             )?;
             before_publish()?;
-            codestory_workspace::atomic_file::publish_existing_file_atomic(&temp_path, &path)?;
-            crate::copy_on_write::make_file_immutable(&path)?;
+            crate::copy_on_write::publish_immutable_file_atomic(&temp_path, &path)?;
             Ok((attestation, work))
         })();
         if result.is_err() {
@@ -1140,8 +1139,7 @@ fn build_and_publish_database(
             None,
         )?;
         before_publish()?;
-        codestory_workspace::atomic_file::publish_existing_file_atomic(&temp_path, &path)?;
-        crate::copy_on_write::make_file_immutable(&path)?;
+        crate::copy_on_write::publish_immutable_file_atomic(&temp_path, &path)?;
         Ok(attestation)
     })();
     if result.is_err() {
@@ -3124,6 +3122,62 @@ mod tests {
             std::fs::read(&evidence_path).expect("read evidence after cancellation"),
             prior_evidence,
             "cancelled evidence publication replaced the prior manifest"
+        );
+    }
+
+    #[test]
+    fn same_generation_vector_retry_replaces_a_readonly_partial_component() {
+        let root = tempdir().expect("tempdir");
+        let layout = layout(root.path());
+        let contract = evidence_contract();
+        let expected = expected_anchors();
+        EmbeddedVectorIndex::build_attested_with_points(
+            &layout,
+            "partial",
+            "generation-v1",
+            "input-v1",
+            &contract,
+            &expected,
+            |visit| {
+                visit(attested_point("1", "document-1", vec![1.0, 0.0]))?;
+                visit(attested_point("2", "document-2", vec![0.0, 1.0]))
+            },
+        )
+        .expect("publish component before envelope");
+        let path = index_path(&layout, "partial");
+        assert!(
+            std::fs::metadata(&path)
+                .expect("partial permissions")
+                .permissions()
+                .readonly()
+        );
+
+        EmbeddedVectorIndex::build_attested_with_points(
+            &layout,
+            "partial",
+            "generation-v1",
+            "input-v1",
+            &contract,
+            &expected,
+            |visit| {
+                visit(attested_point("1", "document-1", vec![0.0, 1.0]))?;
+                visit(attested_point("2", "document-2", vec![1.0, 0.0]))
+            },
+        )
+        .expect("repair same-generation partial component");
+
+        assert!(
+            std::fs::metadata(&path)
+                .expect("repaired permissions")
+                .permissions()
+                .readonly()
+        );
+        assert_eq!(
+            search_database(&path, "generation-v1", "input-v1", &[1.0, 0.0], 1, || false)
+                .expect("search repaired component")[0]
+                .node_id
+                .as_deref(),
+            Some("2")
         );
     }
 

--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -729,11 +729,11 @@ pub fn finalize_index_for_runtime_with_progress_and_cancel(
         .finish()
         .context("finish coherent sidecar input snapshot")?;
     record_finalize_phase_timing("input fingerprint", fingerprint_started.elapsed());
-    let previous_manifest = storage
-        .get_retrieval_index_manifest(&project_id)
-        .context("load previous retrieval_index_manifest")?;
-    let mut previous_manifest_unavailable_reason =
-        previous_manifest.as_ref().and_then(|manifest| {
+    let previous_manifest = physical_predecessor_manifest(&storage, &project_id)?;
+    let mut previous_manifest_unavailable_reason = previous_manifest
+        .as_ref()
+        .filter(|manifest| manifest.project_id == project_id)
+        .and_then(|manifest| {
             manifest_unavailable_reason_for_runtime(&project_id, &storage, manifest, runtime)
         });
     if previous_manifest_unavailable_reason.is_none()
@@ -1006,6 +1006,28 @@ pub fn finalize_index_for_runtime_with_progress_and_cancel(
         degraded_modes,
         SidecarStubFlags { scip_stubbed },
     )
+}
+
+fn physical_predecessor_manifest(
+    storage: &Store,
+    project_id: &str,
+) -> Result<Option<RetrievalIndexManifest>> {
+    if let Some(manifest) = storage
+        .get_retrieval_index_manifest(project_id)
+        .context("load previous retrieval_index_manifest")?
+    {
+        return Ok(Some(manifest));
+    }
+    Ok(storage
+        .list_retrieval_index_manifests()
+        .context("load physical predecessor retrieval manifests")?
+        .into_iter()
+        .filter(|manifest| manifest_has_current_sidecar_contract(&manifest.project_id, manifest))
+        .max_by(|left, right| {
+            left.built_at_epoch_ms
+                .cmp(&right.built_at_epoch_ms)
+                .then_with(|| left.project_id.cmp(&right.project_id))
+        }))
 }
 
 fn with_finalize_progress<T>(
@@ -3897,6 +3919,36 @@ mod tests {
 
         assert_ne!(clean, dirty);
         assert_eq!(dirty, project_id_for_root(project.path()));
+    }
+
+    #[test]
+    fn dirty_identity_reuses_the_latest_valid_physical_predecessor() {
+        let storage_dir = TempDir::new().expect("storage dir");
+        let mut storage = Store::open(storage_dir.path().join("codestory.db"))
+            .expect("open retrieval manifest store");
+        let mut canonical =
+            crate::test_support::retrieval_manifest_fixture("repo-v2-clean", "canonical-input");
+        canonical.built_at_epoch_ms = 7;
+        storage
+            .upsert_retrieval_index_manifest(&canonical)
+            .expect("publish canonical manifest");
+
+        let selected = physical_predecessor_manifest(&storage, "workspace-dirty")
+            .expect("select physical predecessor")
+            .expect("canonical predecessor");
+        assert_eq!(selected, canonical);
+
+        let mut dirty =
+            crate::test_support::retrieval_manifest_fixture("workspace-dirty", "dirty-input");
+        dirty.built_at_epoch_ms = 1;
+        storage
+            .upsert_retrieval_index_manifest(&dirty)
+            .expect("publish dirty manifest");
+
+        let selected = physical_predecessor_manifest(&storage, "workspace-dirty")
+            .expect("select current identity manifest")
+            .expect("dirty predecessor");
+        assert_eq!(selected, dirty, "the exact identity must win over recency");
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -1056,7 +1056,11 @@ fn ensure_lexical_generation(
                 if let Some(work) = work {
                     record_finalize_component_work(
                         "lexical",
-                        "copy_on_write",
+                        if work.direct_reference {
+                            "reused"
+                        } else {
+                            "copy_on_write"
+                        },
                         Some(work.retained),
                         Some(work.inserted),
                         Some(work.removed),
@@ -1318,7 +1322,11 @@ fn ensure_semantic_index(
     {
         record_finalize_component_work(
             "vectors",
-            "copy_on_write",
+            if work.direct_reference {
+                "reused"
+            } else {
+                "copy_on_write"
+            },
             Some(work.retained),
             Some(work.inserted),
             Some(work.removed),
@@ -1681,7 +1689,9 @@ fn ensure_scip_artifacts(
         Ok(outcome) if outcome.revision.is_some() => {
             record_finalize_component_work(
                 "graph",
-                if outcome.cloned {
+                if outcome.direct_reference {
+                    "reused"
+                } else if outcome.cloned {
                     "copy_on_write"
                 } else {
                     "complete"

--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -4600,6 +4600,8 @@ mod tests {
         );
         let vector_path =
             crate::embedded_vector::index_path(&runtime.layout, &previous.semantic_generation);
+        crate::copy_on_write::make_file_owner_writable(&vector_path)
+            .expect("make rollback vector database writable for corruption");
         std::fs::OpenOptions::new()
             .append(true)
             .open(&vector_path)

--- a/crates/codestory-retrieval/src/lexical_index.rs
+++ b/crates/codestory-retrieval/src/lexical_index.rs
@@ -18,6 +18,8 @@ use std::sync::Arc;
 
 pub const LEXICAL_INDEX_VERSION: &str = "sqlite-fts5-v1";
 pub const LEXICAL_INDEX_FILE: &str = "lexical-index.sqlite3";
+const LEXICAL_COMPONENT_ENVELOPE_FILE: &str = "lexical-component-envelope.json";
+const LEXICAL_COMPONENT_ENVELOPE_SCHEMA_VERSION: u32 = 1;
 #[cfg(any(test, feature = "test-support"))]
 const LEGACY_INDEX_FILE: &str = "lexical-index.jsonl";
 #[cfg(any(test, feature = "test-support"))]
@@ -146,6 +148,63 @@ struct LexicalShardMetadata {
     file_count: u32,
     coverage: LexicalCoverage,
     binding_sha256: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct LexicalComponentEnvelope {
+    schema_version: u32,
+    generation: String,
+    sidecar_input_hash: String,
+    physical_project_id: String,
+    physical_input_hash: String,
+    lexical_hash: String,
+    file_count: u32,
+    coverage: LexicalCoverage,
+    binding_sha256: String,
+}
+
+impl LexicalComponentEnvelope {
+    fn new(generation: &str, sidecar_input_hash: &str, physical: &LexicalShardMetadata) -> Self {
+        let mut envelope = Self {
+            schema_version: LEXICAL_COMPONENT_ENVELOPE_SCHEMA_VERSION,
+            generation: generation.to_string(),
+            sidecar_input_hash: sidecar_input_hash.to_string(),
+            physical_project_id: physical.project_id.clone(),
+            physical_input_hash: physical.sidecar_input_hash.clone(),
+            lexical_hash: physical.lexical_hash.clone(),
+            file_count: physical.file_count,
+            coverage: physical.coverage.clone(),
+            binding_sha256: String::new(),
+        };
+        envelope.binding_sha256 = lexical_component_envelope_binding(&envelope);
+        envelope
+    }
+
+    fn validate(&self) -> Result<()> {
+        if self.schema_version != LEXICAL_COMPONENT_ENVELOPE_SCHEMA_VERSION
+            || self.generation.trim().is_empty()
+            || self.sidecar_input_hash.trim().is_empty()
+            || self.physical_project_id.trim().is_empty()
+            || self.physical_input_hash.trim().is_empty()
+            || self.lexical_hash.len() != 64
+            || !self
+                .lexical_hash
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit())
+            || self.binding_sha256 != lexical_component_envelope_binding(self)
+        {
+            bail!("lexical component envelope is invalid");
+        }
+        Ok(())
+    }
+
+    fn matches_physical(&self, physical: &LexicalShardMetadata) -> bool {
+        self.physical_project_id == physical.project_id
+            && self.physical_input_hash == physical.sidecar_input_hash
+            && self.lexical_hash == physical.lexical_hash
+            && self.file_count == physical.file_count
+            && self.coverage == physical.coverage
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -305,6 +364,10 @@ pub fn build_lexical_shard(
             Some((expected.file_count, expected.hash.as_str())),
         )?;
         publish_immutable_lexical_database(&temp_path, &index_path)?;
+        publish_lexical_component_envelope(
+            &shard_dir,
+            &LexicalComponentEnvelope::new(project_id, sidecar_input_hash, &staged),
+        )?;
         Ok(rebuilt)
     })();
     if result.is_err() {
@@ -330,6 +393,7 @@ pub(crate) struct IncrementalLexicalWork {
     pub retained: u64,
     pub inserted: u64,
     pub removed: u64,
+    pub direct_reference: bool,
 }
 
 pub(crate) fn build_prepared_lexical_shard(
@@ -356,22 +420,41 @@ pub(crate) fn build_prepared_lexical_shard(
         std::fs::remove_file(&temp_path)?;
         let mut incremental = None;
         if let Some(previous_project_id) = previous_project_id {
-            let previous_path =
-                shard_dir_for(lexical_data_dir, previous_project_id).join(LEXICAL_INDEX_FILE);
-            let predecessor_is_current = verify_lexical_database_contents(&previous_path)
-                .is_ok_and(|metadata| metadata.lexical_hash.len() == 64);
-            if predecessor_is_current
-                && crate::copy_on_write::clone_file(&previous_path, &temp_path)?
-            {
-                let permissions = std::fs::metadata(&temp_path)?.permissions();
-                make_file_owner_writable(&temp_path, &permissions)?;
-                incremental = Some(reconcile_cloned_lexical_database(
-                    &temp_path,
-                    project_id,
-                    sidecar_input_hash,
-                    &expected.fingerprint,
-                    &expected.documents,
-                )?);
+            let previous_shard = shard_dir_for(lexical_data_dir, previous_project_id);
+            let previous_path = previous_shard.join(LEXICAL_INDEX_FILE);
+            let predecessor =
+                read_lexical_component_envelope(&previous_shard, Some(previous_project_id), None)
+                    .ok()
+                    .and_then(|envelope| {
+                        verify_lexical_database_contents(&previous_path)
+                            .ok()
+                            .filter(|metadata| envelope.matches_physical(metadata))
+                            .map(|metadata| (envelope, metadata))
+                    });
+            if let Some((_, predecessor_metadata)) = predecessor {
+                let same_component = predecessor_metadata.lexical_hash == expected.fingerprint.hash
+                    && predecessor_metadata.file_count == expected.fingerprint.file_count
+                    && predecessor_metadata.coverage == expected.fingerprint.coverage;
+                if same_component
+                    && crate::copy_on_write::reference_file(&previous_path, &temp_path)?
+                {
+                    incremental = Some(IncrementalLexicalWork {
+                        retained: expected.document_count(),
+                        inserted: 0,
+                        removed: 0,
+                        direct_reference: true,
+                    });
+                } else if crate::copy_on_write::clone_file(&previous_path, &temp_path)? {
+                    let permissions = std::fs::metadata(&temp_path)?.permissions();
+                    make_file_owner_writable(&temp_path, &permissions)?;
+                    incremental = Some(reconcile_cloned_lexical_database(
+                        &temp_path,
+                        project_id,
+                        sidecar_input_hash,
+                        &expected.fingerprint,
+                        &expected.documents,
+                    )?);
+                }
             }
         }
         if incremental.is_none() {
@@ -392,17 +475,16 @@ pub(crate) fn build_prepared_lexical_shard(
             )?;
         }
         let staged = verify_lexical_database_contents(&temp_path)?;
-        match_lexical_shard_expectations(
-            &staged,
-            project_id,
-            sidecar_input_hash,
-            Some((
-                expected.fingerprint.file_count,
-                expected.fingerprint.hash.as_str(),
-            )),
-        )?;
+        if staged.lexical_hash != expected.fingerprint.hash
+            || staged.file_count != expected.fingerprint.file_count
+            || staged.coverage != expected.fingerprint.coverage
+        {
+            bail!("staged lexical component does not match current lexical input");
+        }
+        let envelope = LexicalComponentEnvelope::new(project_id, sidecar_input_hash, &staged);
         before_publish()?;
         publish_immutable_lexical_database(&temp_path, &index_path)?;
+        publish_lexical_component_envelope(&shard_dir, &envelope)?;
         Ok((expected.fingerprint.clone(), incremental))
     })();
     if result.is_err() {
@@ -431,10 +513,14 @@ fn publish_immutable_lexical_database(temp_path: &Path, index_path: &Path) -> Re
     match result {
         Ok(()) => {
             let mut permissions = std::fs::metadata(index_path)?.permissions();
-            permissions.set_readonly(true);
-            std::fs::set_permissions(index_path, permissions).with_context(|| {
-                format!("protect immutable lexical shard {}", index_path.display())
-            })
+            if permissions.readonly() {
+                Ok(())
+            } else {
+                permissions.set_readonly(true);
+                std::fs::set_permissions(index_path, permissions).with_context(|| {
+                    format!("protect immutable lexical shard {}", index_path.display())
+                })
+            }
         }
         Err(error) => {
             if let Some(permissions) = previous_permissions {
@@ -575,6 +661,7 @@ fn search_lexical_index_with_cancel_inner(
     connection.progress_handler(1_000, Some(move || progress_cancelled()))?;
     let _metadata = validate_open_database_metadata(
         &connection,
+        shard_dir,
         project_id,
         expected_sidecar_input_hash,
         None,
@@ -616,6 +703,7 @@ pub(crate) fn search_lexical_index_batch_with_cancel(
     connection.progress_handler(1_000, Some(move || progress_cancelled()))?;
     let _metadata = validate_open_database_metadata(
         &connection,
+        shard_dir,
         project_id,
         expected_sidecar_input_hash,
         None,
@@ -1422,6 +1510,7 @@ fn reconcile_cloned_lexical_database(
         retained: u64::try_from(retained).unwrap_or(u64::MAX),
         inserted: u64::try_from(missing.len()).unwrap_or(u64::MAX),
         removed: u64::try_from(removed).unwrap_or(u64::MAX),
+        direct_reference: false,
     })
 }
 
@@ -1439,17 +1528,28 @@ fn validate_lexical_database(
     expected_sidecar_input_hash: &str,
     expected_lexical: Option<(u32, &str)>,
 ) -> Result<LexicalShardMetadata> {
+    let shard_dir = path
+        .parent()
+        .context("lexical shard has no generation directory")?;
     let metadata = LEXICAL_SHARD_RECEIPTS.validate_sealed(
         path.to_path_buf(),
         &sqlite_file_with_sidecars(path),
         || verify_lexical_database_contents(path),
     )?;
-    match_lexical_shard_expectations(
-        &metadata,
+    let envelope = resolve_lexical_component_envelope(
+        shard_dir,
         expected_project_id,
         expected_sidecar_input_hash,
-        expected_lexical,
+        &metadata,
     )?;
+    if !envelope.matches_physical(&metadata) {
+        bail!("lexical component envelope does not match its physical database");
+    }
+    if let Some((file_count, lexical_hash)) = expected_lexical
+        && (metadata.file_count != file_count || metadata.lexical_hash != lexical_hash)
+    {
+        bail!("lexical SQLite shard does not match current lexical input");
+    }
     Ok(metadata)
 }
 
@@ -1524,18 +1624,27 @@ fn verify_open_database_contents(
 
 fn validate_open_database_metadata(
     connection: &Connection,
+    shard_dir: &Path,
     expected_project_id: &str,
     expected_sidecar_input_hash: &str,
     expected_lexical: Option<(u32, &str)>,
     cancelled: &dyn Fn() -> bool,
 ) -> Result<LexicalShardMetadata> {
     let metadata = read_open_database_metadata(connection, cancelled)?;
-    match_lexical_shard_expectations(
-        &metadata,
+    let envelope = resolve_lexical_component_envelope(
+        shard_dir,
         expected_project_id,
         expected_sidecar_input_hash,
-        expected_lexical,
+        &metadata,
     )?;
+    if !envelope.matches_physical(&metadata) {
+        bail!("lexical component envelope does not match its physical database");
+    }
+    if let Some((file_count, lexical_hash)) = expected_lexical
+        && (metadata.file_count != file_count || metadata.lexical_hash != lexical_hash)
+    {
+        bail!("lexical SQLite shard does not match current lexical input");
+    }
     Ok(metadata)
 }
 
@@ -1614,6 +1723,7 @@ fn read_open_database_metadata(
 }
 
 /// The caller-dependent half: never receipted, always re-checked.
+#[cfg(any(test, feature = "test-support"))]
 fn match_lexical_shard_expectations(
     metadata: &LexicalShardMetadata,
     expected_project_id: &str,
@@ -1664,6 +1774,110 @@ fn metadata_binding(
     }
     hasher.update(file_count.to_le_bytes());
     format!("{:x}", hasher.finalize())
+}
+
+fn lexical_component_envelope_binding(envelope: &LexicalComponentEnvelope) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"codestory-lexical-component-envelope-v1\0");
+    for value in [
+        envelope.generation.as_str(),
+        envelope.sidecar_input_hash.as_str(),
+        envelope.physical_project_id.as_str(),
+        envelope.physical_input_hash.as_str(),
+        envelope.lexical_hash.as_str(),
+    ] {
+        hasher.update((value.len() as u64).to_le_bytes());
+        hasher.update(value.as_bytes());
+    }
+    hasher.update(envelope.file_count.to_le_bytes());
+    let coverage = serde_json::to_vec(&envelope.coverage)
+        .expect("lexical coverage serialization is infallible");
+    hasher.update((coverage.len() as u64).to_le_bytes());
+    hasher.update(coverage);
+    format!("{:x}", hasher.finalize())
+}
+
+fn read_lexical_component_envelope(
+    shard_dir: &Path,
+    expected_generation: Option<&str>,
+    expected_sidecar_input_hash: Option<&str>,
+) -> Result<LexicalComponentEnvelope> {
+    let path = shard_dir.join(LEXICAL_COMPONENT_ENVELOPE_FILE);
+    let envelope: LexicalComponentEnvelope = serde_json::from_slice(
+        &std::fs::read(&path)
+            .with_context(|| format!("read lexical component envelope {}", path.display()))?,
+    )
+    .with_context(|| format!("parse lexical component envelope {}", path.display()))?;
+    envelope.validate()?;
+    if expected_generation.is_some_and(|expected| envelope.generation != expected)
+        || expected_sidecar_input_hash
+            .is_some_and(|expected| envelope.sidecar_input_hash != expected)
+    {
+        bail!("lexical component envelope does not match the retrieval publication");
+    }
+    Ok(envelope)
+}
+
+fn resolve_lexical_component_envelope(
+    shard_dir: &Path,
+    expected_generation: &str,
+    expected_sidecar_input_hash: &str,
+    physical: &LexicalShardMetadata,
+) -> Result<LexicalComponentEnvelope> {
+    let path = shard_dir.join(LEXICAL_COMPONENT_ENVELOPE_FILE);
+    match std::fs::symlink_metadata(&path) {
+        Ok(metadata) => {
+            if metadata.file_type().is_symlink() || !metadata.is_file() {
+                bail!("lexical component envelope is not a regular file");
+            }
+            read_lexical_component_envelope(
+                shard_dir,
+                Some(expected_generation),
+                Some(expected_sidecar_input_hash),
+            )
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            if physical.project_id != expected_generation
+                || physical.sidecar_input_hash != expected_sidecar_input_hash
+            {
+                bail!("legacy lexical component is not bound to the retrieval publication");
+            }
+            Ok(LexicalComponentEnvelope::new(
+                expected_generation,
+                expected_sidecar_input_hash,
+                physical,
+            ))
+        }
+        Err(error) => Err(error)
+            .with_context(|| format!("inspect lexical component envelope {}", path.display())),
+    }
+}
+
+fn publish_lexical_component_envelope(
+    shard_dir: &Path,
+    envelope: &LexicalComponentEnvelope,
+) -> Result<()> {
+    envelope.validate()?;
+    let path = shard_dir.join(LEXICAL_COMPONENT_ENVELOPE_FILE);
+    let bytes = serde_json::to_vec_pretty(envelope)?;
+    codestory_workspace::atomic_file::write_file_atomic(
+        &path,
+        "lexical-component-envelope",
+        |file| {
+            use std::io::Write;
+            file.write_all(&bytes)?;
+            Ok(())
+        },
+        |temp_path| {
+            let observed: LexicalComponentEnvelope =
+                serde_json::from_slice(&std::fs::read(temp_path)?)?;
+            observed.validate()?;
+            if &observed != envelope {
+                bail!("staged lexical component envelope changed before publication");
+            }
+            Ok(())
+        },
+    )
 }
 
 fn scan_lexical_documents(
@@ -2501,6 +2715,50 @@ mod tests {
                     .collect::<Vec<_>>()
             );
         }
+    }
+
+    #[test]
+    fn publication_only_lexical_churn_directly_references_the_component_without_clone() {
+        let root = TempDir::new().expect("tempdir");
+        let data = root.path().join("data");
+        let prepared = prepared_documents(vec![
+            source_document("src/a.rs", "alpha"),
+            source_document("src/b.rs", "beta"),
+        ]);
+        build_prepared_lexical_shard(&data, "previous", &prepared, "input-v1", None, || Ok(()))
+            .expect("previous shard");
+        let previous_path = shard_dir_for(&data, "previous").join(LEXICAL_INDEX_FILE);
+
+        let (_, work) = crate::copy_on_write::with_clone_disabled(|| {
+            build_prepared_lexical_shard(
+                &data,
+                "current",
+                &prepared,
+                "input-v2",
+                Some("previous"),
+                || Ok(()),
+            )
+        })
+        .expect("publication-only lexical shard");
+        let work = work.expect("direct-reference work");
+        assert!(work.direct_reference);
+        assert_eq!(work.retained, 2);
+        assert_eq!(work.inserted, 0);
+        assert_eq!(work.removed, 0);
+
+        let current_path = shard_dir_for(&data, "current").join(LEXICAL_INDEX_FILE);
+        assert_eq!(
+            codestory_workspace::workspace_path_identity(&previous_path)
+                .expect("previous identity"),
+            codestory_workspace::workspace_path_identity(&current_path).expect("current identity"),
+            "publication-only churn must retain the exact immutable physical component",
+        );
+        assert_eq!(
+            search_lexical_index(&shard_dir_for(&data, "current"), "input-v2", "alpha", 8)
+                .expect("search current envelope")
+                .len(),
+            1,
+        );
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/lexical_index.rs
+++ b/crates/codestory-retrieval/src/lexical_index.rs
@@ -371,9 +371,7 @@ pub fn build_lexical_shard(
         Ok(rebuilt)
     })();
     if result.is_err() {
-        if let Ok(metadata) = std::fs::metadata(&temp_path) {
-            let _ = make_file_owner_writable(&temp_path, &metadata.permissions());
-        }
+        let _ = crate::copy_on_write::make_file_owner_writable(&temp_path);
         let _ = std::fs::remove_file(&temp_path);
     }
     let rebuilt = result?;
@@ -445,8 +443,7 @@ pub(crate) fn build_prepared_lexical_shard(
                         direct_reference: true,
                     });
                 } else if crate::copy_on_write::clone_file(&previous_path, &temp_path)? {
-                    let permissions = std::fs::metadata(&temp_path)?.permissions();
-                    make_file_owner_writable(&temp_path, &permissions)?;
+                    crate::copy_on_write::make_file_owner_writable(&temp_path)?;
                     incremental = Some(reconcile_cloned_lexical_database(
                         &temp_path,
                         project_id,
@@ -488,65 +485,14 @@ pub(crate) fn build_prepared_lexical_shard(
         Ok((expected.fingerprint.clone(), incremental))
     })();
     if result.is_err() {
-        if let Ok(metadata) = std::fs::metadata(&temp_path) {
-            let _ = make_file_owner_writable(&temp_path, &metadata.permissions());
-        }
+        let _ = crate::copy_on_write::make_file_owner_writable(&temp_path);
         let _ = std::fs::remove_file(&temp_path);
     }
     result
 }
 
 fn publish_immutable_lexical_database(temp_path: &Path, index_path: &Path) -> Result<()> {
-    let previous_permissions = match std::fs::metadata(index_path) {
-        Ok(metadata) => {
-            let permissions = metadata.permissions();
-            if permissions.readonly() {
-                make_file_owner_writable(index_path, &permissions)?;
-            }
-            Some(permissions)
-        }
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
-        Err(error) => return Err(error.into()),
-    };
-    let result =
-        codestory_workspace::atomic_file::publish_existing_file_atomic(temp_path, index_path);
-    match result {
-        Ok(()) => {
-            let mut permissions = std::fs::metadata(index_path)?.permissions();
-            if permissions.readonly() {
-                Ok(())
-            } else {
-                permissions.set_readonly(true);
-                std::fs::set_permissions(index_path, permissions).with_context(|| {
-                    format!("protect immutable lexical shard {}", index_path.display())
-                })
-            }
-        }
-        Err(error) => {
-            if let Some(permissions) = previous_permissions {
-                let _ = std::fs::set_permissions(index_path, permissions);
-            }
-            Err(error)
-        }
-    }
-}
-
-#[allow(clippy::permissions_set_readonly_false)]
-fn make_file_owner_writable(path: &Path, permissions: &std::fs::Permissions) -> Result<()> {
-    let mut writable = permissions.clone();
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        writable.set_mode(writable.mode() | 0o200);
-    }
-    #[cfg(windows)]
-    writable.set_readonly(false);
-    std::fs::set_permissions(path, writable).with_context(|| {
-        format!(
-            "prepare immutable lexical shard replacement {}",
-            path.display()
-        )
-    })
+    crate::copy_on_write::publish_immutable_file_atomic(temp_path, index_path)
 }
 
 pub fn shard_has_lexical_index(shard_dir: &Path, expected_sidecar_input_hash: &str) -> bool {
@@ -2803,10 +2749,8 @@ mod tests {
         build_prepared_lexical_shard(&data, "previous", &previous, "input-v1", None, || Ok(()))
             .expect("previous shard");
         let previous_path = shard_dir_for(&data, "previous").join(LEXICAL_INDEX_FILE);
-        let permissions = std::fs::metadata(&previous_path)
-            .expect("previous metadata")
-            .permissions();
-        make_file_owner_writable(&previous_path, &permissions).expect("make predecessor writable");
+        crate::copy_on_write::make_file_owner_writable(&previous_path)
+            .expect("make predecessor writable");
         std::fs::write(&previous_path, b"not sqlite").expect("corrupt predecessor");
         let current = prepared_documents(vec![source_document("src/a.rs", "current needle")]);
 

--- a/crates/codestory-retrieval/src/rollback.rs
+++ b/crates/codestory-retrieval/src/rollback.rs
@@ -613,6 +613,8 @@ mod tests {
             &fixture.runtime.layout,
             &fixture.rollback.manifest.semantic_generation,
         );
+        crate::copy_on_write::make_file_owner_writable(&vector_path)
+            .expect("make retained rollback vector database writable for corruption");
         std::fs::OpenOptions::new()
             .append(true)
             .open(&vector_path)

--- a/crates/codestory-retrieval/src/scip_index.rs
+++ b/crates/codestory-retrieval/src/scip_index.rs
@@ -969,6 +969,7 @@ pub(crate) struct ScipIncrementalOutcome {
     pub removed_records: u64,
     pub reordered_records: u64,
     pub cloned: bool,
+    pub direct_reference: bool,
 }
 
 pub(crate) fn emit_scip_artifacts_from_store_incremental(
@@ -1036,6 +1037,7 @@ pub(crate) fn emit_scip_artifacts_from_store_incremental(
             removed_records: 0,
             reordered_records: 0,
             cloned: false,
+            direct_reference: false,
         });
     }
 
@@ -1081,6 +1083,7 @@ pub(crate) fn emit_scip_artifacts_from_store_incremental(
         removed_records: work.removed,
         reordered_records: work.reordered,
         cloned: work.cloned,
+        direct_reference: work.direct_reference,
     })
 }
 
@@ -1091,6 +1094,7 @@ struct ScipComponentWork {
     removed: u64,
     reordered: u64,
     cloned: bool,
+    direct_reference: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -1116,30 +1120,51 @@ fn publish_scip_component(
     let result: Result<ScipComponentWork> = (|| {
         std::fs::remove_file(&temp_path)?;
         let mut cloned = false;
+        let mut direct_reference = false;
         if let Some(previous_dir) = previous_project_dir {
             let previous_path = previous_dir.join(SCIP_SYMBOLS_DATABASE_FILE);
-            if load_scip_symbols_database(&previous_path).is_ok()
-                && crate::copy_on_write::clone_file(&previous_path, &temp_path)?
-            {
-                cloned = true;
+            if let Ok(previous) = load_scip_symbols_database(&previous_path) {
+                crate::copy_on_write::make_file_immutable(&previous_path)?;
+                if same_physical_scip_component(&previous, index)
+                    && crate::copy_on_write::reference_file(&previous_path, &temp_path)?
+                {
+                    direct_reference = true;
+                } else if crate::copy_on_write::clone_file(&previous_path, &temp_path)? {
+                    crate::copy_on_write::make_file_owner_writable(&temp_path)?;
+                    cloned = true;
+                }
             }
         }
-        let work = if cloned {
+        let work = if direct_reference {
+            ScipComponentWork {
+                retained: rows.len() as u64,
+                inserted: 0,
+                removed: 0,
+                reordered: 0,
+                cloned: false,
+                direct_reference: true,
+            }
+        } else if cloned {
             reconcile_scip_component(&temp_path, index, &rows)?
         } else {
             write_scip_component(&temp_path, index, &rows)?
         };
-        let observed = load_scip_symbols_database(&temp_path)?;
+        let observed = load_scip_symbols_database_for_generation(&temp_path, &index.generation)?;
         if &observed != index {
             bail!("staged scip component differs from its pinned graph projection");
         }
         before_publish()?;
         codestory_workspace::atomic_file::publish_existing_file_atomic(&temp_path, &path)?;
+        crate::copy_on_write::make_file_immutable(&path)?;
         let legacy = project_dir.join(SCIP_SYMBOLS_FILE);
         if legacy.is_file() {
             std::fs::remove_file(legacy)?;
         }
-        Ok(ScipComponentWork { cloned, ..work })
+        Ok(ScipComponentWork {
+            cloned,
+            direct_reference,
+            ..work
+        })
     })();
     if result.is_err() {
         let _ = std::fs::remove_file(&temp_path);
@@ -1193,6 +1218,13 @@ fn scip_component_rows(index: &ScipSymbolsIndex) -> Result<Vec<ScipComponentRow>
     }
     rows.sort_by(|left, right| left.key.cmp(&right.key));
     Ok(rows)
+}
+
+fn same_physical_scip_component(left: &ScipSymbolsIndex, right: &ScipSymbolsIndex) -> bool {
+    left.revision == right.revision
+        && left.contract == right.contract
+        && left.symbols == right.symbols
+        && left.proofs == right.proofs
 }
 
 fn write_scip_component(
@@ -1259,6 +1291,7 @@ fn write_scip_component(
         removed: 0,
         reordered: 0,
         cloned: false,
+        direct_reference: false,
     })
 }
 
@@ -1369,6 +1402,7 @@ fn reconcile_scip_component(
             })
             .count() as u64,
         cloned: true,
+        direct_reference: false,
     })
 }
 
@@ -1666,6 +1700,21 @@ fn load_scip_symbols_database(path: &Path) -> Result<ScipSymbolsIndex> {
     Ok(index)
 }
 
+fn load_scip_symbols_database_for_generation(
+    path: &Path,
+    generation: &str,
+) -> Result<ScipSymbolsIndex> {
+    if generation.trim().is_empty() {
+        bail!("scip artifact carries no generation");
+    }
+    let mut index = load_scip_symbols_database(path)?;
+    index.generation = generation.to_string();
+    index
+        .validate_records(generation)
+        .context("validate scip component against its publication envelope")?;
+    Ok(index)
+}
+
 pub(crate) fn load_fresh_scip_symbols(
     project_dir: &Path,
     expected_revision: &str,
@@ -1707,8 +1756,15 @@ pub(crate) fn load_fresh_scip_query_view(
             if parse_scip_index_marker(project_dir, expected_revision).is_err() {
                 return Ok(None);
             }
-            let Some(index) = load_scip_symbols(project_dir)? else {
-                return Ok(None);
+            let index = if path.file_name().and_then(|name| name.to_str())
+                == Some(SCIP_SYMBOLS_DATABASE_FILE)
+            {
+                load_scip_symbols_database_for_generation(&path, generation)?
+            } else {
+                let Some(index) = load_scip_symbols(project_dir)? else {
+                    return Ok(None);
+                };
+                index
             };
             if !index.is_fresh_for(expected_revision, generation) || index.symbols.is_empty() {
                 return Ok(None);
@@ -1832,6 +1888,86 @@ mod tests {
     }
 
     #[test]
+    fn publication_only_scip_churn_directly_references_the_component_without_clone() {
+        let root = TempDir::new().expect("tempdir");
+        let previous_dir = root.path().join("previous");
+        let current_dir = root.path().join("current");
+        std::fs::create_dir_all(&previous_dir).expect("previous dir");
+        std::fs::create_dir_all(&current_dir).expect("current dir");
+        let previous = component_index(
+            "generation-v1",
+            vec![
+                component_symbol("1", "src/a.rs", "alpha"),
+                component_symbol("2", "src/b.rs", "beta"),
+            ],
+        );
+        publish_scip_component(&previous_dir, None, &previous, &mut || Ok(()))
+            .expect("previous component");
+        let mut current = previous.clone();
+        current.generation = "generation-v2".into();
+        let previous_path = previous_dir.join(SCIP_SYMBOLS_DATABASE_FILE);
+
+        let work = crate::copy_on_write::with_clone_disabled(|| {
+            publish_scip_component(&current_dir, Some(&previous_dir), &current, &mut || Ok(()))
+        })
+        .expect("publication-only scip component");
+        assert!(work.direct_reference);
+        assert_eq!(work.retained, 4);
+        assert_eq!(work.inserted, 0);
+        assert_eq!(work.removed, 0);
+        assert_eq!(work.reordered, 0);
+        let current_path = current_dir.join(SCIP_SYMBOLS_DATABASE_FILE);
+        assert_eq!(
+            codestory_workspace::workspace_path_identity(&previous_path)
+                .expect("previous identity"),
+            codestory_workspace::workspace_path_identity(&current_path).expect("current identity"),
+        );
+        assert_eq!(
+            load_scip_symbols_database_for_generation(&current_path, "generation-v2")
+                .expect("load current envelope"),
+            current,
+        );
+        assert!(
+            std::fs::metadata(&previous_path)
+                .expect("previous permissions")
+                .permissions()
+                .readonly()
+        );
+        assert!(
+            std::fs::metadata(&current_path)
+                .expect("current permissions")
+                .permissions()
+                .readonly()
+        );
+
+        let changed_dir = root.path().join("changed");
+        std::fs::create_dir_all(&changed_dir).expect("changed dir");
+        let changed = component_index(
+            "generation-v3",
+            vec![
+                component_symbol("1", "src/a.rs", "changed-alpha"),
+                component_symbol("2", "src/b.rs", "beta"),
+            ],
+        );
+        let changed_work =
+            publish_scip_component(&changed_dir, Some(&current_dir), &changed, &mut || Ok(()))
+                .expect("changed component from immutable predecessor");
+        assert!(!changed_work.direct_reference);
+        let changed_path = changed_dir.join(SCIP_SYMBOLS_DATABASE_FILE);
+        assert_eq!(
+            load_scip_symbols_database_for_generation(&changed_path, "generation-v3")
+                .expect("load changed component"),
+            changed,
+        );
+        assert!(
+            std::fs::metadata(changed_path)
+                .expect("changed permissions")
+                .permissions()
+                .readonly()
+        );
+    }
+
+    #[test]
     fn cancelled_scip_component_leaves_no_candidate_database() {
         let root = TempDir::new().expect("tempdir");
         let previous_dir = root.path().join("previous");
@@ -1879,8 +2015,10 @@ mod tests {
         );
         publish_scip_component(&previous_dir, None, &previous, &mut || Ok(()))
             .expect("previous component");
-        std::fs::write(previous_dir.join(SCIP_SYMBOLS_DATABASE_FILE), b"not sqlite")
-            .expect("corrupt predecessor");
+        let previous_path = previous_dir.join(SCIP_SYMBOLS_DATABASE_FILE);
+        crate::copy_on_write::make_file_owner_writable(&previous_path)
+            .expect("authorize hostile corruption");
+        std::fs::write(previous_path, b"not sqlite").expect("corrupt predecessor");
         let current = component_index(
             "generation-v2",
             vec![component_symbol("1", "src/a.rs", "current")],

--- a/crates/codestory-retrieval/src/scip_index.rs
+++ b/crates/codestory-retrieval/src/scip_index.rs
@@ -1154,8 +1154,7 @@ fn publish_scip_component(
             bail!("staged scip component differs from its pinned graph projection");
         }
         before_publish()?;
-        codestory_workspace::atomic_file::publish_existing_file_atomic(&temp_path, &path)?;
-        crate::copy_on_write::make_file_immutable(&path)?;
+        crate::copy_on_write::publish_immutable_file_atomic(&temp_path, &path)?;
         let legacy = project_dir.join(SCIP_SYMBOLS_FILE);
         if legacy.is_file() {
             std::fs::remove_file(legacy)?;
@@ -1962,6 +1961,44 @@ mod tests {
         assert!(
             std::fs::metadata(changed_path)
                 .expect("changed permissions")
+                .permissions()
+                .readonly()
+        );
+    }
+
+    #[test]
+    fn same_generation_scip_retry_replaces_a_readonly_component_before_marker_completion() {
+        let root = TempDir::new().expect("tempdir");
+        let project_dir = root.path().join("partial");
+        std::fs::create_dir_all(&project_dir).expect("partial dir");
+        let partial = component_index(
+            "generation-v1",
+            vec![component_symbol("1", "src/a.rs", "partial")],
+        );
+        publish_scip_component(&project_dir, None, &partial, &mut || Ok(()))
+            .expect("publish component before markers");
+        let path = project_dir.join(SCIP_SYMBOLS_DATABASE_FILE);
+        assert!(
+            std::fs::metadata(&path)
+                .expect("partial permissions")
+                .permissions()
+                .readonly()
+        );
+
+        let repaired = component_index(
+            "generation-v1",
+            vec![component_symbol("1", "src/a.rs", "repaired")],
+        );
+        publish_scip_component(&project_dir, None, &repaired, &mut || Ok(()))
+            .expect("repair same-generation component");
+
+        assert_eq!(
+            load_scip_symbols_database(&path).expect("load repaired component"),
+            repaired
+        );
+        assert!(
+            std::fs::metadata(path)
+                .expect("repaired permissions")
                 .permissions()
                 .readonly()
         );


### PR DESCRIPTION
## Context

The 0.18 product benchmark showed that a single-file incremental refresh rebuilt the complete lexical, vector, and graph bundle. The parser was incremental, but every core publication changed the retrieval generation and left no reusable component at the new generation path.

This PR completes #2084 without changing retrieval or proof contracts.

## What changed

- Reuse immutable lexical, vector, and graph component files when their canonical content is unchanged; publication envelopes still bind them to the new generation and core publication.
- Reconcile changed lexical, vector, and graph content through the existing copy-on-write paths.
- Publish all immutable replacements through one Windows-safe helper that temporarily permits replacement and restores read-only state on every surviving predecessor/current file.
- Recover same-generation vector and graph publication after interruption without mutating a hard-linked predecessor.
- Carry the newest valid physical predecessor across the clean portable repository ID to dirty workspace ID transition used by real incremental refreshes.
- Report component work as `reused`, `copy_on_write`, or `complete`.

No schema, wire DTO, proof kernel, packet/context/search behavior, dense-selection policy, version, or 0.17 surface changes.

## How to review

The trust boundary is the immutable publication helper and the three component admission paths. In particular, verify that direct reuse is content-attested, changed content remains copy-on-write, corrupt predecessors fall back cleanly, and Windows replacement restores read-only state after success or failure.

## Verification

Exact support head: `fe95d0cb2dc47b3da54ccf5f2fbbc122ac7fc5a7`

Tree: `834667198813f43b5fa33f0bac2f0c2bf129d0fb`

- `cargo test --locked -p codestory-retrieval --lib`: 352 passed, 0 failed, 3 ignored.
- Both immutable rollback-corruption fixtures pass after explicitly opening their protected component for hostile test mutation.
- `cargo fmt --all -- --check`: passed.
- `git diff --check`: passed.
- Consolidated adversarial review covered physical identity, publication envelopes, corruption, cancellation, retries, retention, native replacement, and complexity. Its one Windows replacement class is fixed in this head.
- Local macOS-to-Windows cross compilation did not reach CodeStory because the local cross toolchain lacks Windows C headers for native dependencies. Hosted Windows CI remains the native platform receipt.

Redis-class native probe used the support head joined with the current dark activation work needed to index the full pinned corpus:

- cold: 118.1 s;
- incremental: 21.6 s;
- lexical: `copy_on_write` (32,866 retained, 1 inserted, 1 removed);
- vectors: `reused` (22,269 retained);
- graph: `reused` (98,615 retained);
- no incremental component reported `complete`;
- source freshness: 1,410/1,410 files fresh;
- lexical, semantic, and graph lanes: healthy/full.

## Risk and follow-up

The change intentionally retains complete fallback for corrupt, incompatible, or unattested predecessors. Cold dense-selection work remains separate and is not hidden in this PR. After merge, the activation branch must be rebuilt from the new `dev/codestory-0.18` head before any qualification receipts are rerun.

Closes #2084
Refs #2066
