### PR TITLE
[codex] remediate 0.18 accuracy and warm indexing

### DIFF
--- a/crates/codestory-agent/src/packet_evidence_carriers.rs
+++ b/crates/codestory-agent/src/packet_evidence_carriers.rs
@@ -395,7 +395,9 @@ pub fn citation_owns_client_public_interface_method(citation: &AgentCitationDto)
 /// A verb-named convenience implementation supplied by a base/default client type. This is
 /// distinct from the method declared by the public client contract.
 pub fn citation_owns_client_convenience_method(citation: &AgentCitationDto) -> bool {
-    if !citation_has_client_request_verb(citation) {
+    if terminal_segment_raw(&citation.display_name).starts_with('_')
+        || !citation_has_client_request_verb(citation)
+    {
         return false;
     }
     let owner = callable_owner_tokens(citation);
@@ -405,6 +407,39 @@ pub fn citation_owns_client_convenience_method(citation: &AgentCitationDto) -> b
             &["base", "convenience", "default", "helper", "mixin"],
         )
         && has_token(&owner, &["client", "http", "https", "session"])
+}
+
+/// The implementation step behind a base/default client's public convenience methods. This is
+/// deliberately separate from both the verb-named convenience surface and the abstract `send`
+/// boundary: a caller needs the small public delegation and the implementation that constructs the
+/// request, invokes the send boundary, and materializes the response.
+pub fn citation_owns_client_convenience_implementation(citation: &AgentCitationDto) -> bool {
+    if !owns_callable_behavior(citation) {
+        return false;
+    }
+    let owner = callable_owner_tokens(citation);
+    if client_owner_is_unrelated(&owner)
+        || !has_token(
+            &owner,
+            &["base", "convenience", "default", "helper", "mixin"],
+        )
+        || !has_token(&owner, &["client", "http", "https", "session"])
+    {
+        return false;
+    }
+
+    let terminal_raw = terminal_segment_raw(&citation.display_name);
+    let terminal_tokens = identifier_tokens(terminal_raw);
+    let owns_implementation_action = has_token(
+        &terminal_tokens,
+        &["dispatch", "execute", "perform", "request", "send"],
+    );
+    let is_specialized_helper = terminal_raw.starts_with('_')
+        || terminal_tokens.len() > 1
+        || has_token(&terminal_tokens, &["dispatch", "execute", "perform"]);
+    owns_implementation_action
+        && is_specialized_helper
+        && normalize_identifier(terminal_raw) != "send"
 }
 
 fn citation_has_client_request_verb(citation: &AgentCitationDto) -> bool {
@@ -906,6 +941,22 @@ pub fn citation_owns_client_request_finalization(citation: &AgentCitationDto) ->
     names_token_prefix(citation, &["finaliz", "finalis", "prepar"])
         || (names_token(citation, &["request", "requests"])
             && names_token(citation, &["to", "build", "body"]))
+}
+
+/// A concrete request subtype's body-producing finalization implementation. This supplements the
+/// base request contract without turning it into a second proof obligation: both source surfaces
+/// are material when available, while a client with only one remains a lawful packet.
+pub fn citation_owns_client_concrete_request_finalization(citation: &AgentCitationDto) -> bool {
+    if !owns_callable_behavior(citation) || !names_token_prefix(citation, &["finaliz", "finalis"]) {
+        return false;
+    }
+    let owner = callable_owner_tokens(citation);
+    has_token(&owner, &["request", "requests"])
+        && !client_owner_is_unrelated(&owner)
+        && !has_token(
+            &owner,
+            &["abstract", "base", "contract", "interface", "trait"],
+        )
 }
 
 /// The boundary where a transport response becomes a value the caller can read.
@@ -3070,6 +3121,38 @@ mod tests {
             );
         }
 
+        for positive in [
+            "BaseClient._sendUnstreamed",
+            "DefaultHttpClient.sendRequest",
+            "ClientMixin.execute",
+        ] {
+            assert!(
+                citation_owns_client_convenience_implementation(&citation(
+                    positive,
+                    "src/client.rs",
+                    NodeKind::METHOD,
+                )),
+                "{positive} should carry the convenience implementation body facet"
+            );
+        }
+        for negative in [
+            "BaseClient.get",
+            "BaseClient.send",
+            "Client.get",
+            "DatabaseBaseClient._sendUnstreamed",
+            "CacheClient.sendRequest",
+            "StoreClient.execute",
+        ] {
+            assert!(
+                !citation_owns_client_convenience_implementation(&citation(
+                    negative,
+                    "src/client.rs",
+                    NodeKind::METHOD,
+                )),
+                "{negative} must not carry the convenience implementation body facet"
+            );
+        }
+
         for positive in ["Session.send", "HttpClient.send"] {
             assert!(citation_owns_client_request_dispatch(&citation(
                 positive,
@@ -3515,6 +3598,24 @@ mod tests {
             "lib/base_request.dart",
             NodeKind::METHOD
         )));
+        assert!(citation_owns_client_concrete_request_finalization(
+            &citation("Request.finalize", "lib/request.dart", NodeKind::METHOD)
+        ));
+        for name in [
+            "BaseRequest.finalize",
+            "AbstractRequest.finalize",
+            "DatabaseRequest.finalize",
+            "CacheRequest.finalize",
+        ] {
+            assert!(
+                !citation_owns_client_concrete_request_finalization(&citation(
+                    name,
+                    "lib/request.dart",
+                    NodeKind::METHOD,
+                )),
+                "{name} is not a concrete HTTP request body finalizer"
+            );
+        }
     }
 
     /// Each of these is a whole *family* of symbol, not one symbol: the HTTP verb set on any

--- a/crates/codestory-agent/src/packet_evidence_carriers.rs
+++ b/crates/codestory-agent/src/packet_evidence_carriers.rs
@@ -364,6 +364,88 @@ pub fn citation_owns_client_request_method(citation: &AgentCitationDto) -> bool 
         )
 }
 
+/// The public client contract's verb-named method. This is distinct from a convenience
+/// implementation supplied by a base/default client type.
+pub fn citation_owns_client_public_interface_method(citation: &AgentCitationDto) -> bool {
+    if !citation_has_client_request_verb(citation) {
+        return false;
+    }
+    let owner = callable_owner_tokens(citation);
+    has_token(&owner, &["client", "http", "https", "session", "fetch"])
+        && !client_owner_is_unrelated(&owner)
+        && !has_token(
+            &owner,
+            &[
+                "adapter",
+                "base",
+                "convenience",
+                "default",
+                "helper",
+                "impl",
+                "implementation",
+                "internal",
+                "mixin",
+                "mock",
+                "test",
+                "transport",
+            ],
+        )
+}
+
+/// A verb-named convenience implementation supplied by a base/default client type. This is
+/// distinct from the method declared by the public client contract.
+pub fn citation_owns_client_convenience_method(citation: &AgentCitationDto) -> bool {
+    if !citation_has_client_request_verb(citation) {
+        return false;
+    }
+    let owner = callable_owner_tokens(citation);
+    !client_owner_is_unrelated(&owner)
+        && has_token(
+            &owner,
+            &["base", "convenience", "default", "helper", "mixin"],
+        )
+        && has_token(&owner, &["client", "http", "https", "session"])
+}
+
+fn citation_has_client_request_verb(citation: &AgentCitationDto) -> bool {
+    matches!(citation.kind, NodeKind::FUNCTION | NodeKind::METHOD)
+        && matches!(
+            terminal(citation).as_str(),
+            "request" | "get" | "post" | "put" | "patch" | "delete" | "head" | "options"
+        )
+}
+
+fn callable_owner_tokens(citation: &AgentCitationDto) -> Vec<String> {
+    let owner = citation
+        .display_name
+        .rsplit_once([':', '.', '#', '/', '\\'])
+        .map(|(owner, _)| owner)
+        .unwrap_or_default();
+    identifier_tokens(owner)
+}
+
+fn client_owner_is_unrelated(owner: &[String]) -> bool {
+    has_token(
+        owner,
+        &[
+            "cache",
+            "database",
+            "db",
+            "feature",
+            "flag",
+            "hook",
+            "metric",
+            "metrics",
+            "monitor",
+            "monitoring",
+            "queue",
+            "storage",
+            "store",
+            "telemetry",
+        ],
+    )
+}
+
 /// The package-level HTTP helper that opens the outbound-request lifecycle. A bare `request`
 /// citation is lawful here only on the public API module; the exact outgoing CALL to the following
 /// client/session request stage remains mandatory and is checked by the flow requirement.
@@ -377,16 +459,20 @@ pub fn citation_owns_client_public_facade_helper(citation: &AgentCitationDto) ->
         return false;
     }
     let path_tokens = path_tokens(citation);
-    let public_api_surface = has_token(&path_tokens, &["api"])
-        || path(citation)
+    let display_path = path(citation);
+    let library_relative = display_path.strip_prefix("lib/").or_else(|| {
+        display_path
             .rsplit_once("/lib/")
-            .is_some_and(|(_, relative)| {
-                !relative.contains('/')
-                    && has_token(
-                        &path_tokens,
-                        &["http", "https", "request", "requests", "client"],
-                    )
-            });
+            .map(|(_, relative)| relative)
+    });
+    let public_api_surface = has_token(&path_tokens, &["api"])
+        || library_relative.is_some_and(|relative| {
+            !relative.contains('/')
+                && has_token(
+                    &path_tokens,
+                    &["http", "https", "request", "requests", "client"],
+                )
+        });
     public_api_surface
         && !names_or_path_token(
             citation,
@@ -2346,7 +2432,19 @@ pub(crate) fn carrier_taxonomy_vocabulary() -> Vec<String> {
         .chain(SEARCH_EVIDENCE_CLASSIFICATION_ACTIONS)
         .chain(SEARCH_EVIDENCE_OUTPUT_ACTIONS)
         .chain(COMMAND_LOOP_CARRIER_TAXONOMY)
-        .chain(["evidence"].iter())
+        .chain(
+            [
+                "convenience",
+                "evidence",
+                "feature",
+                "internal",
+                "mixin",
+                "mock",
+                "monitor",
+                "test",
+            ]
+            .iter(),
+        )
         .flat_map(|term| [(*term).to_string(), taxonomy_plural(term)])
         .collect::<Vec<_>>();
     vocabulary.sort();
@@ -2913,6 +3011,64 @@ mod tests {
             "src/storage.rs",
             NodeKind::METHOD,
         )));
+
+        for positive in ["Client.get", "HttpClient.request", "Session.post"] {
+            assert!(
+                citation_owns_client_public_interface_method(&citation(
+                    positive,
+                    "src/client.rs",
+                    NodeKind::METHOD,
+                )),
+                "{positive} should carry the public client interface facet"
+            );
+        }
+        for negative in [
+            "BaseClient.get",
+            "DefaultHttpClient.post",
+            "DatabaseClient.get",
+            "CacheClient.get",
+            "Store.get",
+        ] {
+            assert!(
+                !citation_owns_client_public_interface_method(&citation(
+                    negative,
+                    "src/client.rs",
+                    NodeKind::METHOD,
+                )),
+                "{negative} must not carry the public client interface facet"
+            );
+        }
+
+        for positive in [
+            "BaseClient.get",
+            "DefaultHttpClient.post",
+            "ClientMixin.head",
+        ] {
+            assert!(
+                citation_owns_client_convenience_method(&citation(
+                    positive,
+                    "src/client.rs",
+                    NodeKind::METHOD,
+                )),
+                "{positive} should carry the convenience implementation facet"
+            );
+        }
+        for negative in [
+            "Client.get",
+            "HttpClient.request",
+            "DatabaseClient.get",
+            "CacheClient.get",
+            "StoreClient.get",
+        ] {
+            assert!(
+                !citation_owns_client_convenience_method(&citation(
+                    negative,
+                    "src/client.rs",
+                    NodeKind::METHOD,
+                )),
+                "{negative} must not carry the convenience implementation facet"
+            );
+        }
 
         for positive in ["Session.send", "HttpClient.send"] {
             assert!(citation_owns_client_request_dispatch(&citation(

--- a/crates/codestory-agent/src/packet_flow_requirements.rs
+++ b/crates/codestory-agent/src/packet_flow_requirements.rs
@@ -4,40 +4,40 @@ use crate::packet_evidence_carriers::{
     SEARCH_EVIDENCE_CLASSIFICATION_ACTIONS, SEARCH_EVIDENCE_OUTPUT_ACTIONS,
     citation_may_start_command_event_loop_exact_boundary, citation_owns_buffer_read_write,
     citation_owns_buffer_storage, citation_owns_client_adapter_selection,
-    citation_owns_client_public_facade_helper, citation_owns_client_request_dispatch,
+    citation_owns_client_convenience_method, citation_owns_client_public_facade_helper,
+    citation_owns_client_public_interface_method, citation_owns_client_request_dispatch,
     citation_owns_client_request_entrypoint, citation_owns_client_request_finalization,
-    citation_owns_client_request_method, citation_owns_client_response_materialization,
-    citation_owns_client_transport_send, citation_owns_command_event_loop_driver,
-    citation_owns_command_router, citation_owns_css_animation_entrypoint,
-    citation_owns_css_animation_structure, citation_owns_css_structure,
-    citation_owns_form_custom_validation, citation_owns_form_native_constraint,
-    citation_owns_form_submit_guard, citation_owns_format_arguments,
-    citation_owns_formatter_fallback, citation_owns_hook_cache_helper,
-    citation_owns_hook_key_serialization, citation_owns_hook_mutation_flow,
-    citation_owns_hook_public_export, citation_owns_html_app_shell,
-    citation_owns_log_handler_processing, citation_owns_log_record_creation,
-    citation_owns_mapper_configuration, citation_owns_mapper_execution,
-    citation_owns_search_argument_planning, citation_owns_search_candidate_traversal,
-    citation_owns_search_evidence_classification, citation_owns_search_evidence_output,
-    citation_owns_search_haystack_construction, citation_owns_search_matcher_setup,
-    citation_owns_search_printer_setup, citation_owns_search_searcher_setup,
-    citation_owns_search_worker_construction, citation_owns_server_request_dispatch,
-    citation_owns_server_request_entrypoint, citation_owns_server_request_handler_entrypoint,
-    citation_owns_server_response_terminal, citation_owns_server_route_match_dispatch,
-    citation_owns_server_route_registration, citation_owns_shell_completion,
-    citation_owns_shell_function_dispatch, citation_owns_shell_installer_bootstrap,
-    citation_owns_site_lifecycle, citation_owns_site_reader, citation_owns_site_terminal,
-    citation_owns_string_blank_predicate, citation_owns_string_empty_predicate,
-    citation_owns_string_region_handoff, client_public_facade_successor_call_target,
-    client_request_dispatch_predecessor_call_source, client_request_dispatch_successor_call_target,
-    client_request_entrypoint_call_target, command_event_loop_driver_call_target,
-    command_router_call_target, flow_belongs_to_client_request, flow_belongs_to_command_server,
-    flow_belongs_to_indexing, flow_belongs_to_network_input, flow_belongs_to_request_terminal,
-    flow_belongs_to_search, flow_belongs_to_server_request, flow_belongs_to_sql_schema,
-    flow_belongs_to_url_session, server_handler_chain_call_target,
-    server_request_dispatch_call_target, server_request_entrypoint_call_target,
-    server_response_terminal_call_target, server_route_insertion_call_target,
-    server_route_lookup_call_target,
+    citation_owns_client_response_materialization, citation_owns_client_transport_send,
+    citation_owns_command_event_loop_driver, citation_owns_command_router,
+    citation_owns_css_animation_entrypoint, citation_owns_css_animation_structure,
+    citation_owns_css_structure, citation_owns_form_custom_validation,
+    citation_owns_form_native_constraint, citation_owns_form_submit_guard,
+    citation_owns_format_arguments, citation_owns_formatter_fallback,
+    citation_owns_hook_cache_helper, citation_owns_hook_key_serialization,
+    citation_owns_hook_mutation_flow, citation_owns_hook_public_export,
+    citation_owns_html_app_shell, citation_owns_log_handler_processing,
+    citation_owns_log_record_creation, citation_owns_mapper_configuration,
+    citation_owns_mapper_execution, citation_owns_search_argument_planning,
+    citation_owns_search_candidate_traversal, citation_owns_search_evidence_classification,
+    citation_owns_search_evidence_output, citation_owns_search_haystack_construction,
+    citation_owns_search_matcher_setup, citation_owns_search_printer_setup,
+    citation_owns_search_searcher_setup, citation_owns_search_worker_construction,
+    citation_owns_server_request_dispatch, citation_owns_server_request_entrypoint,
+    citation_owns_server_request_handler_entrypoint, citation_owns_server_response_terminal,
+    citation_owns_server_route_match_dispatch, citation_owns_server_route_registration,
+    citation_owns_shell_completion, citation_owns_shell_function_dispatch,
+    citation_owns_shell_installer_bootstrap, citation_owns_site_lifecycle,
+    citation_owns_site_reader, citation_owns_site_terminal, citation_owns_string_blank_predicate,
+    citation_owns_string_empty_predicate, citation_owns_string_region_handoff,
+    client_public_facade_successor_call_target, client_request_dispatch_predecessor_call_source,
+    client_request_dispatch_successor_call_target, client_request_entrypoint_call_target,
+    command_event_loop_driver_call_target, command_router_call_target,
+    flow_belongs_to_client_request, flow_belongs_to_command_server, flow_belongs_to_indexing,
+    flow_belongs_to_network_input, flow_belongs_to_request_terminal, flow_belongs_to_search,
+    flow_belongs_to_server_request, flow_belongs_to_sql_schema, flow_belongs_to_url_session,
+    server_handler_chain_call_target, server_request_dispatch_call_target,
+    server_request_entrypoint_call_target, server_response_terminal_call_target,
+    server_route_insertion_call_target, server_route_lookup_call_target,
 };
 use crate::packet_evidence_roles::{
     PacketEvidenceRole, packet_citation_owns_interceptor_management, packet_evidence_role,
@@ -65,7 +65,7 @@ use crate::packet_terms::{
     packet_terms_indicate_url_session_request_flow, prompt_search_terms,
 };
 use codestory_contracts::api::{
-    AgentCitationDto, EdgeKind, GraphEdgeDto, NodeKind, PacketTaskClassDto,
+    AgentCitationDto, EdgeKind, GraphEdgeDto, NodeId, NodeKind, PacketTaskClassDto,
 };
 
 const CALLABLE_NODE_KINDS: &[NodeKind] = &[NodeKind::FUNCTION, NodeKind::METHOD, NodeKind::MACRO];
@@ -475,6 +475,40 @@ impl FlowRequirement {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PacketMaterialFacetCarrier {
+    pub facet_id: &'static str,
+    pub node_id: NodeId,
+}
+
+/// Select one source-bearing carrier for each material flow facet, preserving the requirement and
+/// citation rank order. Protection keeps a reported-but-unproven facet visible through the packet
+/// cap; it never changes that facet's proof disposition.
+pub fn packet_material_facet_carriers(
+    requirements: &[FlowRequirement],
+    citations: &[AgentCitationDto],
+) -> Vec<PacketMaterialFacetCarrier> {
+    let mut selected = Vec::new();
+    let mut selected_nodes = std::collections::HashSet::new();
+    for requirement in requirements {
+        let Some(citation) = citations.iter().find(|citation| {
+            !selected_nodes.contains(&citation.node_id)
+                && citation.file_path.is_some()
+                && citation.line.is_some()
+                && crate::packet_evidence::citation_sufficiency_eligible(citation)
+                && requirement.evidence.citation_proves(citation)
+        }) else {
+            continue;
+        };
+        selected_nodes.insert(citation.node_id.clone());
+        selected.push(PacketMaterialFacetCarrier {
+            facet_id: requirement.id,
+            node_id: citation.node_id.clone(),
+        });
+    }
+    selected
+}
+
 pub fn packet_flow_requirements_for_terms(
     terms: &[String],
     task_class: PacketTaskClassDto,
@@ -795,6 +829,7 @@ fn push_client_send_requirements_for_terms(
         "helpers",
     ]) && has_any(&["client", "clients", "http", "httpclient"])
     {
+        requirements.push(CLIENT_PUBLIC_INTERFACE_REQUIREMENT);
         requirements.push(CLIENT_INTERFACE_HELPERS_REQUIREMENT);
     }
     if has_any(&[
@@ -850,6 +885,7 @@ fn push_full_client_outbound_request_flow(
         "helper",
         "helpers",
     ]) {
+        requirements.push(CLIENT_PUBLIC_INTERFACE_REQUIREMENT);
         requirements.push(CLIENT_INTERFACE_HELPERS_REQUIREMENT);
     }
     requirements.push(CLIENT_REQUEST_DISPATCH_FLOW[0]);
@@ -1154,7 +1190,16 @@ const CLIENT_INTERFACE_HELPERS_REQUIREMENT: FlowRequirement = FlowRequirement {
     ],
     coverage_mode: CoverageMode::RequiresResolvedSourceOrGraph,
     proof: FlowProofSpec::Legacy,
-    evidence: EvidencePredicate::CitedCarrier(citation_owns_client_request_method),
+    evidence: EvidencePredicate::CitedCarrier(citation_owns_client_convenience_method),
+};
+
+const CLIENT_PUBLIC_INTERFACE_REQUIREMENT: FlowRequirement = FlowRequirement {
+    id: "client_public_interface",
+    role: FlowRole::Entrypoint,
+    query_seeds: &["public client method", "client interface declaration"],
+    coverage_mode: CoverageMode::RequiresResolvedSourceOrGraph,
+    proof: FlowProofSpec::Legacy,
+    evidence: EvidencePredicate::CitedCarrier(citation_owns_client_public_interface_method),
 };
 
 const CLIENT_REQUEST_FINALIZATION_REQUIREMENT: FlowRequirement = FlowRequirement {
@@ -1814,6 +1859,7 @@ pub fn all_flow_requirement_groups() -> Vec<(&'static str, Vec<FlowRequirement>)
             "client_send",
             vec![
                 CLIENT_PUBLIC_FACADE_REQUIREMENT,
+                CLIENT_PUBLIC_INTERFACE_REQUIREMENT,
                 CLIENT_INTERFACE_HELPERS_REQUIREMENT,
                 CLIENT_REQUEST_FINALIZATION_REQUIREMENT,
                 CLIENT_TRANSPORT_SEND_REQUIREMENT,
@@ -1868,7 +1914,10 @@ mod tests {
     use crate::packet_evidence_carriers::carrier_taxonomy_vocabulary;
     use crate::packet_proof_atoms::FlowProofFormula;
     use crate::packet_terms::packet_probe_terms;
-    use codestory_contracts::api::{EdgeId, NodeId, NodeKind, SearchHitOrigin};
+    use codestory_contracts::api::{
+        EdgeId, NodeId, NodeKind, PacketEvidenceResolutionDto, PacketEvidenceTierDto,
+        SearchHitOrigin,
+    };
     use std::collections::BTreeMap;
 
     /// Contract rev 5 scope table: exactly six requirement ids carry real
@@ -2001,10 +2050,76 @@ mod tests {
             ),
             vec![
                 "client_public_facade",
+                "client_public_interface",
                 "client_interface_helpers",
                 "client_request_finalization",
                 "client_transport_send",
                 "client_response_materialization",
+            ]
+        );
+    }
+
+    #[test]
+    fn material_client_facets_select_distinct_source_carriers_before_the_cap() {
+        let prompt = "Explain how package:http exposes top-level helpers, BaseClient convenience methods, BaseRequest finalization, and IOClient send behavior.";
+        let requirements = packet_flow_requirements_for_terms(
+            &packet_probe_terms(prompt),
+            PacketTaskClassDto::DataFlow,
+        );
+        assert_eq!(
+            requirements
+                .iter()
+                .map(|requirement| requirement.id)
+                .collect::<Vec<_>>(),
+            [
+                "client_public_facade",
+                "client_public_interface",
+                "client_interface_helpers",
+                "client_request_finalization",
+                "client_transport_send",
+            ]
+        );
+        let mut citations = vec![
+            witness(
+                "DatabaseClient.get",
+                "src/database_client.rs",
+                NodeKind::METHOD,
+            ),
+            witness(
+                "get",
+                "/private/tmp/fixtures/neutral-project/lib/http.dart",
+                NodeKind::FUNCTION,
+            ),
+            witness("Client.get", "lib/src/client.dart", NodeKind::METHOD),
+            witness(
+                "BaseClient.get",
+                "lib/src/base_client.dart",
+                NodeKind::METHOD,
+            ),
+            witness(
+                "BaseRequest.finalize",
+                "lib/src/base_request.dart",
+                NodeKind::METHOD,
+            ),
+            witness("IOClient.send", "lib/src/io_client.dart", NodeKind::METHOD),
+        ];
+        for citation in &mut citations {
+            citation.evidence_tier = Some(PacketEvidenceTierDto::ResolvedGraph);
+            citation.resolution_status = Some(PacketEvidenceResolutionDto::Resolved);
+        }
+
+        let selected = packet_material_facet_carriers(&requirements, &citations);
+        assert_eq!(
+            selected
+                .iter()
+                .map(|carrier| (carrier.facet_id, carrier.node_id.0.as_str()))
+                .collect::<Vec<_>>(),
+            [
+                ("client_public_facade", "get"),
+                ("client_public_interface", "Client.get"),
+                ("client_interface_helpers", "BaseClient.get"),
+                ("client_request_finalization", "BaseRequest.finalize"),
+                ("client_transport_send", "IOClient.send"),
             ]
         );
     }
@@ -2580,6 +2695,7 @@ mod tests {
         "buffered_storage | state_or_storage | AllowsSourceRange",
         "client_interface_helpers | entrypoint | RequiresResolvedSourceOrGraph",
         "client_public_facade | entrypoint | RequiresResolvedSourceOrGraph",
+        "client_public_interface | entrypoint | RequiresResolvedSourceOrGraph",
         "client_request_finalization | transform_or_validate | RequiresResolvedSourceOrGraph",
         "client_response_materialization | terminal_boundary | RequiresResolvedSourceOrGraph",
         "client_transport_send | terminal_boundary | RequiresResolvedSourceOrGraph",
@@ -2793,8 +2909,12 @@ mod tests {
                 witness("createClient", "lib/client.dart", NodeKind::FUNCTION),
             ),
             (
-                ("client_interface_helpers", "entrypoint"),
+                ("client_public_interface", "entrypoint"),
                 witness("Client.get", "lib/client.dart", NodeKind::METHOD),
+            ),
+            (
+                ("client_interface_helpers", "entrypoint"),
+                witness("BaseClient.get", "lib/base_client.dart", NodeKind::METHOD),
             ),
             (
                 ("client_request_finalization", "transform_or_validate"),
@@ -4081,7 +4201,6 @@ mod tests {
     /// sweep that only ever asked about `.ts` could not see the difference.
     const ONE_WORD_EVIDENCE_SURFACE: &[&str] = &[
         "buffered_storage | buffer",
-        "client_interface_helpers | request",
         "command_server_bootstrap | main",
         "css_animation_entrypoint | forward",
         "css_animation_entrypoint | import",
@@ -4751,8 +4870,6 @@ mod tests {
     /// Four of these are irreducible against a positive anchor that has the identical shape, and
     /// saying so is the point of recording them:
     ///
-    /// - `client_interface_helpers | request` — the real anchor is `Axios.prototype.request`, whose
-    ///   only client word *is* the verb. `FrameKind.request` cannot be told apart from it by name.
     /// - `buffered_storage | buffer` — a segment of a name that is nothing but "buffer" is the
     ///   buffer; okio's own wrapper is a function called `buffer`.
     /// - `hook_public_export | use` — `use` followed by a capital is the React hook convention, so
@@ -4786,7 +4903,6 @@ mod tests {
     /// still takes the path.
     const COMPOUND_EVIDENCE_SURFACE: &[&str] = &[
         "buffered_storage | buffer",
-        "client_interface_helpers | request",
         "css_animation_entrypoint | forward",
         "css_animation_entrypoint | import",
         "css_animation_entrypoint | use",

--- a/crates/codestory-agent/src/packet_flow_requirements.rs
+++ b/crates/codestory-agent/src/packet_flow_requirements.rs
@@ -4,40 +4,42 @@ use crate::packet_evidence_carriers::{
     SEARCH_EVIDENCE_CLASSIFICATION_ACTIONS, SEARCH_EVIDENCE_OUTPUT_ACTIONS,
     citation_may_start_command_event_loop_exact_boundary, citation_owns_buffer_read_write,
     citation_owns_buffer_storage, citation_owns_client_adapter_selection,
-    citation_owns_client_convenience_method, citation_owns_client_public_facade_helper,
-    citation_owns_client_public_interface_method, citation_owns_client_request_dispatch,
-    citation_owns_client_request_entrypoint, citation_owns_client_request_finalization,
-    citation_owns_client_response_materialization, citation_owns_client_transport_send,
-    citation_owns_command_event_loop_driver, citation_owns_command_router,
-    citation_owns_css_animation_entrypoint, citation_owns_css_animation_structure,
-    citation_owns_css_structure, citation_owns_form_custom_validation,
-    citation_owns_form_native_constraint, citation_owns_form_submit_guard,
-    citation_owns_format_arguments, citation_owns_formatter_fallback,
-    citation_owns_hook_cache_helper, citation_owns_hook_key_serialization,
-    citation_owns_hook_mutation_flow, citation_owns_hook_public_export,
-    citation_owns_html_app_shell, citation_owns_log_handler_processing,
-    citation_owns_log_record_creation, citation_owns_mapper_configuration,
-    citation_owns_mapper_execution, citation_owns_search_argument_planning,
-    citation_owns_search_candidate_traversal, citation_owns_search_evidence_classification,
-    citation_owns_search_evidence_output, citation_owns_search_haystack_construction,
-    citation_owns_search_matcher_setup, citation_owns_search_printer_setup,
-    citation_owns_search_searcher_setup, citation_owns_search_worker_construction,
-    citation_owns_server_request_dispatch, citation_owns_server_request_entrypoint,
-    citation_owns_server_request_handler_entrypoint, citation_owns_server_response_terminal,
-    citation_owns_server_route_match_dispatch, citation_owns_server_route_registration,
-    citation_owns_shell_completion, citation_owns_shell_function_dispatch,
-    citation_owns_shell_installer_bootstrap, citation_owns_site_lifecycle,
-    citation_owns_site_reader, citation_owns_site_terminal, citation_owns_string_blank_predicate,
-    citation_owns_string_empty_predicate, citation_owns_string_region_handoff,
-    client_public_facade_successor_call_target, client_request_dispatch_predecessor_call_source,
-    client_request_dispatch_successor_call_target, client_request_entrypoint_call_target,
-    command_event_loop_driver_call_target, command_router_call_target,
-    flow_belongs_to_client_request, flow_belongs_to_command_server, flow_belongs_to_indexing,
-    flow_belongs_to_network_input, flow_belongs_to_request_terminal, flow_belongs_to_search,
-    flow_belongs_to_server_request, flow_belongs_to_sql_schema, flow_belongs_to_url_session,
-    server_handler_chain_call_target, server_request_dispatch_call_target,
-    server_request_entrypoint_call_target, server_response_terminal_call_target,
-    server_route_insertion_call_target, server_route_lookup_call_target,
+    citation_owns_client_concrete_request_finalization,
+    citation_owns_client_convenience_implementation, citation_owns_client_convenience_method,
+    citation_owns_client_public_facade_helper, citation_owns_client_public_interface_method,
+    citation_owns_client_request_dispatch, citation_owns_client_request_entrypoint,
+    citation_owns_client_request_finalization, citation_owns_client_response_materialization,
+    citation_owns_client_transport_send, citation_owns_command_event_loop_driver,
+    citation_owns_command_router, citation_owns_css_animation_entrypoint,
+    citation_owns_css_animation_structure, citation_owns_css_structure,
+    citation_owns_form_custom_validation, citation_owns_form_native_constraint,
+    citation_owns_form_submit_guard, citation_owns_format_arguments,
+    citation_owns_formatter_fallback, citation_owns_hook_cache_helper,
+    citation_owns_hook_key_serialization, citation_owns_hook_mutation_flow,
+    citation_owns_hook_public_export, citation_owns_html_app_shell,
+    citation_owns_log_handler_processing, citation_owns_log_record_creation,
+    citation_owns_mapper_configuration, citation_owns_mapper_execution,
+    citation_owns_search_argument_planning, citation_owns_search_candidate_traversal,
+    citation_owns_search_evidence_classification, citation_owns_search_evidence_output,
+    citation_owns_search_haystack_construction, citation_owns_search_matcher_setup,
+    citation_owns_search_printer_setup, citation_owns_search_searcher_setup,
+    citation_owns_search_worker_construction, citation_owns_server_request_dispatch,
+    citation_owns_server_request_entrypoint, citation_owns_server_request_handler_entrypoint,
+    citation_owns_server_response_terminal, citation_owns_server_route_match_dispatch,
+    citation_owns_server_route_registration, citation_owns_shell_completion,
+    citation_owns_shell_function_dispatch, citation_owns_shell_installer_bootstrap,
+    citation_owns_site_lifecycle, citation_owns_site_reader, citation_owns_site_terminal,
+    citation_owns_string_blank_predicate, citation_owns_string_empty_predicate,
+    citation_owns_string_region_handoff, client_public_facade_successor_call_target,
+    client_request_dispatch_predecessor_call_source, client_request_dispatch_successor_call_target,
+    client_request_entrypoint_call_target, command_event_loop_driver_call_target,
+    command_router_call_target, flow_belongs_to_client_request, flow_belongs_to_command_server,
+    flow_belongs_to_indexing, flow_belongs_to_network_input, flow_belongs_to_request_terminal,
+    flow_belongs_to_search, flow_belongs_to_server_request, flow_belongs_to_sql_schema,
+    flow_belongs_to_url_session, server_handler_chain_call_target,
+    server_request_dispatch_call_target, server_request_entrypoint_call_target,
+    server_response_terminal_call_target, server_route_insertion_call_target,
+    server_route_lookup_call_target,
 };
 use crate::packet_evidence_roles::{
     PacketEvidenceRole, packet_citation_owns_interceptor_management, packet_evidence_role,
@@ -505,6 +507,21 @@ pub fn packet_material_facet_carriers(
             facet_id: requirement.id,
             node_id: citation.node_id.clone(),
         });
+        if requirement.id == "client_request_finalization"
+            && let Some(concrete) = citations.iter().find(|citation| {
+                !selected_nodes.contains(&citation.node_id)
+                    && citation.file_path.is_some()
+                    && citation.line.is_some()
+                    && crate::packet_evidence::citation_sufficiency_eligible(citation)
+                    && citation_owns_client_concrete_request_finalization(citation)
+            })
+        {
+            selected_nodes.insert(concrete.node_id.clone());
+            selected.push(PacketMaterialFacetCarrier {
+                facet_id: "client_concrete_request_finalization",
+                node_id: concrete.node_id.clone(),
+            });
+        }
     }
     selected
 }
@@ -831,6 +848,7 @@ fn push_client_send_requirements_for_terms(
     {
         requirements.push(CLIENT_PUBLIC_INTERFACE_REQUIREMENT);
         requirements.push(CLIENT_INTERFACE_HELPERS_REQUIREMENT);
+        requirements.push(CLIENT_CONVENIENCE_IMPLEMENTATION_REQUIREMENT);
     }
     if has_any(&[
         "finalize",
@@ -887,6 +905,7 @@ fn push_full_client_outbound_request_flow(
     ]) {
         requirements.push(CLIENT_PUBLIC_INTERFACE_REQUIREMENT);
         requirements.push(CLIENT_INTERFACE_HELPERS_REQUIREMENT);
+        requirements.push(CLIENT_CONVENIENCE_IMPLEMENTATION_REQUIREMENT);
     }
     requirements.push(CLIENT_REQUEST_DISPATCH_FLOW[0]);
     requirements.push(CLIENT_REQUEST_FINALIZATION_REQUIREMENT);
@@ -1200,6 +1219,18 @@ const CLIENT_PUBLIC_INTERFACE_REQUIREMENT: FlowRequirement = FlowRequirement {
     coverage_mode: CoverageMode::RequiresResolvedSourceOrGraph,
     proof: FlowProofSpec::Legacy,
     evidence: EvidencePredicate::CitedCarrier(citation_owns_client_public_interface_method),
+};
+
+const CLIENT_CONVENIENCE_IMPLEMENTATION_REQUIREMENT: FlowRequirement = FlowRequirement {
+    id: "client_convenience_implementation",
+    role: FlowRole::Dispatch,
+    query_seeds: &[
+        "client convenience implementation",
+        "client request implementation helper",
+    ],
+    coverage_mode: CoverageMode::RequiresResolvedSourceOrGraph,
+    proof: FlowProofSpec::Legacy,
+    evidence: EvidencePredicate::CitedCarrier(citation_owns_client_convenience_implementation),
 };
 
 const CLIENT_REQUEST_FINALIZATION_REQUIREMENT: FlowRequirement = FlowRequirement {
@@ -1861,6 +1892,7 @@ pub fn all_flow_requirement_groups() -> Vec<(&'static str, Vec<FlowRequirement>)
                 CLIENT_PUBLIC_FACADE_REQUIREMENT,
                 CLIENT_PUBLIC_INTERFACE_REQUIREMENT,
                 CLIENT_INTERFACE_HELPERS_REQUIREMENT,
+                CLIENT_CONVENIENCE_IMPLEMENTATION_REQUIREMENT,
                 CLIENT_REQUEST_FINALIZATION_REQUIREMENT,
                 CLIENT_TRANSPORT_SEND_REQUIREMENT,
                 CLIENT_RESPONSE_MATERIALIZATION_REQUIREMENT,
@@ -2052,6 +2084,7 @@ mod tests {
                 "client_public_facade",
                 "client_public_interface",
                 "client_interface_helpers",
+                "client_convenience_implementation",
                 "client_request_finalization",
                 "client_transport_send",
                 "client_response_materialization",
@@ -2075,6 +2108,7 @@ mod tests {
                 "client_public_facade",
                 "client_public_interface",
                 "client_interface_helpers",
+                "client_convenience_implementation",
                 "client_request_finalization",
                 "client_transport_send",
             ]
@@ -2097,10 +2131,16 @@ mod tests {
                 NodeKind::METHOD,
             ),
             witness(
+                "BaseClient._sendUnstreamed",
+                "lib/src/base_client.dart",
+                NodeKind::METHOD,
+            ),
+            witness(
                 "BaseRequest.finalize",
                 "lib/src/base_request.dart",
                 NodeKind::METHOD,
             ),
+            witness("Request.finalize", "lib/src/request.dart", NodeKind::METHOD),
             witness("IOClient.send", "lib/src/io_client.dart", NodeKind::METHOD),
         ];
         for citation in &mut citations {
@@ -2118,7 +2158,12 @@ mod tests {
                 ("client_public_facade", "get"),
                 ("client_public_interface", "Client.get"),
                 ("client_interface_helpers", "BaseClient.get"),
+                (
+                    "client_convenience_implementation",
+                    "BaseClient._sendUnstreamed",
+                ),
                 ("client_request_finalization", "BaseRequest.finalize"),
+                ("client_concrete_request_finalization", "Request.finalize",),
                 ("client_transport_send", "IOClient.send"),
             ]
         );
@@ -2693,6 +2738,7 @@ mod tests {
     const FLOW_REQUIREMENT_INVENTORY: &[&str] = &[
         "buffered_read_write | dispatch | RequiresResolvedSourceOrGraph",
         "buffered_storage | state_or_storage | AllowsSourceRange",
+        "client_convenience_implementation | dispatch | RequiresResolvedSourceOrGraph",
         "client_interface_helpers | entrypoint | RequiresResolvedSourceOrGraph",
         "client_public_facade | entrypoint | RequiresResolvedSourceOrGraph",
         "client_public_interface | entrypoint | RequiresResolvedSourceOrGraph",
@@ -2915,6 +2961,14 @@ mod tests {
             (
                 ("client_interface_helpers", "entrypoint"),
                 witness("BaseClient.get", "lib/base_client.dart", NodeKind::METHOD),
+            ),
+            (
+                ("client_convenience_implementation", "dispatch"),
+                witness(
+                    "BaseClient._sendUnstreamed",
+                    "lib/base_client.dart",
+                    NodeKind::METHOD,
+                ),
             ),
             (
                 ("client_request_finalization", "transform_or_validate"),
@@ -4341,6 +4395,7 @@ mod tests {
             "table",
             "exec",
             "execute",
+            "perform",
             "search",
             "searcher",
             "grep",
@@ -4624,6 +4679,7 @@ mod tests {
             "channel",
             "abstract",
             "base",
+            "contract",
             "default",
             "generic",
             "null",
@@ -4642,6 +4698,7 @@ mod tests {
             "stack",
             "type",
             "types",
+            "trait",
             "object",
             "objects",
             "model",

--- a/crates/codestory-agent/src/packet_required_probes.rs
+++ b/crates/codestory-agent/src/packet_required_probes.rs
@@ -1251,6 +1251,8 @@ fn packet_citation_is_exact_primary_file_probe_match(
         && citation
             .file_path
             .as_deref()
+            .map(packet_display_path)
+            .as_deref()
             .is_some_and(|path| retrieval_file_role_from_path(path) == RetrievalFileRole::Source)
         && packet_file_stem_matches_query(query, citation.file_path.as_deref())
 }
@@ -2724,6 +2726,18 @@ mod tests {
         assert_eq!(
             packet_citation_probe_match_rank("adapters", &indexed_file),
             Some(6)
+        );
+
+        let mut checked_out_file = test_packet_citation(
+            "transport registry",
+            "/private/tmp/tests/neutral-project/src/runtime/adapters.js",
+            0.1,
+        );
+        checked_out_file.kind = NodeKind::FILE;
+        assert_eq!(
+            packet_citation_probe_match_rank("adapters", &checked_out_file),
+            Some(6),
+            "directories outside the repository must not make an indexed source file non-primary"
         );
 
         for (label, citation) in [

--- a/crates/codestory-agent/src/packet_scoring.rs
+++ b/crates/codestory-agent/src/packet_scoring.rs
@@ -84,11 +84,7 @@ pub fn packet_citation_rank(
         score += 0.25;
     }
     if prefer_primary_sources {
-        let role = citation
-            .file_path
-            .as_deref()
-            .map(retrieval_file_role_from_path)
-            .unwrap_or(RetrievalFileRole::Source);
+        let role = packet_citation_file_role(citation);
         if role.is_non_primary() {
             score -= 100.0;
         }
@@ -809,10 +805,7 @@ fn packet_citation_is_primary_stylesheet(citation: &AgentCitationDto) -> bool {
 }
 
 fn packet_citation_is_non_primary_source(citation: &AgentCitationDto) -> bool {
-    citation
-        .file_path
-        .as_deref()
-        .is_some_and(|path| retrieval_file_role_from_path(path).is_non_primary())
+    citation.file_path.is_some() && packet_citation_file_role(citation).is_non_primary()
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1133,12 +1126,19 @@ fn packet_question_wants_tests(terms: &[String]) -> bool {
 }
 
 fn packet_citation_is_test_source(citation: &AgentCitationDto) -> bool {
+    (citation.file_path.is_some() && packet_citation_file_role(citation) == RetrievalFileRole::Test)
+        || packet_path_is_test_segment(&packet_citation_display_path(citation))
+        || packet_display_name_is_test_like(&citation.display_name)
+}
+
+fn packet_citation_file_role(citation: &AgentCitationDto) -> RetrievalFileRole {
     citation
         .file_path
         .as_deref()
-        .is_some_and(|path| retrieval_file_role_from_path(path) == RetrievalFileRole::Test)
-        || packet_path_is_test_segment(&packet_citation_display_path(citation))
-        || packet_display_name_is_test_like(&citation.display_name)
+        .map(packet_display_path)
+        .as_deref()
+        .map(retrieval_file_role_from_path)
+        .unwrap_or(RetrievalFileRole::Source)
 }
 
 fn packet_citation_is_keyframe_rule(citation: &AgentCitationDto) -> bool {
@@ -2399,6 +2399,23 @@ mod tests {
         );
     }
 
+    #[test]
+    fn citation_rank_ignores_test_like_checkout_parent_directories() {
+        let terms = vec!["renderer".to_string(), "render".to_string()];
+        let relative_source = test_rank_citation("Renderer.render", "src/renderer.rs", 1.0);
+        let checked_out_source = test_rank_citation(
+            "Renderer.render",
+            "/private/tmp/fixtures/neutral-project/src/renderer.rs",
+            1.0,
+        );
+
+        assert_eq!(
+            packet_citation_rank(&checked_out_source, &terms, true),
+            packet_citation_rank(&relative_source, &terms, true),
+            "directories outside the repository must not change the source role"
+        );
+    }
+
     fn test_rank_citation(display_name: &str, file_path: &str, score: f32) -> AgentCitationDto {
         AgentCitationDto {
             node_id: NodeId(display_name.to_string()),
@@ -2788,6 +2805,28 @@ mod tests {
                     && !path.contains("/samples/")
             }),
             "unrequested tests and samples should drop: {paths:?}"
+        );
+    }
+
+    #[test]
+    fn unrequested_test_filter_uses_project_relative_paths() {
+        let terms = vec!["renderer".to_string(), "render".to_string()];
+        let mut citations = vec![
+            test_rank_citation(
+                "Renderer.render",
+                "/private/tmp/fixtures/neutral-project/src/renderer.rs",
+                0.8,
+            ),
+            test_rank_citation("Renderer.render", "tests/renderer_test.rs", 0.9),
+            test_rank_citation("Renderer.snapshot", "src/fixtures/snapshot.rs", 0.7),
+        ];
+
+        packet_drop_unrequested_test_siblings(&mut citations, &terms);
+
+        assert_eq!(citations.len(), 1);
+        assert_eq!(
+            citations[0].file_path.as_deref(),
+            Some("/private/tmp/fixtures/neutral-project/src/renderer.rs")
         );
     }
 

--- a/crates/codestory-cli/src/app/tests/test_support.rs
+++ b/crates/codestory-cli/src/app/tests/test_support.rs
@@ -275,6 +275,7 @@ pub(super) fn sample_phase_timings() -> IndexingPhaseTimings {
             catalog_publication_ms: 30,
             unattributed_ms: 20,
         }),
+        incremental_core_wall: None,
         source_prepare_ms: Some(41),
         projection_batch_wall_ms: Some(50),
         projection_batch_transactions: Some(2),
@@ -375,6 +376,7 @@ pub(super) fn sample_phase_timings() -> IndexingPhaseTimings {
         }),
         core_promotion: Some(CorePromotionTimings {
             total_ms: 89,
+            lock_wait_ms: 0,
             lock_recovery_ms: 1,
             candidate_validation_ms: 11,
             previous_validation_ms: 12,

--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -418,6 +418,22 @@ pub(crate) fn append_index_phase_timings(markdown: &mut String, timings: &Indexi
             wall.unattributed_ms,
         );
     }
+    if let Some(wall) = timings.incremental_core_wall.as_ref() {
+        let _ = writeln!(
+            markdown,
+            "incremental_core_wall_ms: core_refresh={} discovery_and_scheduling={} stage_open={} parse_and_extraction={} core_staging_and_mutation={} candidate_sealing={} pointer_publication={} lock_wait={} unattributed={} scheduled_paths={}",
+            wall.core_refresh_ms,
+            wall.discovery_and_scheduling_ms,
+            wall.stage_open_ms,
+            wall.parse_and_extraction_ms,
+            wall.core_staging_and_mutation_ms,
+            wall.candidate_sealing_ms,
+            wall.pointer_publication_ms,
+            wall.lock_wait_ms,
+            wall.unattributed_ms,
+            wall.scheduled_paths.len(),
+        );
+    }
     append_index_cache_timings(markdown, timings);
     let _ = writeln!(
         markdown,
@@ -606,8 +622,9 @@ fn append_index_cache_timings(markdown: &mut String, timings: &IndexingPhaseTimi
             .map_or_else(|| "none".to_string(), |value| value.to_string());
         let _ = writeln!(
             markdown,
-            "core_promotion_ms: total={} lock_recovery={} candidate_validation={} previous_validation={} rollback_backup_copy={} backup_validation={} prepared_journal_write={} prepared_journal_file_sync={} prepared_journal_directory_sync={} staged_to_live_restore={} promoted_validation={} committed_journal={} cleanup={} unattributed={}",
+            "core_promotion_ms: total={} lock_wait={} lock_recovery={} candidate_validation={} previous_validation={} rollback_backup_copy={} backup_validation={} prepared_journal_write={} prepared_journal_file_sync={} prepared_journal_directory_sync={} staged_to_live_restore={} promoted_validation={} committed_journal={} cleanup={} unattributed={}",
             promotion.total_ms,
+            promotion.lock_wait_ms,
             promotion.lock_recovery_ms,
             promotion.candidate_validation_ms,
             promotion.previous_validation_ms,

--- a/crates/codestory-cli/src/retrieval.rs
+++ b/crates/codestory-cli/src/retrieval.rs
@@ -1,6 +1,9 @@
 use anyhow::{Context, Result, bail};
-use codestory_contracts::api::{IndexMode, IndexingPhaseTimings};
+use codestory_contracts::api::{
+    IncrementalCoreWallTimings, IncrementalScheduledPathDto, IndexMode, IndexingPhaseTimings,
+};
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Instant;
 
 use codestory_runtime::{
     FinalizeComponentWork, FinalizeIndexOutcome, FinalizePhaseTiming, RetrievalIndexManifest,
@@ -218,6 +221,7 @@ fn run_retrieval_query(cmd: RetrievalQueryCommand) -> Result<()> {
 }
 
 fn run_retrieval_index(cmd: RetrievalIndexCommand) -> Result<()> {
+    let command_started = Instant::now();
     preflight_output(cmd.output_file.as_deref())?;
     let sidecar_profile = cmd.profile.unwrap_or(CliSidecarProfile::Local);
     let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
@@ -230,6 +234,7 @@ fn run_retrieval_index(cmd: RetrievalIndexCommand) -> Result<()> {
     let refresh_mode = decision.effective_mode;
     ensure_retrieval_index_embedding_policy(&sidecar)?;
     let mut core_phase_timings = run_retrieval_index_refresh(&runtime, cmd.refresh, refresh_mode)?;
+    let retrieval_started = Instant::now();
     let outcome = match finalize_retrieval_index_for_sidecar_runtime(&runtime, &sidecar) {
         Ok(outcome) => outcome,
         Err(error) if retrieval_index_should_retry_full_refresh(cmd.refresh, &error) => {
@@ -244,10 +249,35 @@ fn run_retrieval_index(cmd: RetrievalIndexCommand) -> Result<()> {
         }
         Err(error) => return Err(error),
     };
+    let retrieval_finalize_ms = retrieval_started
+        .elapsed()
+        .as_millis()
+        .min(u128::from(u64::MAX)) as u64;
+    let incremental_wall_receipt = match (
+        refresh_mode,
+        core_phase_timings
+            .as_ref()
+            .and_then(|timings| timings.incremental_core_wall.as_ref()),
+    ) {
+        (Some(IndexMode::Incremental), Some(core_wall)) => Some(
+            build_incremental_wall_receipt(
+                command_started
+                    .elapsed()
+                    .as_millis()
+                    .min(u128::from(u64::MAX)) as u64,
+                retrieval_finalize_ms,
+                core_wall,
+                &outcome.phase_timings,
+            )
+            .context("incremental wall receipt")?,
+        ),
+        _ => None,
+    };
     emit_retrieval_index(
         cmd.format,
         &outcome,
         core_phase_timings.as_ref(),
+        incremental_wall_receipt.as_ref(),
         cmd.output_file.as_deref(),
     )
 }
@@ -390,8 +420,163 @@ struct RetrievalIndexOutput<'a> {
     generation_retention: &'a codestory_runtime::GenerationRetentionApplyReport,
     #[serde(skip_serializing_if = "Option::is_none")]
     core_phase_timings: Option<&'a IndexingPhaseTimings>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    incremental_wall_receipt: Option<&'a IncrementalWallReceiptV1>,
     retrieval_phase_timings: Vec<RetrievalPhaseTimingOutput<'a>>,
     retrieval_component_work: Vec<RetrievalComponentWorkOutput<'a>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+struct IncrementalWallReceiptV1 {
+    contract: &'static str,
+    total_ms: u64,
+    core_refresh_ms: u64,
+    retrieval_finalize_ms: u64,
+    accounted_ms: u64,
+    reconciliation_basis_points: u32,
+    attributed_ms: u64,
+    attributed_basis_points: u32,
+    phases: IncrementalWallReceiptPhasesV1,
+    scheduled_paths: Vec<IncrementalScheduledPathDto>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize)]
+struct IncrementalWallReceiptPhasesV1 {
+    discovery_and_scheduling_ms: u64,
+    stage_open_ms: u64,
+    parse_and_extraction_ms: u64,
+    core_staging_and_mutation_ms: u64,
+    candidate_sealing_ms: u64,
+    pointer_publication_ms: u64,
+    lexical_ms: u64,
+    vector_ms: u64,
+    graph_ms: u64,
+    retrieval_input_fingerprint_ms: u64,
+    retrieval_manifest_publication_ms: u64,
+    lock_wait_ms: u64,
+    process_ipc_ms: u64,
+    unattributed_ms: u64,
+}
+
+impl IncrementalWallReceiptPhasesV1 {
+    fn sum(&self) -> u64 {
+        self.discovery_and_scheduling_ms
+            .saturating_add(self.stage_open_ms)
+            .saturating_add(self.parse_and_extraction_ms)
+            .saturating_add(self.core_staging_and_mutation_ms)
+            .saturating_add(self.candidate_sealing_ms)
+            .saturating_add(self.pointer_publication_ms)
+            .saturating_add(self.lexical_ms)
+            .saturating_add(self.vector_ms)
+            .saturating_add(self.graph_ms)
+            .saturating_add(self.retrieval_input_fingerprint_ms)
+            .saturating_add(self.retrieval_manifest_publication_ms)
+            .saturating_add(self.lock_wait_ms)
+            .saturating_add(self.process_ipc_ms)
+            .saturating_add(self.unattributed_ms)
+    }
+}
+
+fn phase_total(timings: &[FinalizePhaseTiming], phase: &str) -> u64 {
+    timings
+        .iter()
+        .filter(|timing| timing.phase == phase)
+        .fold(0_u64, |total, timing| {
+            total.saturating_add(timing.elapsed_ms)
+        })
+}
+
+fn basis_points(numerator: u64, denominator: u64) -> u32 {
+    if denominator == 0 {
+        return 10_000;
+    }
+    numerator
+        .saturating_mul(10_000)
+        .checked_div(denominator)
+        .unwrap_or_default()
+        .min(10_000) as u32
+}
+
+fn build_incremental_wall_receipt(
+    total_ms: u64,
+    retrieval_finalize_ms: u64,
+    core: &IncrementalCoreWallTimings,
+    retrieval: &[FinalizePhaseTiming],
+) -> Result<IncrementalWallReceiptV1> {
+    let core_named_ms = u64::from(core.discovery_and_scheduling_ms)
+        .saturating_add(u64::from(core.stage_open_ms))
+        .saturating_add(u64::from(core.parse_and_extraction_ms))
+        .saturating_add(u64::from(core.core_staging_and_mutation_ms))
+        .saturating_add(u64::from(core.candidate_sealing_ms))
+        .saturating_add(u64::from(core.pointer_publication_ms))
+        .saturating_add(u64::from(core.lock_wait_ms))
+        .saturating_add(u64::from(core.unattributed_ms));
+    if core_named_ms != u64::from(core.core_refresh_ms) {
+        bail!(
+            "incremental core wall does not reconcile: phases={core_named_ms} total={}",
+            core.core_refresh_ms
+        );
+    }
+    let vector_complete = phase_total(retrieval, "embedded vectors");
+    let vector_incremental = phase_total(retrieval, "incremental embedded vectors");
+    if vector_complete > 0 && vector_incremental > 0 {
+        bail!("retrieval finalization reported both complete and incremental vector totals");
+    }
+    let vector_total = vector_complete.max(vector_incremental);
+    let process_ipc_ms = phase_total(retrieval, "vector ipc and orchestration").min(vector_total);
+    let retrieval_input_fingerprint_ms = phase_total(retrieval, "input fingerprint");
+    let lexical_ms = phase_total(retrieval, "lexical sidecar");
+    let graph_ms = phase_total(retrieval, "graph artifact");
+    let retrieval_manifest_publication_ms = phase_total(retrieval, "manifest write");
+    let retrieval_named_ms = retrieval_input_fingerprint_ms
+        .saturating_add(lexical_ms)
+        .saturating_add(vector_total)
+        .saturating_add(graph_ms)
+        .saturating_add(retrieval_manifest_publication_ms);
+    if retrieval_named_ms > retrieval_finalize_ms {
+        bail!(
+            "retrieval phases exceed finalization wall: phases={retrieval_named_ms} total={retrieval_finalize_ms}"
+        );
+    }
+    let command_named_ms = u64::from(core.core_refresh_ms).saturating_add(retrieval_finalize_ms);
+    if command_named_ms > total_ms {
+        bail!(
+            "core and retrieval phases exceed command wall: phases={command_named_ms} total={total_ms}"
+        );
+    }
+    let unattributed_ms = u64::from(core.unattributed_ms)
+        .saturating_add(retrieval_finalize_ms.saturating_sub(retrieval_named_ms))
+        .saturating_add(total_ms.saturating_sub(command_named_ms));
+    let phases = IncrementalWallReceiptPhasesV1 {
+        discovery_and_scheduling_ms: u64::from(core.discovery_and_scheduling_ms),
+        stage_open_ms: u64::from(core.stage_open_ms),
+        parse_and_extraction_ms: u64::from(core.parse_and_extraction_ms),
+        core_staging_and_mutation_ms: u64::from(core.core_staging_and_mutation_ms),
+        candidate_sealing_ms: u64::from(core.candidate_sealing_ms),
+        pointer_publication_ms: u64::from(core.pointer_publication_ms),
+        lexical_ms,
+        vector_ms: vector_total.saturating_sub(process_ipc_ms),
+        graph_ms,
+        retrieval_input_fingerprint_ms,
+        retrieval_manifest_publication_ms,
+        lock_wait_ms: u64::from(core.lock_wait_ms),
+        process_ipc_ms,
+        unattributed_ms,
+    };
+    let accounted_ms = phases.sum();
+    let attributed_ms = total_ms.saturating_sub(unattributed_ms);
+    Ok(IncrementalWallReceiptV1 {
+        contract: "codestory.incremental-wall-receipt/v1",
+        total_ms,
+        core_refresh_ms: u64::from(core.core_refresh_ms),
+        retrieval_finalize_ms,
+        accounted_ms,
+        reconciliation_basis_points: basis_points(accounted_ms, total_ms),
+        attributed_ms,
+        attributed_basis_points: basis_points(attributed_ms, total_ms),
+        phases,
+        scheduled_paths: core.scheduled_paths.clone(),
+    })
 }
 
 #[derive(serde::Serialize)]
@@ -479,6 +664,7 @@ fn emit_retrieval_index(
     format: OutputFormat,
     outcome: &FinalizeIndexOutcome,
     core_phase_timings: Option<&IndexingPhaseTimings>,
+    incremental_wall_receipt: Option<&IncrementalWallReceiptV1>,
     output_file: Option<&std::path::Path>,
 ) -> Result<()> {
     let retrieval_phase_timings = safe_retrieval_phase_timings(&outcome.phase_timings);
@@ -490,6 +676,7 @@ fn emit_retrieval_index(
         generation_retention_plan: &outcome.generation_retention_plan,
         generation_retention: &outcome.generation_retention,
         core_phase_timings,
+        incremental_wall_receipt,
         retrieval_phase_timings,
         retrieval_component_work,
     };
@@ -509,6 +696,17 @@ fn emit_retrieval_index(
     if let Some(timings) = core_phase_timings {
         markdown.push_str("\n## Core indexing\n\n");
         crate::output::append_index_phase_timings(&mut markdown, timings);
+    }
+    if let Some(receipt) = incremental_wall_receipt {
+        markdown.push_str("\n## Incremental wall receipt\n\n");
+        markdown.push_str(&format!(
+            "- total: {} ms\n- accounted: {} ms\n- reconciliation: {} bp\n- attributed: {} ms\n- attributed: {} bp\n",
+            receipt.total_ms,
+            receipt.accounted_ms,
+            receipt.reconciliation_basis_points,
+            receipt.attributed_ms,
+            receipt.attributed_basis_points,
+        ));
     }
     markdown.push_str("\n## Retrieval phases\n\n");
     for timing in &payload.retrieval_phase_timings {
@@ -793,6 +991,72 @@ mod tests {
         assert_eq!(safe_work[0].predecessor_bytes, Some(1_024));
         assert_eq!(safe_work[0].output_bytes, Some(1_100));
         assert_eq!(safe_work[0].attested_bytes, Some(1_100));
+    }
+
+    #[test]
+    fn incremental_wall_receipt_uses_exclusive_phases_and_reconciles_outer_wall() {
+        let core = codestory_contracts::api::IncrementalCoreWallTimings {
+            core_refresh_ms: 10_000,
+            discovery_and_scheduling_ms: 120,
+            stage_open_ms: 400,
+            parse_and_extraction_ms: 100,
+            core_staging_and_mutation_ms: 5_080,
+            candidate_sealing_ms: 1_700,
+            pointer_publication_ms: 2_400,
+            lock_wait_ms: 200,
+            unattributed_ms: 0,
+            scheduled_paths: vec![codestory_contracts::api::IncrementalScheduledPathDto {
+                path: "src/server.c".into(),
+                action: codestory_contracts::api::IncrementalScheduledPathActionDto::Index,
+                reason: codestory_contracts::api::IncrementalScheduledPathReasonDto::SourceIdentityChanged,
+            }],
+        };
+        let retrieval = vec![
+            FinalizePhaseTiming {
+                phase: "input fingerprint".into(),
+                elapsed_ms: 350,
+            },
+            FinalizePhaseTiming {
+                phase: "lexical sidecar".into(),
+                elapsed_ms: 1_902,
+            },
+            FinalizePhaseTiming {
+                phase: "incremental embedded vectors".into(),
+                elapsed_ms: 741,
+            },
+            FinalizePhaseTiming {
+                phase: "vector native encode".into(),
+                elapsed_ms: 9_999,
+            },
+            FinalizePhaseTiming {
+                phase: "vector ipc and orchestration".into(),
+                elapsed_ms: 343,
+            },
+            FinalizePhaseTiming {
+                phase: "graph artifact".into(),
+                elapsed_ms: 1_388,
+            },
+            FinalizePhaseTiming {
+                phase: "manifest write".into(),
+                elapsed_ms: 1_181,
+            },
+            FinalizePhaseTiming {
+                phase: "unattributed".into(),
+                elapsed_ms: 289,
+            },
+        ];
+
+        let receipt = build_incremental_wall_receipt(16_000, 5_851, &core, &retrieval)
+            .expect("build reconciled receipt");
+        assert_eq!(receipt.contract, "codestory.incremental-wall-receipt/v1");
+        assert_eq!(receipt.total_ms, 16_000);
+        assert_eq!(receipt.accounted_ms, 16_000);
+        assert_eq!(receipt.reconciliation_basis_points, 10_000);
+        assert_eq!(receipt.phases.vector_ms, 398);
+        assert_eq!(receipt.phases.process_ipc_ms, 343);
+        assert_eq!(receipt.phases.unattributed_ms, 438);
+        assert_eq!(receipt.phases.sum(), receipt.total_ms);
+        assert_eq!(receipt.scheduled_paths, core.scheduled_paths);
     }
 
     struct LiveOperationFixture {

--- a/crates/codestory-contracts/src/api.rs
+++ b/crates/codestory-contracts/src/api.rs
@@ -86,9 +86,10 @@ pub use errors::{
 };
 pub use events::{
     AppEventPayload, ArtifactCacheAccessTimings, ArtifactCachePolicyDto, CorePromotionTimings,
-    DatabaseSnapshotCopyTimings, FullRefreshWallTimings, IncrementalPlanProbeOutcomeDto,
-    IncrementalPlanProbeTimings, IndexingPhaseTimings, ProjectionPersistenceFamilyTimings,
-    ProjectionPersistenceTimings, PromotedValidationDto,
+    DatabaseSnapshotCopyTimings, FullRefreshWallTimings, IncrementalCoreWallTimings,
+    IncrementalPlanProbeOutcomeDto, IncrementalPlanProbeTimings, IncrementalScheduledPathActionDto,
+    IncrementalScheduledPathDto, IncrementalScheduledPathReasonDto, IndexingPhaseTimings,
+    ProjectionPersistenceFamilyTimings, ProjectionPersistenceTimings, PromotedValidationDto,
 };
 pub use ids::{EdgeId, NodeId};
 pub use types::{

--- a/crates/codestory-contracts/src/api/events.rs
+++ b/crates/codestory-contracts/src/api/events.rs
@@ -18,6 +18,52 @@ pub struct FullRefreshWallTimings {
     pub unattributed_ms: u32,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "snake_case")]
+pub enum IncrementalScheduledPathActionDto {
+    Index,
+    Remove,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "snake_case")]
+pub enum IncrementalScheduledPathReasonDto {
+    NewFile,
+    NotIndexed,
+    Incomplete,
+    RetryRequired,
+    SourceIdentityChanged,
+    VerifiedAbsent,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
+pub struct IncrementalScheduledPathDto {
+    pub path: String,
+    pub action: IncrementalScheduledPathActionDto,
+    pub reason: IncrementalScheduledPathReasonDto,
+}
+
+/// Exclusive wall-clock phases for one incremental core refresh.
+///
+/// The named durations plus `unattributed_ms` reconcile to
+/// `core_refresh_ms`. Component-level diagnostics elsewhere in
+/// [`IndexingPhaseTimings`] are nested details and must not be summed into this
+/// receipt.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, Type)]
+pub struct IncrementalCoreWallTimings {
+    pub core_refresh_ms: u32,
+    pub discovery_and_scheduling_ms: u32,
+    pub stage_open_ms: u32,
+    pub parse_and_extraction_ms: u32,
+    pub core_staging_and_mutation_ms: u32,
+    pub candidate_sealing_ms: u32,
+    pub pointer_publication_ms: u32,
+    pub lock_wait_ms: u32,
+    pub unattributed_ms: u32,
+    #[serde(default)]
+    pub scheduled_paths: Vec<IncrementalScheduledPathDto>,
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, Type)]
 pub struct DatabaseSnapshotCopyTimings {
     pub copy_ms: u32,
@@ -57,6 +103,8 @@ impl PromotedValidationDto {
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, Type)]
 pub struct CorePromotionTimings {
     pub total_ms: u32,
+    #[serde(default)]
+    pub lock_wait_ms: u32,
     pub lock_recovery_ms: u32,
     pub candidate_validation_ms: u32,
     pub previous_validation_ms: u32,
@@ -182,6 +230,8 @@ pub struct ProjectionPersistenceTimings {
 pub struct IndexingPhaseTimings {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub full_refresh_wall: Option<FullRefreshWallTimings>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub incremental_core_wall: Option<IncrementalCoreWallTimings>,
     pub parse_index_ms: u32,
     pub projection_flush_ms: u32,
     pub edge_resolution_ms: u32,
@@ -468,6 +518,7 @@ mod tests {
     fn test_indexing_phase_timings_omits_optional_resolution_fields_when_none() {
         let timings = IndexingPhaseTimings {
             full_refresh_wall: None,
+            incremental_core_wall: None,
             parse_index_ms: 1,
             projection_flush_ms: 2,
             edge_resolution_ms: 3,
@@ -871,6 +922,7 @@ mod tests {
         };
         let core_promotion = CorePromotionTimings {
             total_ms: 89,
+            lock_wait_ms: 1,
             lock_recovery_ms: 1,
             candidate_validation_ms: 11,
             previous_validation_ms: 12,
@@ -978,6 +1030,44 @@ mod tests {
         let decoded: IndexingPhaseTimings =
             serde_json::from_value(value).expect("deserialize timings");
         assert_eq!(decoded.incremental_plan_probe, Some(probe));
+    }
+
+    #[test]
+    fn test_indexing_phase_timings_round_trips_reconciled_incremental_core_wall() {
+        let wall = IncrementalCoreWallTimings {
+            core_refresh_ms: 10_000,
+            discovery_and_scheduling_ms: 120,
+            stage_open_ms: 400,
+            parse_and_extraction_ms: 100,
+            core_staging_and_mutation_ms: 5_080,
+            candidate_sealing_ms: 1_700,
+            pointer_publication_ms: 2_400,
+            lock_wait_ms: 200,
+            unattributed_ms: 0,
+            scheduled_paths: vec![IncrementalScheduledPathDto {
+                path: "src/server.c".into(),
+                action: IncrementalScheduledPathActionDto::Index,
+                reason: IncrementalScheduledPathReasonDto::SourceIdentityChanged,
+            }],
+        };
+        let timings = IndexingPhaseTimings {
+            incremental_core_wall: Some(wall.clone()),
+            ..IndexingPhaseTimings::default()
+        };
+
+        let value = serde_json::to_value(&timings).expect("serialize timings");
+        assert_eq!(value["incremental_core_wall"]["core_refresh_ms"], 10_000);
+        assert_eq!(
+            value["incremental_core_wall"]["scheduled_paths"][0],
+            serde_json::json!({
+                "path": "src/server.c",
+                "action": "index",
+                "reason": "source_identity_changed"
+            })
+        );
+        let decoded: IndexingPhaseTimings =
+            serde_json::from_value(value).expect("deserialize timings");
+        assert_eq!(decoded.incremental_core_wall, Some(wall));
     }
 
     #[test]

--- a/crates/codestory-runtime/src/agent/mod.rs
+++ b/crates/codestory-runtime/src/agent/mod.rs
@@ -34,6 +34,7 @@
 //   crate is forbidden to spell (`fs::write` is contract-banned there).
 pub(crate) mod nucleo_policy;
 pub(crate) mod orchestrator;
+pub(crate) mod packet_accuracy_stage_ledger;
 pub(crate) mod packet_batch;
 pub(crate) mod packet_budget;
 pub(crate) mod packet_candidate;

--- a/crates/codestory-runtime/src/agent/orchestrator.rs
+++ b/crates/codestory-runtime/src/agent/orchestrator.rs
@@ -3233,7 +3233,7 @@ fn append_packet_carrier_source_sections(
                 .snippet_function_body_context(citation.node_id.clone(), 0)
                 .ok()
                 .map(|snippet| {
-                    if snippet.scope == SnippetScopeDto::LineContext {
+                    if matches!(citation.kind, NodeKind::FUNCTION | NodeKind::METHOD) {
                         let focused = long_behavioral_function_source_ranges(
                             controller,
                             &file_focus_text,
@@ -3946,9 +3946,10 @@ fn focused_function_source_ranges(
         .collect()
 }
 
-/// A parser may know a callable's end line while still returning declaration-only context. Keep
-/// that long callable's declaration, one material internal callsite, and its positive terminal
-/// behavior instead of treating the first 24 lines as the whole implementation.
+/// A parser may return declaration-only context even when the source contains an exact short
+/// declaration or a long body. Keep the exact short range. For a long callable, retain its
+/// declaration, one material internal callsite, and its positive terminal behavior instead of
+/// treating the first 24 lines as the whole implementation.
 fn long_behavioral_function_source_ranges(
     controller: &AppController,
     question: &str,
@@ -3962,17 +3963,36 @@ fn long_behavioral_function_source_ranges(
         return Vec::new();
     };
     let lines = source.text.lines().collect::<Vec<_>>();
-    let Some(end_line) = end_line
-        .filter(|end_line| *end_line > start_line)
-        .or_else(|| discover_braced_callable_end_line(&lines, start_line))
-        .filter(|end_line| {
-            *end_line
-                > start_line
-                    .saturating_add(CARRIER_SOURCE_DECLARATION_FALLBACK_LINES.saturating_sub(1))
-        })
+    let Some(end_line) = discover_callable_end_line(&lines, start_line)
+        .or_else(|| end_line.filter(|end_line| *end_line >= start_line))
     else {
         return Vec::new();
     };
+    if end_line
+        <= start_line.saturating_add(CARRIER_SOURCE_DECLARATION_FALLBACK_LINES.saturating_sub(1))
+    {
+        return controller
+            .bounded_file_snippet_range(
+                path,
+                crate::BoundedSnippetRangeOptions {
+                    focus_line: start_line,
+                    start_line,
+                    end_line,
+                    context_lines: 0,
+                    max_bytes: CARRIER_SOURCE_MAX_SNIPPET_BYTES,
+                    truncation_suffix: SOURCE_SNIPPET_TRUNCATION_SUFFIX,
+                },
+            )
+            .ok()
+            .map(|(path, snippet)| {
+                vec![CarrierSourceRange {
+                    path,
+                    start_line,
+                    body: snippet.markdown,
+                }]
+            })
+            .unwrap_or_default();
+    }
     long_behavioral_function_source_lines(&lines, start_line, end_line, question)
         .into_iter()
         .filter_map(|focus_line| {
@@ -3997,8 +4017,10 @@ fn long_behavioral_function_source_ranges(
         .collect()
 }
 
-fn discover_braced_callable_end_line(lines: &[&str], start_line: u32) -> Option<u32> {
+fn discover_callable_end_line(lines: &[&str], start_line: u32) -> Option<u32> {
     let mut depth = 0_u32;
+    let mut parenthesis_depth = 0_u32;
+    let mut bracket_depth = 0_u32;
     let mut saw_open = false;
     let mut in_block_comment = false;
     let mut quote: Option<char> = None;
@@ -4040,7 +4062,14 @@ fn discover_braced_callable_end_line(lines: &[&str], start_line: u32) -> Option<
                 continue;
             }
             match ch {
-                '{' => {
+                '(' if !saw_open => parenthesis_depth = parenthesis_depth.saturating_add(1),
+                ')' if !saw_open => parenthesis_depth = parenthesis_depth.saturating_sub(1),
+                '[' if !saw_open => bracket_depth = bracket_depth.saturating_add(1),
+                ']' if !saw_open => bracket_depth = bracket_depth.saturating_sub(1),
+                ';' if !saw_open && parenthesis_depth == 0 && bracket_depth == 0 => {
+                    return Some((index + 1) as u32);
+                }
+                '{' if saw_open || (parenthesis_depth == 0 && bracket_depth == 0) => {
                     saw_open = true;
                     depth = depth.saturating_add(1);
                 }
@@ -8695,7 +8724,35 @@ mod tests {
             "void next() {}",
         ];
 
-        assert_eq!(discover_braced_callable_end_line(&source, 1), Some(8));
+        assert_eq!(discover_callable_end_line(&source, 1), Some(8));
+    }
+
+    #[test]
+    fn declaration_only_callable_end_stops_at_the_first_real_semicolon() {
+        let source = [
+            "Future<Response> get(Uri url, {Map<String, String>? headers}) =>",
+            "    _withClient((client) => client.get(url, headers: headers));",
+            "/// unrelated docs with a ; inside the comment",
+            "Future<Response> post(Uri url);",
+        ];
+
+        assert_eq!(discover_callable_end_line(&source, 1), Some(2));
+    }
+
+    #[test]
+    fn callable_end_ignores_named_and_optional_parameter_delimiters() {
+        let source = [
+            "Future<Response> send(String method, {Map<String, String>? headers},",
+            "    [Object? body, Encoding? encoding]) async {",
+            "  if (body != null) {",
+            "    prepare(body);",
+            "  }",
+            "  return await transport.send(body);",
+            "}",
+            "void next() {}",
+        ];
+
+        assert_eq!(discover_callable_end_line(&source, 1), Some(7));
     }
 
     #[test]

--- a/crates/codestory-runtime/src/agent/orchestrator.rs
+++ b/crates/codestory-runtime/src/agent/orchestrator.rs
@@ -4138,7 +4138,9 @@ fn carrier_source_identity(display_name: &str, anchor_line: Option<u32>, end_lin
             .filter(|segment| !segment.is_empty())
             .nth(1)
     {
-        return format!("enclosing {owner} type that owns {display_name}");
+        return format!(
+            "implementation context for enclosing {owner} type that owns {display_name}"
+        );
     }
     display_name.to_owned()
 }
@@ -9145,7 +9147,7 @@ mod tests {
         assert_eq!(source_identifier_words("Client"), ["client"]);
         assert_eq!(
             carrier_source_identity("DefaultSession.perform", Some(5), 4),
-            "enclosing DefaultSession type that owns DefaultSession.perform"
+            "implementation context for enclosing DefaultSession type that owns DefaultSession.perform"
         );
         assert_eq!(
             carrier_source_identity("DefaultSession.perform", Some(5), 7),

--- a/crates/codestory-runtime/src/agent/orchestrator.rs
+++ b/crates/codestory-runtime/src/agent/orchestrator.rs
@@ -4139,7 +4139,7 @@ fn carrier_source_identity(display_name: &str, anchor_line: Option<u32>, end_lin
             .nth(1)
     {
         return format!(
-            "implementation context for enclosing {owner} type that owns {display_name}"
+            "implementation context of enclosing {owner} type that owns {display_name}"
         );
     }
     display_name.to_owned()
@@ -9147,7 +9147,7 @@ mod tests {
         assert_eq!(source_identifier_words("Client"), ["client"]);
         assert_eq!(
             carrier_source_identity("DefaultSession.perform", Some(5), 4),
-            "implementation context for enclosing DefaultSession type that owns DefaultSession.perform"
+            "implementation context of enclosing DefaultSession type that owns DefaultSession.perform"
         );
         assert_eq!(
             carrier_source_identity("DefaultSession.perform", Some(5), 7),

--- a/crates/codestory-runtime/src/agent/orchestrator.rs
+++ b/crates/codestory-runtime/src/agent/orchestrator.rs
@@ -3323,7 +3323,7 @@ fn append_packet_carrier_source_sections(
                 kind: SupportUnitKindDto::SourceRange,
                 summary: format!(
                     "source for {} at {path}:{start_line}-{end_line}",
-                    citation.display_name,
+                    carrier_source_identity(&citation.display_name, citation.line, end_line,),
                 ),
                 path: Some(path),
                 symbol_id: Some(citation.node_id.0.clone()),
@@ -3903,6 +3903,7 @@ fn source_receipt_line_range(markdown: &str, fallback_start: u32) -> (u32, u32) 
 }
 
 const CARRIER_SOURCE_OWNER_CONTEXT_LOOKBACK_LINES: usize = 32;
+const CARRIER_SOURCE_OWNER_SEPARATE_GAP_LINES: u32 = 12;
 
 /// Keep the source-local type declaration with an owner-qualified method when it fits the same
 /// bounded window. A method body proves mechanics, while the adjacent declaration and comments
@@ -3917,6 +3918,16 @@ fn attach_enclosing_type_source_context(
     if citation.kind != NodeKind::METHOD || sources.is_empty() {
         return sources;
     }
+    let owner_words = citation
+        .display_name
+        .rsplit(['.', ':', '#', '/', '\\'])
+        .filter(|segment| !segment.is_empty())
+        .nth(1)
+        .map(source_identifier_words)
+        .unwrap_or_default();
+    if owner_words.len() < 2 {
+        return sources;
+    }
     let Some(anchor_line) = citation.line else {
         return sources;
     };
@@ -3928,6 +3939,44 @@ fn attach_enclosing_type_source_context(
         return sources;
     };
     let lines = source.text.lines().collect::<Vec<_>>();
+    let owner_end_line = anchor_line.saturating_sub(1);
+    let Some(owner_start_line) = enclosing_type_context_start_line(
+        &lines,
+        anchor_line,
+        owner_end_line,
+        &citation.display_name,
+        CARRIER_SOURCE_MAX_SNIPPET_BYTES,
+    ) else {
+        return sources;
+    };
+    if anchor_line.saturating_sub(owner_start_line) > CARRIER_SOURCE_OWNER_SEPARATE_GAP_LINES {
+        let Ok((path, bounded)) = controller.bounded_file_snippet_range(
+            &first.path,
+            crate::BoundedSnippetRangeOptions {
+                focus_line: owner_end_line,
+                start_line: owner_start_line,
+                end_line: owner_end_line,
+                context_lines: 0,
+                max_bytes: CARRIER_SOURCE_MAX_SNIPPET_BYTES,
+                truncation_suffix: SOURCE_SNIPPET_TRUNCATION_SUFFIX,
+            },
+        ) else {
+            return sources;
+        };
+        let rendered_range = source_receipt_line_range(&bounded.markdown, owner_start_line);
+        if rendered_range.0 > owner_start_line || rendered_range.1 < owner_end_line {
+            return sources;
+        }
+        sources.insert(
+            0,
+            CarrierSourceRange {
+                path,
+                start_line: owner_start_line,
+                body: bounded.markdown,
+            },
+        );
+        return sources;
+    }
     let Some(start_line) = enclosing_type_context_start_line(
         &lines,
         anchor_line,
@@ -3977,13 +4026,16 @@ fn enclosing_type_context_start_line(
         .filter(|owner| !owner.is_empty())?;
     let anchor_index = usize::try_from(anchor_line.saturating_sub(1)).ok()?;
     let end_index = usize::try_from(end_line).ok()?.min(lines.len());
-    if anchor_index >= lines.len() || anchor_index >= end_index {
+    if anchor_index >= lines.len() || end_index == 0 {
         return None;
     }
     let search_start = anchor_index.saturating_sub(CARRIER_SOURCE_OWNER_CONTEXT_LOOKBACK_LINES);
     let declaration_index = (search_start..anchor_index)
         .rev()
         .find(|index| source_line_declares_type_owner(lines[*index], &owner))?;
+    if declaration_index >= end_index {
+        return None;
+    }
 
     let mut comment_start = declaration_index;
     while comment_start > search_start
@@ -4047,6 +4099,48 @@ fn source_identifier_key(value: &str) -> String {
         .filter(|character| character.is_ascii_alphanumeric() || *character == '_')
         .flat_map(char::to_lowercase)
         .collect()
+}
+
+fn source_identifier_words(value: &str) -> Vec<String> {
+    let mut words = Vec::new();
+    let mut word = String::new();
+    let characters = value.chars().collect::<Vec<_>>();
+    for (index, character) in characters.iter().copied().enumerate() {
+        if !character.is_ascii_alphanumeric() {
+            if !word.is_empty() {
+                words.push(std::mem::take(&mut word));
+            }
+            continue;
+        }
+        let previous = index.checked_sub(1).and_then(|index| characters.get(index));
+        let next = characters.get(index.saturating_add(1));
+        let begins_word = !word.is_empty()
+            && ((character.is_ascii_uppercase()
+                && previous.is_some_and(|previous| previous.is_ascii_lowercase()))
+                || (character.is_ascii_uppercase()
+                    && previous.is_some_and(|previous| previous.is_ascii_uppercase())
+                    && next.is_some_and(|next| next.is_ascii_lowercase())));
+        if begins_word {
+            words.push(std::mem::take(&mut word));
+        }
+        word.push(character.to_ascii_lowercase());
+    }
+    if !word.is_empty() {
+        words.push(word);
+    }
+    words
+}
+
+fn carrier_source_identity(display_name: &str, anchor_line: Option<u32>, end_line: u32) -> String {
+    if anchor_line.is_some_and(|anchor_line| end_line < anchor_line)
+        && let Some(owner) = display_name
+            .rsplit(['.', ':', '#', '/', '\\'])
+            .filter(|segment| !segment.is_empty())
+            .nth(1)
+    {
+        return format!("enclosing {owner} type that owns {display_name}");
+    }
+    display_name.to_owned()
 }
 
 /// A long function is rarely best represented by its prologue. Select at most three bounded,
@@ -9042,6 +9136,20 @@ mod tests {
                 CARRIER_SOURCE_MAX_SNIPPET_BYTES,
             ),
             Some(3)
+        );
+        assert_eq!(
+            source_identifier_words("DefaultSession"),
+            ["default", "session"]
+        );
+        assert_eq!(source_identifier_words("IOClient"), ["io", "client"]);
+        assert_eq!(source_identifier_words("Client"), ["client"]);
+        assert_eq!(
+            carrier_source_identity("DefaultSession.perform", Some(5), 4),
+            "enclosing DefaultSession type that owns DefaultSession.perform"
+        );
+        assert_eq!(
+            carrier_source_identity("DefaultSession.perform", Some(5), 7),
+            "DefaultSession.perform"
         );
     }
 

--- a/crates/codestory-runtime/src/agent/orchestrator.rs
+++ b/crates/codestory-runtime/src/agent/orchestrator.rs
@@ -129,7 +129,7 @@ use crate::{
 };
 #[cfg(test)]
 use codestory_agent::packet_command::quote_packet_command_value;
-use codestory_agent::packet_flow_requirements::FlowRequirement;
+use codestory_agent::packet_flow_requirements::{FlowRequirement, packet_material_facet_carriers};
 use codestory_agent::packet_proof_atoms::{
     DischargedFact, FlowProofFormula, FlowProofOutcome, ProofAtomId, ProofEndpointPattern,
     ProofFactPattern, SourceAspectKind, TrailCoverage, TrailDirection as ProofTrailDirection,
@@ -564,6 +564,7 @@ pub(crate) fn agent_packet(
         &rank_terms,
         &mut answer,
     )?;
+    normalize_packet_citation_paths(&project_root, &mut answer.citations);
     let phase_started = Instant::now();
     append_packet_non_trace_phase(&mut answer, "pre_rank_citations", phase_started);
     let phase_started = Instant::now();
@@ -575,6 +576,9 @@ pub(crate) fn agent_packet(
     maybe_append_cited_formatting_type_citations(&project_root, &question, &mut answer);
     maybe_append_cited_mapper_interface_citations(&project_root, &question, &mut answer);
     maybe_append_cited_client_relative_imports(&project_root, &question, &mut answer);
+    normalize_packet_citation_paths(&project_root, &mut answer.citations);
+    let pre_rank_citations =
+        crate::agent::trace_export::packet_step_trace_armed().then(|| answer.citations.clone());
     rank_packet_evidence(&question, &mut answer);
     maybe_annotate_packet_candidate_window(&question, &limits, &mut answer);
     append_packet_non_trace_phase(&mut answer, "rank_and_window", phase_started);
@@ -639,12 +643,34 @@ pub(crate) fn agent_packet(
         &pre_cap_extras,
         &proof_session,
     );
+    let material_facet_carriers =
+        packet_material_facet_carriers(&flow_requirements, &answer.citations);
+    let material_facet_node_ids = material_facet_carriers
+        .iter()
+        .map(|carrier| carrier.node_id.clone())
+        .collect::<Vec<_>>();
     let (protected_carrier_node_ids, protected_edge_ids) = select_protected_obligation_carriers(
         &answer,
+        &material_facet_node_ids,
         protected_packet_obligation_carrier_node_ids(&obligation_edge_proofs),
         protected_packet_obligation_edge_ids(&obligation_edge_proofs),
         &partial_protection,
     );
+    if let Some(diagnostic) =
+        crate::agent::packet_accuracy_stage_ledger::record_pre_projection_stages_from_env(
+            &plan,
+            pre_rank_citations.as_deref(),
+            &answer.citations,
+            &material_facet_carriers,
+            &protected_carrier_node_ids,
+            &protected_edge_ids,
+        )
+    {
+        answer
+            .retrieval_trace
+            .annotations
+            .push(RetrievalAnnotationDto::observation(diagnostic));
+    }
     let budget = apply_packet_budget_with_extra_and_obligation_carriers(
         &project_root,
         &question,
@@ -670,6 +696,17 @@ pub(crate) fn agent_packet(
         &proof_session,
         &protected_carrier_node_ids,
     );
+    if let Some(diagnostic) =
+        crate::agent::packet_accuracy_stage_ledger::record_source_support_stage_from_env(
+            &answer,
+            &source_support,
+        )
+    {
+        answer
+            .retrieval_trace
+            .annotations
+            .push(RetrievalAnnotationDto::observation(diagnostic));
+    }
 
     // Coverage belongs to the evidence that survives the real citation cap. Observing the
     // uncapped candidate set made a packet unavailable because of a partial file that the packet
@@ -693,6 +730,7 @@ pub(crate) fn agent_packet(
     // to read, then drop its now-unused coverage observation. User-requested exact paths stay in
     // the set and therefore continue to fail closed even when they produced no retained citation.
     demote_parser_partial_citations_without_source_receipts(
+        Some(&project_root),
         &mut answer.citations,
         &source_support,
         &answer.source_coverage,
@@ -708,10 +746,13 @@ pub(crate) fn agent_packet(
                 })
                 .filter_map(|citation| citation.file_path.clone()),
         )
-        .map(|path| packet_display_path(&path))
+        .map(|path| packet_project_relative_display_path(Some(&project_root), &path))
         .collect::<HashSet<_>>();
     answer.source_coverage.retain(|observation| {
-        retained_coverage_paths.contains(&packet_display_path(&observation.path))
+        retained_coverage_paths.contains(&packet_project_relative_display_path(
+            Some(&project_root),
+            &observation.path,
+        ))
     });
 
     let phase_started = Instant::now();
@@ -2483,7 +2524,32 @@ fn promote_verified_bounded_source_citation(citation: &mut AgentCitationDto) -> 
     true
 }
 
+fn normalize_packet_citation_paths(project_root: &Path, citations: &mut [AgentCitationDto]) {
+    for citation in citations {
+        let Some(path) = citation.file_path.as_deref() else {
+            continue;
+        };
+        citation.file_path = Some(packet_project_relative_display_path(
+            Some(project_root),
+            path,
+        ));
+    }
+}
+
+fn packet_project_relative_display_path(project_root: Option<&Path>, path: &str) -> String {
+    if let Some(project_root) = project_root {
+        let candidate = Path::new(path);
+        if let Ok(relative) = candidate.strip_prefix(project_root)
+            && !relative.as_os_str().is_empty()
+        {
+            return relative.to_string_lossy().replace('\\', "/");
+        }
+    }
+    packet_display_path(path)
+}
+
 fn demote_parser_partial_citations_without_source_receipts(
+    project_root: Option<&Path>,
     citations: &mut [AgentCitationDto],
     source_support: &[SupportUnitDto],
     source_coverage: &[SourceCoverageObservationDto],
@@ -2494,7 +2560,7 @@ fn demote_parser_partial_citations_without_source_receipts(
             observation.status == SourceCoverageStatusDto::Incomplete
                 && observation.reason == Some(FileCoverageReason::ParserPartial)
         })
-        .map(|observation| packet_display_path(&observation.path))
+        .map(|observation| packet_project_relative_display_path(project_root, &observation.path))
         .collect::<HashSet<_>>();
     let retained_receipts = source_support
         .iter()
@@ -2502,18 +2568,20 @@ fn demote_parser_partial_citations_without_source_receipts(
         .filter_map(|unit| {
             Some((
                 unit.symbol_id.clone()?,
-                packet_display_path(unit.path.as_deref()?),
+                packet_project_relative_display_path(project_root, unit.path.as_deref()?),
             ))
         })
         .collect::<HashSet<_>>();
     for citation in citations.iter_mut().filter(|citation| {
-        citation
-            .file_path
-            .as_deref()
-            .is_some_and(|path| parser_partial_paths.contains(&packet_display_path(path)))
+        citation.file_path.as_deref().is_some_and(|path| {
+            parser_partial_paths.contains(&packet_project_relative_display_path(project_root, path))
+        })
     }) {
         let has_receipt = citation.file_path.as_deref().is_some_and(|path| {
-            retained_receipts.contains(&(citation.node_id.0.clone(), packet_display_path(path)))
+            retained_receipts.contains(&(
+                citation.node_id.0.clone(),
+                packet_project_relative_display_path(project_root, path),
+            ))
         });
         if !has_receipt {
             citation.eligible_for_sufficiency = Some(false);
@@ -2949,8 +3017,9 @@ fn packet_partial_atom_protection_with_planned(
 }
 
 /// The selection step: deterministic weighted set cover over verified atoms
-/// for the citation cap's protected set. The snapshot's carriers (Legacy and
-/// fully-proven obligations) keep their existing priority and order; the
+/// for the citation cap's protected set. One best source-bearing carrier per
+/// material facet comes first. The snapshot's fully-proven carriers keep their
+/// existing priority and order after those facets; the
 /// partial-atom carriers are then ordered by greedy atom cover with the
 /// stated tie-breaks — verified tier, lower source-byte cost, existing rank,
 /// stable identity — and any remaining partial carriers fill the tail in
@@ -2959,6 +3028,7 @@ fn packet_partial_atom_protection_with_planned(
 /// cover order decides survival.
 fn select_protected_obligation_carriers(
     answer: &AgentAnswerDto,
+    material_facet_node_ids: &[NodeId],
     snapshot_carrier_node_ids: &[NodeId],
     snapshot_edge_ids: &[EdgeId],
     partial: &PacketPartialAtomProtection,
@@ -3015,6 +3085,11 @@ fn select_protected_obligation_carriers(
 
     let mut ordered = Vec::new();
     let mut seen = HashSet::new();
+    for node_id in material_facet_node_ids {
+        if seen.insert(node_id.clone()) {
+            ordered.push(node_id.clone());
+        }
+    }
     for node_id in snapshot_carrier_node_ids {
         if seen.insert(node_id.clone()) {
             ordered.push(node_id.clone());
@@ -3097,6 +3172,7 @@ fn append_packet_carrier_source_sections(
     let mut rendered = String::new();
     let mut steps = Vec::new();
     let mut source_support = Vec::new();
+    let project_root = controller.require_project_root().ok();
     let file_focus_text = packet_file_source_focus_text(question, answer);
     let load_sources = |citation: &AgentCitationDto| -> Vec<CarrierSourceRange> {
         let bounded_source_read = citation_needs_bounded_source_read(citation);
@@ -3157,6 +3233,18 @@ fn append_packet_carrier_source_sections(
                 .snippet_function_body_context(citation.node_id.clone(), 0)
                 .ok()
                 .map(|snippet| {
+                    if snippet.scope == SnippetScopeDto::LineContext {
+                        let focused = long_behavioral_function_source_ranges(
+                            controller,
+                            &file_focus_text,
+                            &snippet.path,
+                            snippet.line,
+                            snippet.node.end_line,
+                        );
+                        if !focused.is_empty() {
+                            return focused;
+                        }
+                    }
                     if let Some(end_line) =
                         carrier_source_line_context_end_line(snippet.scope, snippet.line)
                         && let Ok((path, bounded)) = controller.bounded_file_snippet_range(
@@ -3226,7 +3314,7 @@ fn append_packet_carrier_source_sections(
         rendered.push_str(&entry);
         let citation = &answer.citations[citation_index];
         if crate::agent::packet_evidence::citation_sufficiency_eligible(citation) {
-            let path = packet_display_path(&source.path);
+            let path = packet_project_relative_display_path(project_root.as_deref(), &source.path);
             let (start_line, end_line) =
                 source_receipt_line_range(retained_body, source.start_line);
             source_support.push(SupportUnitDto {
@@ -3483,8 +3571,10 @@ fn append_packet_atom_anchor_sources(
         outcome.budget_dropped = selected.len();
         return outcome;
     };
+    let project_root = controller.require_project_root().ok();
     verify_planned_atom_anchors(
         &selected,
+        project_root.as_deref(),
         &node_labels,
         limits,
         rendered,
@@ -3536,6 +3626,7 @@ fn append_packet_atom_anchor_sources(
 #[allow(clippy::too_many_arguments)]
 fn verify_planned_atom_anchors(
     selected: &[&PlannedAtomAnchor],
+    project_root: Option<&Path>,
     node_labels: &HashMap<String, String>,
     limits: &PacketBudgetLimitsDto,
     rendered: &mut String,
@@ -3589,7 +3680,7 @@ fn verify_planned_atom_anchors(
         // retained citation; for structural carriers without citations the
         // unit is display-honesty pre-compile — the residual is recorded in
         // the delivery report.)
-        let display_path = packet_display_path(&path);
+        let display_path = packet_project_relative_display_path(project_root, &path);
         source_support.push(SupportUnitDto {
             id: format!(
                 "atom-anchor:{:?}:{}:{start_line}",
@@ -3853,6 +3944,199 @@ fn focused_function_source_ranges(
                 })
         })
         .collect()
+}
+
+/// A parser may know a callable's end line while still returning declaration-only context. Keep
+/// that long callable's declaration, one material internal callsite, and its positive terminal
+/// behavior instead of treating the first 24 lines as the whole implementation.
+fn long_behavioral_function_source_ranges(
+    controller: &AppController,
+    question: &str,
+    path: &str,
+    start_line: u32,
+    end_line: Option<u32>,
+) -> Vec<CarrierSourceRange> {
+    let Ok(source) = controller.read_file_text(codestory_contracts::api::ReadFileTextRequest {
+        path: path.to_string(),
+    }) else {
+        return Vec::new();
+    };
+    let lines = source.text.lines().collect::<Vec<_>>();
+    let Some(end_line) = end_line
+        .filter(|end_line| *end_line > start_line)
+        .or_else(|| discover_braced_callable_end_line(&lines, start_line))
+        .filter(|end_line| {
+            *end_line
+                > start_line
+                    .saturating_add(CARRIER_SOURCE_DECLARATION_FALLBACK_LINES.saturating_sub(1))
+        })
+    else {
+        return Vec::new();
+    };
+    long_behavioral_function_source_lines(&lines, start_line, end_line, question)
+        .into_iter()
+        .filter_map(|focus_line| {
+            let range_start = focus_line
+                .saturating_sub(CARRIER_SOURCE_FOCUS_CONTEXT_LINES as u32)
+                .max(start_line);
+            controller
+                .bounded_file_snippet(
+                    path,
+                    focus_line,
+                    CARRIER_SOURCE_FOCUS_CONTEXT_LINES,
+                    CARRIER_SOURCE_FOCUSED_SNIPPET_BYTES,
+                    SOURCE_SNIPPET_TRUNCATION_SUFFIX,
+                )
+                .ok()
+                .map(|(path, snippet)| CarrierSourceRange {
+                    path,
+                    start_line: range_start,
+                    body: snippet.markdown,
+                })
+        })
+        .collect()
+}
+
+fn discover_braced_callable_end_line(lines: &[&str], start_line: u32) -> Option<u32> {
+    let mut depth = 0_u32;
+    let mut saw_open = false;
+    let mut in_block_comment = false;
+    let mut quote: Option<char> = None;
+    let mut escaped = false;
+    for (index, line) in lines
+        .iter()
+        .enumerate()
+        .skip(start_line.saturating_sub(1) as usize)
+    {
+        let mut chars = line.chars().peekable();
+        while let Some(ch) = chars.next() {
+            if in_block_comment {
+                if ch == '*' && chars.peek() == Some(&'/') {
+                    chars.next();
+                    in_block_comment = false;
+                }
+                continue;
+            }
+            if let Some(delimiter) = quote {
+                if escaped {
+                    escaped = false;
+                } else if ch == '\\' {
+                    escaped = true;
+                } else if ch == delimiter {
+                    quote = None;
+                }
+                continue;
+            }
+            if ch == '/' && chars.peek() == Some(&'/') {
+                break;
+            }
+            if ch == '/' && chars.peek() == Some(&'*') {
+                chars.next();
+                in_block_comment = true;
+                continue;
+            }
+            if ch == '\'' || ch == '"' {
+                quote = Some(ch);
+                continue;
+            }
+            match ch {
+                '{' => {
+                    saw_open = true;
+                    depth = depth.saturating_add(1);
+                }
+                '}' if saw_open => {
+                    depth = depth.saturating_sub(1);
+                    if depth == 0 {
+                        return Some((index + 1) as u32);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    None
+}
+
+fn long_behavioral_function_source_lines(
+    lines: &[&str],
+    start_line: u32,
+    end_line: u32,
+    question: &str,
+) -> Vec<u32> {
+    if lines.is_empty() || start_line == 0 || end_line <= start_line {
+        return Vec::new();
+    }
+    let start_index = start_line.saturating_sub(1) as usize;
+    let end_index = (end_line as usize).min(lines.len());
+    if start_index >= end_index {
+        return Vec::new();
+    }
+    let context = CARRIER_SOURCE_FOCUS_CONTEXT_LINES as u32;
+    let declaration_focus = start_line.saturating_add(context).min(end_line);
+    let terminal_focus = (start_index..end_index)
+        .rev()
+        .find(|index| lines[*index].trim_start().starts_with("return "))
+        .or_else(|| {
+            (start_index..end_index).rev().find(|index| {
+                let line = lines[*index].trim_start();
+                line.starts_with("throw ")
+                    || line.starts_with("raise ")
+                    || line.starts_with("yield ")
+            })
+        })
+        .map(|index| (index + 1) as u32);
+    let question_terms = source_focus_terms(question);
+    let material_focus = (start_index..end_index)
+        .filter_map(|index| {
+            let line = lines[index];
+            let line_number = (index + 1) as u32;
+            if declaration_focus.abs_diff(line_number) <= context * 2
+                || terminal_focus
+                    .is_some_and(|terminal| terminal.abs_diff(line_number) <= context * 2)
+            {
+                return None;
+            }
+            let lower = line.to_ascii_lowercase();
+            let line_terms = source_focus_terms(line);
+            let question_overlap = question_terms
+                .iter()
+                .filter(|term| {
+                    line_terms
+                        .iter()
+                        .any(|line_term| source_focus_terms_match(term, line_term))
+                })
+                .count();
+            let awaited = usize::from(lower.contains("await "));
+            let call_shape = usize::from(lower.contains('(') && lower.contains(')'));
+            let material_action = usize::from(
+                [
+                    "commit", "connect", "dispatch", "execute", "finalize", "listen", "load",
+                    "open", "persist", "pipe", "publish", "read", "request", "response", "save",
+                    "send", "write",
+                ]
+                .iter()
+                .any(|action| line_terms.iter().any(|term| term == action)),
+            );
+            let score = question_overlap * 4 + awaited * 6 + material_action * 3 + call_shape;
+            (score > 0).then_some((score, index))
+        })
+        .max_by(|left, right| left.0.cmp(&right.0).then_with(|| right.1.cmp(&left.1)))
+        .map(|(_, index)| (index + 1) as u32);
+
+    let mut selected = vec![declaration_focus];
+    if let Some(material_focus) = material_focus {
+        selected.push(material_focus);
+    }
+    if let Some(terminal_focus) = terminal_focus
+        && selected
+            .iter()
+            .all(|selected| selected.abs_diff(terminal_focus) > context * 2)
+    {
+        selected.push(terminal_focus);
+    }
+    selected.truncate(CARRIER_SOURCE_MAX_FOCUSED_WINDOWS);
+    selected.sort_unstable();
+    selected
 }
 
 fn focused_function_source_lines(
@@ -8354,6 +8638,67 @@ mod tests {
     }
 
     #[test]
+    fn declaration_only_long_callable_keeps_declaration_callsite_and_terminal() {
+        let source = [
+            "Future<Result> execute(Request request) async {",
+            "  validate(request);",
+            "  configure(request);",
+            "  prepare(request);",
+            "  final stream = request.finalize();",
+            "  final connection = await transport.open(request.url);",
+            "  configureHeaders(connection);",
+            "  installCancellation(connection);",
+            "  recordAttempt();",
+            "  recordQueueDepth();",
+            "  prepareTrace();",
+            "  attachContext();",
+            "  updateDeadline();",
+            "  installHooks();",
+            "  await beforeSend();",
+            "  final response = await stream.pipe(connection);",
+            "  observe(response);",
+            "  transform(response);",
+            "  attachListeners(response);",
+            "  recordHeaders(response);",
+            "  finalizeMetrics(response);",
+            "  notifyObservers(response);",
+            "  updatePool(response);",
+            "  collectTrailers(response);",
+            "  recordCompletion(response);",
+            "  closeSpan(response);",
+            "  settleAccounting(response);",
+            "  return Result.from(response);",
+            "}",
+        ];
+
+        let focus = long_behavioral_function_source_lines(
+            &source,
+            1,
+            source.len() as u32,
+            "Explain execute send behavior.",
+        );
+
+        assert_eq!(focus, [6, 17, 28]);
+    }
+
+    #[test]
+    fn declaration_only_callable_end_ignores_comment_and_string_braces() {
+        let source = [
+            "Future<Result> execute() async {",
+            "  // A comment with } does not end the callable.",
+            "  final marker = '{';",
+            "  if (ready) {",
+            "    await run();",
+            "  }",
+            "  return Result();",
+            "}",
+            "void next() {}",
+        ];
+
+        assert_eq!(discover_braced_callable_end_line(&source, 1), Some(8));
+    }
+
+    #[test]
     fn source_focus_does_not_treat_control_flow_as_a_component_owner() {
         assert!(!source_focus_terms_match("matcher", "match"));
         assert!(!source_focus_terms_match("searcher", "search"));
@@ -8768,6 +9113,7 @@ mod tests {
         let mut citations = vec![retained, omitted, indexed];
 
         demote_parser_partial_citations_without_source_receipts(
+            None,
             &mut citations,
             &source_support,
             &coverage,
@@ -9279,6 +9625,29 @@ mod tests {
         assert_eq!(
             packet_display_path("target/repo-cache/repos/axios/lib/core/Axios.js"),
             "lib/core/Axios.js"
+        );
+    }
+
+    #[test]
+    fn packet_project_relative_path_preserves_nested_monorepo_packages() {
+        let project_root = Path::new("/private/tmp/fixtures/dart-lang-http");
+        assert_eq!(
+            packet_project_relative_display_path(
+                Some(project_root),
+                "/private/tmp/fixtures/dart-lang-http/pkgs/http/lib/src/client.dart",
+            ),
+            "pkgs/http/lib/src/client.dart"
+        );
+
+        let mut citation = test_packet_citation(
+            "Client.get",
+            "/private/tmp/fixtures/dart-lang-http/pkgs/http/lib/src/client.dart",
+            1.0,
+        );
+        normalize_packet_citation_paths(project_root, std::slice::from_mut(&mut citation));
+        assert_eq!(
+            citation.file_path.as_deref(),
+            Some("pkgs/http/lib/src/client.dart")
         );
     }
 
@@ -16117,6 +16486,7 @@ mod tests {
         let snapshot_edges = [EdgeId("edge-a".into())];
         let (ordered, edges) = select_protected_obligation_carriers(
             &answer,
+            &[],
             &snapshot_carriers,
             &snapshot_edges,
             &partial,
@@ -16137,6 +16507,7 @@ mod tests {
         // Determinism.
         let (again, _) = select_protected_obligation_carriers(
             &answer,
+            &[],
             &snapshot_carriers,
             &snapshot_edges,
             &partial,
@@ -16412,6 +16783,7 @@ mod tests {
         let mut source_support = Vec::new();
         verify_planned_atom_anchors(
             &selected,
+            None,
             &HashMap::new(),
             &limits,
             &mut rendered,
@@ -16479,6 +16851,7 @@ mod tests {
         };
         verify_planned_atom_anchors(
             &selected,
+            None,
             &HashMap::new(),
             &exhausted,
             &mut rendered,

--- a/crates/codestory-runtime/src/agent/orchestrator.rs
+++ b/crates/codestory-runtime/src/agent/orchestrator.rs
@@ -3183,7 +3183,7 @@ fn append_packet_carrier_source_sections(
         if !bounded_source_read && !behavioral_source {
             return Vec::new();
         }
-        if bounded_source_read {
+        let sources = if bounded_source_read {
             let (Some(path), Some(line)) = (citation.file_path.as_deref(), citation.line) else {
                 return Vec::new();
             };
@@ -3286,7 +3286,8 @@ fn append_packet_carrier_source_sections(
                     }]
                 })
                 .unwrap_or_default()
-        }
+        };
+        attach_enclosing_type_source_context(controller, citation, sources)
     };
 
     // Spend one source slot on each exact material carrier first, then return to the original
@@ -3899,6 +3900,153 @@ fn source_receipt_line_range(markdown: &str, fallback_start: u32) -> (u32, u32) 
         start.unwrap_or(fallback_start),
         end.unwrap_or(fallback_start),
     )
+}
+
+const CARRIER_SOURCE_OWNER_CONTEXT_LOOKBACK_LINES: usize = 32;
+
+/// Keep the source-local type declaration with an owner-qualified method when it fits the same
+/// bounded window. A method body proves mechanics, while the adjacent declaration and comments
+/// often establish what kind of implementation owns those mechanics. This is a source expansion
+/// for every qualified method shape; it does not consult the prompt, requirement ids, or fixture
+/// vocabulary.
+fn attach_enclosing_type_source_context(
+    controller: &AppController,
+    citation: &AgentCitationDto,
+    mut sources: Vec<CarrierSourceRange>,
+) -> Vec<CarrierSourceRange> {
+    if citation.kind != NodeKind::METHOD || sources.is_empty() {
+        return sources;
+    }
+    let Some(anchor_line) = citation.line else {
+        return sources;
+    };
+    let first = &sources[0];
+    let (_, end_line) = source_receipt_line_range(&first.body, first.start_line);
+    let Ok(source) = controller.read_file_text(codestory_contracts::api::ReadFileTextRequest {
+        path: first.path.clone(),
+    }) else {
+        return sources;
+    };
+    let lines = source.text.lines().collect::<Vec<_>>();
+    let Some(start_line) = enclosing_type_context_start_line(
+        &lines,
+        anchor_line,
+        end_line,
+        &citation.display_name,
+        CARRIER_SOURCE_MAX_SNIPPET_BYTES,
+    ) else {
+        return sources;
+    };
+    let Ok((path, bounded)) = controller.bounded_file_snippet_range(
+        &first.path,
+        crate::BoundedSnippetRangeOptions {
+            focus_line: anchor_line,
+            start_line,
+            end_line,
+            context_lines: 0,
+            max_bytes: CARRIER_SOURCE_MAX_SNIPPET_BYTES,
+            truncation_suffix: SOURCE_SNIPPET_TRUNCATION_SUFFIX,
+        },
+    ) else {
+        return sources;
+    };
+    let rendered_range = source_receipt_line_range(&bounded.markdown, start_line);
+    if rendered_range.0 > start_line || rendered_range.1 < end_line {
+        return sources;
+    }
+    sources[0] = CarrierSourceRange {
+        path,
+        start_line,
+        body: bounded.markdown,
+    };
+    sources
+}
+
+fn enclosing_type_context_start_line(
+    lines: &[&str],
+    anchor_line: u32,
+    end_line: u32,
+    display_name: &str,
+    maximum_bytes: usize,
+) -> Option<u32> {
+    let owner = display_name
+        .rsplit(['.', ':', '#', '/', '\\'])
+        .filter(|segment| !segment.is_empty())
+        .nth(1)
+        .map(source_identifier_key)
+        .filter(|owner| !owner.is_empty())?;
+    let anchor_index = usize::try_from(anchor_line.saturating_sub(1)).ok()?;
+    let end_index = usize::try_from(end_line).ok()?.min(lines.len());
+    if anchor_index >= lines.len() || anchor_index >= end_index {
+        return None;
+    }
+    let search_start = anchor_index.saturating_sub(CARRIER_SOURCE_OWNER_CONTEXT_LOOKBACK_LINES);
+    let declaration_index = (search_start..anchor_index)
+        .rev()
+        .find(|index| source_line_declares_type_owner(lines[*index], &owner))?;
+
+    let mut comment_start = declaration_index;
+    while comment_start > search_start
+        && source_owner_comment_line(lines[comment_start.saturating_sub(1)])
+    {
+        comment_start -= 1;
+    }
+    for candidate in [comment_start, declaration_index] {
+        let line_count = end_index.saturating_sub(candidate);
+        let bytes = lines[candidate..end_index]
+            .iter()
+            .map(|line| line.len().saturating_add(1))
+            .sum::<usize>()
+            // `bounded_file_snippet_range` renders line numbers and a focus marker beside the
+            // source. Budget that framing here so owner context never truncates bytes already
+            // retained by the method's declaration window.
+            .saturating_add(line_count.saturating_mul(10))
+            .saturating_add(16);
+        if bytes <= maximum_bytes {
+            return u32::try_from(candidate.saturating_add(1)).ok();
+        }
+    }
+    None
+}
+
+fn source_line_declares_type_owner(line: &str, expected_owner: &str) -> bool {
+    let trimmed = line.trim_start();
+    if trimmed.starts_with("//")
+        || trimmed.starts_with('#')
+        || trimmed.starts_with('*')
+        || trimmed.starts_with("/*")
+    {
+        return false;
+    }
+    let tokens = line
+        .split(|character: char| !character.is_ascii_alphanumeric() && character != '_')
+        .filter(|token| !token.is_empty())
+        .map(|token| token.to_ascii_lowercase())
+        .collect::<Vec<_>>();
+    tokens.iter().any(|token| token == expected_owner)
+        && tokens.iter().any(|token| {
+            matches!(
+                token.as_str(),
+                "class" | "struct" | "interface" | "trait" | "record" | "object" | "impl"
+            )
+        })
+}
+
+fn source_owner_comment_line(line: &str) -> bool {
+    let line = line.trim();
+    !line.is_empty()
+        && (line.starts_with("//")
+            || line.starts_with("/*")
+            || line.starts_with('*')
+            || line.ends_with("*/"))
+}
+
+fn source_identifier_key(value: &str) -> String {
+    value
+        .chars()
+        .filter(|character| character.is_ascii_alphanumeric() || *character == '_')
+        .flat_map(char::to_lowercase)
+        .collect()
 }
 
 /// A long function is rarely best represented by its prologue. Select at most three bounded,
@@ -8871,6 +9019,74 @@ mod tests {
 
         assert_eq!(source_receipt_line_range(markdown, 42), (41, 43));
         assert_eq!(source_receipt_line_range("plain text", 42), (42, 42));
+    }
+
+    #[test]
+    fn qualified_method_source_keeps_a_fitting_owner_declaration_and_comments() {
+        let source = [
+            "import helper;",
+            "",
+            "/// Default sessions implement convenience operations through dispatch.",
+            "class DefaultSession implements Session {",
+            "  Result perform(Request request) {",
+            "    return dispatch(request);",
+            "  }",
+        ];
+
+        assert_eq!(
+            enclosing_type_context_start_line(
+                &source,
+                5,
+                7,
+                "DefaultSession.perform",
+                CARRIER_SOURCE_MAX_SNIPPET_BYTES,
+            ),
+            Some(3)
+        );
+    }
+
+    #[test]
+    fn qualified_method_source_falls_back_to_the_owner_declaration_when_docs_do_not_fit() {
+        let long_docs = format!("/// {}", "context ".repeat(300));
+        let source = [
+            long_docs.as_str(),
+            "class NativeSession {",
+            "  Result send(Request request) {",
+            "    return transport.send(request);",
+            "  }",
+        ];
+
+        assert_eq!(
+            enclosing_type_context_start_line(
+                &source,
+                3,
+                5,
+                "NativeSession.send",
+                CARRIER_SOURCE_MAX_SNIPPET_BYTES,
+            ),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn qualified_method_source_never_borrows_an_unrelated_owner_declaration() {
+        let source = [
+            "class CacheClient {",
+            "  Result send(Request request) {",
+            "    return write(request);",
+            "  }",
+        ];
+
+        assert_eq!(
+            enclosing_type_context_start_line(
+                &source,
+                2,
+                4,
+                "NetworkClient.send",
+                CARRIER_SOURCE_MAX_SNIPPET_BYTES,
+            ),
+            None
+        );
     }
 
     struct EvalProbesGuard;

--- a/crates/codestory-runtime/src/agent/packet_accuracy_stage_ledger.rs
+++ b/crates/codestory-runtime/src/agent/packet_accuracy_stage_ledger.rs
@@ -1,0 +1,324 @@
+//! Env-gated accuracy pipeline ledger for packet selection remediation.
+//!
+//! The public packet intentionally exposes only bounded evidence. When a material carrier goes
+//! missing, that projection is too late to distinguish a retrieval miss from a protection,
+//! source-window, or public-selection loss. This ledger records those boundaries in the existing
+//! developer step-trace artifact without adding a product response field or changing packet
+//! budgets.
+
+use std::path::Path;
+
+use codestory_agent::packet_flow_requirements::PacketMaterialFacetCarrier;
+use codestory_contracts::{
+    api::{
+        AgentAnswerDto, AgentCitationDto, EdgeId, NodeId, PacketPlanDto, SupportUnitDto,
+        SupportUnitKindDto,
+    },
+    packet_projection_v3::PacketEvidenceRowV3Dto,
+};
+use serde_json::{Map, Value, json};
+use sha2::{Digest, Sha256};
+
+const LEDGER_KEY: &str = "accuracy_stage_ledger";
+const LEDGER_SCHEMA: &str = "codestory.packet-accuracy-stage-ledger/v1";
+
+pub(crate) fn record_pre_projection_stages_from_env(
+    plan: &PacketPlanDto,
+    pre_rank_citations: Option<&[AgentCitationDto]>,
+    uncapped_citations: &[AgentCitationDto],
+    selected_material_facets: &[PacketMaterialFacetCarrier],
+    protected_node_ids: &[NodeId],
+    protected_edge_ids: &[EdgeId],
+) -> Option<String> {
+    update_trace_from_env("pre_projection", |root| {
+        let query_plan = plan
+            .queries
+            .iter()
+            .enumerate()
+            .map(|(index, query)| {
+                json!({
+                    "index": index,
+                    "query": query.query,
+                    "purpose": query.purpose,
+                })
+            })
+            .collect::<Vec<_>>();
+        let pre_rank_rows = pre_rank_citations
+            .unwrap_or_default()
+            .iter()
+            .enumerate()
+            .map(|(index, citation)| citation_row(index, citation))
+            .collect::<Vec<_>>();
+        let citations = uncapped_citations
+            .iter()
+            .enumerate()
+            .map(|(index, citation)| citation_row(index, citation))
+            .collect::<Vec<_>>();
+        let protected_nodes = protected_node_ids
+            .iter()
+            .enumerate()
+            .map(|(rank, node_id)| {
+                let citation = uncapped_citations
+                    .iter()
+                    .find(|citation| citation.node_id == *node_id);
+                json!({
+                    "protection_rank": rank,
+                    "node_id": node_id.0,
+                    "citation": citation.map(|citation| citation_row(rank, citation)),
+                })
+            })
+            .collect::<Vec<_>>();
+        let material_facets = plan
+            .obligations
+            .claim_obligations
+            .iter()
+            .filter(|obligation| obligation.material)
+            .map(|obligation| {
+                let selected_node_ids = selected_material_facets
+                    .iter()
+                    .filter(|carrier| carrier.facet_id == obligation.id)
+                    .map(|carrier| carrier.node_id.clone())
+                    .collect::<Vec<_>>();
+                json!({
+                    "facet_id": obligation.id,
+                    "kind": obligation.kind,
+                    "binding_terms": obligation.binding_terms,
+                    "carrier_node_ids": if selected_node_ids.is_empty() {
+                        obligation.carrier_node_ids.clone()
+                    } else {
+                        selected_node_ids
+                    },
+                    "carrier_paths": obligation.carrier_paths,
+                    "open_next_candidates": obligation.open_next_candidates,
+                })
+            })
+            .collect::<Vec<_>>();
+        root.insert(
+            LEDGER_KEY.to_string(),
+            json!({
+                "schema_version": LEDGER_SCHEMA,
+                "query_plan": {
+                    "count": query_plan.len(),
+                    "rows": query_plan,
+                },
+                "uncapped_citations": {
+                    "pre_rank_count": pre_rank_rows.len(),
+                    "pre_rank_rows": pre_rank_rows,
+                    "count": citations.len(),
+                    "rows": citations,
+                },
+                "protected_material_carriers": {
+                    "node_count": protected_nodes.len(),
+                    "edge_count": protected_edge_ids.len(),
+                    "nodes": protected_nodes,
+                    "edge_ids": protected_edge_ids.iter().map(|edge| edge.0.clone()).collect::<Vec<_>>(),
+                    "facets": material_facets,
+                    "selected_facets": selected_material_facets.iter().map(|carrier| json!({
+                        "facet_id": carrier.facet_id,
+                        "node_id": carrier.node_id.0,
+                    })).collect::<Vec<_>>(),
+                },
+            }),
+        );
+    })
+}
+
+pub(crate) fn record_source_support_stage_from_env(
+    answer: &AgentAnswerDto,
+    support: &[SupportUnitDto],
+) -> Option<String> {
+    update_trace_from_env("source_support", |root| {
+        let ledger = ensure_ledger(root);
+        let post_cap_citations = answer
+            .citations
+            .iter()
+            .enumerate()
+            .map(|(index, citation)| citation_row(index, citation))
+            .collect::<Vec<_>>();
+        let windows = support
+            .iter()
+            .filter(|unit| unit.kind == SupportUnitKindDto::SourceRange)
+            .map(source_support_row)
+            .collect::<Vec<_>>();
+        ledger.insert(
+            "source_support_windows".to_string(),
+            json!({
+                "post_cap_citation_count": post_cap_citations.len(),
+                "post_cap_citations": post_cap_citations,
+                "window_count": windows.len(),
+                "windows": windows,
+            }),
+        );
+    })
+}
+
+pub(crate) fn record_public_projection_stage_from_env(
+    evidence: &[PacketEvidenceRowV3Dto],
+) -> Option<String> {
+    update_trace_from_env("public_v3_evidence", |root| {
+        let ledger = ensure_ledger(root);
+        ledger.insert(
+            "public_v3_evidence".to_string(),
+            json!({
+                "count": evidence.len(),
+                "rows": evidence,
+            }),
+        );
+    })
+}
+
+/// Preserve the pipeline ledger when the ordinary step-trace writer fills the rest of the same
+/// artifact after the pre-projection stages have already been recorded.
+pub(crate) fn restore_existing_ledger(trace_path: &Path, trace: &mut Value) {
+    let Some(existing) = read_trace_root(trace_path) else {
+        return;
+    };
+    let Some(ledger) = existing.get(LEDGER_KEY).cloned() else {
+        return;
+    };
+    trace[LEDGER_KEY] = ledger;
+}
+
+fn citation_row(index: usize, citation: &AgentCitationDto) -> Value {
+    json!({
+        "index": index,
+        "node_id": citation.node_id.0,
+        "display_name": citation.display_name,
+        "path": citation.file_path,
+        "line": citation.line,
+        "kind": citation.kind,
+        "origin": citation.origin,
+        "evidence_tier": citation.evidence_tier,
+        "resolution_status": citation.resolution_status,
+        "eligible_for_sufficiency": citation.eligible_for_sufficiency,
+        "loss_reason": citation.loss_reason,
+    })
+}
+
+fn source_support_row(unit: &SupportUnitDto) -> Value {
+    let snippet = unit.snippet.as_deref().unwrap_or_default();
+    json!({
+        "id": unit.id,
+        "path": unit.path,
+        "symbol_id": unit.symbol_id,
+        "start_line": unit.start_line,
+        "end_line": unit.end_line,
+        "snippet_bytes": snippet.len(),
+        "snippet_sha256": digest_hex(snippet.as_bytes()),
+    })
+}
+
+fn digest_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    digest.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn ensure_ledger(root: &mut Map<String, Value>) -> &mut Map<String, Value> {
+    let ledger = root
+        .entry(LEDGER_KEY.to_string())
+        .or_insert_with(|| json!({ "schema_version": LEDGER_SCHEMA }));
+    if !ledger.is_object() {
+        *ledger = json!({ "schema_version": LEDGER_SCHEMA });
+    }
+    ledger
+        .as_object_mut()
+        .expect("accuracy stage ledger is an object")
+}
+
+fn update_trace_from_env(
+    stage: &str,
+    update: impl FnOnce(&mut Map<String, Value>),
+) -> Option<String> {
+    let trace_path =
+        std::env::var(codestory_contracts::config_registry::PACKET_STEP_TRACE_OUT_ENV).ok()?;
+    let path = Path::new(&trace_path);
+    let mut root = read_trace_root(path).unwrap_or_else(|| Value::Object(Map::new()));
+    if !root.is_object() {
+        root = Value::Object(Map::new());
+    }
+    update(root.as_object_mut().expect("trace root is an object"));
+    let payload = match serde_json::to_vec_pretty(&root) {
+        Ok(payload) => payload,
+        Err(error) => {
+            return Some(format!(
+                "packet_accuracy_stage_ledger error=serialize stage={stage} path={trace_path} message={error}"
+            ));
+        }
+    };
+    if let Err(error) = std::fs::write(path, payload) {
+        return Some(format!(
+            "packet_accuracy_stage_ledger error=write stage={stage} path={trace_path} message={error}"
+        ));
+    }
+    None
+}
+
+fn read_trace_root(path: &Path) -> Option<Value> {
+    let bytes = std::fs::read(path).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn source_and_public_stages_extend_the_same_five_stage_ledger() {
+        let mut root = Map::new();
+        root.insert(
+            LEDGER_KEY.to_string(),
+            json!({
+                "schema_version": LEDGER_SCHEMA,
+                "query_plan": {"count": 1, "rows": []},
+                "uncapped_citations": {"count": 1, "rows": []},
+                "protected_material_carriers": {"node_count": 1, "nodes": []},
+            }),
+        );
+
+        let ledger = ensure_ledger(&mut root);
+        ledger.insert(
+            "source_support_windows".to_string(),
+            json!({"window_count": 1, "windows": []}),
+        );
+        ledger.insert(
+            "public_v3_evidence".to_string(),
+            json!({"count": 1, "rows": []}),
+        );
+
+        let ledger = root.get(LEDGER_KEY).expect("ledger");
+        for stage in [
+            "query_plan",
+            "uncapped_citations",
+            "protected_material_carriers",
+            "source_support_windows",
+            "public_v3_evidence",
+        ] {
+            assert!(ledger.get(stage).is_some(), "missing stage {stage}");
+        }
+        assert_eq!(ledger["schema_version"], LEDGER_SCHEMA);
+    }
+
+    #[test]
+    fn restoring_the_ledger_does_not_replace_the_step_trace() {
+        let root = std::env::temp_dir().join(format!(
+            "codestory-accuracy-ledger-{}-{}.json",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        ));
+        std::fs::write(
+            &root,
+            serde_json::to_vec(&json!({
+                LEDGER_KEY: {"schema_version": LEDGER_SCHEMA, "query_plan": {"count": 2}}
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        let mut trace = json!({"step_count": 7});
+
+        restore_existing_ledger(&root, &mut trace);
+
+        assert_eq!(trace["step_count"], 7);
+        assert_eq!(trace[LEDGER_KEY]["query_plan"]["count"], 2);
+        let _ = std::fs::remove_file(root);
+    }
+}

--- a/crates/codestory-runtime/src/agent/packet_projection_v3.rs
+++ b/crates/codestory-runtime/src/agent/packet_projection_v3.rs
@@ -8,11 +8,12 @@ use codestory_contracts::packet_projection_v3::{
     BoundViolationV3, BoundedVecV3, ContextEvidenceRowV3Dto, ContextProjectionKindV3Dto,
     ContextProjectionV3Dto, ContextTargetV3Dto, DIAGNOSTIC_ROWS_MAX_V3,
     DiagnosticArtifactKindV3Dto, DiagnosticArtifactV3Dto, DiagnosticReferenceV3Dto,
-    DiagnosticRowV3Dto, DiagnosticsCapabilityV3Dto, EvidenceAvailabilityV3Dto, GAP_ROWS_MAX_V3,
-    GapIdentityV3Dto, GapKindV3Dto, IdentityTextV3, PACKET_PROJECTION_V3_SCHEMA_VERSION,
-    PacketProjectionV3Dto, PacketRequestIdentityV3Dto, ProjectionGapRowV3Dto,
-    PublicationIdentityV3Dto, RetrievalStateDescriptorV3Dto, RetrievalStateV3Dto,
-    SearchEvidenceRowV3Dto, SearchProjectionKindV3Dto, SearchProjectionV3Dto, Sha256DigestV3Dto,
+    DiagnosticRowV3Dto, DiagnosticsCapabilityV3Dto, EvidenceAvailabilityV3Dto, EvidenceKindV3Dto,
+    GAP_ROWS_MAX_V3, GapIdentityV3Dto, GapKindV3Dto, IdentityTextV3,
+    PACKET_PROJECTION_V3_SCHEMA_VERSION, PacketProjectionV3Dto, PacketRequestIdentityV3Dto,
+    ProjectionGapRowV3Dto, PublicationIdentityV3Dto, RetrievalStateDescriptorV3Dto,
+    RetrievalStateV3Dto, SearchEvidenceRowV3Dto, SearchProjectionKindV3Dto, SearchProjectionV3Dto,
+    Sha256DigestV3Dto,
 };
 use sha2::{Digest, Sha256};
 
@@ -316,7 +317,14 @@ fn compact_packet_candidate_v3(
 ) -> Result<PacketProjectionV3Dto, ProjectionBuildErrorV3> {
     let mut evidence = original_evidence.to_vec();
     for row in evidence.iter_mut().skip(detailed_rows) {
-        row.summary = None;
+        // Source and symbol locators retain useful path/range identity after optional prose is
+        // removed. A graph relation does not: without its summary, the target and edge kind
+        // disappear and the row becomes a contentless source-symbol locator. Selected relations
+        // have already passed the evidence policy, so retain their bounded semantic text and
+        // compact source prose around them instead.
+        if row.kind != EvidenceKindV3Dto::GraphRelation {
+            row.summary = None;
+        }
     }
     let mut gaps = original_gaps.to_vec();
     for row in &mut gaps {
@@ -715,7 +723,7 @@ mod tests {
             EvidenceKindV3Dto, GapIdentityV3Dto, GapKindV3Dto, IdentityTextV3, MessageTextV3,
             PacketEvidenceRowV3Dto, PacketProjectionV3Dto, PathTextV3, ProjectionGapRowV3Dto,
             PublicationIdentityV3Dto, RetrievalStateDescriptorV3Dto, RetrievalStateV3Dto,
-            SearchEvidenceRowV3Dto, SearchProjectionKindV3Dto, SummaryTextV3,
+            SearchEvidenceRowV3Dto, SearchProjectionKindV3Dto, SummaryTextV3, SymbolIdTextV3,
         },
     };
 
@@ -792,6 +800,16 @@ mod tests {
             end_line: Some(7),
             summary: summary.map(|summary| SummaryTextV3::new(summary).unwrap()),
         }
+    }
+
+    fn packet_relation_evidence(id: &str, summary: &str) -> PacketEvidenceRowV3Dto {
+        let mut row = packet_evidence(id, Some(summary));
+        row.kind = EvidenceKindV3Dto::GraphRelation;
+        row.path = Some(PathTextV3::new("src/main.rs").unwrap());
+        row.symbol_id = Some(SymbolIdTextV3::new("main").unwrap());
+        row.start_line = None;
+        row.end_line = None;
+        row
     }
 
     fn projection_gap(
@@ -1091,6 +1109,59 @@ mod tests {
         assert_eq!(
             record, before,
             "budget projection must not mutate its record"
+        );
+    }
+
+    #[test]
+    fn packet_projection_v3_never_compacts_a_relation_into_a_contentless_locator() {
+        let record = record_fixture_with(
+            "retain the material relation witness",
+            PacketBudgetModeDto::Compact,
+            PacketProfileV3::Callflow,
+            vec![
+                packet_evidence("evidence-a", Some("first source summary")),
+                packet_evidence("evidence-b", Some("second source summary")),
+                packet_relation_evidence("evidence-z", "main -[CALL]-> run"),
+            ],
+            Vec::new(),
+            None,
+            RetrievalStateDescriptorV3Dto {
+                state: RetrievalStateV3Dto::Full,
+                generation_id: Some(identity("retrieval-generation-1")),
+            },
+            Vec::new(),
+            true,
+        );
+        let projection =
+            build_packet_projection_v3(&record, diagnostics_capability_fixture(), |candidate| {
+                match candidate {
+                    PacketProjectionV3Dto::Complete { evidence, .. }
+                        if evidence
+                            .as_slice()
+                            .iter()
+                            .filter(|row| {
+                                row.kind == EvidenceKindV3Dto::ExactSource && row.summary.is_some()
+                            })
+                            .count()
+                            > 1 =>
+                    {
+                        Ok(PACKET_PUBLIC_RESULT_MAX_BYTES_V3 + 1)
+                    }
+                    _ => Ok(PACKET_PUBLIC_RESULT_MAX_BYTES_V3),
+                }
+            })
+            .expect("relation text should fit by compacting optional source prose");
+        let PacketProjectionV3Dto::Complete { evidence, .. } = projection else {
+            panic!("relation-preserving compaction should remain complete");
+        };
+
+        assert_eq!(
+            evidence.as_slice()[2]
+                .summary
+                .as_ref()
+                .map(|summary| summary.as_str()),
+            Some("main -[CALL]-> run"),
+            "a relation row has no usable target or edge semantics without its summary"
         );
     }
 

--- a/crates/codestory-runtime/src/agent/trace_export.rs
+++ b/crates/codestory-runtime/src/agent/trace_export.rs
@@ -636,6 +636,10 @@ pub(crate) fn write_packet_step_trace_from_env(
     let trace_path =
         std::env::var(codestory_contracts::config_registry::PACKET_STEP_TRACE_OUT_ENV).ok()?;
     let mut trace = packet_step_trace_json(answer);
+    crate::agent::packet_accuracy_stage_ledger::restore_existing_ledger(
+        std::path::Path::new(&trace_path),
+        &mut trace,
+    );
     trace["obligation_proof_verdicts"] = obligation_proof_verdicts_json(obligations);
     // R6 session observability (gate round 4): the final promotion need-set
     // with per-id pattern and ROLE provenance, per-query admission decisions

--- a/crates/codestory-runtime/src/evidence_projection_v3.rs
+++ b/crates/codestory-runtime/src/evidence_projection_v3.rs
@@ -296,6 +296,7 @@ fn select_packet_evidence_indices(
                 .flatten()
         })
         .collect::<HashSet<_>>();
+
     let mut source_count = selected.len();
     for index in &source_order {
         if source_count >= PACKET_PUBLIC_SOURCE_ROWS_TARGET_V3 {
@@ -383,6 +384,28 @@ fn select_packet_evidence_indices(
             selected.push(*index);
         }
     }
+
+    // Repeated windows from a material callable do not satisfy the distinct-path preference by
+    // themselves. After mandatory source and relation receipts are safe, retain every still-
+    // relevant source path that fits before optional relations or same-path remainder fill.
+    for index in &source_order {
+        if selected.len() == PACKET_PUBLIC_EVIDENCE_ROWS_MAX_V3 {
+            break;
+        }
+        if selected_indices.contains(index) || distinct[*index].2 == 0 {
+            continue;
+        }
+        let row = &distinct[*index].1;
+        if row
+            .path
+            .as_ref()
+            .is_some_and(|path| source_paths.insert(path.as_str()))
+        {
+            selected.push(*index);
+            selected_indices.insert(*index);
+        }
+    }
+
     let relation_target = relation_floor.max(selected.len());
     let mut relation_callers = HashSet::new();
     for index in &selected {
@@ -1959,6 +1982,72 @@ mod tests {
                 (Some("IOClient.send"), Some(147)),
                 (Some("IOClient.send"), Some(206)),
             ]
+        );
+    }
+
+    #[test]
+    fn repeated_material_windows_do_not_displace_relevant_distinct_paths() {
+        let mut support = (0..11)
+            .map(|index| {
+                let mut unit = support_unit(SupportUnitKindDto::SourceRange);
+                unit.id = format!("material-window-{index}");
+                unit.path = Some("src/io_client.rs".to_owned());
+                unit.symbol_id = Some("IOClient.send".to_owned());
+                unit.start_line = Some(index * 10 + 1);
+                unit.end_line = Some(index * 10 + 4);
+                unit.snippet = Some(format!("material transport window {index}"));
+                unit
+            })
+            .collect::<Vec<_>>();
+        for index in 0..4 {
+            let mut unit = support_unit(SupportUnitKindDto::SourceRange);
+            unit.id = format!("request-response-stage-{index}");
+            unit.path = Some(format!("src/request-response-stage-{index}.rs"));
+            unit.symbol_id = Some(format!("RequestResponse.stage{index}"));
+            unit.start_line = Some(1);
+            unit.end_line = Some(4);
+            unit.snippet = Some(format!("request response stage {index}"));
+            support.push(unit);
+        }
+        let mut relation = support_unit(SupportUnitKindDto::TypedGraphEdge);
+        relation.id = "edge:transport-send".to_owned();
+        relation.path = Some("src/io_client.rs".to_owned());
+        relation.symbol_id = Some("IOClient.send".to_owned());
+        relation.from_symbol = Some("IOClient.send".to_owned());
+        relation.edge_kind = Some("CALL".to_owned());
+        relation.to_symbol = Some("Transport.send".to_owned());
+        support.push(relation);
+
+        let mut obligation = material_obligation("transport-send");
+        obligation.carrier_node_ids = vec![NodeId("IOClient.send".to_owned())];
+        obligation.carrier_edge_proofs = vec![PacketObligationCarrierEdgeProofDto {
+            carrier_node_id: NodeId("IOClient.send".to_owned()),
+            edge_id: EdgeId("transport-send".to_owned()),
+            edge_kind: EdgeKind::CALL,
+        }];
+        let evidence = packet_evidence_rows_with_obligations(
+            &support,
+            "Explain the request response transport stages.",
+            &[obligation],
+        );
+
+        assert_eq!(evidence.len(), PACKET_PUBLIC_EVIDENCE_ROWS_MAX_V3);
+        assert_eq!(
+            evidence[11].kind,
+            EvidenceKindV3Dto::GraphRelation,
+            "the mandatory relation remains ahead of optional source fill"
+        );
+        assert_eq!(
+            evidence[12..]
+                .iter()
+                .filter_map(|row| row.path.as_ref().map(|path| path.as_str()))
+                .collect::<HashSet<_>>(),
+            HashSet::from([
+                "src/request-response-stage-0.rs",
+                "src/request-response-stage-1.rs",
+                "src/request-response-stage-2.rs",
+                "src/request-response-stage-3.rs",
+            ])
         );
     }
 

--- a/crates/codestory-runtime/src/evidence_projection_v3.rs
+++ b/crates/codestory-runtime/src/evidence_projection_v3.rs
@@ -87,6 +87,9 @@ pub fn project_packet_v3(
         &packet_evidence_ranking_terms(&request.question, &request.option_ids),
         &packet.plan.obligations.claim_obligations,
     );
+    let _ = crate::agent::packet_accuracy_stage_ledger::record_public_projection_stage_from_env(
+        &evidence,
+    );
 
     let mut gaps = packet_gaps(packet);
     if evidence_was_bounded {
@@ -223,9 +226,15 @@ fn packet_evidence_selection(
             distinct.push((unit.kind, row, relevance, material_carrier_ranks));
         }
     }
+    merge_contained_packet_source_rows(&mut distinct);
 
     let distinct_rows = distinct.len();
-    let selected = select_packet_evidence_indices(&distinct);
+    let selected = select_packet_evidence_indices(
+        &distinct,
+        claim_obligations
+            .iter()
+            .any(|obligation| obligation.material),
+    );
     let mut rows = Vec::with_capacity(selected.len());
     for index in selected {
         let mut row = distinct[index].1.clone();
@@ -246,6 +255,7 @@ fn select_packet_evidence_indices(
         usize,
         Vec<usize>,
     )],
+    has_material_obligations: bool,
 ) -> Vec<usize> {
     // Close the mandatory identity envelope before transport compaction. One carrier covers each
     // material obligation before any repeated carrier can consume the bound. Within the source
@@ -261,6 +271,19 @@ fn select_packet_evidence_indices(
     let mandatory_relation_indices = packet_material_relation_indices(distinct);
     for index in &source_order {
         if mandatory_indices.contains(index) && selected_indices.insert(*index) {
+            selected.push(*index);
+        }
+    }
+
+    // Material callables can need more than one disjoint source window: the declaration, a
+    // prompt-relevant internal callsite, and the terminal behavior may be far apart. Keep every
+    // selected material window ahead of optional path diversity so byte compaction preserves the
+    // behavior-bearing summaries rather than an unrelated row that happened to use a new path.
+    for index in &source_order {
+        if selected.len() == PACKET_PUBLIC_EVIDENCE_ROWS_MAX_V3 {
+            break;
+        }
+        if !distinct[*index].3.is_empty() && selected_indices.insert(*index) {
             selected.push(*index);
         }
     }
@@ -335,11 +358,24 @@ fn select_packet_evidence_indices(
         &mut selected_indices,
     );
 
+    let qualified_relation_order = relation_order
+        .iter()
+        .copied()
+        .filter(|index| {
+            !has_material_obligations
+                || mandatory_relation_indices.contains(index)
+                || packet_relation_connects_selected_material_source(distinct, *index, &selected)
+        })
+        .collect::<Vec<_>>();
     let relation_floor = selected
         .len()
-        .saturating_add(PACKET_PUBLIC_RELATION_ROWS_TARGET_V3)
+        .saturating_add(
+            qualified_relation_order
+                .len()
+                .min(PACKET_PUBLIC_RELATION_ROWS_TARGET_V3),
+        )
         .min(PACKET_PUBLIC_EVIDENCE_ROWS_MAX_V3);
-    for index in &relation_order {
+    for index in &qualified_relation_order {
         if selected.len() == PACKET_PUBLIC_EVIDENCE_ROWS_MAX_V3 {
             break;
         }
@@ -360,7 +396,7 @@ fn select_packet_evidence_indices(
             .and_then(|summary| summary.as_str().split_once(" -[").map(|(caller, _)| caller));
         relation_callers.insert(caller);
     }
-    for index in &relation_order {
+    for index in &qualified_relation_order {
         if selected.len() >= relation_target {
             break;
         }
@@ -375,14 +411,19 @@ fn select_packet_evidence_indices(
         }
     }
     select_packet_evidence_kind(
-        &relation_order,
+        &qualified_relation_order,
         relation_target,
         &mut selected,
         &mut selected_indices,
     );
 
     let mut remainder = (0..distinct.len())
-        .filter(|index| !selected_indices.contains(index))
+        .filter(|index| {
+            !selected_indices.contains(index)
+                && (!has_material_obligations
+                    || distinct[*index].0 != SupportUnitKindDto::TypedGraphEdge
+                    || qualified_relation_order.contains(index))
+        })
         .collect::<Vec<_>>();
     remainder.sort_by_key(|index| {
         (
@@ -401,6 +442,151 @@ fn select_packet_evidence_indices(
         selected_indices.insert(index);
     }
     selected
+}
+
+type PacketEvidenceCandidateV3 = (
+    SupportUnitKindDto,
+    PacketEvidenceRowV3Dto,
+    usize,
+    Vec<usize>,
+);
+
+fn merge_contained_packet_source_rows(distinct: &mut Vec<PacketEvidenceCandidateV3>) {
+    let mut left = 0;
+    while left < distinct.len() {
+        let mut right = left + 1;
+        while right < distinct.len() {
+            let left_contains = packet_source_row_contains(&distinct[left].1, &distinct[right].1);
+            let right_contains = packet_source_row_contains(&distinct[right].1, &distinct[left].1);
+            if !left_contains && !right_contains {
+                right += 1;
+                continue;
+            }
+            let carrier_compatible = distinct[left].1.symbol_id == distinct[right].1.symbol_id
+                || distinct[left].3.is_empty()
+                || distinct[right].3.is_empty()
+                || distinct[left]
+                    .3
+                    .iter()
+                    .any(|rank| distinct[right].3.contains(rank));
+            if !carrier_compatible {
+                right += 1;
+                continue;
+            }
+
+            let prefer_right = match (distinct[left].3.is_empty(), distinct[right].3.is_empty()) {
+                (true, false) => true,
+                (false, true) => false,
+                _ => {
+                    right_contains
+                        && (!left_contains
+                            || packet_evidence_summary_len(&distinct[right].1)
+                                > packet_evidence_summary_len(&distinct[left].1))
+                }
+            };
+            if prefer_right {
+                let mut containing = distinct.remove(right);
+                merge_packet_evidence_candidate(&mut containing, &distinct[left]);
+                distinct[left] = containing;
+            } else {
+                let contained = distinct.remove(right);
+                merge_packet_evidence_candidate(&mut distinct[left], &contained);
+            }
+        }
+        left += 1;
+    }
+}
+
+fn packet_source_row_contains(
+    containing: &PacketEvidenceRowV3Dto,
+    contained: &PacketEvidenceRowV3Dto,
+) -> bool {
+    containing.kind == EvidenceKindV3Dto::ExactSource
+        && contained.kind == EvidenceKindV3Dto::ExactSource
+        && containing.path == contained.path
+        && containing
+            .start_line
+            .zip(containing.end_line)
+            .zip(contained.start_line.zip(contained.end_line))
+            .is_some_and(|((outer_start, outer_end), (inner_start, inner_end))| {
+                outer_start <= inner_start && outer_end >= inner_end
+            })
+}
+
+fn packet_relation_connects_selected_material_source(
+    distinct: &[PacketEvidenceCandidateV3],
+    relation_index: usize,
+    selected: &[usize],
+) -> bool {
+    let relation = &distinct[relation_index].1;
+    let Some((caller, target)) = packet_relation_endpoints(relation) else {
+        return false;
+    };
+    selected.iter().any(|source_index| {
+        let (_, source, _, carrier_ranks) = &distinct[*source_index];
+        if carrier_ranks.is_empty()
+            || distinct[*source_index].0 != SupportUnitKindDto::SourceRange
+            || relation.path != source.path
+        {
+            return false;
+        }
+        let source_words: HashSet<String> = source
+            .summary
+            .as_ref()
+            .map(|summary| {
+                packet_relation_words(summary.as_str())
+                    .into_iter()
+                    .collect()
+            })
+            .unwrap_or_default();
+        !caller.is_empty()
+            && !target.is_empty()
+            && caller.iter().all(|word| source_words.contains(word))
+            && target.iter().all(|word| source_words.contains(word))
+    })
+}
+
+fn packet_relation_endpoints(row: &PacketEvidenceRowV3Dto) -> Option<(Vec<String>, Vec<String>)> {
+    let summary = row.summary.as_ref()?.as_str();
+    let (caller, relation) = summary.split_once(" -[")?;
+    let (_, target) = relation.split_once("]-> ")?;
+    Some((packet_relation_words(caller), packet_relation_words(target)))
+}
+
+fn packet_relation_words(value: &str) -> Vec<String> {
+    let mut normalized = String::with_capacity(value.len());
+    let mut previous_was_lower_or_digit = false;
+    for character in value.chars() {
+        if character.is_alphanumeric() {
+            if character.is_uppercase() && previous_was_lower_or_digit {
+                normalized.push(' ');
+            }
+            for lowercase in character.to_lowercase() {
+                normalized.push(lowercase);
+            }
+            previous_was_lower_or_digit = character.is_lowercase() || character.is_ascii_digit();
+        } else {
+            normalized.push(' ');
+            previous_was_lower_or_digit = false;
+        }
+    }
+    normalized.split_whitespace().map(str::to_owned).collect()
+}
+
+fn packet_evidence_summary_len(row: &PacketEvidenceRowV3Dto) -> usize {
+    row.summary
+        .as_ref()
+        .map_or(0, |summary| summary.as_str().len())
+}
+
+fn merge_packet_evidence_candidate(
+    retained: &mut PacketEvidenceCandidateV3,
+    removed: &PacketEvidenceCandidateV3,
+) {
+    retained.2 = retained.2.max(removed.2);
+    retained.3.extend(removed.3.iter().copied());
+    retained.3.sort_unstable();
+    retained.3.dedup();
 }
 
 fn packet_evidence_kind_priority(kind: SupportUnitKindDto) -> u8 {
@@ -464,17 +650,22 @@ fn packet_material_carrier_ranks(
         .filter_map(|(index, obligation)| {
             let matches = match unit.kind {
                 SupportUnitKindDto::SourceRange | SupportUnitKindDto::SymbolLocation => {
-                    unit.symbol_id.as_deref().is_some_and(|symbol_id| {
+                    let node_matches = unit.symbol_id.as_deref().is_some_and(|symbol_id| {
                         obligation
                             .carrier_node_ids
                             .iter()
                             .any(|node_id| node_id.0 == symbol_id)
-                    }) || unit.path.as_deref().is_some_and(|path| {
-                        obligation
-                            .carrier_paths
-                            .iter()
-                            .any(|carrier_path| carrier_path == path)
-                    })
+                    });
+                    let path_is_only_available_identity = obligation.carrier_node_ids.is_empty()
+                        || unit.symbol_id.as_deref().is_none();
+                    node_matches
+                        || (path_is_only_available_identity
+                            && unit.path.as_deref().is_some_and(|path| {
+                                obligation
+                                    .carrier_paths
+                                    .iter()
+                                    .any(|carrier_path| carrier_path == path)
+                            }))
                 }
                 SupportUnitKindDto::TypedGraphEdge => {
                     unit.id.strip_prefix("edge:").is_some_and(|edge_id| {
@@ -1429,6 +1620,32 @@ mod tests {
     }
 
     #[test]
+    fn packet_evidence_deduplicates_contained_ranges_for_the_same_source_carrier() {
+        let mut inner = support_unit(SupportUnitKindDto::SourceRange);
+        inner.id = "inner".to_owned();
+        inner.path = Some("src/request.rs".to_owned());
+        inner.symbol_id = Some("Request.finalize".to_owned());
+        inner.start_line = Some(140);
+        inner.end_line = Some(150);
+        inner.snippet = Some("return body;".to_owned());
+
+        let mut outer = inner.clone();
+        outer.id = "outer".to_owned();
+        outer.start_line = Some(127);
+        outer.snippet = Some("fn finalize() { prepare(); return body; }".to_owned());
+
+        let evidence = packet_evidence_rows(&[inner, outer]);
+
+        assert_eq!(evidence.len(), 1);
+        assert_eq!(evidence[0].start_line, Some(127));
+        assert_eq!(evidence[0].end_line, Some(150));
+        assert_eq!(
+            evidence[0].summary.as_ref().map(|summary| summary.as_str()),
+            Some("fn finalize() { prepare(); return body; }")
+        );
+    }
+
+    #[test]
     fn packet_evidence_drops_a_location_when_the_same_symbol_has_source_content() {
         let mut location = support_unit(SupportUnitKindDto::SymbolLocation);
         location.path = Some("src/mapper.cs".to_owned());
@@ -1687,7 +1904,103 @@ mod tests {
             evidence[8].summary.as_ref().unwrap().as_str(),
             "Flow.dispatch -[CALL]-> Router.handle"
         );
-        assert_eq!(evidence.len(), PACKET_PUBLIC_EVIDENCE_ROWS_MAX_V3);
+        assert_eq!(
+            evidence.len(),
+            13,
+            "unrelated relations must not be added merely to fill the public row budget"
+        );
+    }
+
+    #[test]
+    fn packet_evidence_orders_every_material_callable_window_before_optional_context() {
+        let mut support = (0..10)
+            .map(|index| {
+                let mut unit = support_unit(SupportUnitKindDto::SourceRange);
+                unit.id = format!("optional-{index}");
+                unit.path = Some(format!("src/optional-{index}.rs"));
+                unit.symbol_id = Some(format!("Optional.stage{index}"));
+                unit.start_line = Some(1);
+                unit.end_line = Some(4);
+                unit.snippet = Some(format!("fn optional_{index}() {{}}"));
+                unit
+            })
+            .collect::<Vec<_>>();
+        for (id, start, end, snippet) in [
+            ("declaration", 105, 115, "send declaration and open"),
+            ("callsite", 147, 157, "await request stream pipe"),
+            ("terminal", 206, 216, "return streamed response"),
+        ] {
+            let mut unit = support_unit(SupportUnitKindDto::SourceRange);
+            unit.id = id.to_owned();
+            unit.path = Some("src/io_client.rs".to_owned());
+            unit.symbol_id = Some("IOClient.send".to_owned());
+            unit.start_line = Some(start);
+            unit.end_line = Some(end);
+            unit.snippet = Some(snippet.to_owned());
+            support.push(unit);
+        }
+
+        let mut obligation = material_obligation("transport-send");
+        obligation.carrier_node_ids = vec![NodeId("IOClient.send".to_owned())];
+        let evidence = packet_evidence_rows_with_obligations(
+            &support,
+            "Explain the transport send behavior.",
+            &[obligation],
+        );
+
+        assert_eq!(
+            evidence
+                .iter()
+                .take(3)
+                .map(|row| (row.symbol_id.as_ref().map(|id| id.as_str()), row.start_line))
+                .collect::<Vec<_>>(),
+            [
+                (Some("IOClient.send"), Some(105)),
+                (Some("IOClient.send"), Some(147)),
+                (Some("IOClient.send"), Some(206)),
+            ]
+        );
+    }
+
+    #[test]
+    fn packet_evidence_admits_only_relations_that_connect_retained_material_source() {
+        let mut source = support_unit(SupportUnitKindDto::SourceRange);
+        source.id = "client-get".to_owned();
+        source.path = Some("src/client.dart".to_owned());
+        source.symbol_id = Some("Client.get".to_owned());
+        source.start_line = Some(20);
+        source.end_line = Some(30);
+        source.snippet =
+            Some("get(uri, {headers}) => _withClient(client => client.get(uri));".to_owned());
+
+        let relation = |id: &str, path: &str, caller: &str, target: &str| {
+            let mut unit = support_unit(SupportUnitKindDto::TypedGraphEdge);
+            unit.id = id.to_owned();
+            unit.path = Some(path.to_owned());
+            unit.from_symbol = Some(caller.to_owned());
+            unit.edge_kind = Some("CALL".to_owned());
+            unit.to_symbol = Some(target.to_owned());
+            unit
+        };
+        let support = vec![
+            source,
+            relation("get-edge", "src/client.dart", "get", "_withClient"),
+            relation("head-edge", "src/client.dart", "head", "_withClient"),
+            relation("patch-edge", "src/client.dart", "patch", "_sendUnstreamed"),
+            relation("adapter-edge", "src/adapter.dart", "Adapter.send", "method"),
+        ];
+        let mut obligation = material_obligation("client-public-interface");
+        obligation.carrier_node_ids = vec![NodeId("Client.get".to_owned())];
+
+        let evidence =
+            packet_evidence_rows_with_obligations(&support, "Explain Client.get.", &[obligation]);
+        let relations = evidence
+            .iter()
+            .filter(|row| row.kind == EvidenceKindV3Dto::GraphRelation)
+            .filter_map(|row| row.summary.as_ref().map(|summary| summary.as_str()))
+            .collect::<Vec<_>>();
+
+        assert_eq!(relations, ["get -[CALL]-> _withClient"]);
     }
 
     #[test]
@@ -1761,7 +2074,11 @@ mod tests {
         assert!(symbols.contains("Command.route"));
         assert!(summaries.contains("Loop.drive -[CALL]-> Loop.tick0"));
         assert!(summaries.contains("Command.route -[CALL]-> Command.check"));
-        assert_eq!(evidence.len(), PACKET_PUBLIC_EVIDENCE_ROWS_MAX_V3);
+        assert_eq!(
+            evidence.len(),
+            10,
+            "only the two material relation witnesses may accompany the eight source rows"
+        );
     }
 
     #[test]

--- a/crates/codestory-runtime/src/evidence_projection_v3.rs
+++ b/crates/codestory-runtime/src/evidence_projection_v3.rs
@@ -275,19 +275,6 @@ fn select_packet_evidence_indices(
         }
     }
 
-    // A typed edge can be the only public witness for a material transition. Keep one such
-    // witness immediately after the best source carrier for each obligation. The transport
-    // compactor retains a relevance-ordered summary prefix, so putting mandatory relations after
-    // every repeated source window can preserve the edge locator while erasing the edge text.
-    for index in &relation_order {
-        if selected.len() == PACKET_PUBLIC_EVIDENCE_ROWS_MAX_V3 {
-            break;
-        }
-        if mandatory_relation_indices.contains(index) && selected_indices.insert(*index) {
-            selected.push(*index);
-        }
-    }
-
     // Material callables can need more than one disjoint source window: the declaration, a
     // prompt-relevant internal callsite, and the terminal behavior may be far apart. Keep every
     // selected material window ahead of optional path diversity so byte compaction preserves the
@@ -1965,9 +1952,8 @@ mod tests {
             "a material source carrier must retain more than the optional 512-byte prefix"
         );
         assert_eq!(
-            evidence[2].summary.as_ref().unwrap().as_str(),
-            "Flow.dispatch -[CALL]-> Router.handle",
-            "the material edge follows the best material source carriers before optional fill"
+            evidence[8].summary.as_ref().unwrap().as_str(),
+            "Flow.dispatch -[CALL]-> Router.handle"
         );
         assert_eq!(
             evidence.len(),
@@ -2075,13 +2061,9 @@ mod tests {
 
         assert_eq!(evidence.len(), PACKET_PUBLIC_EVIDENCE_ROWS_MAX_V3);
         assert_eq!(
-            evidence[1].kind,
+            evidence[11].kind,
             EvidenceKindV3Dto::GraphRelation,
-            "the mandatory relation remains immediately after the best material source so output compaction cannot erase its witness text"
-        );
-        assert_eq!(
-            evidence[1].summary.as_ref().map(|summary| summary.as_str()),
-            Some("IOClient.send -[CALL]-> Transport.send")
+            "the mandatory relation remains ahead of optional source fill"
         );
         assert_eq!(
             evidence[12..]

--- a/crates/codestory-runtime/src/evidence_projection_v3.rs
+++ b/crates/codestory-runtime/src/evidence_projection_v3.rs
@@ -275,6 +275,19 @@ fn select_packet_evidence_indices(
         }
     }
 
+    // A typed edge can be the only public witness for a material transition. Keep one such
+    // witness immediately after the best source carrier for each obligation. The transport
+    // compactor retains a relevance-ordered summary prefix, so putting mandatory relations after
+    // every repeated source window can preserve the edge locator while erasing the edge text.
+    for index in &relation_order {
+        if selected.len() == PACKET_PUBLIC_EVIDENCE_ROWS_MAX_V3 {
+            break;
+        }
+        if mandatory_relation_indices.contains(index) && selected_indices.insert(*index) {
+            selected.push(*index);
+        }
+    }
+
     // Material callables can need more than one disjoint source window: the declaration, a
     // prompt-relevant internal callsite, and the terminal behavior may be far apart. Keep every
     // selected material window ahead of optional path diversity so byte compaction preserves the
@@ -297,7 +310,10 @@ fn select_packet_evidence_indices(
         })
         .collect::<HashSet<_>>();
 
-    let mut source_count = selected.len();
+    let mut source_count = selected
+        .iter()
+        .filter(|index| distinct[**index].0 == SupportUnitKindDto::SourceRange)
+        .count();
     for index in &source_order {
         if source_count >= PACKET_PUBLIC_SOURCE_ROWS_TARGET_V3 {
             break;
@@ -368,13 +384,16 @@ fn select_packet_evidence_indices(
                 || packet_relation_connects_selected_material_source(distinct, *index, &selected)
         })
         .collect::<Vec<_>>();
+    let selected_relation_count = selected
+        .iter()
+        .filter(|index| distinct[**index].0 == SupportUnitKindDto::TypedGraphEdge)
+        .count();
+    let desired_relation_count = qualified_relation_order
+        .len()
+        .min(PACKET_PUBLIC_RELATION_ROWS_TARGET_V3);
     let relation_floor = selected
         .len()
-        .saturating_add(
-            qualified_relation_order
-                .len()
-                .min(PACKET_PUBLIC_RELATION_ROWS_TARGET_V3),
-        )
+        .saturating_add(desired_relation_count.saturating_sub(selected_relation_count))
         .min(PACKET_PUBLIC_EVIDENCE_ROWS_MAX_V3);
     for index in &qualified_relation_order {
         if selected.len() == PACKET_PUBLIC_EVIDENCE_ROWS_MAX_V3 {
@@ -1946,8 +1965,9 @@ mod tests {
             "a material source carrier must retain more than the optional 512-byte prefix"
         );
         assert_eq!(
-            evidence[8].summary.as_ref().unwrap().as_str(),
-            "Flow.dispatch -[CALL]-> Router.handle"
+            evidence[2].summary.as_ref().unwrap().as_str(),
+            "Flow.dispatch -[CALL]-> Router.handle",
+            "the material edge follows the best material source carriers before optional fill"
         );
         assert_eq!(
             evidence.len(),
@@ -2055,9 +2075,13 @@ mod tests {
 
         assert_eq!(evidence.len(), PACKET_PUBLIC_EVIDENCE_ROWS_MAX_V3);
         assert_eq!(
-            evidence[11].kind,
+            evidence[1].kind,
             EvidenceKindV3Dto::GraphRelation,
-            "the mandatory relation remains ahead of optional source fill"
+            "the mandatory relation remains immediately after the best material source so output compaction cannot erase its witness text"
+        );
+        assert_eq!(
+            evidence[1].summary.as_ref().map(|summary| summary.as_str()),
+            Some("IOClient.send -[CALL]-> Transport.send")
         );
         assert_eq!(
             evidence[12..]

--- a/crates/codestory-runtime/src/evidence_projection_v3.rs
+++ b/crates/codestory-runtime/src/evidence_projection_v3.rs
@@ -1171,12 +1171,14 @@ const PACKET_MATERIAL_CARRIER_SUMMARY_MAX_BYTES_V3: usize = 2 * 1024;
 
 fn packet_evidence_summary(unit: &SupportUnitDto, material_carrier: bool) -> Option<SummaryTextV3> {
     let text = match unit.kind {
-        SupportUnitKindDto::SourceRange => unit
-            .snippet
-            .as_deref()
-            .filter(|value| !value.trim().is_empty())
-            .unwrap_or(&unit.summary)
-            .to_owned(),
+        // A source row carries two independent facts: which qualified carrier the bytes belong
+        // to, and the exact bytes themselves. `SupportUnitDto` retains both, but the public v3
+        // projection used to replace the qualified source description with the snippet. Methods
+        // then reached the model as an opaque numeric symbol id plus an ownerless declaration,
+        // losing the identity that made the source material in the first place. Keep the rendered
+        // source identity beside the bytes. This exposes evidence already present in the support
+        // unit; it does not expose planner obligations, proof state, or ranking metadata.
+        SupportUnitKindDto::SourceRange => packet_source_evidence_summary(unit),
         SupportUnitKindDto::TypedGraphEdge => {
             match (
                 unit.from_symbol.as_deref(),
@@ -1196,6 +1198,22 @@ fn packet_evidence_summary(unit: &SupportUnitDto, material_carrier: bool) -> Opt
         PACKET_EVIDENCE_SUMMARY_MAX_BYTES_V3
     };
     Some(summary_text_bounded(&text, maximum))
+}
+
+fn packet_source_evidence_summary(unit: &SupportUnitDto) -> String {
+    let source = unit
+        .snippet
+        .as_deref()
+        .filter(|value| !value.trim().is_empty());
+    let identity = (!unit.summary.trim().is_empty()).then_some(unit.summary.trim());
+    match (identity, source) {
+        (Some(identity), Some(source)) if identity != source.trim() => {
+            format!("{identity}\n\n{source}")
+        }
+        (Some(identity), _) => identity.to_owned(),
+        (None, Some(source)) => source.to_owned(),
+        (None, None) => String::new(),
+    }
 }
 
 fn packet_symbol_location_summary(unit: &SupportUnitDto) -> String {
@@ -1547,7 +1565,7 @@ mod tests {
     fn packet_evidence_keeps_ranked_source_and_relation_context_in_compact_identities() {
         let mut source = support_unit(SupportUnitKindDto::SourceRange);
         source.id = "repository-shaped-source-id".to_owned();
-        source.summary = "source range".to_owned();
+        source.summary = "source for Useful.run at src/useful.rs:7-9".to_owned();
         source.snippet = Some(format!("fn useful() {{}}\n{}", "x".repeat(700)));
         source.path = Some("src/useful.rs".to_owned());
         let source = packet_evidence_row(7, &source, false).expect("source evidence");
@@ -1559,7 +1577,7 @@ mod tests {
                 .as_ref()
                 .unwrap()
                 .as_str()
-                .starts_with("fn useful()")
+                .starts_with("source for Useful.run at src/useful.rs:7-9\n\nfn useful()")
         );
 
         let mut relation = support_unit(SupportUnitKindDto::TypedGraphEdge);
@@ -1589,7 +1607,11 @@ mod tests {
             rows.iter()
                 .map(|row| row.summary.as_ref().unwrap().as_str())
                 .collect::<Vec<_>>(),
-            ["fn useful() {}", "caller -[CALL]-> callee", "location"]
+            [
+                "fixture\n\nfn useful() {}",
+                "caller -[CALL]-> callee",
+                "location"
+            ]
         );
         assert_eq!(
             rows.iter()
@@ -1664,7 +1686,7 @@ mod tests {
         assert_eq!(evidence[0].end_line, Some(150));
         assert_eq!(
             evidence[0].summary.as_ref().map(|summary| summary.as_str()),
-            Some("fn finalize() { prepare(); return body; }")
+            Some("fixture\n\nfn finalize() { prepare(); return body; }")
         );
     }
 
@@ -1686,7 +1708,7 @@ mod tests {
         assert_eq!(evidence.len(), 1);
         assert_eq!(
             evidence[0].summary.as_ref().unwrap().as_str(),
-            "public object Map(...) => MapCore(...);"
+            "fixture\n\npublic object Map(...) => MapCore(...);"
         );
     }
 
@@ -1774,22 +1796,22 @@ mod tests {
                 .filter_map(|row| row.summary.as_ref().map(|summary| summary.as_str()))
                 .collect::<Vec<_>>(),
             [
-                "fn source_0() {}",
-                "fn source_1() {}",
-                "fn source_2() {}",
-                "fn source_3() {}",
-                "fn source_4() {}",
-                "fn source_5() {}",
-                "fn source_6() {}",
-                "fn source_7() {}",
+                "fixture\n\nfn source_0() {}",
+                "fixture\n\nfn source_1() {}",
+                "fixture\n\nfn source_2() {}",
+                "fixture\n\nfn source_3() {}",
+                "fixture\n\nfn source_4() {}",
+                "fixture\n\nfn source_5() {}",
+                "fixture\n\nfn source_6() {}",
+                "fixture\n\nfn source_7() {}",
                 "caller-0 -[CALL]-> callee-0",
                 "caller-1 -[CALL]-> callee-1",
                 "caller-2 -[CALL]-> callee-2",
                 "caller-3 -[CALL]-> callee-3",
-                "fn source_8() {}",
-                "fn source_9() {}",
-                "fn source_10() {}",
-                "fn source_11() {}",
+                "fixture\n\nfn source_8() {}",
+                "fixture\n\nfn source_9() {}",
+                "fixture\n\nfn source_10() {}",
+                "fixture\n\nfn source_11() {}",
             ]
         );
         assert!(packet_evidence_was_bounded(&support));

--- a/crates/codestory-runtime/src/index_incremental.rs
+++ b/crates/codestory-runtime/src/index_incremental.rs
@@ -29,7 +29,8 @@ use crate::{
 use crate::{publication::run_incremental_staged_store_hook, test_sidecar_runtime_from_env};
 use codestory_contracts::api::{
     ApiError, ApiErrorDetails, AppEventPayload, FileCoverageDiagnosticDto,
-    IncrementalPlanProbeOutcomeDto, IndexingPhaseTimings,
+    IncrementalCoreWallTimings, IncrementalPlanProbeOutcomeDto, IncrementalScheduledPathActionDto,
+    IncrementalScheduledPathDto, IncrementalScheduledPathReasonDto, IndexingPhaseTimings,
 };
 use codestory_contracts::events::{Event, EventBus};
 use codestory_contracts::graph::FileCoverageReason;
@@ -38,7 +39,8 @@ use codestory_indexer::{
 };
 use codestory_store::{
     CURRENT_SCHEMA_VERSION, IndexPublicationMode, IndexPublicationRecord, SnapshotStore,
-    SourcePolicyExclusionRecord, StagedSnapshot, StagedSnapshotFinalizeStats, Store,
+    SourcePolicyExclusionRecord, StagedSnapshot, StagedSnapshotFinalizeStats,
+    StagedSnapshotPublishStats, Store,
 };
 use codestory_workspace::{
     OversizedSourceExclusionCandidate, RefreshExecutionPlan, SourceIndexPolicy,
@@ -47,7 +49,7 @@ use codestory_workspace::{
 use crossbeam_channel::{Receiver, Sender};
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use uuid::Uuid;
 
 #[cfg(test)]
@@ -418,7 +420,14 @@ fn incremental_execution_plan(
     root: &Path,
     storage_path: &Path,
     source_index_policy: &SourceIndexPolicy,
-) -> Result<(RefreshExecutionPlan, Vec<OversizedSourceExclusionCandidate>), ApiError> {
+) -> Result<
+    (
+        RefreshExecutionPlan,
+        Vec<OversizedSourceExclusionCandidate>,
+        Vec<IncrementalScheduledPathDto>,
+    ),
+    ApiError,
+> {
     let workspace = runtime_workspace_manifest(root, storage_path)
         .map_err(|error| ApiError::internal(format!("Failed to open project: {error}")))?;
     let refresh_inputs = workspace_refresh_inputs(staged.store_mut())?;
@@ -426,9 +435,12 @@ fn incremental_execution_plan(
         .build_execution_outcome_with_policy(&refresh_inputs, source_index_policy)
         .map_err(|error| ApiError::internal(format!("Failed to generate refresh info: {error}")))?;
     if policy_refresh.refresh.inventory_outcome == WorkspaceInventoryOutcome::Complete {
+        let scheduled_paths =
+            incremental_scheduled_paths(root, &refresh_inputs, &policy_refresh.refresh.plan);
         return Ok((
             policy_refresh.refresh.plan,
             policy_refresh.policy_exclusions,
+            scheduled_paths,
         ));
     }
     let reason =
@@ -466,6 +478,63 @@ fn incremental_execution_plan(
         ),
         gaps,
     ))
+}
+
+fn incremental_scheduled_paths(
+    root: &Path,
+    refresh_inputs: &codestory_contracts::workspace::RefreshInputs,
+    execution_plan: &RefreshExecutionPlan,
+) -> Vec<IncrementalScheduledPathDto> {
+    let stored = refresh_inputs.inventory_map();
+    let stored_by_path = stored
+        .values()
+        .map(|state| (runtime_relative_path(root, &state.path), state))
+        .collect::<HashMap<_, _>>();
+    let stored_by_id = stored
+        .values()
+        .map(|state| (state.id, state))
+        .collect::<HashMap<_, _>>();
+    let mut scheduled = execution_plan
+        .files_to_index
+        .iter()
+        .map(|path| {
+            let path = runtime_relative_path(root, path);
+            let reason = match stored_by_path.get(&path) {
+                None => IncrementalScheduledPathReasonDto::NewFile,
+                Some(state) if state.retry_required => {
+                    IncrementalScheduledPathReasonDto::RetryRequired
+                }
+                Some(state) if !state.indexed => IncrementalScheduledPathReasonDto::NotIndexed,
+                Some(state) if !state.complete => IncrementalScheduledPathReasonDto::Incomplete,
+                Some(_) => IncrementalScheduledPathReasonDto::SourceIdentityChanged,
+            };
+            IncrementalScheduledPathDto {
+                path,
+                action: IncrementalScheduledPathActionDto::Index,
+                reason,
+            }
+        })
+        .collect::<Vec<_>>();
+    scheduled.extend(execution_plan.files_to_remove.iter().map(|file_id| {
+        IncrementalScheduledPathDto {
+            path: stored_by_id
+                .get(file_id)
+                .map(|state| runtime_relative_path(root, &state.path))
+                .unwrap_or_else(|| format!("file-id:{file_id}")),
+            action: IncrementalScheduledPathActionDto::Remove,
+            reason: IncrementalScheduledPathReasonDto::VerifiedAbsent,
+        }
+    }));
+    scheduled.sort_by(|left, right| {
+        let action_rank = |action| match action {
+            IncrementalScheduledPathActionDto::Index => 0_u8,
+            IncrementalScheduledPathActionDto::Remove => 1_u8,
+        };
+        left.path
+            .cmp(&right.path)
+            .then_with(|| action_rank(left.action).cmp(&action_rank(right.action)))
+    });
+    scheduled
 }
 
 struct IncrementalSemanticPlan {
@@ -697,12 +766,85 @@ struct PreparedIncrementalRefresh {
     semantic_refresh_scope: HashSet<codestory_contracts::graph::NodeId>,
     policy_exclusions: Vec<OversizedSourceExclusionCandidate>,
     probe: IncrementalPlanProbe,
+    wall: IncrementalCoreWallDurations,
+}
+
+#[derive(Debug, Default)]
+struct IncrementalCoreWallDurations {
+    discovery_and_scheduling: Duration,
+    stage_open: Duration,
+    parse_and_extraction: Duration,
+    core_staging_and_mutation: Duration,
+    candidate_sealing: Duration,
+    scheduled_paths: Vec<IncrementalScheduledPathDto>,
+}
+
+impl IncrementalCoreWallDurations {
+    fn finish(
+        mut self,
+        core_refresh: Duration,
+        commit: Option<(Duration, &StagedSnapshotPublishStats)>,
+    ) -> IncrementalCoreWallTimings {
+        let mut pointer_publication = Duration::ZERO;
+        let mut lock_wait = Duration::ZERO;
+        if let Some((commit_wall, publish_stats)) = commit {
+            let seal_ms = publish_stats
+                .sqlite_checkpoint_ms
+                .unwrap_or_default()
+                .saturating_add(publish_stats.sqlite_sync_ms.unwrap_or_default())
+                .saturating_add(publish_stats.core_promotion.candidate_validation_ms);
+            self.candidate_sealing = self
+                .candidate_sealing
+                .saturating_add(Duration::from_millis(u64::from(seal_ms)));
+            lock_wait = Duration::from_millis(u64::from(publish_stats.core_promotion.lock_wait_ms));
+            pointer_publication = commit_wall
+                .saturating_sub(Duration::from_millis(u64::from(seal_ms)))
+                .saturating_sub(lock_wait);
+        }
+        let named = self
+            .discovery_and_scheduling
+            .saturating_add(self.stage_open)
+            .saturating_add(self.parse_and_extraction)
+            .saturating_add(self.core_staging_and_mutation)
+            .saturating_add(self.candidate_sealing)
+            .saturating_add(pointer_publication)
+            .saturating_add(lock_wait);
+        let mut receipt = IncrementalCoreWallTimings {
+            core_refresh_ms: clamp_u128_to_u32(core_refresh.as_millis()),
+            discovery_and_scheduling_ms: clamp_u128_to_u32(
+                self.discovery_and_scheduling.as_millis(),
+            ),
+            stage_open_ms: clamp_u128_to_u32(self.stage_open.as_millis()),
+            parse_and_extraction_ms: clamp_u128_to_u32(self.parse_and_extraction.as_millis()),
+            core_staging_and_mutation_ms: clamp_u128_to_u32(
+                self.core_staging_and_mutation.as_millis(),
+            ),
+            candidate_sealing_ms: clamp_u128_to_u32(self.candidate_sealing.as_millis()),
+            pointer_publication_ms: clamp_u128_to_u32(pointer_publication.as_millis()),
+            lock_wait_ms: clamp_u128_to_u32(lock_wait.as_millis()),
+            unattributed_ms: clamp_u128_to_u32(core_refresh.saturating_sub(named).as_millis()),
+            scheduled_paths: self.scheduled_paths,
+        };
+        let named_ms = receipt
+            .discovery_and_scheduling_ms
+            .saturating_add(receipt.stage_open_ms)
+            .saturating_add(receipt.parse_and_extraction_ms)
+            .saturating_add(receipt.core_staging_and_mutation_ms)
+            .saturating_add(receipt.candidate_sealing_ms)
+            .saturating_add(receipt.pointer_publication_ms)
+            .saturating_add(receipt.lock_wait_ms);
+        receipt.unattributed_ms = receipt.core_refresh_ms.saturating_sub(named_ms);
+        receipt
+    }
 }
 
 /// Either the staged republication is required, or the published core already
 /// satisfies the request and nothing may be written.
 enum IncrementalRefreshPreparation {
-    Unchanged(IncrementalPlanProbe),
+    Unchanged {
+        probe: IncrementalPlanProbe,
+        wall: IncrementalCoreWallDurations,
+    },
     Prepared(Box<PreparedIncrementalRefresh>),
 }
 
@@ -714,20 +856,26 @@ fn prepare_incremental_refresh(
     runtime: &codestory_retrieval::SidecarRuntimeConfig,
     source_index_policy: &SourceIndexPolicy,
 ) -> Result<IncrementalRefreshPreparation, ApiError> {
+    let mut wall = IncrementalCoreWallDurations::default();
+    let discovery_started = Instant::now();
     ensure_incremental_refresh_compatible(root, storage_path)?;
     ensure_indexing_active(cancel_token)?;
     let probe = probe_incremental_plan(root, storage_path, source_index_policy);
     // Cancellation raised during the probe still cancels the request, so a
     // short-circuit never reports success for an abandoned refresh.
     ensure_indexing_active(cancel_token)?;
+    wall.discovery_and_scheduling = discovery_started.elapsed();
     if probe.short_circuited() {
-        return Ok(IncrementalRefreshPreparation::Unchanged(probe));
+        return Ok(IncrementalRefreshPreparation::Unchanged { probe, wall });
     }
+    let stage_open_started = Instant::now();
     let staged = SnapshotStore::clone_live_to_staged(storage_path).map_err(|error| {
         ApiError::internal(format!(
             "Failed to clone live storage for incremental build: {error}"
         ))
     })?;
+    wall.stage_open = stage_open_started.elapsed();
+    let staging_started = Instant::now();
     let mut preparation = StagedPreparation::new(staged);
     let previous_publication = preparation
         .staged_mut()
@@ -772,14 +920,25 @@ fn prepare_incremental_refresh(
                 "Failed to invalidate staged derived index snapshots: {error}"
             ))
         })?;
-    let (execution_plan, mut policy_exclusions) = incremental_execution_plan(
+    wall.core_staging_and_mutation = staging_started.elapsed();
+    let discovery_started = Instant::now();
+    let (execution_plan, mut policy_exclusions, scheduled_paths) = incremental_execution_plan(
         preparation.staged_mut(),
         root,
         storage_path,
         source_index_policy,
     )?;
+    wall.discovery_and_scheduling = wall
+        .discovery_and_scheduling
+        .saturating_add(discovery_started.elapsed());
+    wall.scheduled_paths = scheduled_paths;
+    let staging_started = Instant::now();
     let mut semantic_plan =
         plan_incremental_semantics(preparation.staged_mut(), root, &execution_plan)?;
+    wall.core_staging_and_mutation = wall
+        .core_staging_and_mutation
+        .saturating_add(staging_started.elapsed());
+    let parse_started = Instant::now();
     let stats = run_incremental_indexer(
         preparation.staged_mut(),
         IncrementalIndexerContext {
@@ -792,6 +951,8 @@ fn prepare_incremental_refresh(
         &mut semantic_plan,
         &mut policy_exclusions,
     )?;
+    wall.parse_and_extraction = parse_started.elapsed();
+    let staging_started = Instant::now();
     validate_incremental_refresh_coverage(preparation.staged_mut(), root)?;
     rematerialize_staged_proof_resolution_projection(
         preparation.staged_mut(),
@@ -816,6 +977,10 @@ fn prepare_incremental_refresh(
         },
     )?;
     ensure_indexing_active(cancel_token)?;
+    wall.core_staging_and_mutation = wall
+        .core_staging_and_mutation
+        .saturating_add(staging_started.elapsed());
+    let sealing_started = Instant::now();
     let finalize_stats = preparation
         .staged_mut()
         .snapshots()
@@ -836,6 +1001,7 @@ fn prepare_incremental_refresh(
             ))
         })?;
     ensure_indexing_active(cancel_token)?;
+    wall.candidate_sealing = sealing_started.elapsed();
     Ok(IncrementalRefreshPreparation::Prepared(Box::new(
         PreparedIncrementalRefresh {
             staged: preparation.release(),
@@ -847,6 +1013,7 @@ fn prepare_incremental_refresh(
             semantic_refresh_scope,
             policy_exclusions,
             probe,
+            wall,
         },
     )))
 }
@@ -859,6 +1026,7 @@ fn run_incremental_indexing_common(
     runtime: &codestory_retrieval::SidecarRuntimeConfig,
     source_index_policy: &SourceIndexPolicy,
 ) -> Result<IndexingRunSummary, ApiError> {
+    let core_started = Instant::now();
     let prepared = prepare_incremental_refresh(
         root,
         storage_path,
@@ -868,8 +1036,11 @@ fn run_incremental_indexing_common(
         source_index_policy,
     )?;
     let prepared = match prepared {
-        IncrementalRefreshPreparation::Unchanged(probe) => {
-            return Ok(unchanged_incremental_run_summary(probe));
+        IncrementalRefreshPreparation::Unchanged { probe, wall } => {
+            return Ok(unchanged_incremental_run_summary(
+                probe,
+                wall.finish(core_started.elapsed(), None),
+            ));
         }
         IncrementalRefreshPreparation::Prepared(prepared) => prepared,
     };
@@ -883,7 +1054,9 @@ fn run_incremental_indexing_common(
         semantic_refresh_scope: llm_refresh_scope,
         policy_exclusions,
         probe,
+        mut wall,
     } = *prepared;
+    let staging_started = Instant::now();
     let workspace = match runtime_workspace_manifest(root, storage_path) {
         Ok(workspace) => workspace,
         Err(error) => {
@@ -929,8 +1102,13 @@ fn run_incremental_indexing_common(
     }
     let prepared_commit =
         PreparedCoreCommit::new(staged, prepared_search_state, storage_path, &publication);
+    wall.core_staging_and_mutation = wall
+        .core_staging_and_mutation
+        .saturating_add(staging_started.elapsed());
+    let commit_started = Instant::now();
     let (prepared_search_state, staged_publish_stats, publish_duration) =
         prepared_commit.commit(CoreCommitMode::Incremental, cancel_token)?;
+    let commit_wall = commit_started.elapsed();
     let mut phase_timings = core_indexing_phase_timings(
         &index_stats,
         staged_finalize_stats,
@@ -940,6 +1118,10 @@ fn run_incremental_indexing_common(
         staged_semantic_stats.semantic_context_index_ms,
     );
     phase_timings.incremental_plan_probe = Some(incremental_plan_probe_timings(&probe));
+    phase_timings.incremental_core_wall = Some(wall.finish(
+        core_started.elapsed(),
+        Some((commit_wall, &staged_publish_stats)),
+    ));
     Ok(IndexingRunSummary {
         phase_timings,
         staged_semantic_stats,
@@ -954,9 +1136,13 @@ fn run_incremental_indexing_common(
 /// Summarize a refresh that proved the published core already satisfied the
 /// request. No staged image was opened, so no publication or search generation
 /// was written and the previous ones stay pinned.
-fn unchanged_incremental_run_summary(probe: IncrementalPlanProbe) -> IndexingRunSummary {
+fn unchanged_incremental_run_summary(
+    probe: IncrementalPlanProbe,
+    wall: IncrementalCoreWallTimings,
+) -> IndexingRunSummary {
     let phase_timings = IndexingPhaseTimings {
         incremental_plan_probe: Some(incremental_plan_probe_timings(&probe)),
+        incremental_core_wall: Some(wall),
         ..IndexingPhaseTimings::default()
     };
     IndexingRunSummary {

--- a/crates/codestory-runtime/src/index_timings.rs
+++ b/crates/codestory-runtime/src/index_timings.rs
@@ -385,6 +385,7 @@ pub(super) fn core_promotion_timings(
 ) -> CorePromotionTimings {
     CorePromotionTimings {
         total_ms: stats.total_ms,
+        lock_wait_ms: stats.lock_wait_ms,
         lock_recovery_ms: stats.lock_recovery_ms,
         candidate_validation_ms: stats.candidate_validation_ms,
         previous_validation_ms: stats.previous_validation_ms,

--- a/crates/codestory-runtime/src/tests.rs
+++ b/crates/codestory-runtime/src/tests.rs
@@ -9355,6 +9355,32 @@ fn changed_incremental_refresh_publishes_and_reports_the_probe_as_overhead() {
         timings.cache_refresh_ms.is_some(),
         "a changed workspace must still run the runtime cache rebuild"
     );
+    let wall = timings
+        .incremental_core_wall
+        .as_ref()
+        .expect("a changed incremental refresh must emit one exclusive core wall receipt");
+    assert_eq!(
+        wall.discovery_and_scheduling_ms
+            .saturating_add(wall.stage_open_ms)
+            .saturating_add(wall.parse_and_extraction_ms)
+            .saturating_add(wall.core_staging_and_mutation_ms)
+            .saturating_add(wall.candidate_sealing_ms)
+            .saturating_add(wall.pointer_publication_ms)
+            .saturating_add(wall.lock_wait_ms)
+            .saturating_add(wall.unattributed_ms),
+        wall.core_refresh_ms,
+        "exclusive incremental core phases must reconcile to the outer core wall"
+    );
+    assert_eq!(wall.scheduled_paths.len(), 1);
+    assert_eq!(wall.scheduled_paths[0].path, "lib.rs");
+    assert_eq!(
+        wall.scheduled_paths[0].action,
+        codestory_contracts::api::IncrementalScheduledPathActionDto::Index
+    );
+    assert_eq!(
+        wall.scheduled_paths[0].reason,
+        codestory_contracts::api::IncrementalScheduledPathReasonDto::SourceIdentityChanged
+    );
 
     let storage = Storage::open(&fixture.storage_path).expect("open post-refresh storage");
     let published = storage

--- a/crates/codestory-store/src/snapshot_store.rs
+++ b/crates/codestory-store/src/snapshot_store.rs
@@ -357,7 +357,8 @@ mod tests {
 
     fn named_promotion_ms(stats: &CorePromotionStats) -> u32 {
         stats
-            .lock_recovery_ms
+            .lock_wait_ms
+            .saturating_add(stats.lock_recovery_ms)
             .saturating_add(stats.candidate_validation_ms)
             .saturating_add(stats.previous_validation_ms)
             .saturating_add(stats.rollback_backup_copy_ms.unwrap_or_default())

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -191,6 +191,7 @@ pub struct RehydratedCacheRebaseStats {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct CorePromotionStats {
     pub total_ms: u32,
+    pub lock_wait_ms: u32,
     pub lock_recovery_ms: u32,
     pub candidate_validation_ms: u32,
     pub previous_validation_ms: u32,
@@ -220,6 +221,7 @@ struct PromotionJournalWriteStats {
 
 #[derive(Debug, Clone, Copy, Default)]
 struct CorePromotionDurations {
+    lock_wait: Duration,
     lock_recovery: Duration,
     candidate_validation: Duration,
     previous_validation: Duration,
@@ -244,6 +246,7 @@ impl CorePromotionDurations {
         promoted_validation: PromotedValidation,
     ) -> CorePromotionStats {
         let total_ms = duration_ms(total);
+        let lock_wait_ms = duration_ms(self.lock_wait);
         let lock_recovery_ms = duration_ms(self.lock_recovery);
         let candidate_validation_ms = duration_ms(self.candidate_validation);
         let previous_validation_ms = duration_ms(self.previous_validation);
@@ -256,7 +259,8 @@ impl CorePromotionDurations {
         let promoted_validation_ms = duration_ms(self.promoted_validation);
         let committed_journal_ms = duration_ms(self.committed_journal);
         let cleanup_ms = duration_ms(self.cleanup);
-        let named_ms = lock_recovery_ms
+        let named_ms = lock_wait_ms
+            .saturating_add(lock_recovery_ms)
             .saturating_add(candidate_validation_ms)
             .saturating_add(previous_validation_ms)
             .saturating_add(rollback_backup_copy_ms.unwrap_or_default())
@@ -270,6 +274,7 @@ impl CorePromotionDurations {
             .saturating_add(cleanup_ms);
         CorePromotionStats {
             total_ms,
+            lock_wait_ms,
             lock_recovery_ms,
             candidate_validation_ms,
             previous_validation_ms,
@@ -6234,8 +6239,10 @@ impl Storage {
         let promotion_started = Instant::now();
         let mut durations = CorePromotionDurations::default();
 
-        let lock_recovery_started = Instant::now();
+        let lock_wait_started = Instant::now();
         let _promotion_lock = PromotionLock::acquire(live_path)?;
+        durations.lock_wait = lock_wait_started.elapsed();
+        let lock_recovery_started = Instant::now();
         recover_interrupted_promotion_locked(live_path)?;
         if promotion_artifacts_exist(live_path) {
             return Err(promotion_error(format!(

--- a/crates/codestory-store/src/storage_impl/tests/mod.rs
+++ b/crates/codestory-store/src/storage_impl/tests/mod.rs
@@ -148,7 +148,8 @@ fn assert_no_sqlite_sidecars(path: &Path) {
 
 fn assert_core_promotion_stats_reconcile(stats: &CorePromotionStats) {
     let named_ms = stats
-        .lock_recovery_ms
+        .lock_wait_ms
+        .saturating_add(stats.lock_recovery_ms)
         .saturating_add(stats.candidate_validation_ms)
         .saturating_add(stats.previous_validation_ms)
         .saturating_add(stats.rollback_backup_copy_ms.unwrap_or_default())

--- a/scripts/codestory-agent-ab-benchmark.mjs
+++ b/scripts/codestory-agent-ab-benchmark.mjs
@@ -2980,6 +2980,97 @@ function benchmarkRunId(parts) {
   return parts.map(artifactNamePart).join("-");
 }
 
+function installedAgentTimingCohortId(dimensions) {
+  const requiredStrings = [
+    "execution_window_id",
+    "model",
+    "load_policy",
+    "task_id",
+  ];
+  for (const field of requiredStrings) {
+    if (typeof dimensions?.[field] !== "string" || !dimensions[field].trim()) {
+      throw new Error(`installed timing cohort ${field} is required`);
+    }
+  }
+  if (!Number.isInteger(dimensions?.repeat) || dimensions.repeat <= 0) {
+    throw new Error("installed timing cohort repeat must be a positive integer");
+  }
+  if (!dimensions.host || typeof dimensions.host !== "object" || Array.isArray(dimensions.host)) {
+    throw new Error("installed timing cohort host is required");
+  }
+  const host = Object.fromEntries([
+    "platform",
+    "arch",
+    "cpu_model",
+    "logical_cpu_count",
+    "total_memory_bytes",
+  ].map((field) => [field, dimensions.host[field] ?? null]));
+  return sha256Bytes(stableJsonForHash({
+    contract: "codestory.installed-agent-timing-cohort/v1",
+    execution_window_id: dimensions.execution_window_id,
+    host,
+    model: dimensions.model,
+    load_policy: dimensions.load_policy,
+    task_id: dimensions.task_id,
+    repeat: dimensions.repeat,
+  }));
+}
+
+function installedAgentTiming(values) {
+  if (!SHA256_PATTERN.test(String(values?.timing_cohort_id ?? ""))) {
+    throw new Error("installed timing cohort id must be a lowercase SHA-256 digest");
+  }
+  const fields = [
+    "agent_runner_ms",
+    "time_to_first_packet_ms",
+    "continuation_ms",
+    "whole_task_wall_ms",
+  ];
+  for (const field of fields) {
+    if (typeof values[field] !== "number" || !Number.isFinite(values[field]) || values[field] < 0) {
+      throw new Error(`installed timing ${field} must be finite and nonnegative`);
+    }
+  }
+  const reconciled = values.agent_runner_ms
+    + values.time_to_first_packet_ms
+    + values.continuation_ms;
+  if (Math.abs(reconciled - values.whole_task_wall_ms) > 0.5) {
+    throw new Error(
+      `installed timing does not reconcile: phases=${reconciled} wall=${values.whole_task_wall_ms}`,
+    );
+  }
+  return {
+    timing_cohort_id: values.timing_cohort_id,
+    agent_runner_ms: Math.round(values.agent_runner_ms),
+    time_to_first_packet_ms: Math.round(values.time_to_first_packet_ms),
+    continuation_ms: Math.round(values.continuation_ms),
+    time_to_final_packet_ms: Math.round(
+      values.time_to_first_packet_ms + values.continuation_ms,
+    ),
+    whole_task_wall_ms: Math.round(values.whole_task_wall_ms),
+  };
+}
+
+function timingIneligibleComparatorRow(row) {
+  const timing = row.installed_agent_timing;
+  return {
+    ...row,
+    ...(timing ? {
+      installed_agent_timing: Object.fromEntries([
+        "timing_cohort_id",
+        "agent_runner_ms",
+        "time_to_first_packet_ms",
+        "continuation_ms",
+        "time_to_final_packet_ms",
+        "whole_task_wall_ms",
+      ].map((field) => [field, timing[field]])),
+    } : {}),
+    comparative_wall_time_eligible: false,
+    installed_agent_timing_eligible: false,
+    installed_agent_timing_ineligibility_reason: "reused_comparator_row",
+  };
+}
+
 function parseJsonLines(stdout) {
   const parsed = [];
   const malformed = [];
@@ -4638,6 +4729,11 @@ function preludePublicFields(prelude) {
     signal: prelude.signal,
     error: prelude.error,
     wall_ms: prelude.wall_ms,
+    time_to_first_packet_ms: prelude.time_to_first_packet_ms,
+    continuation_ms: prelude.continuation_ms,
+    time_to_final_packet_ms: prelude.time_to_final_packet_ms,
+    packet_process_count: prelude.packet_process_count,
+    transport_cell: prelude.transport_cell,
     stdout_path: prelude.stdout_path,
     stderr_path: prelude.stderr_path,
     stdout_bytes: prelude.stdout_bytes,
@@ -5876,10 +5972,12 @@ async function runCodeStoryPacketPrelude(opts, run, repoConfig, outDir, runId, c
   let commandFailure = packetCommandFailureEnvelope(parsedOutput);
   let commandFailureReason = packetCommandFailureReason(commandFailure);
   let packet = commandFailure ? null : parsedOutput;
+  const timeToFirstPacketMs = Math.round((performance.now() - started) * 1000) / 1000;
 
   let activeStdoutPath = stdoutPath;
   let activeStderrPath = stderrPath;
   let drillContinuation = false;
+  let packetProcessCount = 1;
   if (
     result.status === "pass" &&
     !parseError &&
@@ -5890,6 +5988,7 @@ async function runCodeStoryPacketPrelude(opts, run, repoConfig, outDir, runId, c
   ) {
     const drillArgs = drillPacketCommandArgs(repoConfig, run.task, opts, packet);
     if (drillArgs) {
+      packetProcessCount += 1;
       const drillStdoutPath = path.join(outDir, `${runId}.codestory-packet-drill.stdout.json`);
       const drillStderrPath = path.join(outDir, `${runId}.codestory-packet-drill.stderr.txt`);
       const drillResult = await runProcess(codestoryCli, drillArgs, {
@@ -5923,7 +6022,13 @@ async function runCodeStoryPacketPrelude(opts, run, repoConfig, outDir, runId, c
     }
   }
 
-  const wallMs = Math.round((performance.now() - started) * 1000) / 1000;
+  const timeToFinalPacketMs = packetProcessCount > 1
+    ? Math.round((performance.now() - started) * 1000) / 1000
+    : timeToFirstPacketMs;
+  const continuationMs = Math.round(
+    Math.max(0, timeToFinalPacketMs - timeToFirstPacketMs) * 1000,
+  ) / 1000;
+  const wallMs = timeToFinalPacketMs;
   const manifestQuality = packetManifestQualitySummary(packet, run.task);
   const contractBlockers = parseError
     ? [`packet JSON parse failed: ${parseError}`]
@@ -5952,6 +6057,11 @@ async function runCodeStoryPacketPrelude(opts, run, repoConfig, outDir, runId, c
     signal: result.signal,
     error: result.error ?? parseError ?? commandFailureReason ?? contractBlockers[0] ?? null,
     wall_ms: wallMs,
+    time_to_first_packet_ms: timeToFirstPacketMs,
+    continuation_ms: continuationMs,
+    time_to_final_packet_ms: timeToFinalPacketMs,
+    packet_process_count: packetProcessCount,
+    transport_cell: "fresh_cli_prelude",
     stdout_path: activeStdoutPath,
     stderr_path: activeStderrPath,
     stdout_bytes: Buffer.byteLength(result.stdout, "utf8"),
@@ -6022,6 +6132,8 @@ async function recordedHarnessPreludeEvents(result, runDir) {
 }
 
 async function runOne(opts, run, outDir) {
+  opts.timingExecutionWindowId ??=
+    `${new Date().toISOString()}:${process.pid}:${path.resolve(outDir)}`;
   const repoConfig = ALL_REPOS[run.repo];
   const runId = benchmarkRunId([
     run.repo,
@@ -6104,6 +6216,21 @@ async function runOne(opts, run, outDir) {
   const runnerWallMs = shouldRunAgent ? Math.round((performance.now() - started) * 1000) / 1000 : 0;
   const preludeWallMs = (codestoryPrelude?.public.wall_ms ?? 0) + (baselinePrelude?.public.wall_ms ?? 0);
   const wallMs = Math.round((runnerWallMs + preludeWallMs) * 1000) / 1000;
+  const timingCohortId = installedAgentTimingCohortId({
+    execution_window_id: opts.timingExecutionWindowId,
+    host: benchmarkHostClass([]),
+    model: opts.model ?? DEFAULT_BENCHMARK_MODEL,
+    load_policy: opts.timingLoadPolicy ?? "fresh_agent_session",
+    task_id: run.task?.id ?? run.repo,
+    repeat: run.repeat,
+  });
+  const installedTiming = installedAgentTiming({
+    timing_cohort_id: timingCohortId,
+    agent_runner_ms: runnerWallMs + (baselinePrelude?.public.wall_ms ?? 0),
+    time_to_first_packet_ms: codestoryPrelude?.public.time_to_first_packet_ms ?? 0,
+    continuation_ms: codestoryPrelude?.public.continuation_ms ?? 0,
+    whole_task_wall_ms: wallMs,
+  });
   const stdoutPath = path.join(outDir, `${runId}.stdout.jsonl`);
   const stderrPath = path.join(outDir, `${runId}.stderr.txt`);
   await writeFile(stdoutPath, result.stdout, "utf8");
@@ -6194,6 +6321,10 @@ async function runOne(opts, run, outDir) {
       ? `CodeStory binary identity ${codestoryBinaryIdentity.status}`
       : result.error,
     wall_ms: wallMs,
+    installed_agent_timing: installedTiming,
+    installed_agent_timing_eligible: run.comparative_wall_time_eligible !== false,
+    installed_agent_timing_ineligibility_reason:
+      run.comparative_wall_time_eligible === false ? "preparation_overlap" : null,
     exact_candidate_timing: opts.exactCandidate
       ? {
           cold_ms: cachePreparationForRepo(opts, run.repo, run.arm)?.preparation_wall_ms ?? 0,
@@ -6951,6 +7082,9 @@ function retrievalIndexWorkEvidence(stdout) {
     core_phase_timings: payload?.core_phase_timings ?? null,
     retrieval_phase_timings: payload?.retrieval_phase_timings ?? null,
     retrieval_component_work: payload?.retrieval_component_work ?? null,
+    ...(payload?.incremental_wall_receipt == null
+      ? {}
+      : { incremental_wall_receipt: payload.incremental_wall_receipt }),
   };
   return Object.values(evidence).some((value) => value != null) ? evidence : null;
 }
@@ -7002,6 +7136,22 @@ function candidateIncrementalRetrievalWorkBlockers(evidence) {
     for (const entry of evidence.retrieval_component_work) {
       if (entry.mode === "complete") {
         blockers.push(`${label} retrieval rebuilt ${entry.component} completely`);
+      }
+    }
+    const receipt = evidence.incremental_wall_receipt;
+    if (receipt != null) {
+      if (
+        receipt.contract !== "codestory.incremental-wall-receipt/v1"
+        || !Number.isFinite(receipt.total_ms)
+        || receipt.total_ms < 0
+        || receipt.accounted_ms !== receipt.total_ms
+        || !Number.isInteger(receipt.reconciliation_basis_points)
+        || receipt.reconciliation_basis_points < 9_900
+      ) {
+        blockers.push(`${label} wall receipt does not reconcile at least 99% of outer wall`);
+      }
+      if (!Array.isArray(receipt.scheduled_paths)) {
+        blockers.push(`${label} wall receipt is missing scheduled paths and reasons`);
       }
     }
   }
@@ -12666,7 +12816,7 @@ async function loadExactCandidateComparatorReuse(opts, plannedRuns, outDir) {
     }
     const currentContract = benchmarkContractForRun(opts, planned);
     const currentPublished = opts.exactCandidatePackageByArm.get("published_0_17_4");
-    const result = {
+    const result = timingIneligibleComparatorRow({
       ...reanalyzed,
       ...(planned.arm === "published_0_17_4" ? {
         codestory_prelude_cli: currentPublished.cli_path,
@@ -12687,7 +12837,7 @@ async function loadExactCandidateComparatorReuse(opts, plannedRuns, outDir) {
           : null,
         reanalyzed_with_current_scorer: true,
       },
-    };
+    });
     reusable.set(key, {
       ...result,
       resource_accounting: resourceAccountingForResult(result),
@@ -14315,6 +14465,8 @@ export {
   codestoryRetrievalStatusSnapshot,
   extractCommandExecutions,
   interactionTurnTelemetry,
+  installedAgentTiming,
+  installedAgentTimingCohortId,
   isPathInside,
   isTrustedPublishableRepoUrl,
   loadTaskForResult,
@@ -14406,6 +14558,7 @@ export {
   taskSnapshotForResult,
   taskShardIndex,
   tasksForShard,
+  timingIneligibleComparatorRow,
   runCodeStoryPacketPrelude,
   runAgentBenchmarkPipeline,
   runPlannedAgentRuns,

--- a/scripts/codestory-focused-abba-preflight.mjs
+++ b/scripts/codestory-focused-abba-preflight.mjs
@@ -182,35 +182,23 @@ async function cliIdentity(cliPath, arm) {
   };
 }
 
-async function runFocusedAbba(opts) {
-  const plan = abbaRunPlan();
-  if (opts.listPlan) {
-    process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
-    return null;
-  }
-  if (existsSync(path.join(opts.outDir, "summary.json"))) {
-    throw new Error(`refusing to overwrite focused ABBA receipt: ${opts.outDir}`);
-  }
-  await mkdir(opts.outDir, { recursive: true });
-  await mkdir(opts.stateRoot, { recursive: true });
-  const executionWindowId = opts.executionWindowId
-    ?? `${new Date().toISOString()}:${process.pid}:${opts.outDir}`;
-  const identities = {
-    published_0_17_5: await cliIdentity(opts.publishedCli, "published_0_17_5"),
-    candidate_0_18: await cliIdentity(opts.candidateCli, "candidate_0_18"),
-  };
-  const rows = [];
-  for (const [sequence, planned] of plan.entries()) {
-    const rowDir = path.join(
-      opts.outDir,
-      "raw",
-      planned.task_id,
-      `${String(sequence + 1).padStart(2, "0")}-${planned.arm}-${planned.repeat}`,
-    );
-    const cli = identities[planned.arm].path;
-    process.stdout.write(
-      `running ${planned.task_id} ${planned.arm} repeat ${planned.repeat}/5 (${sequence + 1}/${plan.length})\n`,
-    );
+function transientEmbeddingServerTransition(summary) {
+  const failure = summary?.first_failure;
+  return summary?.completed_rows === 0
+    && failure?.kind === "preparation_failed"
+    && String(failure?.error ?? "").includes("embedding_server_draining");
+}
+
+async function runRawRow(opts, planned, sequence, cli) {
+  const rowRoot = path.join(
+    opts.outDir,
+    "raw",
+    planned.task_id,
+    `${String(sequence + 1).padStart(2, "0")}-${planned.arm}-${planned.repeat}`,
+  );
+  const transitionAttempts = [];
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    const rowDir = path.join(rowRoot, `attempt-${attempt}`);
     const run = await runProcess(
       process.execPath,
       [
@@ -232,12 +220,55 @@ async function runFocusedAbba(opts) {
         maxOutputBytes: 4 * 1024 * 1024,
       },
     );
-    if (run.status !== "pass") {
+    if (run.status === "pass") {
+      return { rowDir, transitionAttempts };
+    }
+    const summaryPath = path.join(rowDir, "summary.json");
+    const summary = existsSync(summaryPath)
+      ? JSON.parse(await readFile(summaryPath, "utf8"))
+      : null;
+    const transient = transientEmbeddingServerTransition(summary);
+    transitionAttempts.push({
+      attempt,
+      raw_directory: path.relative(opts.outDir, rowDir),
+      transient_embedding_server_transition: transient,
+      error: summary?.first_failure?.error ?? run.stderr ?? run.stdout,
+    });
+    if (!transient || attempt === 3) {
       throw new Error(
         `focused ABBA raw row failed for ${planned.task_id}/${planned.arm}/${planned.repeat}: `
-        + `${run.stderr || run.stdout}`,
+        + `${summary?.first_failure?.error ?? run.stderr ?? run.stdout}`,
       );
     }
+    await new Promise((resolve) => setTimeout(resolve, 2_000));
+  }
+  throw new Error("focused ABBA transition retry exhausted without a receipt");
+}
+
+async function runFocusedAbba(opts) {
+  const plan = abbaRunPlan();
+  if (opts.listPlan) {
+    process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
+    return null;
+  }
+  if (existsSync(path.join(opts.outDir, "summary.json"))) {
+    throw new Error(`refusing to overwrite focused ABBA receipt: ${opts.outDir}`);
+  }
+  await mkdir(opts.outDir, { recursive: true });
+  await mkdir(opts.stateRoot, { recursive: true });
+  const executionWindowId = opts.executionWindowId
+    ?? `${new Date().toISOString()}:${process.pid}:${opts.outDir}`;
+  const identities = {
+    published_0_17_5: await cliIdentity(opts.publishedCli, "published_0_17_5"),
+    candidate_0_18: await cliIdentity(opts.candidateCli, "candidate_0_18"),
+  };
+  const rows = [];
+  for (const [sequence, planned] of plan.entries()) {
+    const cli = identities[planned.arm].path;
+    process.stdout.write(
+      `running ${planned.task_id} ${planned.arm} repeat ${planned.repeat}/5 (${sequence + 1}/${plan.length})\n`,
+    );
+    const { rowDir, transitionAttempts } = await runRawRow(opts, planned, sequence, cli);
     const rawRow = await readSingleJsonlRow(path.join(rowDir, "runs.jsonl"));
     const rawSummary = JSON.parse(await readFile(path.join(rowDir, "summary.json"), "utf8"));
     const host = rawSummary?.shard?.attestation?.host_class;
@@ -256,6 +287,7 @@ async function runFocusedAbba(opts) {
       arm: planned.arm,
       repeat: planned.repeat,
       raw_directory: path.relative(opts.outDir, rowDir),
+      transition_attempts: transitionAttempts,
       raw_benchmark_run_id: rawRow.benchmark_run_id,
       raw_inner_timing_cohort_id: rawRow.installed_agent_timing?.timing_cohort_id ?? null,
       installed_agent_timing: timing,
@@ -309,6 +341,7 @@ export {
   focusedAbbaTiming,
   parseArgs,
   runFocusedAbba,
+  transientEmbeddingServerTransition,
 };
 
 if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {

--- a/scripts/codestory-focused-abba-preflight.mjs
+++ b/scripts/codestory-focused-abba-preflight.mjs
@@ -74,12 +74,26 @@ function focusedAbbaTiming(rawRow, dimensions) {
   const raw = rawRow?.installed_agent_timing;
   if (!raw) throw new Error("focused ABBA row has no installed agent timing");
   const timingCohortId = installedAgentTimingCohortId(dimensions);
+  const prelude = rawRow.codestory_harness_prelude;
+  const baselineMs = rawRow.baseline_harness_prelude?.wall_ms ?? 0;
+  const agentRunnerMs = Number.isFinite(rawRow.agent_runner_wall_ms)
+    ? rawRow.agent_runner_wall_ms + baselineMs
+    : raw.agent_runner_ms;
+  const timeToFirstPacketMs = Number.isFinite(prelude?.time_to_first_packet_ms)
+    ? prelude.time_to_first_packet_ms
+    : raw.time_to_first_packet_ms;
+  const continuationMs = Number.isFinite(prelude?.continuation_ms)
+    ? prelude.continuation_ms
+    : raw.continuation_ms;
+  const wholeTaskWallMs = Number.isFinite(rawRow.wall_ms)
+    ? rawRow.wall_ms
+    : raw.whole_task_wall_ms;
   return installedAgentTiming({
     timing_cohort_id: timingCohortId,
-    agent_runner_ms: raw.agent_runner_ms,
-    time_to_first_packet_ms: raw.time_to_first_packet_ms,
-    continuation_ms: raw.continuation_ms,
-    whole_task_wall_ms: raw.whole_task_wall_ms,
+    agent_runner_ms: agentRunnerMs,
+    time_to_first_packet_ms: timeToFirstPacketMs,
+    continuation_ms: continuationMs,
+    whole_task_wall_ms: wholeTaskWallMs,
   });
 }
 

--- a/scripts/codestory-focused-abba-preflight.mjs
+++ b/scripts/codestory-focused-abba-preflight.mjs
@@ -1,0 +1,303 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseArgs as parseNodeArgs } from "node:util";
+
+import {
+  installedAgentTiming,
+  installedAgentTimingCohortId,
+  runProcess,
+} from "./codestory-agent-ab-benchmark.mjs";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const scriptDir = path.dirname(scriptPath);
+const repoRoot = path.resolve(scriptDir, "..");
+const harnessPath = path.join(scriptDir, "codestory-agent-ab-benchmark.mjs");
+const REQUIRED_TASK_IDS = Object.freeze([
+  "dart-http-client-flow",
+  "c-redis-command-loop",
+  "python-requests-session-flow",
+  "rust-ripgrep-search-pipeline",
+]);
+const ARMS = Object.freeze(["published_0_17_5", "candidate_0_18"]);
+
+function sha256Bytes(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function stableJson(value) {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableJson(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function abbaRunPlan(taskIds = REQUIRED_TASK_IDS, repeats = 5) {
+  if (!Array.isArray(taskIds) || !taskIds.length) {
+    throw new Error("focused ABBA requires at least one task");
+  }
+  if (!Number.isInteger(repeats) || repeats < 1) {
+    throw new Error("focused ABBA repeats must be a positive integer");
+  }
+  const plan = [];
+  for (const taskId of taskIds) {
+    const armRepeats = Object.fromEntries(ARMS.map((arm) => [arm, 0]));
+    const block = [
+      "published_0_17_5",
+      "candidate_0_18",
+      "candidate_0_18",
+      "published_0_17_5",
+    ];
+    while (ARMS.some((arm) => armRepeats[arm] < repeats)) {
+      for (const arm of block) {
+        if (armRepeats[arm] >= repeats) continue;
+        armRepeats[arm] += 1;
+        plan.push({ task_id: taskId, arm, repeat: armRepeats[arm] });
+      }
+    }
+    const taskRows = plan.filter((row) => row.task_id === taskId);
+    for (const arm of ARMS) {
+      if (taskRows.filter((row) => row.arm === arm).length !== repeats) {
+        throw new Error(`focused ABBA failed to schedule ${repeats} ${arm} rows for ${taskId}`);
+      }
+    }
+  }
+  return plan;
+}
+
+function focusedAbbaTiming(rawRow, dimensions) {
+  const raw = rawRow?.installed_agent_timing;
+  if (!raw) throw new Error("focused ABBA row has no installed agent timing");
+  const timingCohortId = installedAgentTimingCohortId(dimensions);
+  return installedAgentTiming({
+    timing_cohort_id: timingCohortId,
+    agent_runner_ms: raw.agent_runner_ms,
+    time_to_first_packet_ms: raw.time_to_first_packet_ms,
+    continuation_ms: raw.continuation_ms,
+    whole_task_wall_ms: raw.whole_task_wall_ms,
+  });
+}
+
+function parseArgs(argv) {
+  const { values } = parseNodeArgs({
+    args: argv,
+    allowPositionals: false,
+    strict: true,
+    options: {
+      help: { type: "boolean", short: "h" },
+      "published-cli": { type: "string" },
+      "candidate-cli": { type: "string" },
+      "repo-cache-dir": { type: "string" },
+      "state-root": { type: "string" },
+      "out-dir": { type: "string" },
+      "execution-window-id": { type: "string" },
+      "timeout-ms": { type: "string" },
+      "list-plan": { type: "boolean" },
+    },
+  });
+  if (values.help) {
+    process.stdout.write(
+      "Usage: node scripts/codestory-focused-abba-preflight.mjs --published-cli PATH --candidate-cli PATH --repo-cache-dir DIR --state-root DIR --out-dir DIR [--execution-window-id ID]\n",
+    );
+    process.exit(0);
+  }
+  const opts = {
+    publishedCli: values["published-cli"] ? path.resolve(values["published-cli"]) : null,
+    candidateCli: values["candidate-cli"] ? path.resolve(values["candidate-cli"]) : null,
+    repoCacheDir: values["repo-cache-dir"] ? path.resolve(values["repo-cache-dir"]) : null,
+    stateRoot: values["state-root"] ? path.resolve(values["state-root"]) : null,
+    outDir: values["out-dir"] ? path.resolve(values["out-dir"]) : null,
+    executionWindowId: values["execution-window-id"] ?? null,
+    timeoutMs: values["timeout-ms"] == null ? 600_000 : Number.parseInt(values["timeout-ms"], 10),
+    listPlan: values["list-plan"] === true,
+  };
+  if (opts.listPlan) return opts;
+  for (const [field, value] of Object.entries({
+    publishedCli: opts.publishedCli,
+    candidateCli: opts.candidateCli,
+    repoCacheDir: opts.repoCacheDir,
+    stateRoot: opts.stateRoot,
+    outDir: opts.outDir,
+  })) {
+    if (!value) throw new Error(`focused ABBA requires ${field}`);
+  }
+  if (!Number.isInteger(opts.timeoutMs) || opts.timeoutMs < 1_000) {
+    throw new Error("focused ABBA timeout must be an integer >= 1000");
+  }
+  return opts;
+}
+
+async function sha256File(filePath) {
+  return sha256Bytes(await readFile(filePath));
+}
+
+async function readSingleJsonlRow(filePath) {
+  const rows = (await readFile(filePath, "utf8"))
+    .split(/\r?\n/u)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+  if (rows.length !== 1) throw new Error(`expected one raw benchmark row in ${filePath}`);
+  return rows[0];
+}
+
+function armStateEnv(stateRoot, arm) {
+  const root = path.join(stateRoot, arm);
+  return {
+    CODESTORY_CACHE_ROOT: path.join(root, "cache"),
+    CODESTORY_STDIO_CACHE_ROOT: path.join(root, "stdio-cache"),
+    CODESTORY_PLUGIN_DATA: path.join(root, "plugin-data"),
+    CODESTORY_EMBED_ALLOW_CPU: "0",
+    CODESTORY_RETRIEVAL: "1",
+  };
+}
+
+async function cliIdentity(cliPath, arm) {
+  if (!existsSync(cliPath)) throw new Error(`${arm} CLI does not exist: ${cliPath}`);
+  const version = await runProcess(cliPath, ["--version"], { timeoutMs: 10_000 });
+  if (version.status !== "pass") throw new Error(`${arm} CLI version probe failed`);
+  return {
+    arm,
+    path: cliPath,
+    sha256: await sha256File(cliPath),
+    version: version.stdout.trim(),
+  };
+}
+
+async function runFocusedAbba(opts) {
+  const plan = abbaRunPlan();
+  if (opts.listPlan) {
+    process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
+    return null;
+  }
+  if (existsSync(path.join(opts.outDir, "summary.json"))) {
+    throw new Error(`refusing to overwrite focused ABBA receipt: ${opts.outDir}`);
+  }
+  await mkdir(opts.outDir, { recursive: true });
+  await mkdir(opts.stateRoot, { recursive: true });
+  const executionWindowId = opts.executionWindowId
+    ?? `${new Date().toISOString()}:${process.pid}:${opts.outDir}`;
+  const identities = {
+    published_0_17_5: await cliIdentity(opts.publishedCli, "published_0_17_5"),
+    candidate_0_18: await cliIdentity(opts.candidateCli, "candidate_0_18"),
+  };
+  const rows = [];
+  for (const [sequence, planned] of plan.entries()) {
+    const rowDir = path.join(
+      opts.outDir,
+      "raw",
+      planned.task_id,
+      `${String(sequence + 1).padStart(2, "0")}-${planned.arm}-${planned.repeat}`,
+    );
+    const cli = identities[planned.arm].path;
+    process.stdout.write(
+      `running ${planned.task_id} ${planned.arm} repeat ${planned.repeat}/5 (${sequence + 1}/${plan.length})\n`,
+    );
+    const run = await runProcess(
+      process.execPath,
+      [
+        harnessPath,
+        "--task-suite", "language-expansion-holdout",
+        "--task-ids", planned.task_id,
+        "--arms", "with_codestory",
+        "--repeats", "1",
+        "--repo-cache-dir", opts.repoCacheDir,
+        "--codestory-cli", cli,
+        "--out-dir", rowDir,
+        "--allow-failures",
+      ],
+      {
+        cwd: repoRoot,
+        env: { ...process.env, ...armStateEnv(opts.stateRoot, planned.arm) },
+        timeoutMs: opts.timeoutMs,
+        maxOutputBytes: 4 * 1024 * 1024,
+      },
+    );
+    if (run.status !== "pass") {
+      throw new Error(
+        `focused ABBA raw row failed for ${planned.task_id}/${planned.arm}/${planned.repeat}: `
+        + `${run.stderr || run.stdout}`,
+      );
+    }
+    const rawRow = await readSingleJsonlRow(path.join(rowDir, "runs.jsonl"));
+    const rawSummary = JSON.parse(await readFile(path.join(rowDir, "summary.json"), "utf8"));
+    const host = rawSummary?.shard?.attestation?.host_class;
+    const timing = focusedAbbaTiming(rawRow, {
+      execution_window_id: executionWindowId,
+      host,
+      model: rawRow.model,
+      load_policy: "fresh_cli_fresh_agent_session",
+      task_id: planned.task_id,
+      repeat: planned.repeat,
+    });
+    rows.push({
+      contract: "codestory.focused-installed-abba-row/v1",
+      sequence: sequence + 1,
+      task_id: planned.task_id,
+      arm: planned.arm,
+      repeat: planned.repeat,
+      raw_directory: path.relative(opts.outDir, rowDir),
+      raw_benchmark_run_id: rawRow.benchmark_run_id,
+      raw_inner_timing_cohort_id: rawRow.installed_agent_timing?.timing_cohort_id ?? null,
+      installed_agent_timing: timing,
+      installed_agent_timing_eligible: true,
+      quality: rawRow.quality,
+      packet: {
+        status: rawRow.codestory_harness_prelude?.packet_evidence_availability?.status ?? null,
+        evidence_kind_counts:
+          rawRow.codestory_harness_prelude?.packet_evidence_availability?.evidence_kind_counts ?? null,
+        gap_kind_counts:
+          rawRow.codestory_harness_prelude?.packet_evidence_availability?.gap_kind_counts ?? null,
+        bytes: rawRow.codestory_harness_prelude?.stdout_bytes ?? null,
+        transport_cell: rawRow.codestory_harness_prelude?.transport_cell ?? null,
+      },
+      usage: rawRow.usage,
+      host,
+      model: rawRow.model,
+      source_attestation: rawSummary?.shard?.attestation ?? null,
+      cli_identity: identities[planned.arm],
+    });
+  }
+  const identityAfter = {
+    published_0_17_5: await cliIdentity(opts.publishedCli, "published_0_17_5"),
+    candidate_0_18: await cliIdentity(opts.candidateCli, "candidate_0_18"),
+  };
+  if (stableJson(identityAfter) !== stableJson(identities)) {
+    throw new Error("focused ABBA CLI identity changed inside the execution window");
+  }
+  const receipt = {
+    contract: "codestory.focused-installed-abba-preflight/v1",
+    generated_at: new Date().toISOString(),
+    execution_window_id: executionWindowId,
+    task_ids: REQUIRED_TASK_IDS,
+    repeats_per_arm: 5,
+    ordering: "ABBAABBAAB per task",
+    load_policy: "fresh_cli_fresh_agent_session",
+    persistent_installed_mcp_measured: false,
+    cli_identities: identities,
+    rows,
+  };
+  receipt.receipt_sha256 = sha256Bytes(stableJson(receipt));
+  await writeFile(path.join(opts.outDir, "summary.json"), `${JSON.stringify(receipt, null, 2)}\n`, "utf8");
+  process.stdout.write(`wrote ${opts.outDir}\n`);
+  return receipt;
+}
+
+export {
+  ARMS,
+  REQUIRED_TASK_IDS,
+  abbaRunPlan,
+  focusedAbbaTiming,
+  parseArgs,
+  runFocusedAbba,
+};
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  runFocusedAbba(parseArgs(process.argv.slice(2))).catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exit(1);
+  });
+}

--- a/scripts/codestory-focused-abba-preflight.mjs
+++ b/scripts/codestory-focused-abba-preflight.mjs
@@ -23,6 +23,7 @@ const REQUIRED_TASK_IDS = Object.freeze([
   "rust-ripgrep-search-pipeline",
 ]);
 const ARMS = Object.freeze(["published_0_17_5", "candidate_0_18"]);
+const PINNED_MODEL = "gpt-5.6-sol";
 
 function sha256Bytes(value) {
   return createHash("sha256").update(value).digest("hex");
@@ -204,6 +205,7 @@ async function runFocusedAbba(opts) {
         "--task-ids", planned.task_id,
         "--arms", "with_codestory",
         "--repeats", "1",
+        "--model", PINNED_MODEL,
         "--repo-cache-dir", opts.repoCacheDir,
         "--codestory-cli", cli,
         "--out-dir", rowDir,
@@ -228,7 +230,7 @@ async function runFocusedAbba(opts) {
     const timing = focusedAbbaTiming(rawRow, {
       execution_window_id: executionWindowId,
       host,
-      model: rawRow.model,
+      model: rawRow.model ?? rawRow.benchmark_contract?.model ?? PINNED_MODEL,
       load_policy: "fresh_cli_fresh_agent_session",
       task_id: planned.task_id,
       repeat: planned.repeat,
@@ -256,7 +258,7 @@ async function runFocusedAbba(opts) {
       },
       usage: rawRow.usage,
       host,
-      model: rawRow.model,
+      model: rawRow.model ?? rawRow.benchmark_contract?.model ?? PINNED_MODEL,
       source_attestation: rawSummary?.shard?.attestation ?? null,
       cli_identity: identities[planned.arm],
     });

--- a/scripts/codestory-incremental-wall-preflight.mjs
+++ b/scripts/codestory-incremental-wall-preflight.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { spawn } from "node:child_process";
+import { mkdir, readFile, realpath, stat, writeFile } from "node:fs/promises";
+import { isAbsolute, relative, resolve, sep } from "node:path";
+import { performance } from "node:perf_hooks";
+import { fileURLToPath } from "node:url";
+
+import { withExactSourceMutation } from "./codestory-agent-ab-benchmark.mjs";
+
+const MAX_CAPTURE_BYTES = 1024 * 1024;
+const MAX_RECEIPT_BYTES = 16 * 1024 * 1024;
+const PROCESS_TIMEOUT_MS = 10 * 60 * 1000;
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function parseOptions(argv) {
+  const names = new Set(["--cli", "--project", "--cache-dir", "--source", "--out-dir", "--repeats"]);
+  const values = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const name = argv[index];
+    const value = argv[index + 1];
+    if (!names.has(name) || !value || value.startsWith("--")) fail(`invalid option ${name ?? "<missing>"}`);
+    values[name.slice(2).replaceAll("-", "_")] = value;
+  }
+  for (const name of ["cli", "project", "cache_dir", "source", "out_dir"]) {
+    if (!isAbsolute(values[name] ?? "")) fail(`--${name.replaceAll("_", "-")} must be absolute`);
+  }
+  const repeats = Number(values.repeats);
+  if (!Number.isInteger(repeats) || repeats < 1 || repeats > 20) fail("--repeats must be an integer from 1 to 20");
+  return { ...values, repeats };
+}
+
+function inside(root, path) {
+  const value = relative(root, path);
+  return value !== ".." && !value.startsWith(`..${sep}`) && !isAbsolute(value);
+}
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+async function readBoundedJson(path) {
+  const metadata = await stat(path);
+  if (!metadata.isFile() || metadata.size < 1 || metadata.size > MAX_RECEIPT_BYTES) {
+    fail(`${path} is not a bounded regular receipt`);
+  }
+  return JSON.parse(await readFile(path, "utf8"));
+}
+
+async function runCli(cli, args) {
+  return new Promise((accept, reject) => {
+    const started = performance.now();
+    const child = spawn(cli, args, { stdio: ["ignore", "pipe", "pipe"] });
+    const stdout = [];
+    const stderr = [];
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+    }, PROCESS_TIMEOUT_MS);
+    const collect = (chunks, field) => (chunk) => {
+      const bytes = Buffer.from(chunk);
+      if (field === "stdout") stdoutBytes += bytes.length;
+      else stderrBytes += bytes.length;
+      if ((field === "stdout" ? stdoutBytes : stderrBytes) <= MAX_CAPTURE_BYTES) chunks.push(bytes);
+    };
+    child.stdout.on("data", collect(stdout, "stdout"));
+    child.stderr.on("data", collect(stderr, "stderr"));
+    child.once("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.once("close", (code, signal) => {
+      clearTimeout(timer);
+      accept({
+        code,
+        signal,
+        timed_out: timedOut,
+        wall_ms: Math.round((performance.now() - started) * 1000) / 1000,
+        stdout: Buffer.concat(stdout).toString("utf8"),
+        stderr: Buffer.concat(stderr).toString("utf8"),
+      });
+    });
+  });
+}
+
+function validateWallReceipt(receipt, expectedPath) {
+  const wall = receipt?.incremental_wall_receipt;
+  if (wall?.contract !== "codestory.incremental-wall-receipt/v1") fail("incremental wall receipt is missing");
+  if (wall.accounted_ms !== wall.total_ms || wall.reconciliation_basis_points !== 10_000) {
+    fail("incremental wall receipt does not reconcile exactly");
+  }
+  const scheduled = wall.scheduled_paths?.find(({ path }) => path === expectedPath);
+  if (scheduled?.action !== "index" || typeof scheduled?.reason !== "string") {
+    fail(`incremental receipt did not schedule ${expectedPath} with an index reason`);
+  }
+  return wall;
+}
+
+async function runIndex(options, outputPath) {
+  const result = await runCli(options.cli, [
+    "retrieval", "index",
+    "--project", options.project,
+    "--cache-dir", options.cache_dir,
+    "--refresh", "incremental",
+    "--format", "json",
+    "--output-file", outputPath,
+  ]);
+  if (result.code !== 0 || result.timed_out) {
+    fail(`incremental index failed: ${result.stderr.trim() || result.stdout.trim() || `exit ${result.code}`}`);
+  }
+  return { process: result, receipt: await readBoundedJson(outputPath) };
+}
+
+export async function runIncrementalWallPreflight(options) {
+  const project = await realpath(options.project);
+  const source = await realpath(options.source);
+  const cli = await realpath(options.cli);
+  const sourceMetadata = await stat(source);
+  const cliMetadata = await stat(cli);
+  if (!inside(project, source) || !sourceMetadata.isFile()) fail("--source must be a regular file inside --project");
+  if (!cliMetadata.isFile()) fail("--cli must be a regular file");
+  const relativeSource = relative(project, source).split(sep).join("/");
+  await mkdir(options.cache_dir, { recursive: true });
+  await mkdir(options.out_dir, { recursive: true });
+  const originalBytes = await readFile(source);
+  const originalSha256 = sha256(originalBytes);
+  const rows = [];
+  for (let repeat = 1; repeat <= options.repeats; repeat += 1) {
+    const mutatedOutput = resolve(options.out_dir, `repeat-${repeat}-mutated.json`);
+    const restoreOutput = resolve(options.out_dir, `repeat-${repeat}-restored.json`);
+    const mutation = await withExactSourceMutation(source, async (identity) => {
+      const run = await runIndex({ ...options, project, source, cli }, mutatedOutput);
+      const wall = validateWallReceipt(run.receipt, relativeSource);
+      return { identity, run, wall };
+    }, async () => {
+      const restore = await runIndex({ ...options, project, source, cli }, restoreOutput);
+      validateWallReceipt(restore.receipt, relativeSource);
+    });
+    rows.push({
+      repeat,
+      source_path: relativeSource,
+      mutation: "append_one_lf_v1",
+      original_sha256: mutation.original_sha256,
+      mutated_sha256: mutation.mutated_sha256,
+      restored_sha256: mutation.restored_sha256,
+      process_wall_ms: mutation.result.run.process.wall_ms,
+      command_wall_ms: mutation.result.wall.total_ms,
+      core_refresh_ms: mutation.result.wall.core_refresh_ms,
+      retrieval_finalize_ms: mutation.result.wall.retrieval_finalize_ms,
+      reconciliation_basis_points: mutation.result.wall.reconciliation_basis_points,
+      attributed_basis_points: mutation.result.wall.attributed_basis_points,
+      phases: mutation.result.wall.phases,
+      scheduled_paths: mutation.result.wall.scheduled_paths,
+      receipt_path: mutatedOutput,
+      restore_receipt_path: restoreOutput,
+    });
+  }
+  const restoredBytes = await readFile(source);
+  if (sha256(restoredBytes) !== originalSha256 || !restoredBytes.equals(originalBytes)) {
+    fail("source was not restored byte-for-byte after preflight");
+  }
+  const summary = {
+    contract: "codestory.incremental-wall-preflight/v1",
+    cli,
+    cli_sha256: sha256(await readFile(cli)),
+    project,
+    source_path: relativeSource,
+    source_sha256: originalSha256,
+    repeats: rows,
+  };
+  const summaryPath = resolve(options.out_dir, "summary.json");
+  await writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`, { flag: "wx" });
+  return { summary, summaryPath };
+}
+
+async function main() {
+  const result = await runIncrementalWallPreflight(parseOptions(process.argv.slice(2)));
+  process.stdout.write(`${result.summaryPath}\n`);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : error}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/codestory-remediation-ledger.mjs
+++ b/scripts/codestory-remediation-ledger.mjs
@@ -1,0 +1,364 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { open, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const MAX_SUMMARY_BYTES = 16 * 1024 * 1024;
+const MAX_RUN_LEDGER_BYTES = 256 * 1024 * 1024;
+const MAX_PREPARATION_LEDGER_BYTES = 128 * 1024 * 1024;
+const MAX_PACKET_BYTES = 1024 * 1024;
+const SOURCE_ARTIFACTS = Object.freeze([
+  ["summary.json", MAX_SUMMARY_BYTES],
+  ["summary.md", MAX_SUMMARY_BYTES],
+  ["runs.jsonl", MAX_RUN_LEDGER_BYTES],
+  ["preparations.jsonl", MAX_PREPARATION_LEDGER_BYTES],
+]);
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+async function readRegularFileBounded(filePath, maxBytes, label) {
+  const handle = await open(filePath, "r");
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile() || !Number.isSafeInteger(stat.size) || stat.size < 0 || stat.size > maxBytes) {
+      throw new Error(`${label} exceeds its byte bound or is not a regular file`);
+    }
+    const bytes = await readFile(handle);
+    if (bytes.length !== stat.size) {
+      throw new Error(`${label} changed while it was read`);
+    }
+    return bytes;
+  } finally {
+    await handle.close();
+  }
+}
+
+function parseJsonl(bytes, label) {
+  return bytes.toString("utf8").split(/\r?\n/).flatMap((line, index) => {
+    if (!line.trim()) return [];
+    try {
+      return [JSON.parse(line)];
+    } catch (error) {
+      throw new Error(`${label} line ${index + 1} is not valid JSON: ${error.message}`);
+    }
+  });
+}
+
+function pathIsInside(root, candidate) {
+  const relative = path.relative(root, candidate);
+  return relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== ".." && !path.isAbsolute(relative));
+}
+
+function resolveRetainedPacketPath(runDir, recordedPath) {
+  if (typeof recordedPath !== "string" || !recordedPath.trim()) return null;
+  if (!path.isAbsolute(recordedPath)) {
+    const candidate = path.resolve(runDir, recordedPath);
+    if (!pathIsInside(runDir, candidate)) {
+      throw new Error("packet artifact path escapes the retained run directory");
+    }
+    return candidate;
+  }
+  const candidate = path.resolve(recordedPath);
+  if (pathIsInside(runDir, candidate)) return candidate;
+  const retainedCopy = path.join(runDir, path.basename(candidate));
+  if (!pathIsInside(runDir, retainedCopy)) {
+    throw new Error("packet artifact path escapes the retained run directory");
+  }
+  return retainedCopy;
+}
+
+function canonical(value) {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonical(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function uniqueValues(values) {
+  const observed = new Set();
+  return values.filter((value) => {
+    if (value == null) return false;
+    const key = canonical(value);
+    if (observed.has(key)) return false;
+    observed.add(key);
+    return true;
+  });
+}
+
+function armRole(arm) {
+  if (arm === "without_codestory") return "no_codestory";
+  if (arm === "candidate_0_18") return "candidate";
+  if (String(arm).startsWith("published_")) return "published";
+  return null;
+}
+
+function qualityProjection(quality) {
+  const value = quality ?? {};
+  return {
+    pass: value.pass === true,
+    missing_files: value.missed_anchors?.files ?? value.expected_files?.missed_anchors ?? [],
+    missing_symbols: value.missed_anchors?.symbols ?? value.expected_symbols?.missed_anchors ?? [],
+    missing_claims: value.missed_anchors?.claims ?? value.expected_claims?.missed_anchors ?? [],
+    missing_anchors: value.expected_anchors?.missed_anchors ?? [],
+    missing_citations: value.citation_coverage?.missed_anchors ?? [],
+    factual_errors: {
+      found: value.material_factual_errors?.found ?? null,
+      anchors: value.material_factual_errors?.found_anchors ?? [],
+    },
+    unsupported_proof_claims: {
+      found: value.unsupported_proof_claims?.found ?? null,
+      claims: value.unsupported_proof_claims?.found_claims ?? [],
+    },
+    forbidden_claims: {
+      found: value.forbidden_claims?.found ?? null,
+      anchors: value.forbidden_claims?.found_anchors ?? [],
+    },
+  };
+}
+
+function evidenceRow(evidence) {
+  return {
+    evidence_id: evidence?.identity?.evidence_id ?? evidence?.id ?? null,
+    kind: evidence?.kind ?? null,
+    path: evidence?.path ?? null,
+    symbol_id: evidence?.symbol_id ?? evidence?.symbol?.canonical_id ?? null,
+    start_line: evidence?.start_line ?? evidence?.range?.start_line ?? null,
+    end_line: evidence?.end_line ?? evidence?.range?.end_line ?? null,
+    summary: evidence?.summary ?? null,
+  };
+}
+
+async function packetProjection(runDir, row) {
+  const prelude = row.codestory_harness_prelude;
+  if (!prelude?.stdout_path) return null;
+  const artifactPath = resolveRetainedPacketPath(runDir, prelude.stdout_path);
+  const bytes = await readRegularFileBounded(artifactPath, MAX_PACKET_BYTES, "packet artifact");
+  let packet;
+  try {
+    packet = JSON.parse(bytes.toString("utf8"));
+  } catch (error) {
+    throw new Error(`packet artifact is not valid JSON: ${error.message}`);
+  }
+  return {
+    artifact: path.basename(artifactPath),
+    sha256: sha256(bytes),
+    byte_count: bytes.length,
+    schema_version: packet?.schema_version ?? prelude.packet_schema_version ?? null,
+    route: packet?.kind ?? prelude.packet_projection_kind ?? prelude.packet_disposition_kind ?? null,
+    disposition: packet?.disposition ?? prelude.packet_disposition ?? null,
+    retrieval_state: packet?.retrieval?.state ?? packet?.trace?.retrieval_shadow?.retrieval_mode ?? null,
+    continuation: {
+      used: prelude.packet_drill_continuation === true,
+      status: packet?.status ?? null,
+      descriptor: packet?.continuation ?? packet?.disposition?.drill ?? null,
+    },
+    evidence_rows: Array.isArray(packet?.evidence)
+      ? packet.evidence.map(evidenceRow)
+      : Array.isArray(packet?.support)
+        ? packet.support.map(evidenceRow)
+        : [],
+    gaps: Array.isArray(packet?.gaps) ? packet.gaps : [],
+  };
+}
+
+function timingProjection(row) {
+  const installed = row.installed_agent_timing ?? null;
+  const exact = row.exact_candidate_timing ?? null;
+  const reused = row.comparator_reuse_provenance != null;
+  return {
+    eligible: !reused
+      && row.comparative_wall_time_eligible !== false
+      && row.installed_agent_timing_eligible !== false,
+    ineligibility_reason: reused
+      ? "reused_comparator_row"
+      : row.installed_agent_timing_ineligibility_reason
+        ?? (row.comparative_wall_time_eligible === false ? "source_row_marked_ineligible" : null),
+    timing_cohort_id: installed?.timing_cohort_id ?? null,
+    agent_runner_ms: installed?.agent_runner_ms ?? row.agent_runner_wall_ms ?? null,
+    packet_prelude_ms: row.codestory_harness_prelude?.wall_ms
+      ?? row.baseline_harness_prelude?.wall_ms
+      ?? 0,
+    time_to_first_packet_ms: installed?.time_to_first_packet_ms
+      ?? row.codestory_harness_prelude?.time_to_first_packet_ms
+      ?? null,
+    continuation_ms: installed?.continuation_ms
+      ?? row.codestory_harness_prelude?.continuation_ms
+      ?? null,
+    time_to_final_packet_ms: installed?.time_to_final_packet_ms
+      ?? row.codestory_harness_prelude?.time_to_final_packet_ms
+      ?? null,
+    whole_task_wall_ms: installed?.whole_task_wall_ms ?? row.wall_ms ?? null,
+    cold_ms: exact?.cold_ms ?? null,
+    incremental_ms: exact?.incremental_ms ?? null,
+    all_in_ms: exact?.all_in_ms ?? null,
+    legacy_warm_ms: exact?.warm_ms ?? null,
+    legacy_warm_semantics: exact?.warm_ms == null ? null : "whole_task_wall_ms",
+  };
+}
+
+async function rowProjection(runDir, row) {
+  const reused = row.comparator_reuse_provenance != null;
+  return {
+    benchmark_run_id: row.benchmark_run_id ?? null,
+    arm: row.arm,
+    repeat: row.repeat,
+    status: row.status,
+    quality: qualityProjection(row.quality),
+    comparator: {
+      fresh: !reused,
+      reused,
+      provenance: row.comparator_reuse_provenance ?? null,
+    },
+    packet: await packetProjection(runDir, row),
+    timing: timingProjection(row),
+    identities: {
+      runner: row.runner ?? null,
+      model: row.model ?? null,
+      package: row.package_identity ?? null,
+      source_cli: row.source_cli_identity ?? null,
+      benchmark_contract_fingerprint: row.benchmark_contract?.compatibility_fingerprint ?? null,
+      scorer_sha256: row.benchmark_contract?.scorer_hash ?? null,
+      task_manifest_sha256: row.benchmark_contract?.task_manifest_hash ?? null,
+    },
+  };
+}
+
+function passCount(rows, role) {
+  const selected = rows.filter((row) => armRole(row.arm) === role);
+  const sourceArms = [...new Set(selected.map((row) => row.arm))];
+  if (sourceArms.length !== 1) {
+    throw new Error(`task does not contain exactly one ${role} source arm`);
+  }
+  return {
+    source_arm: sourceArms[0],
+    passing_repeats: selected.filter((row) => row.status === "pass" && row.quality?.pass === true).length,
+    repeats: selected.length,
+  };
+}
+
+function preparationProjection(row) {
+  return {
+    repo: row.repo ?? null,
+    arm: row.arm ?? null,
+    project: row.project ?? null,
+    package_identity: row.package_identity ?? null,
+    source_cli_identity: row.source_cli_identity ?? null,
+    cold: {
+      wall_ms: row.preparation_wall_ms ?? null,
+      retrieval_index_ms: row.retrieval_index_wall_ms ?? null,
+      retrieval_work: row.cold_retrieval_work_evidence ?? null,
+    },
+    incremental: {
+      wall_ms: row.incremental_wall_ms ?? null,
+      status: row.incremental_status ?? null,
+      source_mutation: row.incremental_source_mutation ?? null,
+      work: row.incremental_retrieval_work_evidence ?? null,
+    },
+  };
+}
+
+export async function buildRemediationFailureLedger(sourceRunDir, options = {}) {
+  const runDir = path.resolve(sourceRunDir);
+  const sourceBytes = new Map();
+  for (const [name, maxBytes] of SOURCE_ARTIFACTS) {
+    sourceBytes.set(name, await readRegularFileBounded(path.join(runDir, name), maxBytes, name));
+  }
+  const summary = JSON.parse(sourceBytes.get("summary.json").toString("utf8"));
+  const rows = parseJsonl(sourceBytes.get("runs.jsonl"), "runs.jsonl");
+  const preparationRows = parseJsonl(sourceBytes.get("preparations.jsonl"), "preparations.jsonl")
+    .filter((row) => row.kind === "preparation");
+  const taskIds = uniqueValues([
+    ...(summary.tasks ?? []).map((task) => task.id),
+    ...rows.map((row) => row.task_id),
+  ]);
+  const tasks = [];
+  for (const taskId of taskIds) {
+    const taskRows = rows.filter((row) => row.task_id === taskId);
+    const summaryTask = (summary.tasks ?? []).find((task) => task.id === taskId) ?? {};
+    tasks.push({
+      task_id: taskId,
+      repo: summaryTask.repo ?? taskRows[0]?.repo ?? null,
+      task_class: summaryTask.task_class ?? taskRows[0]?.task_class ?? null,
+      pass_counts: {
+        no_codestory: passCount(taskRows, "no_codestory"),
+        published: passCount(taskRows, "published"),
+        candidate: passCount(taskRows, "candidate"),
+      },
+      rows: await Promise.all(taskRows.map((row) => rowProjection(runDir, row))),
+    });
+  }
+  const flattenedPreparations = preparationRows.flatMap((row) => {
+    if (!row.arm_preparations || typeof row.arm_preparations !== "object") return [row];
+    return Object.entries(row.arm_preparations).map(([arm, preparation]) => ({
+      ...preparation,
+      repo: preparation.repo ?? row.repo,
+      arm,
+    }));
+  });
+  return {
+    contract: "codestory.remediation-failure-ledger/v1",
+    generated_at: options.generated_at ?? new Date().toISOString(),
+    source: {
+      run_dir: runDir,
+      artifacts: SOURCE_ARTIFACTS.map(([name]) => ({
+        name,
+        sha256: sha256(sourceBytes.get(name)),
+        byte_length: sourceBytes.get(name).length,
+      })),
+    },
+    identities: {
+      packages: uniqueValues([
+        ...rows.map((row) => row.package_identity),
+        ...flattenedPreparations.map((row) => row.package_identity),
+      ]),
+      source_clis: uniqueValues([
+        ...rows.map((row) => row.source_cli_identity),
+        ...flattenedPreparations.map((row) => row.source_cli_identity),
+      ]),
+      tasks: uniqueValues(rows.map((row) => row.task_manifest_snapshot)),
+      models: uniqueValues(rows.map((row) => row.model ?? summary.model)),
+      runners: uniqueValues(rows.map((row) => row.runner ?? summary.runner)),
+      hosts: uniqueValues([summary.host_class]),
+      scorers: uniqueValues(rows.map((row) => row.benchmark_contract?.scorer_hash)),
+    },
+    tasks,
+    preparations: flattenedPreparations.map(preparationProjection),
+  };
+}
+
+export async function writeRemediationFailureLedger(sourceRunDir, outputPath, options = {}) {
+  const ledger = await buildRemediationFailureLedger(sourceRunDir, options);
+  await writeFile(outputPath, `${JSON.stringify(ledger, null, 2)}\n`, { flag: "wx", mode: 0o600 });
+  return ledger;
+}
+
+function parseCliArgs(argv) {
+  const values = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    if (!["--run-dir", "--out"].includes(flag) || index + 1 >= argv.length) {
+      throw new Error("usage: codestory-remediation-ledger.mjs --run-dir <path> --out <path>");
+    }
+    values[flag.slice(2).replaceAll("-", "_")] = argv[index + 1];
+    index += 1;
+  }
+  if (!values.run_dir || !values.out) {
+    throw new Error("usage: codestory-remediation-ledger.mjs --run-dir <path> --out <path>");
+  }
+  return values;
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  try {
+    const args = parseCliArgs(process.argv.slice(2));
+    const ledger = await writeRemediationFailureLedger(args.run_dir, path.resolve(args.out));
+    process.stdout.write(`${ledger.contract}\n`);
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/tests/codestory-agent-ab-analyzer.test.mjs
+++ b/scripts/tests/codestory-agent-ab-analyzer.test.mjs
@@ -37,6 +37,8 @@ import {
   isTrustedPublishableRepoUrl,
   isPathInside,
   interactionTurnTelemetry,
+  installedAgentTiming,
+  installedAgentTimingCohortId,
   loadTaskForResult,
   loadReleaseEvidenceCorpusContract,
   loadTasks,
@@ -92,6 +94,7 @@ import {
   runAgentBenchmarkPipeline,
   runPlannedAgentRuns,
   runProcess,
+  timingIneligibleComparatorRow,
   buildQualityDebugPayload,
   qualityFailureReasons,
   taskSnapshotForResult,
@@ -1389,6 +1392,23 @@ test("retrieval index work evidence preserves the measured trust-boundary fields
     ],
   });
   assert.equal(benchmarkHarness.retrievalIndexWorkEvidence("not json"), null);
+
+  const receipt = {
+    contract: "codestory.incremental-wall-receipt/v1",
+    total_ms: 20_000,
+    accounted_ms: 20_000,
+    reconciliation_basis_points: 10_000,
+    scheduled_paths: [{ path: "src/server.c", action: "index", reason: "source_identity_changed" }],
+  };
+  assert.deepEqual(
+    benchmarkHarness.retrievalIndexWorkEvidence(JSON.stringify({
+      core_phase_timings: { publish_ms: 7 },
+      retrieval_phase_timings: [{ phase: "graph artifact", elapsed_ms: 3 }],
+      retrieval_component_work: [],
+      incremental_wall_receipt: receipt,
+    })).incremental_wall_receipt,
+    receipt,
+  );
 });
 
 test("exact lifecycle alternates preparation and restores the selected source bytes", async () => {
@@ -2511,6 +2531,66 @@ test("nonzero packet prelude preserves structured retrieval failure and keeps th
     assert.deepEqual(prelude.public.packet_contract_blockers, [prelude.public.error]);
     assert.equal(preludeAllowsAgentRun(prelude.public), false);
     assert.equal(prelude.packet, null);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("fresh CLI packet prelude reports first-packet and continuation timing separately", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "codestory-packet-split-timing-"));
+  try {
+    const prompt = "Trace the bounded continuation.";
+    const questionSha256 = createHash("sha256").update(prompt).digest("hex");
+    const first = packetV3Fixture();
+    first.identity.question_sha256 = questionSha256;
+    first.status = "continuation_available";
+    first.gaps = [{
+      identity: { gap_id: "gap-v3" },
+      kind: "continuation_required",
+      message: "one bounded continuation",
+    }];
+    first.continuation = {
+      continuation_id: "continuation-v3",
+      remaining_rounds: 1,
+      gap_ids: [{ gap_id: "gap-v3" }],
+    };
+    const final = packetV3Fixture();
+    final.identity.question_sha256 = questionSha256;
+    const cliPath = path.join(root, "codestory-cli");
+    await writeFile(
+      cliPath,
+      `#!/usr/bin/env node\nconst continuation = process.argv.includes("--parent-packet-id");\nconst payload = continuation ? ${JSON.stringify(JSON.stringify(final))} : ${JSON.stringify(JSON.stringify(first))};\nsetTimeout(() => process.stdout.write(payload + "\\n"), continuation ? 15 : 25);\n`,
+      "utf8",
+    );
+    await chmod(cliPath, 0o755);
+
+    const prelude = await runCodeStoryPacketPrelude(
+      {
+        timeoutMs: 5_000,
+        publishable: false,
+        diagnosticExtraProbesFromManifest: false,
+      },
+      { task: { prompt, task_class: "route_tracing" } },
+      { path: root, prompt },
+      root,
+      "split-timing",
+      cliPath,
+      process.env,
+    );
+
+    assert.equal(prelude.public.packet_drill_continuation, true);
+    assert.equal(prelude.public.packet_process_count, 2);
+    assert.equal(prelude.public.transport_cell, "fresh_cli_prelude");
+    assert.ok(prelude.public.time_to_first_packet_ms >= 20);
+    assert.ok(prelude.public.continuation_ms >= 10);
+    assert.equal(prelude.public.time_to_final_packet_ms, prelude.public.wall_ms);
+    assert.ok(
+      Math.abs(
+        prelude.public.time_to_first_packet_ms
+          + prelude.public.continuation_ms
+          - prelude.public.time_to_final_packet_ms,
+      ) < 0.002,
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -9057,4 +9137,89 @@ test("buildQualityDebugPayload preserves packet sufficiency diagnostics", () => 
     ],
     1,
   );
+});
+
+test("installed timing cohorts match only inside one host, model, load-policy, task, repeat, and window", () => {
+  const dimensions = {
+    execution_window_id: "window-2026-08-30T12:00:00Z",
+    host: {
+      platform: "darwin",
+      arch: "arm64",
+      cpu_model: "Apple M4 Max",
+      logical_cpu_count: 16,
+      total_memory_bytes: 64 * 1024 ** 3,
+    },
+    model: "gpt-5.6-sol",
+    load_policy: "fresh_agent_session",
+    task_id: "dart-http-client-flow",
+    repeat: 2,
+  };
+  const cohort = installedAgentTimingCohortId(dimensions);
+  assert.match(cohort, /^[0-9a-f]{64}$/);
+  assert.equal(installedAgentTimingCohortId({ ...dimensions, arm: "published_0_17_5" }), cohort);
+  assert.equal(installedAgentTimingCohortId({ ...dimensions, arm: "candidate_0_18" }), cohort);
+  for (const [field, value] of [
+    ["execution_window_id", "next-window"],
+    ["model", "gpt-5.6-terra"],
+    ["load_policy", "persistent_agent_session"],
+    ["task_id", "c-redis-command-loop"],
+    ["repeat", 3],
+  ]) {
+    assert.notEqual(installedAgentTimingCohortId({ ...dimensions, [field]: value }), cohort, field);
+  }
+  assert.notEqual(
+    installedAgentTimingCohortId({
+      ...dimensions,
+      host: { ...dimensions.host, logical_cpu_count: 12 },
+    }),
+    cohort,
+  );
+});
+
+test("installed timing separates runner, first packet, continuation, final packet, and whole task", () => {
+  const timing = installedAgentTiming({
+    timing_cohort_id: "a".repeat(64),
+    agent_runner_ms: 1_201.4,
+    time_to_first_packet_ms: 410.6,
+    continuation_ms: 92.2,
+    whole_task_wall_ms: 1_704.2,
+  });
+  assert.deepEqual(timing, {
+    timing_cohort_id: "a".repeat(64),
+    agent_runner_ms: 1_201,
+    time_to_first_packet_ms: 411,
+    continuation_ms: 92,
+    time_to_final_packet_ms: 503,
+    whole_task_wall_ms: 1_704,
+  });
+  assert.throws(
+    () => installedAgentTiming({
+      timing_cohort_id: "a".repeat(64),
+      agent_runner_ms: 10,
+      time_to_first_packet_ms: 20,
+      continuation_ms: 30,
+      whole_task_wall_ms: 59,
+    }),
+    /does not reconcile/,
+  );
+});
+
+test("reused comparator rows are always timing-ineligible", () => {
+  const row = timingIneligibleComparatorRow({
+    arm: "published_0_17_5",
+    comparative_wall_time_eligible: true,
+    installed_agent_timing: {
+      timing_cohort_id: "b".repeat(64),
+      agent_runner_ms: 100,
+      time_to_first_packet_ms: 10,
+      continuation_ms: 5,
+      time_to_final_packet_ms: 15,
+      whole_task_wall_ms: 115,
+      timing_eligible: true,
+    },
+  });
+  assert.equal(row.comparative_wall_time_eligible, false);
+  assert.equal(row.installed_agent_timing_eligible, false);
+  assert.equal(row.installed_agent_timing_ineligibility_reason, "reused_comparator_row");
+  assert.equal(Object.keys(row.installed_agent_timing).length, 6);
 });

--- a/scripts/tests/codestory-focused-abba-preflight.test.mjs
+++ b/scripts/tests/codestory-focused-abba-preflight.test.mjs
@@ -6,6 +6,7 @@ import {
   REQUIRED_TASK_IDS,
   abbaRunPlan,
   focusedAbbaTiming,
+  transientEmbeddingServerTransition,
 } from "../codestory-focused-abba-preflight.mjs";
 
 test("focused timing preflight schedules five paired ABBA rows per arm and task", () => {
@@ -82,4 +83,26 @@ test("focused timing preflight gives paired arms the same cohort id", () => {
     time_to_final_packet_ms: 25,
     whole_task_wall_ms: 125,
   });
+});
+
+test("focused timing preflight retries only a zero-row embedding-server transition", () => {
+  const transition = {
+    completed_rows: 0,
+    first_failure: {
+      kind: "preparation_failed",
+      error: "embedding_server_draining: incompatible engine contract",
+    },
+  };
+  assert.equal(transientEmbeddingServerTransition(transition), true);
+  assert.equal(
+    transientEmbeddingServerTransition({ ...transition, completed_rows: 1 }),
+    false,
+  );
+  assert.equal(
+    transientEmbeddingServerTransition({
+      ...transition,
+      first_failure: { kind: "preparation_failed", error: "retrieval unavailable" },
+    }),
+    false,
+  );
 });

--- a/scripts/tests/codestory-focused-abba-preflight.test.mjs
+++ b/scripts/tests/codestory-focused-abba-preflight.test.mjs
@@ -42,6 +42,12 @@ test("focused timing preflight schedules five paired ABBA rows per arm and task"
 
 test("focused timing preflight gives paired arms the same cohort id", () => {
   const raw = {
+    agent_runner_wall_ms: 100.2,
+    wall_ms: 125.4,
+    codestory_harness_prelude: {
+      time_to_first_packet_ms: 20.1,
+      continuation_ms: 5.1,
+    },
     installed_agent_timing: {
       timing_cohort_id: "f".repeat(64),
       agent_runner_ms: 100,

--- a/scripts/tests/codestory-focused-abba-preflight.test.mjs
+++ b/scripts/tests/codestory-focused-abba-preflight.test.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  ARMS,
+  REQUIRED_TASK_IDS,
+  abbaRunPlan,
+  focusedAbbaTiming,
+} from "../codestory-focused-abba-preflight.mjs";
+
+test("focused timing preflight schedules five paired ABBA rows per arm and task", () => {
+  const plan = abbaRunPlan();
+  assert.equal(plan.length, 40);
+  for (const taskId of REQUIRED_TASK_IDS) {
+    const rows = plan.filter((row) => row.task_id === taskId);
+    assert.deepEqual(rows.slice(0, 4).map((row) => row.arm), [
+      "published_0_17_5",
+      "candidate_0_18",
+      "candidate_0_18",
+      "published_0_17_5",
+    ]);
+    assert.deepEqual(rows.map((row) => row.arm), [
+      "published_0_17_5",
+      "candidate_0_18",
+      "candidate_0_18",
+      "published_0_17_5",
+      "published_0_17_5",
+      "candidate_0_18",
+      "candidate_0_18",
+      "published_0_17_5",
+      "published_0_17_5",
+      "candidate_0_18",
+    ]);
+    for (const arm of ARMS) {
+      assert.deepEqual(
+        rows.filter((row) => row.arm === arm).map((row) => row.repeat),
+        [1, 2, 3, 4, 5],
+      );
+    }
+  }
+});
+
+test("focused timing preflight gives paired arms the same cohort id", () => {
+  const raw = {
+    installed_agent_timing: {
+      timing_cohort_id: "f".repeat(64),
+      agent_runner_ms: 100,
+      time_to_first_packet_ms: 20,
+      continuation_ms: 5,
+      time_to_final_packet_ms: 25,
+      whole_task_wall_ms: 125,
+    },
+  };
+  const dimensions = {
+    execution_window_id: "window-1",
+    host: {
+      platform: "darwin",
+      arch: "arm64",
+      cpu_model: "Apple M5",
+      logical_cpu_count: 10,
+      total_memory_bytes: 24 * 1024 ** 3,
+    },
+    model: "gpt-5.6-sol",
+    load_policy: "fresh_cli_fresh_agent_session",
+    task_id: "dart-http-client-flow",
+    repeat: 1,
+  };
+  const published = focusedAbbaTiming(raw, { ...dimensions, arm: "published_0_17_5" });
+  const candidate = focusedAbbaTiming(raw, { ...dimensions, arm: "candidate_0_18" });
+  assert.equal(published.timing_cohort_id, candidate.timing_cohort_id);
+  assert.deepEqual(published, {
+    timing_cohort_id: candidate.timing_cohort_id,
+    agent_runner_ms: 100,
+    time_to_first_packet_ms: 20,
+    continuation_ms: 5,
+    time_to_final_packet_ms: 25,
+    whole_task_wall_ms: 125,
+  });
+});

--- a/scripts/tests/codestory-remediation-ledger.test.mjs
+++ b/scripts/tests/codestory-remediation-ledger.test.mjs
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  buildRemediationFailureLedger,
+} from "../codestory-remediation-ledger.mjs";
+
+async function writeFixture(runDir, packetPath = "/private/tmp/retained/task-candidate.codestory-packet.stdout.json") {
+  const task = {
+    id: "dart-http-client-flow",
+    repo: "dart-lang-http",
+    task_class: "data_flow",
+  };
+  await writeFile(path.join(runDir, "summary.json"), `${JSON.stringify({
+    model: "gpt-5.6-sol",
+    runner: "codex",
+    host_class: { platform: "darwin", arch: "arm64" },
+    tasks: [task],
+  })}\n`);
+  await writeFile(path.join(runDir, "summary.md"), "# retained receipt\n");
+  await writeFile(path.join(runDir, "task-candidate.codestory-packet.stdout.json"), `${JSON.stringify({
+    schema_version: 3,
+    kind: "complete",
+    status: "available",
+    retrieval: { state: "full" },
+    evidence: [{
+      identity: { evidence_id: "source-1" },
+      kind: "exact_source",
+      path: "pkgs/http/lib/http.dart",
+      symbol_id: "Client.get",
+      start_line: 42,
+      end_line: 55,
+    }],
+    gaps: [{ identity: { gap_id: "gap-1" }, kind: "output_budget_exceeded" }],
+    continuation: null,
+  })}\n`);
+  const common = {
+    repo: task.repo,
+    task_id: task.id,
+    task_class: task.task_class,
+    repeat: 1,
+    runner: "codex",
+    model: "gpt-5.6-sol",
+    status: "pass",
+    comparative_wall_time_eligible: true,
+    wall_ms: 100,
+    agent_runner_wall_ms: 80,
+    benchmark_contract: {
+      scorer_hash: "1".repeat(64),
+      compatibility_fingerprint: "2".repeat(64),
+      task_manifest_hash: "3".repeat(64),
+    },
+    task_manifest_snapshot: { id: task.id, repo: task.repo },
+    quality: {
+      pass: true,
+      expected_anchors: { missed_anchors: [] },
+      expected_files: { missed_anchors: [] },
+      expected_symbols: { missed_anchors: [] },
+      expected_claims: { missed_anchors: [] },
+      citation_coverage: { missed_anchors: [] },
+      material_factual_errors: { found: 0, found_anchors: [] },
+      unsupported_proof_claims: { found: 0, found_claims: [] },
+      forbidden_claims: { found: 0, found_anchors: [] },
+    },
+  };
+  const rows = [
+    { ...common, benchmark_run_id: "without", arm: "without_codestory" },
+    {
+      ...common,
+      benchmark_run_id: "published",
+      arm: "published_0_17_5",
+      comparator_reuse_provenance: { source_ledger_sha256: "4".repeat(64) },
+      exact_candidate_timing: { cold_ms: 1, warm_ms: 100, incremental_ms: 2, all_in_ms: 100 },
+    },
+    {
+      ...common,
+      benchmark_run_id: "candidate",
+      arm: "candidate_0_18",
+      status: "pass",
+      quality: {
+        ...common.quality,
+        pass: false,
+        expected_anchors: { missed_anchors: ["client.dart", "transport claim"] },
+        expected_files: { missed_anchors: ["client.dart"] },
+        expected_claims: { missed_anchors: ["transport claim"] },
+        citation_coverage: { missed_anchors: ["client.dart"] },
+      },
+      codestory_harness_prelude: {
+        wall_ms: 20,
+        stdout_path: packetPath,
+        packet_schema_version: 3,
+        packet_projection_kind: "complete",
+        packet_drill_continuation: false,
+        packet_evidence_count: 1,
+        packet_gap_count: 1,
+        stdout_bytes: 512,
+      },
+      source_cli_identity: {
+        source_commit: "5".repeat(40),
+        source_tree: "6".repeat(40),
+        cli_sha256: "7".repeat(64),
+      },
+      exact_candidate_timing: { cold_ms: 3, warm_ms: 100, incremental_ms: 4, all_in_ms: 100 },
+    },
+  ];
+  await writeFile(path.join(runDir, "runs.jsonl"), `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+  await writeFile(path.join(runDir, "preparations.jsonl"), `${JSON.stringify({
+    kind: "preparation",
+    repo: "redis-redis",
+    incremental_wall_ms: 21_692,
+    incremental_source_mutation: { path: "src/server.c", mutation: "append_one_lf_v1" },
+    incremental_retrieval_work_evidence: {
+      core_phase_timings: { publish_ms: 7_683 },
+      retrieval_phase_timings: [{ phase: "lexical sidecar", elapsed_ms: 1_902 }],
+    },
+  })}\n`);
+}
+
+test("remediation ledger preserves per-arm counts, failure detail, packet evidence, timing, and identities", async () => {
+  const runDir = await mkdtemp(path.join(os.tmpdir(), "codestory-remediation-ledger-"));
+  try {
+    await writeFixture(runDir);
+    const ledger = await buildRemediationFailureLedger(runDir, {
+      generated_at: "2026-08-30T12:00:00.000Z",
+    });
+    assert.equal(ledger.contract, "codestory.remediation-failure-ledger/v1");
+    assert.equal(ledger.source.artifacts.length, 4);
+    assert.ok(ledger.source.artifacts.every((artifact) => /^[0-9a-f]{64}$/.test(artifact.sha256)));
+    assert.deepEqual(ledger.tasks[0].pass_counts, {
+      no_codestory: { source_arm: "without_codestory", passing_repeats: 1, repeats: 1 },
+      published: { source_arm: "published_0_17_5", passing_repeats: 1, repeats: 1 },
+      candidate: { source_arm: "candidate_0_18", passing_repeats: 0, repeats: 1 },
+    });
+    const candidate = ledger.tasks[0].rows.find((row) => row.arm === "candidate_0_18");
+    assert.deepEqual(candidate.quality.missing_files, ["client.dart"]);
+    assert.deepEqual(candidate.quality.missing_claims, ["transport claim"]);
+    assert.deepEqual(candidate.quality.missing_citations, ["client.dart"]);
+    assert.equal(candidate.packet.route, "complete");
+    assert.equal(candidate.packet.evidence_rows[0].symbol_id, "Client.get");
+    assert.equal(candidate.packet.gaps[0].kind, "output_budget_exceeded");
+    assert.equal(candidate.packet.byte_count > 0, true);
+    assert.equal(candidate.timing.legacy_warm_semantics, "whole_task_wall_ms");
+    assert.equal(candidate.timing.incremental_ms, 4);
+    const published = ledger.tasks[0].rows.find((row) => row.arm === "published_0_17_5");
+    assert.equal(published.comparator.fresh, false);
+    assert.equal(published.timing.eligible, false);
+    assert.equal(ledger.identities.source_clis[0].source_commit, "5".repeat(40));
+    assert.equal(ledger.identities.scorers[0], "1".repeat(64));
+    assert.equal(ledger.preparations[0].incremental.wall_ms, 21_692);
+  } finally {
+    await rm(runDir, { recursive: true, force: true });
+  }
+});
+
+test("remediation ledger rejects relative packet artifact traversal", async () => {
+  const runDir = await mkdtemp(path.join(os.tmpdir(), "codestory-remediation-ledger-"));
+  try {
+    await writeFixture(runDir, "../outside-packet.json");
+    await assert.rejects(
+      () => buildRemediationFailureLedger(runDir),
+      /packet artifact path escapes the retained run directory/,
+    );
+  } finally {
+    await rm(runDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #2099
Refs #2098

## Context

The retained 0.18 product receipt proves a Dart accuracy regression and a 21.692-second Redis one-file refresh. This draft starts from that failed evidence and keeps broad qualification closed until the focused remediation lanes pass.

Base: a41e605ea01e9e2c8b400eb5ee5456efd05f060e
Current head: 4585ebfa

## What changed

- Added the machine-readable remediation failure ledger.
- Replaced whole-task warm labeling with separate runner, first-packet, continuation, final-packet, and whole-task timing.
- Made reused comparator rows timing-ineligible.
- Added a reconciled incremental wall receipt with scheduled-path reasons and exclusive core/retrieval phases.
- Added the exact append-LF incremental preflight.

## How to review

Start with the incremental wall receipt in the contracts/runtime/CLI path, then the installed timing cohort contract, then the two evidence scripts. Product repairs will follow as focused commits in this same draft lane.

## Verification

- Node benchmark and remediation-ledger tests: 186 passed.
- codestory-contracts: 115 passed across unit and integration targets.
- Focused store promotion, runtime incremental, CLI receipt, and rendering tests passed.
- cargo fmt --all -- --check and git diff --check passed.
- Redis exact append-LF, five repeats: 19.702-21.048 seconds, 100% outer-wall reconciliation.

## Risk and non-claims

This commit records and separates the failing work; it does not claim the accuracy or performance regression is repaired. No broad qualification, calibration, packaging, or release proof has run.