### PR TITLE
[codex] bind proof parser provenance to selected language

### DIFF
--- a/crates/codestory-indexer/src/proof_resolution.rs
+++ b/crates/codestory-indexer/src/proof_resolution.rs
@@ -4015,10 +4015,22 @@ fn c_cpp_sort_calls_by_span(calls: &mut Vec<IndexedCCppCall<'_>>) {
     }
 }
 
+fn parser_config_for_indexed_language(
+    path: &Path,
+    selected_language: &str,
+) -> Option<crate::LanguageConfig> {
+    let extension = crate::normalized_path_extension(path)?;
+    let extension_config = crate::get_language_for_ext(&extension)?;
+    if extension_config.language_name == selected_language {
+        return Some(extension_config);
+    }
+
+    (extension == "h" && selected_language == "cpp").then(crate::cpp_language_config)
+}
+
 fn expected_parser_fingerprint(path: &Path, language: &str) -> Option<String> {
-    let extension = path.extension()?.to_str()?;
-    let config = crate::get_language_for_ext(extension)?;
-    (config.language_name == language).then(|| crate::resolution_parser_fingerprint(&config))
+    parser_config_for_indexed_language(path, language)
+        .map(|config| crate::resolution_parser_fingerprint(&config))
 }
 
 pub(crate) fn cached_resolution_inputs_are_current(
@@ -13393,23 +13405,15 @@ pub fn rematerialize_proof_resolution_projection(
                     indexed_file.path.display()
                 )
             })?;
-            let extension = indexed_file
-                .path
-                .extension()
-                .and_then(|extension| extension.to_str())
-                .ok_or_else(|| anyhow!("proof resolution semantic cache path has no extension"))?;
-            let config = crate::get_language_for_ext(extension).ok_or_else(|| {
-                anyhow!(
-                    "proof resolution semantic cache has no parser for {}",
-                    indexed_file.path.display()
-                )
-            })?;
-            if config.language_name != indexed_file.language {
-                return Err(anyhow!(
-                    "proof resolution semantic cache parser language drifted for {}",
-                    indexed_file.path.display()
-                ));
-            }
+            let config =
+                parser_config_for_indexed_language(&indexed_file.path, &indexed_file.language)
+                    .ok_or_else(|| {
+                        anyhow!(
+                            "proof resolution semantic cache has no selected parser for {} ({})",
+                            indexed_file.language,
+                            indexed_file.path.display()
+                        )
+                    })?;
             let mut parser = Parser::new();
             parser.set_language(&config.language).map_err(|error| {
                 anyhow!("proof resolution semantic cache parser failed: {error:?}")

--- a/crates/codestory-indexer/tests/proof_resolution.rs
+++ b/crates/codestory-indexer/tests/proof_resolution.rs
@@ -3428,6 +3428,114 @@ fn c_cpp_header_extensions_are_always_canonical_nonexact() -> anyhow::Result<()>
 }
 
 #[test]
+fn c_cpp_header_provenance_uses_the_language_selected_during_indexing() -> anyhow::Result<()> {
+    let project = tempfile::tempdir()?;
+    let mut store = Store::new_in_memory()?;
+    index_files(
+        project.path(),
+        &mut store,
+        &[
+            (
+                "plain.h",
+                "void c_target(void) {}\nvoid c_caller(void) { c_target(); }\n",
+            ),
+            (
+                "selected.h",
+                concat!(
+                    "namespace fixture {\n",
+                    "void cpp_target() {}\n",
+                    "void cpp_caller() { cpp_target(); }\n",
+                    "}\n",
+                ),
+            ),
+        ],
+    )?;
+
+    let indexed_languages = store
+        .get_files()?
+        .into_iter()
+        .map(|file| {
+            (
+                file.path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .expect("UTF-8 fixture name")
+                    .to_string(),
+                file.language,
+            )
+        })
+        .collect::<HashMap<_, _>>();
+    assert_eq!(
+        indexed_languages.get("plain.h").map(String::as_str),
+        Some("c")
+    );
+    assert_eq!(
+        indexed_languages.get("selected.h").map(String::as_str),
+        Some("cpp")
+    );
+
+    let cached_fingerprints = {
+        let mut statement = store
+            .get_connection()
+            .prepare("SELECT artifact_blob FROM index_artifact_cache ORDER BY file_path")?;
+        let rows = statement.query_map([], |row| row.get::<_, Vec<u8>>(0))?;
+        let mut fingerprints = HashMap::new();
+        for row in rows {
+            let artifact: serde_json::Value = serde_json::from_slice(&row?)?;
+            let file = &artifact["resolution_file"];
+            let language = file["language"].as_str().expect("cached language");
+            let fingerprint = file["parser_fingerprint"]
+                .as_str()
+                .expect("cached parser fingerprint");
+            fingerprints.insert(language.to_string(), fingerprint.to_string());
+        }
+        fingerprints
+    };
+    assert_ne!(cached_fingerprints.get("c"), cached_fingerprints.get("cpp"));
+
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    store.validate_proof_resolution_publication(&publication(1))?;
+    assert!(store.get_proof_resolution_facts()?.iter().any(|fact| {
+        fact.provenance.language_adapter == "cpp" && fact.callsite.raw_target == "cpp_target"
+    }));
+
+    let c_fingerprint = cached_fingerprints
+        .get("c")
+        .expect("C parser fingerprint")
+        .clone();
+    let cached_rows = {
+        let mut statement = store.get_connection().prepare(
+            "SELECT file_path, artifact_blob FROM index_artifact_cache ORDER BY file_path",
+        )?;
+        let rows = statement.query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, Vec<u8>>(1)?))
+        })?;
+        rows.collect::<Result<Vec<_>, _>>()?
+    };
+    for (file_path, artifact_blob) in cached_rows {
+        let mut artifact: serde_json::Value = serde_json::from_slice(&artifact_blob)?;
+        if artifact["resolution_file"]["language"] == "cpp" {
+            artifact["resolution_file"]["parser_fingerprint"] = c_fingerprint.clone().into();
+            for call in artifact["call_resolution_inputs"]
+                .as_array_mut()
+                .expect("call inputs")
+            {
+                call["parser_fingerprint"] = c_fingerprint.clone().into();
+            }
+            store.get_connection().execute(
+                "UPDATE index_artifact_cache SET artifact_blob = ?1 WHERE file_path = ?2",
+                (serde_json::to_vec(&artifact)?, file_path),
+            )?;
+        }
+    }
+
+    let error = rematerialize_proof_resolution_projection(&mut store, &publication(2))
+        .expect_err("a C fingerprint must not authenticate source selected as C++");
+    assert!(error.to_string().contains("fingerprint"), "{error}");
+    Ok(())
+}
+
+#[test]
 fn python_closed_exact_subset_authorizes_s1_through_s4() -> anyhow::Result<()> {
     let project = tempfile::tempdir()?;
     let mut store = Store::new_in_memory()?;


### PR DESCRIPTION
## Context

An ambiguous `.h` file can be selected as C++ from source evidence during indexing, while proof rematerialization previously derived its expected parser only from the `.h` extension and incorrectly selected C. That rejected the complete proof projection before retrieval construction.

## What changed

- Resolve the proof parser configuration from the indexed language while preserving extension-specific parser dialects.
- Admit the existing `.h` to C++ source-selection seam and keep every other path/language mismatch fail-closed.
- Use that same configuration for fingerprint validation and semantic-cache parser regeneration.
- Add one regression covering C versus source-selected C++ headers, distinct fingerprints, complete rematerialization, and hostile fingerprint substitution.

## Verification

- `cargo test --locked -p codestory-indexer --test proof_resolution c_cpp_header -- --nocapture` — 2 passed
- `cargo test --locked -p codestory-indexer --test proof_resolution complete_projection_rejects_an_attacker_supplied_parser_fingerprint -- --exact --nocapture` — 1 passed
- `cargo fmt --all -- --check`
- `git diff --check`

## Scope

No retrieval policy, public proof activation, wire/schema, release, 0.17, `main`, or `dev/codestory-next` changes.

Closes #2090
Refs #2023