### PR TITLE
Bound cold dense selection

### DIFF
--- a/crates/codestory-runtime/src/semantic_projection.rs
+++ b/crates/codestory-runtime/src/semantic_projection.rs
@@ -2507,7 +2507,6 @@ pub(super) fn dense_anchor_public_kind(kind: codestory_contracts::graph::NodeKin
         codestory_contracts::graph::NodeKind::STRUCT
             | codestory_contracts::graph::NodeKind::CLASS
             | codestory_contracts::graph::NodeKind::INTERFACE
-            | codestory_contracts::graph::NodeKind::ANNOTATION
             | codestory_contracts::graph::NodeKind::UNION
             | codestory_contracts::graph::NodeKind::ENUM
             | codestory_contracts::graph::NodeKind::TYPEDEF
@@ -2550,7 +2549,6 @@ pub(super) fn semantic_file_is_package_callable_surface(path: Option<&str>) -> b
         matches!(
             segment,
             "lib"
-                | "src"
                 | "pkg"
                 | "packages"
                 | "routes"
@@ -2600,6 +2598,11 @@ fn base_dense_anchor_reason_for_node(
     if dense_anchor_public_kind(node.kind)
         && (matches!(access, Some(AccessKind::Public | AccessKind::Protected))
             || semantic_file_is_public_surface(file_path))
+    {
+        return Some(DenseAnchorReason::PublicApi);
+    }
+    if node.kind == codestory_contracts::graph::NodeKind::ANNOTATION
+        && semantic_file_is_public_surface(file_path)
     {
         return Some(DenseAnchorReason::PublicApi);
     }

--- a/crates/codestory-runtime/src/tests.rs
+++ b/crates/codestory-runtime/src/tests.rs
@@ -729,8 +729,84 @@ fn dense_policy_skips_private_trivial_helpers() {
 }
 
 #[test]
+fn dense_policy_does_not_treat_the_generic_src_directory_as_a_public_api() {
+    let path = "src/networking.c";
+    let node = semantic_policy_node(11, NodeKind::FUNCTION, "process_command", 1);
+    let context = semantic_policy_context(path, &node);
+
+    assert!(!semantic_file_is_package_callable_surface(Some(path)));
+    assert_eq!(
+        dense_anchor_reason_for_node(
+            &context,
+            &node,
+            "process_command",
+            Some(path),
+            "semantic_doc_version: 9\nsymbol: process_command\n",
+            None,
+        ),
+        None,
+        "ordinary implementation callables remain available to lexical and graph retrieval"
+    );
+    assert_eq!(
+        dense_anchor_reason_for_node(
+            &context,
+            &node,
+            "process_command",
+            Some(path),
+            "semantic_doc_version: 9\nsymbol: process_command\n",
+            Some(AccessKind::Public),
+        ),
+        None,
+        "access metadata alone does not turn a generic source directory into a package surface"
+    );
+
+    let entrypoint = semantic_policy_node(12, NodeKind::FUNCTION, "main", 1);
+    let entrypoint_context = semantic_policy_context("src/main.c", &entrypoint);
+    assert_eq!(
+        dense_anchor_reason_for_node(
+            &entrypoint_context,
+            &entrypoint,
+            "main",
+            Some("src/main.c"),
+            "semantic_doc_version: 9\nsymbol: main\n",
+            None,
+        ),
+        Some(DenseAnchorReason::Entrypoint),
+        "the entrypoint policy remains independent of package-surface selection"
+    );
+
+    let preprocessor_definition = semantic_policy_node(13, NodeKind::ANNOTATION, "REDIS_STATIC", 1);
+    assert_eq!(
+        dense_anchor_reason_for_node(
+            &context,
+            &preprocessor_definition,
+            "REDIS_STATIC",
+            Some("src/server.h"),
+            "semantic_doc_version: 9\nsymbol: REDIS_STATIC\n",
+            Some(AccessKind::Public),
+        ),
+        None,
+        "C preprocessor definitions are not public APIs merely because C has no private access"
+    );
+
+    let java_annotation = semantic_policy_node(14, NodeKind::ANNOTATION, "StableApi", 1);
+    assert_eq!(
+        dense_anchor_reason_for_node(
+            &context,
+            &java_annotation,
+            "StableApi",
+            Some("app/src/main/java/com/acme/StableApi.java"),
+            "semantic_doc_version: 9\nsymbol: StableApi\n",
+            Some(AccessKind::Public),
+        ),
+        Some(DenseAnchorReason::PublicApi),
+        "annotation declarations on an explicit public package surface remain dense"
+    );
+}
+
+#[test]
 fn package_callable_surfaces_accept_relative_roots_without_admitting_tests() {
-    for path in ["lib/application.js", "src/server.js"] {
+    for path in ["lib/application.js"] {
         assert!(semantic_file_is_package_callable_surface(Some(path)));
 
         let node = semantic_policy_node(11, NodeKind::FUNCTION, "handle", 1);


### PR DESCRIPTION
## Context

Recorded Redis phase timings put 95.2 seconds of a 118.1-second cold retrieval build in vector construction. Of 22,269 dense anchors, 21,178 were labeled `public_api`. Two broad selectors caused that roster: any callable below a generic `src/**` segment, and C preprocessor definitions represented as annotation nodes with public access because C has no private access.

This PR is the bounded cold-index correction owned by #2087. It is separate from #2084's incremental component reuse.

## What changed

- A generic `src/**` directory no longer makes every callable a package API.
- Annotation nodes require an explicit public package surface rather than public access alone, retaining Java/Kotlin-style annotations under declared package layouts while excluding C preprocessor definitions in ordinary source directories.
- Existing entrypoint, explicit package/public surface, public structural type, documented nontrivial, graph-central, flow-neighbor, component-report, and documentation selection remain unchanged.
- Skipped symbols remain available to lexical and graph retrieval.

No storage, graph, proof, packet/context/search DTO, schema, model, embedding engine, or version change.

## Verification

Exact support head: `4f6cec953ac0ed85823857ac72b0ceb25485f85b`

Tree: `a428c91872912bcea7712b1a749359b09cba7aa4`

- Dense-policy focused tests: 10 passed.
- Package-surface focused test: 1 passed.
- `cargo fmt --all -- --check`: passed.
- `git diff --check`: passed.

Redis native release-class measurement on the joined 0.18 candidate:

| Metric | Before | After |
|---|---:|---:|
| Cold total | 118.1 s | 39.2 s |
| Vector phase | 95.2 s | 17.1 s |
| Dense anchors | 22,269 | 2,601 |
| Dense `public_api` | 21,178 | 4 |
| Vector bytes | 107.7 MB | 12.6 MB |

The remaining dense roster is composed of explicit public API, entrypoints, documented nontrivial symbols, central graph nodes, flow neighbors, component reports, and documentation.

## Risk and follow-up

This intentionally reduces dense recall for ordinary implementation symbols while preserving them in lexical and graph retrieval. The unchanged product-value and accuracy gates will measure that tradeoff on the frozen joined candidate before activation. No historical benchmark result is reused as acceptance.

Closes #2087
Refs #2066
