### PR TITLE
[codex] bind proof evidence to raw source hashes

### DIFF
--- a/crates/codestory-indexer/src/cache.rs
+++ b/crates/codestory-indexer/src/cache.rs
@@ -830,11 +830,12 @@ mod tests {
                 &decoded,
                 "typescript",
                 &"0".repeat(64),
+                &"0".repeat(64),
             )
         );
         assert!(
             !crate::proof_resolution::cached_resolution_inputs_are_current(
-                &decoded, "go", "unused",
+                &decoded, "go", "unused", "unused",
             ),
             "a legacy cache without proof inputs cannot satisfy the installed Go adapter"
         );

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -3191,6 +3191,7 @@ impl WorkspaceIndexer {
                         &artifact,
                         language_config.language_name,
                         &resolution_parser_fingerprint(&language_config),
+                        &content_hash,
                     ) =>
                 {
                     let mut artifact = rebase_cached_index_artifact(
@@ -3711,6 +3712,7 @@ impl WorkspaceIndexer {
         let index_result = index_file_with_resolution_inputs(
             &prepared_input.full_path,
             &prepared_input.source,
+            &prepared_input.content_hash,
             &prepared_input.language_config,
             prepared_input.compilation_info.clone(),
             Some(Arc::clone(symbol_table)),
@@ -15564,9 +15566,11 @@ pub fn index_file(
     compilation_info: Option<compilation_database::CompilationInfo>,
     symbol_table: Option<Arc<SymbolTable>>,
 ) -> Result<IndexResult> {
+    let source_sha256 = source_content_hash(source.as_bytes());
     index_file_with_resolution_inputs(
         path,
         source,
+        &source_sha256,
         language_config,
         compilation_info,
         symbol_table,
@@ -15577,6 +15581,7 @@ pub fn index_file(
 fn index_file_with_resolution_inputs(
     path: &Path,
     source: &str,
+    raw_source_sha256: &str,
     language_config: &LanguageConfig,
     compilation_info: Option<compilation_database::CompilationInfo>,
     symbol_table: Option<Arc<SymbolTable>>,
@@ -16279,6 +16284,7 @@ fn index_file_with_resolution_inputs(
     let resolution_inputs = proof_resolution::collect_call_resolution_inputs(
         &tree,
         source,
+        raw_source_sha256,
         path,
         language_config.language_name,
         &resolution_parser_fingerprint(language_config),

--- a/crates/codestory-indexer/src/proof_resolution.rs
+++ b/crates/codestory-indexer/src/proof_resolution.rs
@@ -263,6 +263,9 @@ pub(crate) struct CollectedResolutionInputs {
     pub file: Option<CachedResolutionFile>,
 }
 
+// Keep the raw byte hash explicit beside the decoded parser input: combining either
+// with another argument would blur the proof provenance boundary this collector owns.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn collect_call_resolution_inputs(
     tree: &Tree,
     source: &str,

--- a/crates/codestory-indexer/src/proof_resolution.rs
+++ b/crates/codestory-indexer/src/proof_resolution.rs
@@ -266,6 +266,7 @@ pub(crate) struct CollectedResolutionInputs {
 pub(crate) fn collect_call_resolution_inputs(
     tree: &Tree,
     source: &str,
+    raw_source_sha256: &str,
     source_path: &Path,
     language: &str,
     parser_fingerprint: &str,
@@ -280,7 +281,7 @@ pub(crate) fn collect_call_resolution_inputs(
     }
     let complete = !tree.root_node().has_error();
     let lookup_input_complete = complete;
-    let source_sha256 = source_content_hash(source.as_bytes());
+    let source_sha256 = raw_source_sha256.to_string();
     let javascript_index = is_javascript_language(language).then(|| {
         JavascriptResolutionIndex::build(tree, source, source_path, language, file_id, nodes)
     });
@@ -4025,6 +4026,7 @@ pub(crate) fn cached_resolution_inputs_are_current(
     artifact: &CachedIndexArtifact,
     language: &str,
     expected_parser_fingerprint: &str,
+    expected_source_sha256: &str,
 ) -> bool {
     !is_installed_language(language)
         || (artifact.resolution_input_schema_version == RESOLUTION_INPUT_SCHEMA_VERSION
@@ -4032,10 +4034,12 @@ pub(crate) fn cached_resolution_inputs_are_current(
                 file.language == language
                     && file.adapter_version == adapter_version(language)
                     && file.parser_fingerprint == expected_parser_fingerprint
+                    && file.source_sha256 == expected_source_sha256
                     && artifact.call_resolution_inputs.iter().all(|call| {
                         call.language == language
                             && call.adapter_version == adapter_version(language)
                             && call.parser_fingerprint == expected_parser_fingerprint
+                            && call.callsite.source_sha256 == expected_source_sha256
                     })
             }))
 }
@@ -13420,6 +13424,7 @@ pub fn rematerialize_proof_resolution_projection(
             let regenerated = collect_call_resolution_inputs(
                 &tree,
                 source,
+                stored_hash,
                 &indexed_file.path,
                 &indexed_file.language,
                 &expected_parser_fingerprint,

--- a/crates/codestory-indexer/tests/proof_resolution.rs
+++ b/crates/codestory-indexer/tests/proof_resolution.rs
@@ -13,6 +13,7 @@ use codestory_store::{
     seal_call_resolution_fact,
 };
 use codestory_workspace::{BuildMode, RefreshInfo};
+use sha2::{Digest, Sha256};
 use std::collections::{BTreeSet, HashMap};
 use std::fs;
 use std::path::PathBuf;
@@ -3424,6 +3425,86 @@ fn c_cpp_header_extensions_are_always_canonical_nonexact() -> anyhow::Result<()>
             );
         }
     }
+    Ok(())
+}
+
+#[test]
+fn proof_parser_evidence_uses_the_raw_predecode_source_hash() -> anyhow::Result<()> {
+    let project = tempfile::tempdir()?;
+    let path = project.path().join("fixture.c");
+    let raw_source =
+        b"void target(void) {}\nvoid caller(void) { target(); }\n/* non-UTF-8: \xff */\n";
+    fs::write(&path, raw_source)?;
+
+    let mut store = Store::new_in_memory()?;
+    WorkspaceIndexer::new(project.path().to_path_buf()).run_incremental(
+        &mut store,
+        &RefreshInfo {
+            mode: BuildMode::Incremental,
+            files_to_index: vec![path.clone()],
+            files_to_remove: Vec::new(),
+            existing_file_ids: HashMap::new(),
+        },
+        &EventBus::new(),
+        None,
+    )?;
+
+    let indexed_file = store
+        .get_files()?
+        .into_iter()
+        .find(|file| file.path == path)
+        .expect("indexed C fixture");
+    let raw_hash = store
+        .get_file_content_hash(indexed_file.id)?
+        .expect("raw source hash");
+    let decoded_hash = format!(
+        "{:x}",
+        Sha256::digest(String::from_utf8_lossy(raw_source).as_bytes())
+    );
+    assert_ne!(
+        raw_hash, decoded_hash,
+        "fixture must exercise lossy decoding"
+    );
+
+    let artifact_blob = store.get_connection().query_row(
+        "SELECT artifact_blob FROM index_artifact_cache",
+        [],
+        |row| row.get::<_, Vec<u8>>(0),
+    )?;
+    let artifact: serde_json::Value = serde_json::from_slice(&artifact_blob)?;
+    assert_eq!(artifact["resolution_file"]["source_sha256"], raw_hash);
+    assert!(
+        artifact["call_resolution_inputs"]
+            .as_array()
+            .expect("call inputs")
+            .iter()
+            .all(|call| call["callsite"]["source_sha256"] == raw_hash)
+    );
+
+    rematerialize_proof_resolution_projection(&mut store, &publication(1))?;
+    store.validate_proof_resolution_publication(&publication(1))?;
+    let fact = store
+        .get_proof_resolution_facts()?
+        .into_iter()
+        .find(|fact| fact.callsite.raw_target == "target")
+        .expect("C target fact");
+    assert_eq!(fact.callsite.source_sha256, raw_hash);
+
+    let mut substituted: serde_json::Value = serde_json::from_slice(&artifact_blob)?;
+    substituted["resolution_file"]["source_sha256"] = decoded_hash.clone().into();
+    for call in substituted["call_resolution_inputs"]
+        .as_array_mut()
+        .expect("call inputs")
+    {
+        call["callsite"]["source_sha256"] = decoded_hash.clone().into();
+    }
+    store.get_connection().execute(
+        "UPDATE index_artifact_cache SET artifact_blob = ?1",
+        [serde_json::to_vec(&substituted)?],
+    )?;
+    let error = rematerialize_proof_resolution_projection(&mut store, &publication(2))
+        .expect_err("a decoded-text hash must not substitute for the raw source hash");
+    assert!(error.to_string().contains("hash"), "{error}");
     Ok(())
 }
 


### PR DESCRIPTION
## Context

Parser-backed indexing deliberately decodes invalid UTF-8 lossily for ordinary graph construction. Proof cache collection then hashed that decoded string, while the core file record retained SHA-256 over the original bytes. Honest non-UTF-8 C files therefore blocked complete proof rematerialization.

## What changed

- Thread the raw pre-decode source SHA-256 already captured by indexing into proof input collection.
- Require cache-hit proof inputs to match that raw hash.
- Reuse the authenticated stored raw hash when semantic cache inputs are regenerated.
- Add a non-UTF-8 C regression covering successful complete rematerialization, raw-hash callsite binding, and hostile decoded-hash substitution.

Ordinary graph parsing remains lossy. Strict public proof source receipts and wire/schema contracts are unchanged.

## Verification

- `cargo test --locked -p codestory-indexer --test proof_resolution proof_parser_evidence_uses_the_raw_predecode_source_hash -- --exact --nocapture` — 1 passed
- `cargo test --locked -p codestory-indexer --test proof_resolution complete_projection_requires_cache_coverage_but_empty_and_unsupported_repositories_work -- --exact --nocapture` — 1 passed
- `cargo test --locked -p codestory-indexer --lib cache::tests::parser_cache_without_resolution_inputs_decodes_as_an_empty_legacy_projection -- --exact --nocapture` — 1 passed
- `cargo fmt --all -- --check`
- `git diff --check`

## Scope

No retrieval policy, public activation, proof receipt, schema, wire, release, or other lane changes.

Closes #2092
Refs #2023