### PR TITLE
[codex] compile packets from repository evidence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,17 +39,17 @@ pages, runbooks, and workflows own detailed mechanics.
   publication.
 - `codestory-retrieval`: lexical, semantic, and SCIP artifacts; immutable
   sidecar generations; manifests; health; and fail-closed query execution.
-- `codestory-agent`: prompt-blind packet seed planning and pure evidence-policy
-  helpers. Horizon A forwards the unchanged question to generic retrieval and
-  accepts caller-supplied free-query seeds; it does not infer answer shapes or
-  traversal policy. It depends on `codestory-contracts` alone and can never
-  activate, store, execute retrieval, admit or hydrate candidates, retry a
-  publication, or move readiness. Repository-derived compilation is owned by
-  Horizon B (#2106), not the interim product graph.
+- `codestory-agent`: syntactic retrieval-seed planning and pure
+  repository-derived packet compilation over typed admitted evidence. Only the
+  seed plan may retain the unchanged question; the compiler cannot receive
+  prompt terms, task classes, obligations, roles, carriers, or sufficiency
+  policy. It depends on `codestory-contracts` alone and can never activate,
+  store, execute retrieval, admit or hydrate candidates, retry a publication,
+  or move readiness.
 - `codestory-runtime`: the only product orchestration layer. Indexing,
   grounding, search, packet assembly, and retrieval execution belong here.
-  Retrieval, admission, hydration, retry, and interim packet assembly belong
-  here; prompt-blind seed planning belongs in `codestory-agent`.
+  Retrieval, admission, hydration, retry, and packet assembly belong here;
+  pure seed planning and evidence selection belong in `codestory-agent`.
 - `codestory-cli`: command and transport parsing, output rendering, process
   configuration capture, and managed sidecar lifecycle boundaries. Do not move
   product orchestration into adapters.

--- a/crates/codestory-agent/src/evidence_compiler.rs
+++ b/crates/codestory-agent/src/evidence_compiler.rs
@@ -40,6 +40,7 @@ pub fn compile_repository_evidence(
     let mut support = Vec::new();
     let mut source_budget_omissions = BTreeSet::new();
     let mut relation_budget_omissions = BTreeSet::new();
+    let mut represented_identities = BTreeSet::new();
 
     // Weave the path-diverse source order with the directed forest. This keeps
     // exact selectors and first-path witnesses ahead of repeated ranges while
@@ -48,14 +49,19 @@ pub fn compile_repository_evidence(
     let mut relation_index = 0;
     while source_index < sources.len() || relation_index < relations.len() {
         if let Some(source) = sources.get(source_index) {
-            if !push_if_within_public_budget(&mut support, source_support_unit(source.witness)) {
+            if push_if_within_public_budget(&mut support, source_support_unit(source.witness)) {
+                represented_identities.insert(source.witness.stable_identity.clone());
+            } else {
                 source_budget_omissions.extend(source.represented_identities.iter().cloned());
             }
             source_index += 1;
         }
 
         if let Some(relation) = relations.get(relation_index) {
-            if !push_if_within_public_budget(&mut support, relation_support_unit(relation)) {
+            if push_if_within_public_budget(&mut support, relation_support_unit(relation)) {
+                represented_identities.insert(relation.from_identity.clone());
+                represented_identities.insert(relation.to_identity.clone());
+            } else {
                 relation_budget_omissions.insert(relation.from_identity.clone());
                 relation_budget_omissions.insert(relation.to_identity.clone());
             }
@@ -63,10 +69,10 @@ pub fn compile_repository_evidence(
         }
     }
 
-    let source_identities = support
+    let source_identities = sources
         .iter()
-        .filter(|unit| unit.kind == SupportUnitKindDto::SourceRange)
-        .filter_map(|unit| unit.symbol_id.clone())
+        .filter(|source| represented_identities.contains(&source.witness.stable_identity))
+        .map(|source| source.witness.stable_identity.as_str())
         .collect::<BTreeSet<_>>();
     let represented_source_paths = sources
         .iter()
@@ -82,16 +88,22 @@ pub fn compile_repository_evidence(
         if source_identities.contains(admission.stable_identity.as_str()) {
             continue;
         }
-        let _ = push_if_within_public_budget(
+        let retained = push_if_within_public_budget(
             &mut support,
             SupportUnitDto {
                 id: format!("symbol:{}", admission.stable_identity),
                 kind: SupportUnitKindDto::SymbolLocation,
                 summary: admission.stable_identity.clone(),
-                path: represented_source_paths
-                    .get(admission.stable_identity.as_str())
-                    .map(|path| (*path).to_string()),
-                symbol_id: Some(admission.stable_identity.clone()),
+                path: admission
+                    .stable_identity
+                    .strip_prefix("path:")
+                    .map(ToOwned::to_owned)
+                    .or_else(|| {
+                        represented_source_paths
+                            .get(admission.stable_identity.as_str())
+                            .map(|path| (*path).to_string())
+                    }),
+                symbol_id: public_symbol_id(&admission.stable_identity),
                 start_line: None,
                 end_line: None,
                 snippet: None,
@@ -101,6 +113,9 @@ pub fn compile_repository_evidence(
                 query: None,
             },
         );
+        if retained {
+            represented_identities.insert(admission.stable_identity.clone());
+        }
     }
 
     support.truncate(INTERIM_MAX_ADMITTED_CANDIDATES);
@@ -110,7 +125,7 @@ pub fn compile_repository_evidence(
         &relations,
         &source_budget_omissions,
         &relation_budget_omissions,
-        &support,
+        &represented_identities,
     );
     RepositoryDerivedCompilationV1 {
         support,
@@ -257,10 +272,12 @@ fn selected_relations<'a>(
             admission_order.contains_key(relation.from_identity.as_str())
                 && admission_order.contains_key(relation.to_identity.as_str())
         })
+        .filter(|relation| relation.from_identity != relation.to_identity)
         .collect::<Vec<_>>();
     certain.sort_by(|left, right| {
         relation_priority(left, admission_order)
             .cmp(&relation_priority(right, admission_order))
+            .then_with(|| left.relation_kind.cmp(&right.relation_kind))
             .then_with(|| left.relation_id.cmp(&right.relation_id))
     });
 
@@ -318,7 +335,7 @@ fn selected_relations<'a>(
 fn relation_priority(
     relation: &PacketDirectedRelationV1,
     admission_order: &HashMap<&str, usize>,
-) -> (u8, usize, usize) {
+) -> (u8, usize, usize, usize, usize) {
     let from = admission_order
         .get(relation.from_identity.as_str())
         .copied()
@@ -331,6 +348,8 @@ fn relation_priority(
         u8::from(from == usize::MAX || to == usize::MAX),
         from.max(to),
         from.min(to),
+        from,
+        to,
     )
 }
 
@@ -353,7 +372,7 @@ fn source_support_unit(source: &PacketHydratedSourceRangeV1) -> SupportUnitDto {
             .clone()
             .unwrap_or_else(|| source.stable_identity.clone()),
         path: Some(source.path.clone()),
-        symbol_id: Some(source.stable_identity.clone()),
+        symbol_id: public_symbol_id(&source.stable_identity),
         start_line: Some(source.start_line),
         end_line: Some(source.end_line),
         snippet: Some(source.source.clone()),
@@ -375,13 +394,13 @@ fn relation_support_unit(relation: &PacketDirectedRelationV1) -> SupportUnitDto 
             relation.to_identity
         ),
         path: None,
-        symbol_id: Some(relation.from_identity.clone()),
+        symbol_id: public_symbol_id(&relation.from_identity),
         start_line: None,
         end_line: None,
         snippet: None,
         edge_kind: Some(relation.relation_kind.as_str().to_string()),
-        from_symbol: Some(relation.from_identity.clone()),
-        to_symbol: Some(relation.to_identity.clone()),
+        from_symbol: public_symbol_id(&relation.from_identity),
+        to_symbol: public_symbol_id(&relation.to_identity),
         query: None,
     }
 }
@@ -404,17 +423,28 @@ fn push_if_within_public_budget(
     true
 }
 
+fn public_symbol_id(stable_identity: &str) -> Option<String> {
+    stable_identity.strip_prefix("node:").map(ToOwned::to_owned)
+}
+
 fn continuation_selectors(
     input: &PacketCompilationInputV1,
     sources: &[SelectedSourceRange<'_>],
     relations: &[&PacketDirectedRelationV1],
     source_budget_omissions: &BTreeSet<String>,
     relation_budget_omissions: &BTreeSet<String>,
-    support: &[SupportUnitDto],
+    represented_identities: &BTreeSet<String>,
 ) -> Vec<PacketContinuationSelectorV1> {
     let mut selectors = Vec::new();
     let mut identities_with_explicit_gaps = BTreeSet::new();
-    for gap in &input.admission_gaps {
+    let mut ordered_gaps = input.admission_gaps.iter().enumerate().collect::<Vec<_>>();
+    ordered_gaps.sort_by(|(left_index, left), (right_index, right)| {
+        left.exact_selector_ordinal
+            .unwrap_or(u32::MAX)
+            .cmp(&right.exact_selector_ordinal.unwrap_or(u32::MAX))
+            .then_with(|| left_index.cmp(right_index))
+    });
+    for (_, gap) in ordered_gaps {
         let Some(stable_identity) = gap.stable_identity.clone() else {
             continue;
         };
@@ -455,23 +485,6 @@ fn continuation_selectors(
         .iter()
         .flat_map(|relation| [relation.from_identity.clone(), relation.to_identity.clone()])
         .collect::<BTreeSet<_>>();
-    let represented_identities = support
-        .iter()
-        .flat_map(|unit| {
-            let mut identities = Vec::new();
-            if let Some(identity) = unit.symbol_id.clone() {
-                identities.push(identity);
-            }
-            if let Some(identity) = unit.from_symbol.clone() {
-                identities.push(identity);
-            }
-            if let Some(identity) = unit.to_symbol.clone() {
-                identities.push(identity);
-            }
-            identities
-        })
-        .collect::<BTreeSet<_>>();
-
     for admission in ordered_admissions(input) {
         let identity = &admission.stable_identity;
         if identities_with_explicit_gaps.contains(identity) {
@@ -494,25 +507,17 @@ fn continuation_selectors(
         }
     }
 
-    selectors.sort_by(|left, right| {
-        left.stable_identity
-            .cmp(&right.stable_identity)
-            .then_with(|| structural_gap_rank(left.reason).cmp(&structural_gap_rank(right.reason)))
-    });
-    selectors.dedup_by(|left, right| {
-        left.stable_identity == right.stable_identity && left.reason == right.reason
+    let mut seen = Vec::new();
+    selectors.retain(|selector| {
+        let key = (selector.stable_identity.clone(), selector.reason);
+        if seen.contains(&key) {
+            false
+        } else {
+            seen.push(key);
+            true
+        }
     });
     selectors
-}
-
-fn structural_gap_rank(reason: PacketStructuralGapReasonV1) -> u8 {
-    match reason {
-        PacketStructuralGapReasonV1::CandidateCountExceeded => 0,
-        PacketStructuralGapReasonV1::SourceBudgetExceeded => 1,
-        PacketStructuralGapReasonV1::SourceUnavailable => 2,
-        PacketStructuralGapReasonV1::AmbiguousSelector => 3,
-        PacketStructuralGapReasonV1::DisconnectedSeed => 4,
-    }
 }
 
 fn continuation_selector(
@@ -555,14 +560,14 @@ mod tests {
             admissions: vec![
                 PacketAdmissionReceiptV1 {
                     packet_ordinal: 1,
-                    stable_identity: "retrieved".into(),
+                    stable_identity: "node:retrieved".into(),
                     score_version: "v1".into(),
                     reserved_source_bytes: 128,
                     origin: PacketAdmissionOriginV1::Retrieval,
                 },
                 PacketAdmissionReceiptV1 {
                     packet_ordinal: 0,
-                    stable_identity: "exact".into(),
+                    stable_identity: "node:exact".into(),
                     score_version: "v1".into(),
                     reserved_source_bytes: 128,
                     origin: PacketAdmissionOriginV1::ExactTypedSelector,
@@ -570,7 +575,7 @@ mod tests {
             ],
             sources: vec![
                 PacketHydratedSourceRangeV1 {
-                    stable_identity: "retrieved".into(),
+                    stable_identity: "node:retrieved".into(),
                     path: "src/shared.rs".into(),
                     symbol: Some("retrieved".into()),
                     start_line: 5,
@@ -579,7 +584,7 @@ mod tests {
                     parser_completeness: PacketParserCompletenessV1::Complete,
                 },
                 PacketHydratedSourceRangeV1 {
-                    stable_identity: "exact".into(),
+                    stable_identity: "node:exact".into(),
                     path: "src/exact.rs".into(),
                     symbol: Some("exact".into()),
                     start_line: 1,
@@ -588,7 +593,7 @@ mod tests {
                     parser_completeness: PacketParserCompletenessV1::Complete,
                 },
                 PacketHydratedSourceRangeV1 {
-                    stable_identity: "exact".into(),
+                    stable_identity: "node:exact".into(),
                     path: "src/exact.rs".into(),
                     symbol: Some("exact".into()),
                     start_line: 3,
@@ -623,15 +628,15 @@ mod tests {
         input.relations = vec![
             PacketDirectedRelationV1 {
                 relation_id: "certain".into(),
-                from_identity: "exact".into(),
-                to_identity: "retrieved".into(),
+                from_identity: "node:exact".into(),
+                to_identity: "node:retrieved".into(),
                 relation_kind: PacketRelationKindV1::Call,
                 certainty: PacketRelationCertaintyV1::Certain,
             },
             PacketDirectedRelationV1 {
                 relation_id: "uncertain".into(),
-                from_identity: "exact".into(),
-                to_identity: "retrieved".into(),
+                from_identity: "node:exact".into(),
+                to_identity: "node:retrieved".into(),
                 relation_kind: PacketRelationKindV1::Call,
                 certainty: PacketRelationCertaintyV1::Uncertain,
             },
@@ -651,11 +656,11 @@ mod tests {
         let mut input = input();
         input
             .sources
-            .retain(|source| source.stable_identity == "exact");
+            .retain(|source| source.stable_identity == "node:exact");
         input.relations = vec![PacketDirectedRelationV1 {
             relation_id: "connects-seeds".into(),
-            from_identity: "exact".into(),
-            to_identity: "retrieved".into(),
+            from_identity: "node:exact".into(),
+            to_identity: "node:retrieved".into(),
             relation_kind: PacketRelationKindV1::Call,
             certainty: PacketRelationCertaintyV1::Certain,
         }];
@@ -669,7 +674,7 @@ mod tests {
         let fallback_index = product
             .support
             .iter()
-            .position(|unit| unit.id == "symbol:retrieved")
+            .position(|unit| unit.id == "symbol:node:retrieved")
             .expect("symbol fallback");
         assert!(relation_index < fallback_index);
     }
@@ -680,7 +685,7 @@ mod tests {
         input.sources.insert(
             0,
             PacketHydratedSourceRangeV1 {
-                stable_identity: "retrieved".into(),
+                stable_identity: "node:retrieved".into(),
                 path: "src/shared.rs".into(),
                 symbol: Some("retrieved".into()),
                 start_line: 5,
@@ -706,15 +711,15 @@ mod tests {
         input.relations = vec![
             PacketDirectedRelationV1 {
                 relation_id: "first-incident".into(),
-                from_identity: "retrieved".into(),
-                to_identity: "external-a".into(),
+                from_identity: "node:retrieved".into(),
+                to_identity: "node:external-a".into(),
                 relation_kind: PacketRelationKindV1::Usage,
                 certainty: PacketRelationCertaintyV1::Certain,
             },
             PacketDirectedRelationV1 {
                 relation_id: "second-incident".into(),
-                from_identity: "retrieved".into(),
-                to_identity: "external-b".into(),
+                from_identity: "node:retrieved".into(),
+                to_identity: "node:external-b".into(),
                 relation_kind: PacketRelationKindV1::Usage,
                 certainty: PacketRelationCertaintyV1::Certain,
             },

--- a/crates/codestory-agent/src/evidence_compiler.rs
+++ b/crates/codestory-agent/src/evidence_compiler.rs
@@ -1,0 +1,746 @@
+//! Pure repository-derived evidence compilation.
+//!
+//! The compiler receives only admitted, hydrated repository evidence. It has
+//! no access to the original question and therefore cannot encode prompt
+//! taxonomies or expected answer stages.
+
+use codestory_contracts::api::{SupportUnitDto, SupportUnitKindDto};
+use codestory_contracts::compilation::{
+    INTERIM_MAX_ADMITTED_CANDIDATES, PACKET_COMPILATION_CONTRACT_VERSION_V1,
+    PUBLIC_PACKET_SERIALIZED_MAX_BYTES, PacketAdmissionGapKindV1, PacketAdmissionOriginV1,
+    PacketCompilationInputV1, PacketContinuationSelectorV1, PacketDirectedRelationV1,
+    PacketHydratedSourceRangeV1, PacketRelationCertaintyV1, PacketStructuralGapReasonV1,
+};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepositoryDerivedCompilationV1 {
+    pub support: Vec<SupportUnitDto>,
+    pub continuation: Vec<PacketContinuationSelectorV1>,
+}
+
+pub fn compile_repository_evidence(
+    input: &PacketCompilationInputV1,
+) -> RepositoryDerivedCompilationV1 {
+    if input.contract_version != PACKET_COMPILATION_CONTRACT_VERSION_V1 {
+        return RepositoryDerivedCompilationV1 {
+            support: Vec::new(),
+            continuation: Vec::new(),
+        };
+    }
+
+    let admissions = ordered_admissions(input);
+    let admission_order = admissions
+        .iter()
+        .enumerate()
+        .map(|(index, admission)| (admission.stable_identity.as_str(), index))
+        .collect::<HashMap<_, _>>();
+    let sources = selected_source_ranges(input, &admission_order);
+    let relations = selected_relations(input, &admission_order);
+    let mut support = Vec::new();
+    let mut source_budget_omissions = BTreeSet::new();
+    let mut relation_budget_omissions = BTreeSet::new();
+
+    // Weave the path-diverse source order with the directed forest. This keeps
+    // exact selectors and first-path witnesses ahead of repeated ranges while
+    // preventing sixteen source rows from starving every structural edge.
+    let mut source_index = 0;
+    let mut relation_index = 0;
+    while source_index < sources.len() || relation_index < relations.len() {
+        if let Some(source) = sources.get(source_index) {
+            if !push_if_within_public_budget(&mut support, source_support_unit(source.witness)) {
+                source_budget_omissions.extend(source.represented_identities.iter().cloned());
+            }
+            source_index += 1;
+        }
+
+        if let Some(relation) = relations.get(relation_index) {
+            if !push_if_within_public_budget(&mut support, relation_support_unit(relation)) {
+                relation_budget_omissions.insert(relation.from_identity.clone());
+                relation_budget_omissions.insert(relation.to_identity.clone());
+            }
+            relation_index += 1;
+        }
+    }
+
+    let source_identities = support
+        .iter()
+        .filter(|unit| unit.kind == SupportUnitKindDto::SourceRange)
+        .filter_map(|unit| unit.symbol_id.clone())
+        .collect::<BTreeSet<_>>();
+    let represented_source_paths = sources
+        .iter()
+        .flat_map(|source| {
+            source
+                .represented_identities
+                .iter()
+                .map(|identity| (identity.as_str(), source.witness.path.as_str()))
+        })
+        .collect::<HashMap<_, _>>();
+
+    for admission in &admissions {
+        if source_identities.contains(admission.stable_identity.as_str()) {
+            continue;
+        }
+        let _ = push_if_within_public_budget(
+            &mut support,
+            SupportUnitDto {
+                id: format!("symbol:{}", admission.stable_identity),
+                kind: SupportUnitKindDto::SymbolLocation,
+                summary: admission.stable_identity.clone(),
+                path: represented_source_paths
+                    .get(admission.stable_identity.as_str())
+                    .map(|path| (*path).to_string()),
+                symbol_id: Some(admission.stable_identity.clone()),
+                start_line: None,
+                end_line: None,
+                snippet: None,
+                edge_kind: None,
+                from_symbol: None,
+                to_symbol: None,
+                query: None,
+            },
+        );
+    }
+
+    support.truncate(INTERIM_MAX_ADMITTED_CANDIDATES);
+    let continuation = continuation_selectors(
+        input,
+        &sources,
+        &relations,
+        &source_budget_omissions,
+        &relation_budget_omissions,
+        &support,
+    );
+    RepositoryDerivedCompilationV1 {
+        support,
+        continuation,
+    }
+}
+
+fn ordered_admissions(
+    input: &PacketCompilationInputV1,
+) -> Vec<&codestory_contracts::compilation::PacketAdmissionReceiptV1> {
+    let mut admissions = input.admissions.iter().collect::<Vec<_>>();
+    admissions.sort_by(|left, right| {
+        admission_origin_rank(left.origin)
+            .cmp(&admission_origin_rank(right.origin))
+            .then_with(|| left.packet_ordinal.cmp(&right.packet_ordinal))
+            .then_with(|| left.stable_identity.cmp(&right.stable_identity))
+    });
+    admissions.dedup_by(|left, right| left.stable_identity == right.stable_identity);
+    admissions.truncate(INTERIM_MAX_ADMITTED_CANDIDATES);
+    admissions
+}
+
+fn admission_origin_rank(origin: PacketAdmissionOriginV1) -> u8 {
+    match origin {
+        PacketAdmissionOriginV1::ExactTypedSelector => 0,
+        PacketAdmissionOriginV1::Retrieval => 1,
+    }
+}
+
+struct SelectedSourceRange<'a> {
+    witness: &'a PacketHydratedSourceRangeV1,
+    represented_identities: BTreeSet<String>,
+}
+
+fn selected_source_ranges<'a>(
+    input: &'a PacketCompilationInputV1,
+    admission_order: &HashMap<&str, usize>,
+) -> Vec<SelectedSourceRange<'a>> {
+    let mut candidates = input
+        .sources
+        .iter()
+        .filter(|source| {
+            admission_order.contains_key(source.stable_identity.as_str())
+                && source.start_line > 0
+                && source.end_line >= source.start_line
+                && !source.source.trim().is_empty()
+        })
+        .collect::<Vec<_>>();
+    candidates.sort_by(|left, right| {
+        admission_order[left.stable_identity.as_str()]
+            .cmp(&admission_order[right.stable_identity.as_str()])
+            .then_with(|| {
+                parser_completeness_rank(left.parser_completeness)
+                    .cmp(&parser_completeness_rank(right.parser_completeness))
+            })
+            .then_with(|| left.path.cmp(&right.path))
+            .then_with(|| left.start_line.cmp(&right.start_line))
+            .then_with(|| right.end_line.cmp(&left.end_line))
+            .then_with(|| left.symbol.cmp(&right.symbol))
+            .then_with(|| left.source.cmp(&right.source))
+    });
+
+    // One containment group emits one source range. The highest-priority
+    // admitted identity owns that source row; lower-priority identities remain
+    // recorded so the caller can retain them as symbol locations instead of
+    // silently erasing them during deduplication.
+    let mut deduped: Vec<SelectedSourceRange<'a>> = Vec::new();
+    for candidate in candidates {
+        let overlapping = deduped.iter().position(|kept| {
+            kept.witness.path == candidate.path
+                && ((kept.witness.start_line <= candidate.start_line
+                    && kept.witness.end_line >= candidate.end_line)
+                    || (candidate.start_line <= kept.witness.start_line
+                        && candidate.end_line >= kept.witness.end_line))
+        });
+        if let Some(index) = overlapping {
+            deduped[index]
+                .represented_identities
+                .insert(candidate.stable_identity.clone());
+            continue;
+        }
+        deduped.push(SelectedSourceRange {
+            witness: candidate,
+            represented_identities: BTreeSet::from([candidate.stable_identity.clone()]),
+        });
+    }
+
+    let exact_identities = input
+        .admissions
+        .iter()
+        .filter(|admission| admission.origin == PacketAdmissionOriginV1::ExactTypedSelector)
+        .map(|admission| admission.stable_identity.as_str())
+        .collect::<BTreeSet<_>>();
+    let (exact, retrieval): (Vec<_>, Vec<_>) = deduped
+        .into_iter()
+        .partition(|source| exact_identities.contains(source.witness.stable_identity.as_str()));
+    let mut ordered = Vec::new();
+    let mut seen_paths = BTreeSet::new();
+    extend_path_diverse(exact, &mut seen_paths, &mut ordered);
+    extend_path_diverse(retrieval, &mut seen_paths, &mut ordered);
+    ordered
+}
+
+fn extend_path_diverse<'a>(
+    sources: Vec<SelectedSourceRange<'a>>,
+    seen_paths: &mut BTreeSet<String>,
+    ordered: &mut Vec<SelectedSourceRange<'a>>,
+) {
+    let mut repeated = Vec::new();
+    for source in sources {
+        if seen_paths.insert(source.witness.path.clone()) {
+            ordered.push(source);
+        } else {
+            repeated.push(source);
+        }
+    }
+    ordered.extend(repeated);
+}
+
+fn parser_completeness_rank(
+    completeness: codestory_contracts::compilation::PacketParserCompletenessV1,
+) -> u8 {
+    use codestory_contracts::compilation::PacketParserCompletenessV1;
+    match completeness {
+        PacketParserCompletenessV1::Complete => 0,
+        PacketParserCompletenessV1::Partial => 1,
+        PacketParserCompletenessV1::Unknown => 2,
+    }
+}
+
+fn selected_relations<'a>(
+    input: &'a PacketCompilationInputV1,
+    admission_order: &HashMap<&str, usize>,
+) -> Vec<&'a PacketDirectedRelationV1> {
+    let mut certain = input
+        .relations
+        .iter()
+        .filter(|relation| relation.certainty == PacketRelationCertaintyV1::Certain)
+        .filter(|relation| {
+            relation.relation_kind
+                != codestory_contracts::compilation::PacketRelationKindV1::Unknown
+        })
+        .filter(|relation| {
+            admission_order.contains_key(relation.from_identity.as_str())
+                && admission_order.contains_key(relation.to_identity.as_str())
+        })
+        .collect::<Vec<_>>();
+    certain.sort_by(|left, right| {
+        relation_priority(left, admission_order)
+            .cmp(&relation_priority(right, admission_order))
+            .then_with(|| left.relation_id.cmp(&right.relation_id))
+    });
+
+    let mut forest = Vec::new();
+    let mut incident_candidates = Vec::new();
+    let mut connected = BTreeSet::new();
+    let mut components = admission_order
+        .keys()
+        .map(|identity| ((*identity).to_string(), (*identity).to_string()))
+        .collect::<BTreeMap<_, _>>();
+    for relation in certain {
+        let from_admitted = admission_order.contains_key(relation.from_identity.as_str());
+        let to_admitted = admission_order.contains_key(relation.to_identity.as_str());
+        if from_admitted && to_admitted {
+            let from_root = component_root(&components, &relation.from_identity);
+            let to_root = component_root(&components, &relation.to_identity);
+            if from_root != to_root {
+                for root in components.values_mut() {
+                    if *root == to_root {
+                        *root = from_root.clone();
+                    }
+                }
+                connected.insert(relation.from_identity.clone());
+                connected.insert(relation.to_identity.clone());
+                forest.push(relation);
+                continue;
+            }
+        }
+        incident_candidates.push(relation);
+    }
+
+    // A seed that the admitted-seed forest could not connect may contribute
+    // one certain incident relation. This keeps graph context broad across
+    // seeds instead of spending the remaining packet on one dense node.
+    for relation in incident_candidates {
+        let admitted_endpoints = [
+            relation.from_identity.as_str(),
+            relation.to_identity.as_str(),
+        ]
+        .into_iter()
+        .filter(|identity| admission_order.contains_key(*identity))
+        .collect::<Vec<_>>();
+        if admitted_endpoints
+            .iter()
+            .all(|identity| connected.contains(*identity))
+        {
+            continue;
+        }
+        connected.extend(admitted_endpoints.into_iter().map(ToOwned::to_owned));
+        forest.push(relation);
+    }
+    forest
+}
+
+fn relation_priority(
+    relation: &PacketDirectedRelationV1,
+    admission_order: &HashMap<&str, usize>,
+) -> (u8, usize, usize) {
+    let from = admission_order
+        .get(relation.from_identity.as_str())
+        .copied()
+        .unwrap_or(usize::MAX);
+    let to = admission_order
+        .get(relation.to_identity.as_str())
+        .copied()
+        .unwrap_or(usize::MAX);
+    (
+        u8::from(from == usize::MAX || to == usize::MAX),
+        from.max(to),
+        from.min(to),
+    )
+}
+
+fn component_root(components: &BTreeMap<String, String>, identity: &str) -> String {
+    components
+        .get(identity)
+        .cloned()
+        .unwrap_or_else(|| identity.to_string())
+}
+
+fn source_support_unit(source: &PacketHydratedSourceRangeV1) -> SupportUnitDto {
+    SupportUnitDto {
+        id: format!(
+            "source:{}:{}:{}",
+            source.stable_identity, source.start_line, source.end_line
+        ),
+        kind: SupportUnitKindDto::SourceRange,
+        summary: source
+            .symbol
+            .clone()
+            .unwrap_or_else(|| source.stable_identity.clone()),
+        path: Some(source.path.clone()),
+        symbol_id: Some(source.stable_identity.clone()),
+        start_line: Some(source.start_line),
+        end_line: Some(source.end_line),
+        snippet: Some(source.source.clone()),
+        edge_kind: None,
+        from_symbol: None,
+        to_symbol: None,
+        query: None,
+    }
+}
+
+fn relation_support_unit(relation: &PacketDirectedRelationV1) -> SupportUnitDto {
+    SupportUnitDto {
+        id: format!("edge:{}", relation.relation_id),
+        kind: SupportUnitKindDto::TypedGraphEdge,
+        summary: format!(
+            "`{}` {} `{}`",
+            relation.from_identity,
+            relation.relation_kind.as_str(),
+            relation.to_identity
+        ),
+        path: None,
+        symbol_id: Some(relation.from_identity.clone()),
+        start_line: None,
+        end_line: None,
+        snippet: None,
+        edge_kind: Some(relation.relation_kind.as_str().to_string()),
+        from_symbol: Some(relation.from_identity.clone()),
+        to_symbol: Some(relation.to_identity.clone()),
+        query: None,
+    }
+}
+
+fn push_if_within_public_budget(
+    support: &mut Vec<SupportUnitDto>,
+    candidate: SupportUnitDto,
+) -> bool {
+    if support.len() >= INTERIM_MAX_ADMITTED_CANDIDATES {
+        return false;
+    }
+    support.push(candidate);
+    let within_budget = serde_json::to_vec(support)
+        .map(|serialized| serialized.len() <= PUBLIC_PACKET_SERIALIZED_MAX_BYTES)
+        .unwrap_or(false);
+    if !within_budget {
+        support.pop();
+        return false;
+    }
+    true
+}
+
+fn continuation_selectors(
+    input: &PacketCompilationInputV1,
+    sources: &[SelectedSourceRange<'_>],
+    relations: &[&PacketDirectedRelationV1],
+    source_budget_omissions: &BTreeSet<String>,
+    relation_budget_omissions: &BTreeSet<String>,
+    support: &[SupportUnitDto],
+) -> Vec<PacketContinuationSelectorV1> {
+    let mut selectors = Vec::new();
+    let mut identities_with_explicit_gaps = BTreeSet::new();
+    for gap in &input.admission_gaps {
+        let Some(stable_identity) = gap.stable_identity.clone() else {
+            continue;
+        };
+        identities_with_explicit_gaps.insert(stable_identity.clone());
+        let reason = match gap.kind {
+            PacketAdmissionGapKindV1::CandidateCountExceeded => {
+                PacketStructuralGapReasonV1::CandidateCountExceeded
+            }
+            PacketAdmissionGapKindV1::SourceBudgetExceeded => {
+                PacketStructuralGapReasonV1::SourceBudgetExceeded
+            }
+            PacketAdmissionGapKindV1::StableIdentityMissing
+            | PacketAdmissionGapKindV1::SourceBoundMissing
+            | PacketAdmissionGapKindV1::SourceUnavailable => {
+                PacketStructuralGapReasonV1::SourceUnavailable
+            }
+        };
+        if let Some(selector) = continuation_selector(stable_identity, reason) {
+            selectors.push(selector);
+        }
+    }
+    for ambiguity in &input.ambiguities {
+        for stable_identity in &ambiguity.candidate_identities {
+            if let Some(selector) = continuation_selector(
+                stable_identity.clone(),
+                PacketStructuralGapReasonV1::AmbiguousSelector,
+            ) {
+                selectors.push(selector);
+            }
+        }
+    }
+
+    let source_identities = sources
+        .iter()
+        .flat_map(|source| source.represented_identities.iter().cloned())
+        .collect::<BTreeSet<_>>();
+    let incident_identities = relations
+        .iter()
+        .flat_map(|relation| [relation.from_identity.clone(), relation.to_identity.clone()])
+        .collect::<BTreeSet<_>>();
+    let represented_identities = support
+        .iter()
+        .flat_map(|unit| {
+            let mut identities = Vec::new();
+            if let Some(identity) = unit.symbol_id.clone() {
+                identities.push(identity);
+            }
+            if let Some(identity) = unit.from_symbol.clone() {
+                identities.push(identity);
+            }
+            if let Some(identity) = unit.to_symbol.clone() {
+                identities.push(identity);
+            }
+            identities
+        })
+        .collect::<BTreeSet<_>>();
+
+    for admission in ordered_admissions(input) {
+        let identity = &admission.stable_identity;
+        if identities_with_explicit_gaps.contains(identity) {
+            continue;
+        }
+        let reason = if source_budget_omissions.contains(identity) {
+            Some(PacketStructuralGapReasonV1::SourceBudgetExceeded)
+        } else if relation_budget_omissions.contains(identity)
+            || !represented_identities.contains(identity)
+            || (!source_identities.contains(identity) && !incident_identities.contains(identity))
+        {
+            Some(PacketStructuralGapReasonV1::DisconnectedSeed)
+        } else {
+            None
+        };
+        if let Some(reason) = reason
+            && let Some(selector) = continuation_selector(identity.clone(), reason)
+        {
+            selectors.push(selector);
+        }
+    }
+
+    selectors.sort_by(|left, right| {
+        left.stable_identity
+            .cmp(&right.stable_identity)
+            .then_with(|| structural_gap_rank(left.reason).cmp(&structural_gap_rank(right.reason)))
+    });
+    selectors.dedup_by(|left, right| {
+        left.stable_identity == right.stable_identity && left.reason == right.reason
+    });
+    selectors
+}
+
+fn structural_gap_rank(reason: PacketStructuralGapReasonV1) -> u8 {
+    match reason {
+        PacketStructuralGapReasonV1::CandidateCountExceeded => 0,
+        PacketStructuralGapReasonV1::SourceBudgetExceeded => 1,
+        PacketStructuralGapReasonV1::SourceUnavailable => 2,
+        PacketStructuralGapReasonV1::AmbiguousSelector => 3,
+        PacketStructuralGapReasonV1::DisconnectedSeed => 4,
+    }
+}
+
+fn continuation_selector(
+    stable_identity: String,
+    reason: PacketStructuralGapReasonV1,
+) -> Option<PacketContinuationSelectorV1> {
+    if let Some(path) = stable_identity.strip_prefix("path:") {
+        return Some(PacketContinuationSelectorV1 {
+            stable_identity: stable_identity.clone(),
+            path: Some(path.to_string()),
+            symbol_id: None,
+            reason,
+        });
+    }
+    let symbol_id = stable_identity.strip_prefix("node:")?;
+    Some(PacketContinuationSelectorV1 {
+        stable_identity: stable_identity.clone(),
+        path: None,
+        symbol_id: Some(symbol_id.to_string()),
+        reason,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codestory_contracts::compilation::{
+        PacketAdmissionReceiptV1, PacketCompilationPublicationV1, PacketParserCompletenessV1,
+        PacketRelationKindV1,
+    };
+
+    fn input() -> PacketCompilationInputV1 {
+        PacketCompilationInputV1 {
+            contract_version: PACKET_COMPILATION_CONTRACT_VERSION_V1,
+            publication: PacketCompilationPublicationV1 {
+                project_id: "project".into(),
+                core_generation_id: "core".into(),
+                retrieval_generation: Some("retrieval".into()),
+            },
+            admissions: vec![
+                PacketAdmissionReceiptV1 {
+                    packet_ordinal: 1,
+                    stable_identity: "retrieved".into(),
+                    score_version: "v1".into(),
+                    reserved_source_bytes: 128,
+                    origin: PacketAdmissionOriginV1::Retrieval,
+                },
+                PacketAdmissionReceiptV1 {
+                    packet_ordinal: 0,
+                    stable_identity: "exact".into(),
+                    score_version: "v1".into(),
+                    reserved_source_bytes: 128,
+                    origin: PacketAdmissionOriginV1::ExactTypedSelector,
+                },
+            ],
+            sources: vec![
+                PacketHydratedSourceRangeV1 {
+                    stable_identity: "retrieved".into(),
+                    path: "src/shared.rs".into(),
+                    symbol: Some("retrieved".into()),
+                    start_line: 5,
+                    end_line: 8,
+                    source: "fn retrieved() {}".into(),
+                    parser_completeness: PacketParserCompletenessV1::Complete,
+                },
+                PacketHydratedSourceRangeV1 {
+                    stable_identity: "exact".into(),
+                    path: "src/exact.rs".into(),
+                    symbol: Some("exact".into()),
+                    start_line: 1,
+                    end_line: 10,
+                    source: "fn exact() {}".into(),
+                    parser_completeness: PacketParserCompletenessV1::Complete,
+                },
+                PacketHydratedSourceRangeV1 {
+                    stable_identity: "exact".into(),
+                    path: "src/exact.rs".into(),
+                    symbol: Some("exact".into()),
+                    start_line: 3,
+                    end_line: 4,
+                    source: "nested".into(),
+                    parser_completeness: PacketParserCompletenessV1::Complete,
+                },
+            ],
+            relations: Vec::new(),
+            ambiguities: Vec::new(),
+            admission_gaps: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn exact_sources_lead_and_contained_ranges_are_deduplicated() {
+        let product = compile_repository_evidence(&input());
+        assert_eq!(product.support[0].symbol_id.as_deref(), Some("exact"));
+        assert_eq!(
+            product
+                .support
+                .iter()
+                .filter(|unit| unit.path.as_deref() == Some("src/exact.rs"))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn only_certain_relations_enter_the_product() {
+        let mut input = input();
+        input.relations = vec![
+            PacketDirectedRelationV1 {
+                relation_id: "certain".into(),
+                from_identity: "exact".into(),
+                to_identity: "retrieved".into(),
+                relation_kind: PacketRelationKindV1::Call,
+                certainty: PacketRelationCertaintyV1::Certain,
+            },
+            PacketDirectedRelationV1 {
+                relation_id: "uncertain".into(),
+                from_identity: "exact".into(),
+                to_identity: "retrieved".into(),
+                relation_kind: PacketRelationKindV1::Call,
+                certainty: PacketRelationCertaintyV1::Uncertain,
+            },
+        ];
+        let product = compile_repository_evidence(&input);
+        assert!(product.support.iter().any(|unit| unit.id == "edge:certain"));
+        assert!(
+            !product
+                .support
+                .iter()
+                .any(|unit| unit.id == "edge:uncertain")
+        );
+    }
+
+    #[test]
+    fn connecting_forest_precedes_symbol_only_fallbacks() {
+        let mut input = input();
+        input
+            .sources
+            .retain(|source| source.stable_identity == "exact");
+        input.relations = vec![PacketDirectedRelationV1 {
+            relation_id: "connects-seeds".into(),
+            from_identity: "exact".into(),
+            to_identity: "retrieved".into(),
+            relation_kind: PacketRelationKindV1::Call,
+            certainty: PacketRelationCertaintyV1::Certain,
+        }];
+
+        let product = compile_repository_evidence(&input);
+        let relation_index = product
+            .support
+            .iter()
+            .position(|unit| unit.id == "edge:connects-seeds")
+            .expect("connecting relation");
+        let fallback_index = product
+            .support
+            .iter()
+            .position(|unit| unit.id == "symbol:retrieved")
+            .expect("symbol fallback");
+        assert!(relation_index < fallback_index);
+    }
+
+    #[test]
+    fn parser_complete_source_wins_identical_range_ties() {
+        let mut input = input();
+        input.sources.insert(
+            0,
+            PacketHydratedSourceRangeV1 {
+                stable_identity: "retrieved".into(),
+                path: "src/shared.rs".into(),
+                symbol: Some("retrieved".into()),
+                start_line: 5,
+                end_line: 8,
+                source: "partial witness".into(),
+                parser_completeness: PacketParserCompletenessV1::Partial,
+            },
+        );
+
+        let product = compile_repository_evidence(&input);
+        let retained = product
+            .support
+            .iter()
+            .find(|unit| unit.path.as_deref() == Some("src/shared.rs"))
+            .expect("shared source witness");
+        assert_eq!(retained.snippet.as_deref(), Some("fn retrieved() {}"));
+    }
+
+    #[test]
+    fn relations_to_unadmitted_endpoints_never_enter_the_product() {
+        let mut input = input();
+        input.sources.clear();
+        input.relations = vec![
+            PacketDirectedRelationV1 {
+                relation_id: "first-incident".into(),
+                from_identity: "retrieved".into(),
+                to_identity: "external-a".into(),
+                relation_kind: PacketRelationKindV1::Usage,
+                certainty: PacketRelationCertaintyV1::Certain,
+            },
+            PacketDirectedRelationV1 {
+                relation_id: "second-incident".into(),
+                from_identity: "retrieved".into(),
+                to_identity: "external-b".into(),
+                relation_kind: PacketRelationKindV1::Usage,
+                certainty: PacketRelationCertaintyV1::Certain,
+            },
+        ];
+
+        let product = compile_repository_evidence(&input);
+        let relation_ids = product
+            .support
+            .iter()
+            .filter(|unit| unit.kind == SupportUnitKindDto::TypedGraphEdge)
+            .map(|unit| unit.id.as_str())
+            .collect::<Vec<_>>();
+        assert!(relation_ids.is_empty());
+    }
+
+    #[test]
+    fn pure_input_makes_prompt_paraphrases_observationally_irrelevant() {
+        let frozen = input();
+        let first = compile_repository_evidence(&frozen);
+        let second = compile_repository_evidence(&frozen);
+        assert_eq!(first, second);
+        assert!(
+            serde_json::to_value(frozen)
+                .unwrap()
+                .get("question")
+                .is_none()
+        );
+    }
+}

--- a/crates/codestory-agent/src/lib.rs
+++ b/crates/codestory-agent/src/lib.rs
@@ -1,6 +1,7 @@
 //! Pure packet seed planning and repository-derived evidence compilation.
 //!
-//! The original question may seed generic retrieval and explicit selectors.
+//! The original question may seed generic retrieval. Exact selectors come only
+//! from typed probes.
 //! Once retrieval has produced typed candidates, compilation sees only stable
 //! identities, source ranges, directed relations, ambiguity, and publication
 //! identity. It owns none of the machinery that answers those questions.

--- a/crates/codestory-agent/src/lib.rs
+++ b/crates/codestory-agent/src/lib.rs
@@ -1,9 +1,9 @@
-//! Prompt-blind packet seed planning and evidence-policy helpers.
+//! Pure packet seed planning and repository-derived evidence compilation.
 //!
-//! Horizon A forwards the unchanged question to generic retrieval and records
-//! caller-supplied free-query seeds. It does not infer answer shapes, material
-//! roles, lifecycle stages, or structural traversal from prompt wording. The
-//! repository-derived evidence compiler belongs to Horizon B (`#2106`).
+//! The original question may seed generic retrieval and explicit selectors.
+//! Once retrieval has produced typed candidates, compilation sees only stable
+//! identities, source ranges, directed relations, ambiguity, and publication
+//! identity. It owns none of the machinery that answers those questions.
 //!
 //! Specifically, nothing here may activate a publication, open or write
 //! storage, execute retrieval, retry a publication, or move readiness. The only
@@ -16,6 +16,7 @@
 pub mod citation;
 #[cfg(any(test, feature = "test-support"))]
 pub mod eval_probes;
+pub mod evidence_compiler;
 pub mod packet_citations;
 pub mod packet_command;
 pub mod packet_coverage;

--- a/crates/codestory-agent/src/packet_plan.rs
+++ b/crates/codestory-agent/src/packet_plan.rs
@@ -1,18 +1,17 @@
 //! Pure packet seed planning.
 //!
-//! The original wording may reach generic retrieval unchanged. Beyond that,
-//! planning recognizes only identities the caller delimited as inline code:
-//! repository paths, canonical IDs, and qualified symbols. Typed free-query
-//! probes remain generic retrieval seeds. Planning does not infer an answer
-//! shape or translate prose into a domain-specific traversal policy.
+//! The original wording reaches generic retrieval unchanged and has no exact
+//! selector authority. Exact paths, canonical IDs, and qualified symbols enter
+//! only through typed probes. Planning does not infer an answer shape or
+//! translate prose into a domain-specific traversal policy.
 
 use crate::planning::dedupe_packet_plan_queries;
-use crate::text::exact_symbol_query_terms;
-use codestory_contracts::api::{PacketBudgetModeDto, PacketPlanDto, PacketPlanQueryDto};
+use codestory_contracts::api::{
+    PacketBudgetModeDto, PacketPlanDto, PacketPlanQueryDto, PacketProbeDto,
+};
 use codestory_contracts::compilation::{
     PACKET_COMPILATION_CONTRACT_VERSION_V1, PacketSeedSelectorV1, RetrievalSeedPlanV1,
 };
-use std::path::{Component, Path};
 
 const GENERIC_RETRIEVAL_PURPOSE: &str =
     "unchanged question for generic lexical and semantic retrieval";
@@ -27,7 +26,12 @@ pub fn build_packet_plan_with_extra(
     budget: PacketBudgetModeDto,
     free_queries: &[String],
 ) -> PacketPlanDto {
-    let seed_plan = build_retrieval_seed_plan(question, free_queries);
+    let probes = free_queries
+        .iter()
+        .cloned()
+        .map(|query| PacketProbeDto::FreeQuery { query })
+        .collect::<Vec<_>>();
+    let seed_plan = build_retrieval_seed_plan(question, &probes);
     build_packet_plan_from_seed_plan(&seed_plan, budget)
 }
 
@@ -65,39 +69,81 @@ pub fn build_packet_plan_from_seed_plan(
 }
 
 /// Build the only compiler-side value permitted to carry original wording.
-/// Extraction is syntactic: inline-code repository paths, canonical `node:`
-/// IDs, and qualified symbols only. Natural-language relations are not
-/// inferred.
-pub fn build_retrieval_seed_plan(question: &str, free_queries: &[String]) -> RetrievalSeedPlanV1 {
+/// The question has generic-retrieval authority only. Exact selectors are
+/// copied from typed probes without interpreting question text.
+pub fn build_retrieval_seed_plan(
+    question: &str,
+    typed_probes: &[PacketProbeDto],
+) -> RetrievalSeedPlanV1 {
     let mut exact_selectors = Vec::new();
-    let explicit_fragments = inline_code_spans(question);
-    for path in explicit_source_paths(&explicit_fragments) {
-        push_selector(
-            &mut exact_selectors,
-            PacketSeedSelectorV1::ExactPath { path },
-        );
-    }
-    for id in explicit_canonical_ids(&explicit_fragments) {
-        push_selector(
-            &mut exact_selectors,
-            PacketSeedSelectorV1::CanonicalId { id },
-        );
-    }
-    for symbol in explicit_qualified_symbols(&explicit_fragments) {
-        push_selector(
-            &mut exact_selectors,
-            PacketSeedSelectorV1::QualifiedSymbol { symbol },
-        );
-    }
     let mut retained_free_queries = Vec::new();
-    for query in free_queries {
-        let query = query.trim();
-        if !query.is_empty()
-            && !retained_free_queries
-                .iter()
-                .any(|existing: &String| existing == query)
-        {
-            retained_free_queries.push(query.to_string());
+    for probe in typed_probes {
+        match probe {
+            PacketProbeDto::ExactPath { path } => push_selector(
+                &mut exact_selectors,
+                PacketSeedSelectorV1::ExactPath {
+                    path: path.trim().to_string(),
+                },
+            ),
+            PacketProbeDto::SymbolId { id } => push_selector(
+                &mut exact_selectors,
+                PacketSeedSelectorV1::CanonicalId {
+                    id: format!(
+                        "node:{}",
+                        id.trim().strip_prefix("node:").unwrap_or(id.trim())
+                    ),
+                },
+            ),
+            PacketProbeDto::QualifiedSymbol { symbol } => push_selector(
+                &mut exact_selectors,
+                PacketSeedSelectorV1::QualifiedSymbol {
+                    symbol: symbol.trim().to_string(),
+                },
+            ),
+            PacketProbeDto::FileSymbol { path, symbol } => {
+                push_selector(
+                    &mut exact_selectors,
+                    PacketSeedSelectorV1::ExactPath {
+                        path: path.trim().to_string(),
+                    },
+                );
+                push_selector(
+                    &mut exact_selectors,
+                    PacketSeedSelectorV1::QualifiedSymbol {
+                        symbol: symbol.trim().to_string(),
+                    },
+                );
+            }
+            PacketProbeDto::FreeQuery { query } => {
+                let query = query.trim();
+                if !query.is_empty()
+                    && !retained_free_queries
+                        .iter()
+                        .any(|existing: &String| existing == query)
+                {
+                    retained_free_queries.push(query.to_string());
+                }
+            }
+            PacketProbeDto::Continuation { selector, .. } => {
+                if let Some(symbol_id) = selector.symbol_id.as_deref() {
+                    push_selector(
+                        &mut exact_selectors,
+                        PacketSeedSelectorV1::CanonicalId {
+                            id: format!(
+                                "node:{}",
+                                symbol_id.strip_prefix("node:").unwrap_or(symbol_id)
+                            ),
+                        },
+                    );
+                } else if let Some(path) = selector.path.as_deref() {
+                    push_selector(
+                        &mut exact_selectors,
+                        PacketSeedSelectorV1::ExactPath {
+                            path: path.to_string(),
+                        },
+                    );
+                }
+            }
         }
     }
     RetrievalSeedPlanV1 {
@@ -112,134 +158,6 @@ fn push_selector(selectors: &mut Vec<PacketSeedSelectorV1>, selector: PacketSeed
     if !selectors.contains(&selector) {
         selectors.push(selector);
     }
-}
-
-fn inline_code_spans(question: &str) -> Vec<&str> {
-    #[derive(Clone, Copy)]
-    struct Fence {
-        marker: u8,
-        length: usize,
-    }
-
-    let mut spans = Vec::new();
-    let mut fence: Option<Fence> = None;
-    for line in question.split_inclusive('\n') {
-        let content = markdown_container_content(line);
-        if let Some(active) = fence {
-            if markdown_fence_run(content).is_some_and(|(marker, length, suffix)| {
-                marker == active.marker && length >= active.length && suffix.trim().is_empty()
-            }) {
-                fence = None;
-            }
-            continue;
-        }
-        if let Some((marker, length, suffix)) = markdown_fence_run(content)
-            && (marker != b'`' || !suffix.contains('`'))
-        {
-            fence = Some(Fence { marker, length });
-            continue;
-        }
-
-        let bytes = line.as_bytes();
-        let mut index = 0;
-        let mut opening = None;
-        while index < bytes.len() {
-            if bytes[index] != b'`' {
-                index += 1;
-                continue;
-            }
-            let run_start = index;
-            while index < bytes.len() && bytes[index] == b'`' {
-                index += 1;
-            }
-            if index - run_start != 1 {
-                opening = None;
-                continue;
-            }
-            match opening.take() {
-                Some(start) if start < run_start => spans.push(&line[start..run_start]),
-                Some(_) => {}
-                None => opening = Some(index),
-            }
-        }
-    }
-    spans
-}
-
-fn markdown_container_content(mut line: &str) -> &str {
-    loop {
-        let mut indent = 0;
-        while indent < 3 && line.as_bytes().get(indent) == Some(&b' ') {
-            indent += 1;
-        }
-        let after_indent = &line[indent..];
-        if let Some(after_quote) = after_indent.strip_prefix('>') {
-            line = strip_markdown_container_padding(after_quote);
-            continue;
-        }
-        if let Some(after_list) = markdown_list_item_content(after_indent) {
-            line = strip_markdown_container_padding(after_list);
-            continue;
-        }
-        return after_indent;
-    }
-}
-
-fn strip_markdown_container_padding(line: &str) -> &str {
-    line.trim_start_matches([' ', '\t'])
-}
-
-fn markdown_list_item_content(line: &str) -> Option<&str> {
-    let bytes = line.as_bytes();
-    if matches!(bytes.first(), Some(b'-' | b'+' | b'*'))
-        && matches!(bytes.get(1), Some(b' ' | b'\t'))
-    {
-        return Some(&line[2..]);
-    }
-
-    let digits = bytes
-        .iter()
-        .take(9)
-        .take_while(|byte| byte.is_ascii_digit())
-        .count();
-    if digits == 0
-        || !matches!(bytes.get(digits), Some(b'.' | b')'))
-        || !matches!(bytes.get(digits + 1), Some(b' ' | b'\t'))
-    {
-        return None;
-    }
-    Some(&line[digits + 2..])
-}
-
-fn markdown_fence_run(line: &str) -> Option<(u8, usize, &str)> {
-    let bytes = line.as_bytes();
-    let marker = *bytes.first()?;
-    if !matches!(marker, b'`' | b'~') {
-        return None;
-    }
-    let length = bytes.iter().take_while(|byte| **byte == marker).count();
-    (length >= 3).then(|| (marker, length, &line[length..]))
-}
-
-fn explicit_canonical_ids(explicit_fragments: &[&str]) -> Vec<String> {
-    explicit_fragments
-        .iter()
-        .flat_map(|fragment| fragment.split_whitespace())
-        .map(|token| {
-            token.trim_matches(|ch: char| {
-                matches!(
-                    ch,
-                    '`' | '\'' | '"' | '(' | ')' | '[' | ']' | '{' | '}' | ',' | ';' | '.'
-                )
-            })
-        })
-        .filter(|token| {
-            token
-                .strip_prefix("node:")
-                .is_some_and(|id| id.parse::<i64>().is_ok())
-        })
-        .map(str::to_string)
-        .collect()
 }
 
 pub fn packet_explicit_request_probe_queries(plan: &PacketPlanDto) -> Vec<String> {
@@ -270,83 +188,6 @@ fn packet_plan_query_cap(budget: PacketBudgetModeDto) -> usize {
     }
 }
 
-fn explicit_qualified_symbols(explicit_fragments: &[&str]) -> Vec<String> {
-    explicit_fragments
-        .iter()
-        .flat_map(|fragment| exact_symbol_query_terms(fragment))
-        .filter(|candidate| {
-            (candidate.contains("::") || candidate.contains('.'))
-                && !candidate.contains("://")
-                && !candidate.contains(['/', '\\'])
-                && codestory_contracts::language_support::language_support_profile_for_path(Some(
-                    source_path_without_location_suffix(candidate),
-                ))
-                .is_none()
-        })
-        .collect()
-}
-
-fn explicit_source_paths(explicit_fragments: &[&str]) -> Vec<String> {
-    let mut paths = Vec::new();
-    for token in explicit_fragments
-        .iter()
-        .flat_map(|fragment| fragment.split_whitespace())
-    {
-        let mut candidate = token.trim_matches(|ch: char| {
-            matches!(
-                ch,
-                '`' | '\'' | '"' | '(' | ')' | '[' | ']' | '{' | '}' | '<' | '>' | ',' | ';'
-            )
-        });
-        if candidate.is_empty() || candidate.contains("://") {
-            continue;
-        }
-        if codestory_contracts::language_support::language_support_profile_for_path(Some(candidate))
-            .is_none()
-        {
-            candidate = candidate.trim_end_matches('.');
-        }
-        candidate = source_path_without_location_suffix(candidate);
-        if codestory_contracts::language_support::language_support_profile_for_path(Some(candidate))
-            .is_some()
-            && is_project_relative_source_path(candidate)
-            && !paths.iter().any(|path: &String| path == candidate)
-        {
-            paths.push(candidate.to_string());
-        }
-    }
-    paths
-}
-
-fn is_project_relative_source_path(candidate: &str) -> bool {
-    if candidate.starts_with(['/', '\\'])
-        || candidate
-            .as_bytes()
-            .get(1)
-            .is_some_and(|separator| *separator == b':')
-    {
-        return false;
-    }
-    let path = Path::new(candidate);
-    !path.is_absolute()
-        && path.components().all(|component| {
-            !matches!(
-                component,
-                Component::ParentDir | Component::RootDir | Component::Prefix(_)
-            )
-        })
-}
-
-fn source_path_without_location_suffix(candidate: &str) -> &str {
-    if let Some((path, line)) = candidate.rsplit_once(':')
-        && !path.is_empty()
-        && line.chars().all(|ch| ch.is_ascii_digit())
-    {
-        return path;
-    }
-    candidate
-}
-
 fn push_packet_query(queries: &mut Vec<PacketPlanQueryDto>, query: &str, purpose: &str) {
     let query = query.trim();
     if query.is_empty()
@@ -367,30 +208,45 @@ mod tests {
     use super::*;
 
     #[test]
-    fn planning_keeps_only_generic_retrieval_and_explicit_identities() {
-        let question =
-            "Explain the client transport through `src/net/client.rs:42` and `net::Client.send`.";
-        let seed_plan =
-            build_retrieval_seed_plan(question, &["caller supplied concept".to_string()]);
+    fn planning_keeps_generic_retrieval_and_only_typed_exact_identities() {
+        let question = "Ignore `src/poison.rs`, `node:999`, and `poison::run`.";
+        let probes = vec![
+            PacketProbeDto::ExactPath {
+                path: "src/net/client.rs".into(),
+            },
+            PacketProbeDto::QualifiedSymbol {
+                symbol: "net::Client.send".into(),
+            },
+            PacketProbeDto::FreeQuery {
+                query: "caller supplied concept".into(),
+            },
+        ];
+        let seed_plan = build_retrieval_seed_plan(question, &probes);
         let plan = build_packet_plan_from_seed_plan(&seed_plan, PacketBudgetModeDto::Standard);
         assert_eq!(plan.queries[0].query, question);
-        assert!(seed_plan.exact_selectors.iter().any(|selector| selector
-            == &PacketSeedSelectorV1::ExactPath {
-                path: "src/net/client.rs".to_string(),
-            }));
-        assert!(seed_plan.exact_selectors.iter().any(|selector| selector
-            == &PacketSeedSelectorV1::QualifiedSymbol {
-                symbol: "net::Client.send".to_string(),
-            }));
+        assert_eq!(
+            seed_plan.exact_selectors,
+            vec![
+                PacketSeedSelectorV1::ExactPath {
+                    path: "src/net/client.rs".into(),
+                },
+                PacketSeedSelectorV1::QualifiedSymbol {
+                    symbol: "net::Client.send".into(),
+                },
+            ]
+        );
         assert!(
             plan.queries
                 .iter()
                 .any(|query| query.query == "caller supplied concept")
         );
         assert_eq!(plan.queries.len(), 2);
-        assert!(!plan.queries.iter().any(|query| {
-            query.query == "src/net/client.rs" || query.query == "net::Client.send"
-        }));
+        assert!(
+            !seed_plan
+                .exact_selectors
+                .iter()
+                .any(|selector| format!("{selector:?}").contains("poison"))
+        );
     }
 
     #[test]
@@ -408,104 +264,52 @@ mod tests {
     }
 
     #[test]
-    fn prose_extraction_rejects_urls_and_paths_outside_the_project() {
+    fn typed_probes_map_to_seed_selectors_without_textual_reinterpretation() {
         let seed_plan = build_retrieval_seed_plan(
-            "Compare https://example.invalid/api with /tmp/secret.rs and ../outside.rs.",
-            &[],
+            "The question contributes no exact selectors.",
+            &[
+                PacketProbeDto::ExactPath {
+                    path: " src/lib.rs ".into(),
+                },
+                PacketProbeDto::SymbolId {
+                    id: "node:-42".into(),
+                },
+                PacketProbeDto::QualifiedSymbol {
+                    symbol: " crate::run ".into(),
+                },
+                PacketProbeDto::FileSymbol {
+                    path: "src/worker.rs".into(),
+                    symbol: "worker::run".into(),
+                },
+            ],
         );
-        assert!(
-            seed_plan.exact_selectors.is_empty(),
-            "unsafe prose tokens became exact selectors: {:?}",
-            seed_plan.exact_selectors
-        );
-    }
-
-    #[test]
-    fn source_location_is_not_also_treated_as_a_qualified_symbol() {
-        let seed_plan = build_retrieval_seed_plan("Inspect `lib.rs:42` and `crate::run`.", &[]);
         assert_eq!(
             seed_plan.exact_selectors,
             vec![
                 PacketSeedSelectorV1::ExactPath {
-                    path: "lib.rs".into(),
+                    path: "src/lib.rs".into(),
+                },
+                PacketSeedSelectorV1::CanonicalId {
+                    id: "node:-42".into(),
                 },
                 PacketSeedSelectorV1::QualifiedSymbol {
                     symbol: "crate::run".into(),
                 },
-            ]
-        );
-    }
-
-    #[test]
-    fn canonical_identity_survives_sentence_punctuation() {
-        let seed_plan = build_retrieval_seed_plan("Inspect `node:42`.", &[]);
-        assert_eq!(
-            seed_plan.exact_selectors,
-            vec![PacketSeedSelectorV1::CanonicalId {
-                id: "node:42".into(),
-            }]
-        );
-    }
-
-    #[test]
-    fn unquoted_dotted_prose_cannot_consume_exact_admission_slots() {
-        let question = (0..20)
-            .map(|index| format!("Example{index}.js"))
-            .chain(["e.g.".to_string(), "Node.js".to_string()])
-            .collect::<Vec<_>>()
-            .join(" ");
-        let seed_plan = build_retrieval_seed_plan(&question, &[]);
-        assert!(
-            seed_plan.exact_selectors.is_empty(),
-            "ordinary prose became exact selectors: {:?}",
-            seed_plan.exact_selectors
-        );
-    }
-
-    #[test]
-    fn signed_node_ids_use_the_real_node_id_grammar() {
-        let seed_plan = build_retrieval_seed_plan("Compare `node:-42` with `node:7`.", &[]);
-        assert_eq!(
-            seed_plan.exact_selectors,
-            vec![
-                PacketSeedSelectorV1::CanonicalId {
-                    id: "node:-42".into(),
-                },
-                PacketSeedSelectorV1::CanonicalId {
-                    id: "node:7".into(),
-                },
-            ]
-        );
-    }
-
-    #[test]
-    fn fenced_diagnostics_cannot_create_exact_selectors() {
-        let fenced = (0..20)
-            .map(|index| format!("src/generated_{index}.rs net::Generated{index} node:{index}"))
-            .collect::<Vec<_>>()
-            .join("\n");
-        let question = format!(
-            "Ignore this diagnostic:\n```text\n{fenced}\n```\nInspect `src/real.rs` and `crate::real` instead."
-        );
-
-        let seed_plan = build_retrieval_seed_plan(&question, &[]);
-
-        assert_eq!(
-            seed_plan.exact_selectors,
-            vec![
                 PacketSeedSelectorV1::ExactPath {
-                    path: "src/real.rs".into(),
+                    path: "src/worker.rs".into(),
                 },
                 PacketSeedSelectorV1::QualifiedSymbol {
-                    symbol: "crate::real".into(),
+                    symbol: "worker::run".into(),
                 },
             ]
         );
     }
 
     #[test]
-    fn every_markdown_fence_shape_keeps_diagnostics_out_of_exact_selectors() {
+    fn raw_question_text_never_creates_exact_selectors() {
         let question = r#"
+Inline `src/inline_poison.rs`, `node:41`, and `poison::inline`.
+
 > ```text
 > panic at `src/blockquote_poison.rs`
 > ```
@@ -518,22 +322,41 @@ panic at `src/tilde_poison.rs`
   panic at `src/list_poison.rs`
   ```
 
+- outer
+  - inner
+    ````text
+    panic at `src/nested_list_poison.rs`
+    ````
+
 ````text
 panic at `src/four_tick_poison.rs`
 ```
 panic at `src/nested_short_fence_poison.rs`
 ````
 
-Inspect `src/real.rs`.
+Inspect `src/real.rs`, `node:42`, and `crate::real`.
 "#;
 
         let seed_plan = build_retrieval_seed_plan(question, &[]);
 
-        assert_eq!(
-            seed_plan.exact_selectors,
-            vec![PacketSeedSelectorV1::ExactPath {
-                path: "src/real.rs".into(),
-            }]
+        assert!(seed_plan.exact_selectors.is_empty());
+        assert_eq!(seed_plan.generic_query, question);
+    }
+
+    #[test]
+    fn typed_free_queries_are_trimmed_and_deduplicated() {
+        let seed_plan = build_retrieval_seed_plan(
+            "ordinary wording",
+            &[
+                PacketProbeDto::FreeQuery {
+                    query: " publication recovery ".into(),
+                },
+                PacketProbeDto::FreeQuery {
+                    query: "publication recovery".into(),
+                },
+                PacketProbeDto::FreeQuery { query: " ".into() },
+            ],
         );
+        assert_eq!(seed_plan.free_queries, ["publication recovery"]);
     }
 }

--- a/crates/codestory-agent/src/packet_plan.rs
+++ b/crates/codestory-agent/src/packet_plan.rs
@@ -1,9 +1,10 @@
 //! Pure packet seed planning.
 //!
 //! The original wording may reach generic retrieval unchanged. Beyond that,
-//! planning recognizes only identities the caller wrote explicitly: repository
-//! paths, qualified symbols, and typed free-query probes. It does not infer an
-//! answer shape or translate prose into a domain-specific traversal policy.
+//! planning recognizes only identities the caller delimited as inline code:
+//! repository paths, canonical IDs, and qualified symbols. Typed free-query
+//! probes remain generic retrieval seeds. Planning does not infer an answer
+//! shape or translate prose into a domain-specific traversal policy.
 
 use crate::planning::dedupe_packet_plan_queries;
 use crate::text::exact_symbol_query_terms;
@@ -64,23 +65,25 @@ pub fn build_packet_plan_from_seed_plan(
 }
 
 /// Build the only compiler-side value permitted to carry original wording.
-/// Extraction is syntactic: explicit repository paths, canonical `node:` IDs,
-/// and qualified symbols only. Natural-language relations are not inferred.
+/// Extraction is syntactic: inline-code repository paths, canonical `node:`
+/// IDs, and qualified symbols only. Natural-language relations are not
+/// inferred.
 pub fn build_retrieval_seed_plan(question: &str, free_queries: &[String]) -> RetrievalSeedPlanV1 {
     let mut exact_selectors = Vec::new();
-    for path in explicit_source_paths(question) {
+    let explicit_fragments = inline_code_spans(question);
+    for path in explicit_source_paths(&explicit_fragments) {
         push_selector(
             &mut exact_selectors,
             PacketSeedSelectorV1::ExactPath { path },
         );
     }
-    for id in explicit_canonical_ids(question) {
+    for id in explicit_canonical_ids(&explicit_fragments) {
         push_selector(
             &mut exact_selectors,
             PacketSeedSelectorV1::CanonicalId { id },
         );
     }
-    for symbol in explicit_qualified_symbols(question) {
+    for symbol in explicit_qualified_symbols(&explicit_fragments) {
         push_selector(
             &mut exact_selectors,
             PacketSeedSelectorV1::QualifiedSymbol { symbol },
@@ -111,9 +114,18 @@ fn push_selector(selectors: &mut Vec<PacketSeedSelectorV1>, selector: PacketSeed
     }
 }
 
-fn explicit_canonical_ids(question: &str) -> Vec<String> {
+fn inline_code_spans(question: &str) -> Vec<&str> {
     question
-        .split_whitespace()
+        .split('`')
+        .enumerate()
+        .filter_map(|(index, span)| (index % 2 == 1).then_some(span))
+        .collect()
+}
+
+fn explicit_canonical_ids(explicit_fragments: &[&str]) -> Vec<String> {
+    explicit_fragments
+        .iter()
+        .flat_map(|fragment| fragment.split_whitespace())
         .map(|token| {
             token.trim_matches(|ch: char| {
                 matches!(
@@ -125,7 +137,7 @@ fn explicit_canonical_ids(question: &str) -> Vec<String> {
         .filter(|token| {
             token
                 .strip_prefix("node:")
-                .is_some_and(|id| !id.is_empty() && id.chars().all(|ch| ch.is_ascii_digit()))
+                .is_some_and(|id| id.parse::<i64>().is_ok())
         })
         .map(str::to_string)
         .collect()
@@ -159,9 +171,10 @@ fn packet_plan_query_cap(budget: PacketBudgetModeDto) -> usize {
     }
 }
 
-fn explicit_qualified_symbols(question: &str) -> Vec<String> {
-    exact_symbol_query_terms(question)
-        .into_iter()
+fn explicit_qualified_symbols(explicit_fragments: &[&str]) -> Vec<String> {
+    explicit_fragments
+        .iter()
+        .flat_map(|fragment| exact_symbol_query_terms(fragment))
         .filter(|candidate| {
             (candidate.contains("::") || candidate.contains('.'))
                 && !candidate.contains("://")
@@ -174,9 +187,12 @@ fn explicit_qualified_symbols(question: &str) -> Vec<String> {
         .collect()
 }
 
-fn explicit_source_paths(question: &str) -> Vec<String> {
+fn explicit_source_paths(explicit_fragments: &[&str]) -> Vec<String> {
     let mut paths = Vec::new();
-    for token in question.split_whitespace() {
+    for token in explicit_fragments
+        .iter()
+        .flat_map(|fragment| fragment.split_whitespace())
+    {
         let mut candidate = token.trim_matches(|ch: char| {
             matches!(
                 ch,
@@ -323,12 +339,43 @@ mod tests {
 
     #[test]
     fn canonical_identity_survives_sentence_punctuation() {
-        let seed_plan = build_retrieval_seed_plan("Inspect node:42.", &[]);
+        let seed_plan = build_retrieval_seed_plan("Inspect `node:42`.", &[]);
         assert_eq!(
             seed_plan.exact_selectors,
             vec![PacketSeedSelectorV1::CanonicalId {
                 id: "node:42".into(),
             }]
+        );
+    }
+
+    #[test]
+    fn unquoted_dotted_prose_cannot_consume_exact_admission_slots() {
+        let question = (0..20)
+            .map(|index| format!("Example{index}.js"))
+            .chain(["e.g.".to_string(), "Node.js".to_string()])
+            .collect::<Vec<_>>()
+            .join(" ");
+        let seed_plan = build_retrieval_seed_plan(&question, &[]);
+        assert!(
+            seed_plan.exact_selectors.is_empty(),
+            "ordinary prose became exact selectors: {:?}",
+            seed_plan.exact_selectors
+        );
+    }
+
+    #[test]
+    fn signed_node_ids_use_the_real_node_id_grammar() {
+        let seed_plan = build_retrieval_seed_plan("Compare `node:-42` with `node:7`.", &[]);
+        assert_eq!(
+            seed_plan.exact_selectors,
+            vec![
+                PacketSeedSelectorV1::CanonicalId {
+                    id: "node:-42".into(),
+                },
+                PacketSeedSelectorV1::CanonicalId {
+                    id: "node:7".into(),
+                },
+            ]
         );
     }
 }

--- a/crates/codestory-agent/src/packet_plan.rs
+++ b/crates/codestory-agent/src/packet_plan.rs
@@ -115,11 +115,41 @@ fn push_selector(selectors: &mut Vec<PacketSeedSelectorV1>, selector: PacketSeed
 }
 
 fn inline_code_spans(question: &str) -> Vec<&str> {
-    question
-        .split('`')
-        .enumerate()
-        .filter_map(|(index, span)| (index % 2 == 1).then_some(span))
-        .collect()
+    let mut spans = Vec::new();
+    let mut fenced = false;
+    for line in question.split_inclusive('\n') {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("```") {
+            fenced = !fenced;
+            continue;
+        }
+        if fenced {
+            continue;
+        }
+        let bytes = line.as_bytes();
+        let mut index = 0;
+        let mut opening = None;
+        while index < bytes.len() {
+            if bytes[index] != b'`' {
+                index += 1;
+                continue;
+            }
+            let run_start = index;
+            while index < bytes.len() && bytes[index] == b'`' {
+                index += 1;
+            }
+            if index - run_start != 1 {
+                opening = None;
+                continue;
+            }
+            match opening.take() {
+                Some(start) if start < run_start => spans.push(&line[start..run_start]),
+                Some(_) => {}
+                None => opening = Some(index),
+            }
+        }
+    }
+    spans
 }
 
 fn explicit_canonical_ids(explicit_fragments: &[&str]) -> Vec<String> {
@@ -374,6 +404,31 @@ mod tests {
                 },
                 PacketSeedSelectorV1::CanonicalId {
                     id: "node:7".into(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn fenced_diagnostics_cannot_create_exact_selectors() {
+        let fenced = (0..20)
+            .map(|index| format!("src/generated_{index}.rs net::Generated{index} node:{index}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let question = format!(
+            "Ignore this diagnostic:\n```text\n{fenced}\n```\nInspect `src/real.rs` and `crate::real` instead."
+        );
+
+        let seed_plan = build_retrieval_seed_plan(&question, &[]);
+
+        assert_eq!(
+            seed_plan.exact_selectors,
+            vec![
+                PacketSeedSelectorV1::ExactPath {
+                    path: "src/real.rs".into(),
+                },
+                PacketSeedSelectorV1::QualifiedSymbol {
+                    symbol: "crate::real".into(),
                 },
             ]
         );

--- a/crates/codestory-agent/src/packet_plan.rs
+++ b/crates/codestory-agent/src/packet_plan.rs
@@ -115,17 +115,31 @@ fn push_selector(selectors: &mut Vec<PacketSeedSelectorV1>, selector: PacketSeed
 }
 
 fn inline_code_spans(question: &str) -> Vec<&str> {
+    #[derive(Clone, Copy)]
+    struct Fence {
+        marker: u8,
+        length: usize,
+    }
+
     let mut spans = Vec::new();
-    let mut fenced = false;
+    let mut fence: Option<Fence> = None;
     for line in question.split_inclusive('\n') {
-        let trimmed = line.trim_start();
-        if trimmed.starts_with("```") {
-            fenced = !fenced;
+        let content = markdown_container_content(line);
+        if let Some(active) = fence {
+            if markdown_fence_run(content).is_some_and(|(marker, length, suffix)| {
+                marker == active.marker && length >= active.length && suffix.trim().is_empty()
+            }) {
+                fence = None;
+            }
             continue;
         }
-        if fenced {
+        if let Some((marker, length, suffix)) = markdown_fence_run(content)
+            && (marker != b'`' || !suffix.contains('`'))
+        {
+            fence = Some(Fence { marker, length });
             continue;
         }
+
         let bytes = line.as_bytes();
         let mut index = 0;
         let mut opening = None;
@@ -150,6 +164,61 @@ fn inline_code_spans(question: &str) -> Vec<&str> {
         }
     }
     spans
+}
+
+fn markdown_container_content(mut line: &str) -> &str {
+    loop {
+        let mut indent = 0;
+        while indent < 3 && line.as_bytes().get(indent) == Some(&b' ') {
+            indent += 1;
+        }
+        let after_indent = &line[indent..];
+        if let Some(after_quote) = after_indent.strip_prefix('>') {
+            line = strip_markdown_container_padding(after_quote);
+            continue;
+        }
+        if let Some(after_list) = markdown_list_item_content(after_indent) {
+            line = strip_markdown_container_padding(after_list);
+            continue;
+        }
+        return after_indent;
+    }
+}
+
+fn strip_markdown_container_padding(line: &str) -> &str {
+    line.trim_start_matches([' ', '\t'])
+}
+
+fn markdown_list_item_content(line: &str) -> Option<&str> {
+    let bytes = line.as_bytes();
+    if matches!(bytes.first(), Some(b'-' | b'+' | b'*'))
+        && matches!(bytes.get(1), Some(b' ' | b'\t'))
+    {
+        return Some(&line[2..]);
+    }
+
+    let digits = bytes
+        .iter()
+        .take(9)
+        .take_while(|byte| byte.is_ascii_digit())
+        .count();
+    if digits == 0
+        || !matches!(bytes.get(digits), Some(b'.' | b')'))
+        || !matches!(bytes.get(digits + 1), Some(b' ' | b'\t'))
+    {
+        return None;
+    }
+    Some(&line[digits + 2..])
+}
+
+fn markdown_fence_run(line: &str) -> Option<(u8, usize, &str)> {
+    let bytes = line.as_bytes();
+    let marker = *bytes.first()?;
+    if !matches!(marker, b'`' | b'~') {
+        return None;
+    }
+    let length = bytes.iter().take_while(|byte| **byte == marker).count();
+    (length >= 3).then(|| (marker, length, &line[length..]))
 }
 
 fn explicit_canonical_ids(explicit_fragments: &[&str]) -> Vec<String> {
@@ -431,6 +500,40 @@ mod tests {
                     symbol: "crate::real".into(),
                 },
             ]
+        );
+    }
+
+    #[test]
+    fn every_markdown_fence_shape_keeps_diagnostics_out_of_exact_selectors() {
+        let question = r#"
+> ```text
+> panic at `src/blockquote_poison.rs`
+> ```
+
+~~~text
+panic at `src/tilde_poison.rs`
+~~~
+
+- ```text
+  panic at `src/list_poison.rs`
+  ```
+
+````text
+panic at `src/four_tick_poison.rs`
+```
+panic at `src/nested_short_fence_poison.rs`
+````
+
+Inspect `src/real.rs`.
+"#;
+
+        let seed_plan = build_retrieval_seed_plan(question, &[]);
+
+        assert_eq!(
+            seed_plan.exact_selectors,
+            vec![PacketSeedSelectorV1::ExactPath {
+                path: "src/real.rs".into(),
+            }]
         );
     }
 }

--- a/crates/codestory-agent/src/packet_plan.rs
+++ b/crates/codestory-agent/src/packet_plan.rs
@@ -1,11 +1,17 @@
-//! Prompt-blind Horizon A packet seed planning.
+//! Pure packet seed planning.
 //!
-//! Ordinary wording is forwarded unchanged to generic retrieval. Typed
-//! free-query probes may add retrieval queries, but neither source receives
-//! protection, materiality, sufficiency, or structural-traversal authority.
+//! The original wording may reach generic retrieval unchanged. Beyond that,
+//! planning recognizes only identities the caller wrote explicitly: repository
+//! paths, qualified symbols, and typed free-query probes. It does not infer an
+//! answer shape or translate prose into a domain-specific traversal policy.
 
 use crate::planning::dedupe_packet_plan_queries;
+use crate::text::exact_symbol_query_terms;
 use codestory_contracts::api::{PacketBudgetModeDto, PacketPlanDto, PacketPlanQueryDto};
+use codestory_contracts::compilation::{
+    PACKET_COMPILATION_CONTRACT_VERSION_V1, PacketSeedSelectorV1, RetrievalSeedPlanV1,
+};
+use std::path::{Component, Path};
 
 const GENERIC_RETRIEVAL_PURPOSE: &str =
     "unchanged question for generic lexical and semantic retrieval";
@@ -20,13 +26,26 @@ pub fn build_packet_plan_with_extra(
     budget: PacketBudgetModeDto,
     free_queries: &[String],
 ) -> PacketPlanDto {
+    let seed_plan = build_retrieval_seed_plan(question, free_queries);
+    build_packet_plan_from_seed_plan(&seed_plan, budget)
+}
+
+pub fn build_packet_plan_from_seed_plan(
+    seed_plan: &RetrievalSeedPlanV1,
+    budget: PacketBudgetModeDto,
+) -> PacketPlanDto {
     let mut queries = Vec::new();
-    push_packet_query(&mut queries, question, GENERIC_RETRIEVAL_PURPOSE);
-    for query in free_queries {
+    push_packet_query(
+        &mut queries,
+        &seed_plan.generic_query,
+        GENERIC_RETRIEVAL_PURPOSE,
+    );
+
+    for query in &seed_plan.free_queries {
         push_packet_query(&mut queries, query, TYPED_FREE_QUERY_PURPOSE);
     }
-    queries.truncate(packet_plan_query_cap(budget));
 
+    queries.truncate(packet_plan_query_cap(budget));
     let mut plan = PacketPlanDto {
         queries,
         probe_resolutions: Vec::new(),
@@ -35,13 +54,81 @@ pub fn build_packet_plan_with_extra(
     dedupe_packet_plan_queries(&mut plan);
     plan.trace
         .push(format!("planned_queries={}", plan.queries.len()));
-    if !free_queries.is_empty() {
+    if !seed_plan.free_queries.is_empty() {
         plan.trace.push(format!(
             "typed_free_queries={} source=request",
-            free_queries.len()
+            seed_plan.free_queries.len()
         ));
     }
     plan
+}
+
+/// Build the only compiler-side value permitted to carry original wording.
+/// Extraction is syntactic: explicit repository paths, canonical `node:` IDs,
+/// and qualified symbols only. Natural-language relations are not inferred.
+pub fn build_retrieval_seed_plan(question: &str, free_queries: &[String]) -> RetrievalSeedPlanV1 {
+    let mut exact_selectors = Vec::new();
+    for path in explicit_source_paths(question) {
+        push_selector(
+            &mut exact_selectors,
+            PacketSeedSelectorV1::ExactPath { path },
+        );
+    }
+    for id in explicit_canonical_ids(question) {
+        push_selector(
+            &mut exact_selectors,
+            PacketSeedSelectorV1::CanonicalId { id },
+        );
+    }
+    for symbol in explicit_qualified_symbols(question) {
+        push_selector(
+            &mut exact_selectors,
+            PacketSeedSelectorV1::QualifiedSymbol { symbol },
+        );
+    }
+    let mut retained_free_queries = Vec::new();
+    for query in free_queries {
+        let query = query.trim();
+        if !query.is_empty()
+            && !retained_free_queries
+                .iter()
+                .any(|existing: &String| existing == query)
+        {
+            retained_free_queries.push(query.to_string());
+        }
+    }
+    RetrievalSeedPlanV1 {
+        contract_version: PACKET_COMPILATION_CONTRACT_VERSION_V1,
+        generic_query: question.to_string(),
+        exact_selectors,
+        free_queries: retained_free_queries,
+    }
+}
+
+fn push_selector(selectors: &mut Vec<PacketSeedSelectorV1>, selector: PacketSeedSelectorV1) {
+    if !selectors.contains(&selector) {
+        selectors.push(selector);
+    }
+}
+
+fn explicit_canonical_ids(question: &str) -> Vec<String> {
+    question
+        .split_whitespace()
+        .map(|token| {
+            token.trim_matches(|ch: char| {
+                matches!(
+                    ch,
+                    '`' | '\'' | '"' | '(' | ')' | '[' | ']' | '{' | '}' | ',' | ';' | '.'
+                )
+            })
+        })
+        .filter(|token| {
+            token
+                .strip_prefix("node:")
+                .is_some_and(|id| !id.is_empty() && id.chars().all(|ch| ch.is_ascii_digit()))
+        })
+        .map(str::to_string)
+        .collect()
 }
 
 pub fn packet_explicit_request_probe_queries(plan: &PacketPlanDto) -> Vec<String> {
@@ -72,6 +159,79 @@ fn packet_plan_query_cap(budget: PacketBudgetModeDto) -> usize {
     }
 }
 
+fn explicit_qualified_symbols(question: &str) -> Vec<String> {
+    exact_symbol_query_terms(question)
+        .into_iter()
+        .filter(|candidate| {
+            (candidate.contains("::") || candidate.contains('.'))
+                && !candidate.contains("://")
+                && !candidate.contains(['/', '\\'])
+                && codestory_contracts::language_support::language_support_profile_for_path(Some(
+                    source_path_without_location_suffix(candidate),
+                ))
+                .is_none()
+        })
+        .collect()
+}
+
+fn explicit_source_paths(question: &str) -> Vec<String> {
+    let mut paths = Vec::new();
+    for token in question.split_whitespace() {
+        let mut candidate = token.trim_matches(|ch: char| {
+            matches!(
+                ch,
+                '`' | '\'' | '"' | '(' | ')' | '[' | ']' | '{' | '}' | '<' | '>' | ',' | ';'
+            )
+        });
+        if candidate.is_empty() || candidate.contains("://") {
+            continue;
+        }
+        if codestory_contracts::language_support::language_support_profile_for_path(Some(candidate))
+            .is_none()
+        {
+            candidate = candidate.trim_end_matches('.');
+        }
+        candidate = source_path_without_location_suffix(candidate);
+        if codestory_contracts::language_support::language_support_profile_for_path(Some(candidate))
+            .is_some()
+            && is_project_relative_source_path(candidate)
+            && !paths.iter().any(|path: &String| path == candidate)
+        {
+            paths.push(candidate.to_string());
+        }
+    }
+    paths
+}
+
+fn is_project_relative_source_path(candidate: &str) -> bool {
+    if candidate.starts_with(['/', '\\'])
+        || candidate
+            .as_bytes()
+            .get(1)
+            .is_some_and(|separator| *separator == b':')
+    {
+        return false;
+    }
+    let path = Path::new(candidate);
+    !path.is_absolute()
+        && path.components().all(|component| {
+            !matches!(
+                component,
+                Component::ParentDir | Component::RootDir | Component::Prefix(_)
+            )
+        })
+}
+
+fn source_path_without_location_suffix(candidate: &str) -> &str {
+    if let Some((path, line)) = candidate.rsplit_once(':')
+        && !path.is_empty()
+        && line.chars().all(|ch| ch.is_ascii_digit())
+    {
+        return path;
+    }
+    candidate
+}
+
 fn push_packet_query(queries: &mut Vec<PacketPlanQueryDto>, query: &str, purpose: &str) {
     let query = query.trim();
     if query.is_empty()
@@ -92,36 +252,83 @@ mod tests {
     use super::*;
 
     #[test]
-    fn ordinary_question_is_the_only_implicit_query() {
-        let question = "Trace Alpha::beta in src/alpha.rs through Gamma::delta";
-        let plan = build_packet_plan(question, PacketBudgetModeDto::Standard);
-        assert_eq!(plan.queries.len(), 1);
+    fn planning_keeps_only_generic_retrieval_and_explicit_identities() {
+        let question =
+            "Explain the client transport through `src/net/client.rs:42` and `net::Client.send`.";
+        let seed_plan =
+            build_retrieval_seed_plan(question, &["caller supplied concept".to_string()]);
+        let plan = build_packet_plan_from_seed_plan(&seed_plan, PacketBudgetModeDto::Standard);
         assert_eq!(plan.queries[0].query, question);
-        assert_eq!(plan.queries[0].purpose, GENERIC_RETRIEVAL_PURPOSE);
-    }
-
-    #[test]
-    fn typed_free_queries_are_additional_generic_seeds() {
-        let plan = build_packet_plan_with_extra(
-            "ordinary wording",
-            PacketBudgetModeDto::Standard,
-            &["caller supplied concept".into()],
+        assert!(seed_plan.exact_selectors.iter().any(|selector| selector
+            == &PacketSeedSelectorV1::ExactPath {
+                path: "src/net/client.rs".to_string(),
+            }));
+        assert!(seed_plan.exact_selectors.iter().any(|selector| selector
+            == &PacketSeedSelectorV1::QualifiedSymbol {
+                symbol: "net::Client.send".to_string(),
+            }));
+        assert!(
+            plan.queries
+                .iter()
+                .any(|query| query.query == "caller supplied concept")
         );
         assert_eq!(plan.queries.len(), 2);
-        assert_eq!(plan.queries[1].purpose, TYPED_FREE_QUERY_PURPOSE);
+        assert!(!plan.queries.iter().any(|query| {
+            query.query == "src/net/client.rs" || query.query == "net::Client.send"
+        }));
     }
 
     #[test]
-    fn domain_vocabulary_does_not_change_plan_shape() {
+    fn ordinary_paraphrase_does_not_create_structural_queries() {
         let first = build_packet_plan(
-            "Explain client cache request finalization",
+            "Explain how the service starts and dispatches requests.",
             PacketBudgetModeDto::Standard,
         );
         let second = build_packet_plan(
-            "Explain alpha beta gamma delta",
+            "Describe where incoming work goes after startup.",
             PacketBudgetModeDto::Standard,
         );
-        assert_eq!(first.queries.len(), second.queries.len());
-        assert_eq!(first.queries[0].purpose, second.queries[0].purpose);
+        assert_eq!(first.queries.len(), 1);
+        assert_eq!(second.queries.len(), 1);
+    }
+
+    #[test]
+    fn prose_extraction_rejects_urls_and_paths_outside_the_project() {
+        let seed_plan = build_retrieval_seed_plan(
+            "Compare https://example.invalid/api with /tmp/secret.rs and ../outside.rs.",
+            &[],
+        );
+        assert!(
+            seed_plan.exact_selectors.is_empty(),
+            "unsafe prose tokens became exact selectors: {:?}",
+            seed_plan.exact_selectors
+        );
+    }
+
+    #[test]
+    fn source_location_is_not_also_treated_as_a_qualified_symbol() {
+        let seed_plan = build_retrieval_seed_plan("Inspect `lib.rs:42` and `crate::run`.", &[]);
+        assert_eq!(
+            seed_plan.exact_selectors,
+            vec![
+                PacketSeedSelectorV1::ExactPath {
+                    path: "lib.rs".into(),
+                },
+                PacketSeedSelectorV1::QualifiedSymbol {
+                    symbol: "crate::run".into(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn canonical_identity_survives_sentence_punctuation() {
+        let seed_plan = build_retrieval_seed_plan("Inspect node:42.", &[]);
+        assert_eq!(
+            seed_plan.exact_selectors,
+            vec![PacketSeedSelectorV1::CanonicalId {
+                id: "node:42".into(),
+            }]
+        );
     }
 }

--- a/crates/codestory-agent/tests/packet_generalization_boundary.rs
+++ b/crates/codestory-agent/tests/packet_generalization_boundary.rs
@@ -1,6 +1,6 @@
 //! Black-box boundary tests for repository-derived packet compilation.
 
-use codestory_agent::packet_plan::build_packet_plan_with_extra;
+use codestory_agent::packet_plan::{build_packet_plan_with_extra, build_retrieval_seed_plan};
 use codestory_contracts::api::PacketBudgetModeDto;
 
 #[test]
@@ -74,4 +74,21 @@ fn free_queries_are_explicit_and_have_no_protection_role() {
     assert!(serialized.get("coverage_role").is_none());
     assert!(serialized.get("task_class").is_none());
     assert!(serialized.get("obligations").is_none());
+}
+
+#[test]
+fn raw_question_markup_has_no_exact_selector_authority() {
+    let question = r#"
+- outer
+  - inner
+    ````text
+    panic at `src/nested_list_poison.rs` in `poison::run` for `node:999`
+    ````
+Inspect `src/real.rs`, `crate::real`, and `node:42`.
+"#;
+
+    let seed_plan = build_retrieval_seed_plan(question, &[]);
+
+    assert_eq!(seed_plan.generic_query, question);
+    assert!(seed_plan.exact_selectors.is_empty());
 }

--- a/crates/codestory-agent/tests/repository_evidence_metamorphic.rs
+++ b/crates/codestory-agent/tests/repository_evidence_metamorphic.rs
@@ -204,14 +204,14 @@ fn containment_deduplication_preserves_exact_and_retrieved_identities() {
     );
     assert_eq!(
         product.support[0].symbol_id.as_deref(),
-        Some("node:exact"),
+        Some("exact"),
         "the exact selector keeps source-bearing precedence"
     );
     assert!(
         product
             .support
             .iter()
-            .any(|unit| unit.symbol_id.as_deref() == Some("node:retrieved")),
+            .any(|unit| unit.symbol_id.as_deref() == Some("retrieved")),
         "deduplication must not erase the other admitted identity"
     );
 }
@@ -238,7 +238,7 @@ fn distinct_retrieval_paths_precede_repeated_paths_after_exact_sources() {
             .filter(|unit| unit.kind == SupportUnitKindDto::SourceRange)
             .filter_map(|unit| unit.symbol_id.as_deref())
             .collect::<Vec<_>>(),
-        vec!["node:exact", "node:distinct", "node:repeat"]
+        vec!["exact", "distinct", "repeat"]
     );
 }
 
@@ -360,4 +360,148 @@ fn bijective_identity_and_path_rename_preserves_compilation_shape() {
         .collect::<Vec<_>>()
     };
     assert_eq!(compile_shape("alpha"), compile_shape("omega"));
+}
+
+#[test]
+fn opaque_edge_id_swaps_do_not_change_selected_relation_semantics() {
+    let compile_relations = |first_id: &str, second_id: &str| {
+        compile_repository_evidence(&input(
+            vec![
+                admission(0, "node:1", PacketAdmissionOriginV1::ExactTypedSelector),
+                admission(1, "node:2", PacketAdmissionOriginV1::Retrieval),
+            ],
+            Vec::new(),
+            vec![
+                relation(
+                    first_id,
+                    "node:1",
+                    "node:2",
+                    PacketRelationCertaintyV1::Certain,
+                ),
+                PacketDirectedRelationV1 {
+                    relation_id: second_id.into(),
+                    from_identity: "node:2".into(),
+                    to_identity: "node:1".into(),
+                    relation_kind: PacketRelationKindV1::Import,
+                    certainty: PacketRelationCertaintyV1::Certain,
+                },
+            ],
+        ))
+        .support
+        .into_iter()
+        .filter(|unit| unit.kind == SupportUnitKindDto::TypedGraphEdge)
+        .map(|unit| (unit.edge_kind, unit.from_symbol, unit.to_symbol))
+        .collect::<Vec<_>>()
+    };
+
+    assert_eq!(compile_relations("a", "z"), compile_relations("z", "a"));
+}
+
+#[test]
+fn self_loops_never_spend_bounded_public_rows() {
+    let admissions = (0..16)
+        .map(|index| {
+            admission(
+                index,
+                &format!("node:{}", index + 1),
+                PacketAdmissionOriginV1::Retrieval,
+            )
+        })
+        .collect::<Vec<_>>();
+    let sources = (0..16)
+        .map(|index| {
+            source(
+                &format!("node:{}", index + 1),
+                &format!("src/{index}.rs"),
+                1,
+                2,
+            )
+        })
+        .collect::<Vec<_>>();
+    let relations = (0..16)
+        .map(|index| {
+            let identity = format!("node:{}", index + 1);
+            relation(
+                &format!("loop-{index}"),
+                &identity,
+                &identity,
+                PacketRelationCertaintyV1::Certain,
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let product = compile_repository_evidence(&input(admissions, sources, relations));
+    assert!(
+        product
+            .support
+            .iter()
+            .all(|unit| unit.kind != SupportUnitKindDto::TypedGraphEdge),
+        "self loops displaced source witnesses: {:?}",
+        product.support
+    );
+    assert_eq!(product.support.len(), 16);
+}
+
+#[test]
+fn exact_continuations_follow_selector_order_not_identity_spelling() {
+    let mut compiler_input = input(Vec::new(), Vec::new(), Vec::new());
+    compiler_input.admission_gaps = (0..10)
+        .map(
+            |ordinal| codestory_contracts::compilation::PacketAdmissionGapV1 {
+                kind: codestory_contracts::compilation::PacketAdmissionGapKindV1::SourceUnavailable,
+                stable_identity: Some(format!("node:{}", 100 - ordinal)),
+                exact_selector_ordinal: Some(ordinal),
+            },
+        )
+        .collect();
+    let product = compile_repository_evidence(&compiler_input);
+    assert_eq!(
+        product
+            .continuation
+            .iter()
+            .take(8)
+            .map(|selector| selector.stable_identity.as_str())
+            .collect::<Vec<_>>(),
+        (0..8)
+            .map(|ordinal| format!("node:{}", 100 - ordinal))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn public_symbol_ids_are_raw_and_paths_never_masquerade_as_symbols() {
+    let product = compile_repository_evidence(&input(
+        vec![
+            admission(0, "node:-42", PacketAdmissionOriginV1::ExactTypedSelector),
+            admission(
+                1,
+                "path:src/lib.rs",
+                PacketAdmissionOriginV1::ExactTypedSelector,
+            ),
+        ],
+        vec![
+            source("node:-42", "src/node.rs", 1, 2),
+            source("path:src/lib.rs", "src/lib.rs", 1, 2),
+        ],
+        Vec::new(),
+    ));
+    let node = product
+        .support
+        .iter()
+        .find(|unit| unit.path.as_deref() == Some("src/node.rs"))
+        .expect("node source");
+    assert_eq!(node.symbol_id.as_deref(), Some("-42"));
+    assert_eq!(
+        codestory_contracts::api::NodeId(node.symbol_id.clone().expect("raw node id"))
+            .to_core()
+            .expect("packet symbol id must round-trip through context")
+            .0,
+        -42
+    );
+    let path = product
+        .support
+        .iter()
+        .find(|unit| unit.path.as_deref() == Some("src/lib.rs"))
+        .expect("path source");
+    assert_eq!(path.symbol_id, None);
 }

--- a/crates/codestory-agent/tests/repository_evidence_metamorphic.rs
+++ b/crates/codestory-agent/tests/repository_evidence_metamorphic.rs
@@ -1,0 +1,363 @@
+//! Contract tests for prompt-blind repository evidence compilation.
+
+use codestory_agent::evidence_compiler::compile_repository_evidence;
+use codestory_contracts::api::SupportUnitKindDto;
+use codestory_contracts::compilation::{
+    PACKET_COMPILATION_CONTRACT_VERSION_V1, PUBLIC_PACKET_SERIALIZED_MAX_BYTES,
+    PacketAdmissionOriginV1, PacketAdmissionReceiptV1, PacketCompilationInputV1,
+    PacketCompilationPublicationV1, PacketDirectedRelationV1, PacketHydratedSourceRangeV1,
+    PacketParserCompletenessV1, PacketRelationCertaintyV1, PacketRelationKindV1,
+    PacketStructuralGapReasonV1,
+};
+
+fn admission(
+    ordinal: u32,
+    identity: &str,
+    origin: PacketAdmissionOriginV1,
+) -> PacketAdmissionReceiptV1 {
+    PacketAdmissionReceiptV1 {
+        packet_ordinal: ordinal,
+        stable_identity: identity.to_string(),
+        score_version: "retrieval-score/v1".into(),
+        reserved_source_bytes: 512,
+        origin,
+    }
+}
+
+fn source(
+    identity: &str,
+    path: &str,
+    start_line: u32,
+    end_line: u32,
+) -> PacketHydratedSourceRangeV1 {
+    PacketHydratedSourceRangeV1 {
+        stable_identity: identity.to_string(),
+        path: path.to_string(),
+        symbol: Some(identity.to_string()),
+        start_line,
+        end_line,
+        source: format!("fn {}() {{}}", identity.replace([':', '-'], "_")),
+        parser_completeness: PacketParserCompletenessV1::Complete,
+    }
+}
+
+fn relation(
+    id: &str,
+    from: &str,
+    to: &str,
+    certainty: PacketRelationCertaintyV1,
+) -> PacketDirectedRelationV1 {
+    PacketDirectedRelationV1 {
+        relation_id: id.to_string(),
+        from_identity: from.to_string(),
+        to_identity: to.to_string(),
+        relation_kind: PacketRelationKindV1::Call,
+        certainty,
+    }
+}
+
+fn input(
+    admissions: Vec<PacketAdmissionReceiptV1>,
+    sources: Vec<PacketHydratedSourceRangeV1>,
+    relations: Vec<PacketDirectedRelationV1>,
+) -> PacketCompilationInputV1 {
+    PacketCompilationInputV1 {
+        contract_version: PACKET_COMPILATION_CONTRACT_VERSION_V1,
+        publication: PacketCompilationPublicationV1 {
+            project_id: "project".into(),
+            core_generation_id: "core".into(),
+            retrieval_generation: Some("retrieval".into()),
+        },
+        admissions,
+        sources,
+        relations,
+        ambiguities: Vec::new(),
+        admission_gaps: Vec::new(),
+    }
+}
+
+#[test]
+fn compiler_is_prompt_blind_and_invariant_to_input_permutation() {
+    let admissions = vec![
+        admission(0, "node:alpha", PacketAdmissionOriginV1::ExactTypedSelector),
+        admission(1, "node:omega", PacketAdmissionOriginV1::Retrieval),
+    ];
+    let sources = vec![
+        source("node:alpha", "src/alpha.rs", 1, 3),
+        source("node:omega", "src/omega.rs", 5, 7),
+    ];
+    let relations = vec![relation(
+        "edge-1",
+        "node:alpha",
+        "node:omega",
+        PacketRelationCertaintyV1::Certain,
+    )];
+    let baseline = input(admissions.clone(), sources.clone(), relations.clone());
+    let mut permuted = input(admissions, sources, relations);
+    permuted.admissions.reverse();
+    permuted.sources.reverse();
+    permuted.relations.reverse();
+
+    assert_eq!(
+        compile_repository_evidence(&baseline),
+        compile_repository_evidence(&permuted)
+    );
+    let serialized = serde_json::to_value(baseline).expect("serialize compiler input");
+    for forbidden in [
+        "question",
+        "prompt",
+        "task_class",
+        "obligations",
+        "coverage_role",
+    ] {
+        assert!(
+            serialized.get(forbidden).is_none(),
+            "unexpected {forbidden}"
+        );
+    }
+}
+
+#[test]
+fn duplicate_source_ties_are_deterministic_under_input_permutation() {
+    let admissions = vec![admission(
+        0,
+        "node:alpha",
+        PacketAdmissionOriginV1::ExactTypedSelector,
+    )];
+    let mut first = source("node:alpha", "src/alpha.rs", 1, 3);
+    first.source = "zeta".into();
+    let mut second = first.clone();
+    second.source = "alpha".into();
+    let baseline = input(
+        admissions.clone(),
+        vec![first.clone(), second.clone()],
+        Vec::new(),
+    );
+    let permuted = input(admissions, vec![second, first], Vec::new());
+    assert_eq!(
+        compile_repository_evidence(&baseline),
+        compile_repository_evidence(&permuted)
+    );
+}
+
+#[test]
+fn connecting_forest_is_not_starved_by_sixteen_source_witnesses() {
+    let admissions = (0..16)
+        .map(|index| {
+            admission(
+                index,
+                &format!("node:{index}"),
+                PacketAdmissionOriginV1::Retrieval,
+            )
+        })
+        .collect::<Vec<_>>();
+    let sources = (0..16)
+        .map(|index| source(&format!("node:{index}"), &format!("src/{index}.rs"), 1, 3))
+        .collect::<Vec<_>>();
+    let relations = (1..16)
+        .map(|index| {
+            relation(
+                &format!("edge-{index}"),
+                &format!("node:{}", index - 1),
+                &format!("node:{index}"),
+                PacketRelationCertaintyV1::Certain,
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let product = compile_repository_evidence(&input(admissions, sources, relations));
+    assert!(product.support.len() <= 16);
+    assert!(
+        product
+            .support
+            .iter()
+            .any(|unit| unit.kind == SupportUnitKindDto::TypedGraphEdge),
+        "a full source set must not erase the admitted-seed connecting forest"
+    );
+}
+
+#[test]
+fn containment_deduplication_preserves_exact_and_retrieved_identities() {
+    let product = compile_repository_evidence(&input(
+        vec![
+            admission(0, "node:exact", PacketAdmissionOriginV1::ExactTypedSelector),
+            admission(1, "node:retrieved", PacketAdmissionOriginV1::Retrieval),
+        ],
+        vec![
+            source("node:retrieved", "src/shared.rs", 1, 10),
+            source("node:exact", "src/shared.rs", 3, 4),
+        ],
+        Vec::new(),
+    ));
+
+    assert_eq!(
+        product
+            .support
+            .iter()
+            .filter(|unit| {
+                unit.kind == SupportUnitKindDto::SourceRange
+                    && unit.path.as_deref() == Some("src/shared.rs")
+            })
+            .count(),
+        1,
+        "contained ranges from one path must not both be emitted"
+    );
+    assert_eq!(
+        product.support[0].symbol_id.as_deref(),
+        Some("node:exact"),
+        "the exact selector keeps source-bearing precedence"
+    );
+    assert!(
+        product
+            .support
+            .iter()
+            .any(|unit| unit.symbol_id.as_deref() == Some("node:retrieved")),
+        "deduplication must not erase the other admitted identity"
+    );
+}
+
+#[test]
+fn distinct_retrieval_paths_precede_repeated_paths_after_exact_sources() {
+    let product = compile_repository_evidence(&input(
+        vec![
+            admission(0, "node:exact", PacketAdmissionOriginV1::ExactTypedSelector),
+            admission(1, "node:repeat", PacketAdmissionOriginV1::Retrieval),
+            admission(2, "node:distinct", PacketAdmissionOriginV1::Retrieval),
+        ],
+        vec![
+            source("node:exact", "src/shared.rs", 1, 2),
+            source("node:repeat", "src/shared.rs", 10, 11),
+            source("node:distinct", "src/distinct.rs", 1, 2),
+        ],
+        Vec::new(),
+    ));
+    assert_eq!(
+        product
+            .support
+            .iter()
+            .filter(|unit| unit.kind == SupportUnitKindDto::SourceRange)
+            .filter_map(|unit| unit.symbol_id.as_deref())
+            .collect::<Vec<_>>(),
+        vec!["node:exact", "node:distinct", "node:repeat"]
+    );
+}
+
+#[test]
+fn uncertain_relations_never_become_compiled_evidence() {
+    let product = compile_repository_evidence(&input(
+        vec![
+            admission(0, "node:left", PacketAdmissionOriginV1::Retrieval),
+            admission(1, "node:right", PacketAdmissionOriginV1::Retrieval),
+        ],
+        vec![
+            source("node:left", "src/left.rs", 1, 2),
+            source("node:right", "src/right.rs", 1, 2),
+        ],
+        vec![relation(
+            "uncertain",
+            "node:left",
+            "node:right",
+            PacketRelationCertaintyV1::Uncertain,
+        )],
+    ));
+    assert!(
+        product
+            .support
+            .iter()
+            .all(|unit| unit.id != "edge:uncertain")
+    );
+}
+
+#[test]
+fn unknown_relation_kinds_never_become_compiled_evidence() {
+    let mut unknown = relation(
+        "unknown",
+        "node:left",
+        "node:right",
+        PacketRelationCertaintyV1::Certain,
+    );
+    unknown.relation_kind = PacketRelationKindV1::Unknown;
+    let product = compile_repository_evidence(&input(
+        vec![
+            admission(0, "node:left", PacketAdmissionOriginV1::Retrieval),
+            admission(1, "node:right", PacketAdmissionOriginV1::Retrieval),
+        ],
+        vec![
+            source("node:left", "src/left.rs", 1, 2),
+            source("node:right", "src/right.rs", 1, 2),
+        ],
+        vec![unknown],
+    ));
+    assert!(product.support.iter().all(|unit| unit.id != "edge:unknown"));
+}
+
+#[test]
+fn admitted_identity_without_source_or_certain_relation_gets_typed_continuation() {
+    let product = compile_repository_evidence(&input(
+        vec![
+            admission(
+                0,
+                "node:grounded",
+                PacketAdmissionOriginV1::ExactTypedSelector,
+            ),
+            admission(1, "node:orphan", PacketAdmissionOriginV1::Retrieval),
+        ],
+        vec![source("node:grounded", "src/grounded.rs", 1, 2)],
+        Vec::new(),
+    ));
+    assert!(product.continuation.iter().any(|selector| {
+        selector.stable_identity == "node:orphan"
+            && selector.reason == PacketStructuralGapReasonV1::DisconnectedSeed
+    }));
+}
+
+#[test]
+fn source_that_cannot_fit_reports_a_typed_source_budget_gap() {
+    let mut oversized = source("node:large", "src/large.rs", 1, 2);
+    oversized.source = "x".repeat(PUBLIC_PACKET_SERIALIZED_MAX_BYTES * 2);
+    let product = compile_repository_evidence(&input(
+        vec![admission(
+            0,
+            "node:large",
+            PacketAdmissionOriginV1::ExactTypedSelector,
+        )],
+        vec![oversized],
+        Vec::new(),
+    ));
+    assert!(
+        serde_json::to_vec(&product.support).unwrap().len() <= PUBLIC_PACKET_SERIALIZED_MAX_BYTES
+    );
+    assert!(product.continuation.iter().any(|selector| {
+        selector.stable_identity == "node:large"
+            && selector.reason == PacketStructuralGapReasonV1::SourceBudgetExceeded
+    }));
+}
+
+#[test]
+fn bijective_identity_and_path_rename_preserves_compilation_shape() {
+    let compile_shape = |prefix: &str| {
+        let left = format!("node:{prefix}-left");
+        let right = format!("node:{prefix}-right");
+        compile_repository_evidence(&input(
+            vec![
+                admission(0, &left, PacketAdmissionOriginV1::ExactTypedSelector),
+                admission(1, &right, PacketAdmissionOriginV1::Retrieval),
+            ],
+            vec![
+                source(&left, &format!("src/{prefix}_left.rs"), 1, 2),
+                source(&right, &format!("src/{prefix}_right.rs"), 1, 2),
+            ],
+            vec![relation(
+                "edge",
+                &left,
+                &right,
+                PacketRelationCertaintyV1::Certain,
+            )],
+        ))
+        .support
+        .into_iter()
+        .map(|unit| unit.kind)
+        .collect::<Vec<_>>()
+    };
+    assert_eq!(compile_shape("alpha"), compile_shape("omega"));
+}

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -693,8 +693,16 @@ fn repository_derived_compiler_is_the_public_evidence_planning_boundary() {
     assert!(!orchestrator.contains("append_packet_source_evidence"));
     assert!(!orchestrator.contains("directed_relations_from_graphs(&answer.graphs"));
     let adapter = read("crates/codestory-runtime/src/agent/packet_compiler.rs");
-    assert!(adapter.contains("hydrate_admitted_sources(controller, &admissions"));
+    assert!(adapter.contains("hydrate_admitted_sources(controller, &storage, &admissions"));
     assert!(adapter.contains("get_certain_edge_representatives_between_node_ids(&node_ids)"));
+    assert!(
+        !adapter.contains("controller.node_details("),
+        "packet compiler hydration must not open graph neighborhoods through node_details"
+    );
+    assert!(
+        !adapter.contains("observe_source_coverage("),
+        "packet compiler coverage must stay admission-scoped"
+    );
     let input_build = adapter
         .find("let input = PacketCompilationInputV1")
         .expect("runtime builds typed compiler input");
@@ -702,6 +710,21 @@ fn repository_derived_compiler_is_the_public_evidence_planning_boundary() {
         .find("let product = compile_repository_evidence(&input)")
         .expect("runtime compiles the frozen typed input");
     assert!(input_build < compile);
+    let services = read("crates/codestory-runtime/src/services.rs");
+    let agent_service = source_between(
+        &services,
+        "pub struct AgentService",
+        "pub struct BookmarkService",
+    );
+    assert!(agent_service.contains("public_operation: PublicOperationService"));
+    assert!(agent_service.contains(".run_with_cancel(\"packet\""));
+    let controller_symbols = read("crates/codestory-runtime/src/controller_symbols.rs");
+    let packet_entry = source_between(
+        &controller_symbols,
+        "pub fn agent_packet",
+        "pub fn graph_neighborhood",
+    );
+    assert!(packet_entry.contains("self.with_complete_core_snapshot"));
     let current_dto = read("crates/codestory-contracts/src/api/dto.rs");
     let packet_request = source_between(
         &current_dto,

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -680,19 +680,28 @@ fn repository_derived_compiler_is_the_public_evidence_planning_boundary() {
         );
     }
     let orchestrator = read("crates/codestory-runtime/src/agent/orchestrator.rs");
-    let source_capture = orchestrator
-        .find("let source_support = append_packet_source_evidence")
-        .expect("runtime captures admitted source for the compiler");
-    let relation_capture = orchestrator
-        .find("directed_relations_from_graphs(&answer.graphs")
-        .expect("runtime captures admitted relations for the compiler");
+    let compiler_freeze = orchestrator
+        .find("let frozen_compilation = freeze_packet_compilation")
+        .expect("runtime freezes admitted repository evidence for the compiler");
     let presentation_cap = orchestrator
         .find("let budget = apply_packet_budget")
         .expect("runtime applies the presentation budget");
     assert!(
-        source_capture < presentation_cap && relation_capture < presentation_cap,
-        "legacy presentation capping must not select compiler source or graph evidence"
+        compiler_freeze < presentation_cap,
+        "compiler input and output must be frozen before presentation capping"
     );
+    assert!(!orchestrator.contains("append_packet_source_evidence"));
+    assert!(!orchestrator.contains("directed_relations_from_graphs(&answer.graphs"));
+    let adapter = read("crates/codestory-runtime/src/agent/packet_compiler.rs");
+    assert!(adapter.contains("hydrate_admitted_sources(controller, &admissions"));
+    assert!(adapter.contains("get_certain_edge_representatives_between_node_ids(&node_ids)"));
+    let input_build = adapter
+        .find("let input = PacketCompilationInputV1")
+        .expect("runtime builds typed compiler input");
+    let compile = adapter
+        .find("let product = compile_repository_evidence(&input)")
+        .expect("runtime compiles the frozen typed input");
+    assert!(input_build < compile);
     let current_dto = read("crates/codestory-contracts/src/api/dto.rs");
     let packet_request = source_between(
         &current_dto,

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -725,6 +725,15 @@ fn repository_derived_compiler_is_the_public_evidence_planning_boundary() {
         "pub fn graph_neighborhood",
     );
     assert!(packet_entry.contains("self.with_complete_core_snapshot"));
+    assert!(packet_entry.contains("&publication.generation_id"));
+    assert!(packet_entry.contains("&publication.run_id"));
+    let retrieval_primary = read("crates/codestory-runtime/src/agent/retrieval_primary.rs");
+    let packet_pin = source_between(
+        &retrieval_primary,
+        "pub(crate) fn with_stable_packet_retrieval_publication",
+        "pub(crate) fn with_pinned_retrieval_publication_value",
+    );
+    assert!(packet_pin.contains("ensure_pinned_core_publication"));
     let current_dto = read("crates/codestory-contracts/src/api/dto.rs");
     let packet_request = source_between(
         &current_dto,

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -593,8 +593,9 @@ fn indexer_crate_stays_decoupled_from_runtime_and_cli() {
 /// `agent_module_allowlist_stays_in_sync_with_the_agent_source_tree` enforces
 /// that, so adding a module to the crate without extending this list fails
 /// loudly instead of silently escaping every contract built on it.
-const AGENT_PLANNING_MODULES: [&str; 17] = [
+const AGENT_PLANNING_MODULES: [&str; 18] = [
     "citation.rs",
+    "evidence_compiler.rs",
     "packet_citations.rs",
     "packet_command.rs",
     "packet_coverage.rs",
@@ -626,29 +627,72 @@ const AGENT_PLANNING_MODULES: [&str; 17] = [
 const AGENT_MODULE_ALLOWLIST_EXCLUSIONS: [&str; 2] = ["lib.rs", "eval_probes.rs"];
 
 #[test]
-fn horizon_a_exposes_only_prompt_blind_seed_planning_and_admission() {
+fn repository_derived_compiler_is_the_public_evidence_planning_boundary() {
     let agent_lib = read("crates/codestory-agent/src/lib.rs");
     assert!(
-        !agent_lib.contains("pub mod evidence_compiler;"),
-        "the Horizon B compiler must not enter the Horizon A product graph"
+        agent_lib.contains("pub mod evidence_compiler;"),
+        "the repository-derived evidence compiler must compile in the public product graph"
+    );
+    assert!(
+        AGENT_PLANNING_MODULES.contains(&"evidence_compiler.rs"),
+        "the evidence compiler must count as a production planning module"
     );
     let contracts = read("crates/codestory-contracts/src/compilation.rs");
     for required in [
+        "RetrievalSeedPlanV1",
         "PacketCandidateDescriptorV1",
         "PacketAdmissionReceiptV1",
-        "PacketContinuationSelectorV1",
+        "PacketCompilationInputV1",
     ] {
         assert!(
             contracts.contains(required),
-            "the typed Horizon A admission boundary lost {required}"
+            "the typed compiler boundary lost {required}"
         );
     }
-    for deferred in ["RetrievalSeedPlanV1", "PacketCompilationInputV1"] {
+    let compiler_input = source_between(
+        &contracts,
+        "pub struct PacketCompilationInputV1",
+        "pub enum PacketStructuralGapReasonV1",
+    );
+    for forbidden in [
+        "pub question:",
+        "pub prompt:",
+        "task_class",
+        "obligation",
+        "coverage_role",
+        "carrier",
+        "sufficiency",
+    ] {
         assert!(
-            !contracts.contains(deferred),
-            "Horizon B contract {deferred} entered Horizon A"
+            !compiler_input.contains(forbidden),
+            "PacketCompilationInputV1 regained forbidden prompt policy: {forbidden}"
         );
     }
+    let compiler = read("crates/codestory-agent/src/evidence_compiler.rs");
+    for forbidden in [
+        "RetrievalSeedPlanV1",
+        "AgentPacketRequestDto",
+        "PacketPlanDto",
+    ] {
+        assert!(
+            !compiler.contains(forbidden),
+            "the pure evidence compiler regained request/planning input: {forbidden}"
+        );
+    }
+    let orchestrator = read("crates/codestory-runtime/src/agent/orchestrator.rs");
+    let source_capture = orchestrator
+        .find("let source_support = append_packet_source_evidence")
+        .expect("runtime captures admitted source for the compiler");
+    let relation_capture = orchestrator
+        .find("directed_relations_from_graphs(&answer.graphs")
+        .expect("runtime captures admitted relations for the compiler");
+    let presentation_cap = orchestrator
+        .find("let budget = apply_packet_budget")
+        .expect("runtime applies the presentation budget");
+    assert!(
+        source_capture < presentation_cap && relation_capture < presentation_cap,
+        "legacy presentation capping must not select compiler source or graph evidence"
+    );
     let current_dto = read("crates/codestory-contracts/src/api/dto.rs");
     let packet_request = source_between(
         &current_dto,

--- a/crates/codestory-contracts/src/compilation.rs
+++ b/crates/codestory-contracts/src/compilation.rs
@@ -1,7 +1,9 @@
-//! Horizon A packet admission and public-status contracts.
+//! Packet seed, admission, and repository-derived compilation contracts.
 //!
-//! Repository-derived compiler input and selection contracts belong to
-//! Horizon B (`#2106`) and do not ship on this interim surface.
+//! These types make the compiler boundary enforceable. Only
+//! [`RetrievalSeedPlanV1`] may carry the original question. Everything after
+//! retrieval is expressed as stable identities, hydrated repository evidence,
+//! and a pinned publication.
 
 use serde::{Deserialize, Serialize};
 use specta::Type;
@@ -23,15 +25,35 @@ pub const INTERIM_MAX_ADMITTED_SOURCE_BYTES: usize = PUBLIC_PACKET_SERIALIZED_MA
 /// missing bound is not silently replaced with a speculative fallback.
 pub const INTERIM_SOURCE_ROW_UPPER_BOUND: usize = 512;
 
-/// Version of the retrieval score consumed by packet admission.
-pub const PACKET_RETRIEVAL_SCORE_VERSION_V1: &str = "retrieval-score/v1";
-
 /// Production never asserts semantic sufficiency. Offline evaluation owns that.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum AnswerSufficiencyV1 {
     #[default]
     NotAsserted,
+}
+
+pub const PACKET_COMPILATION_CONTRACT_VERSION_V1: u16 = 1;
+pub const PACKET_RETRIEVAL_SCORE_VERSION_V1: &str = "retrieval-score/v1";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum PacketSeedSelectorV1 {
+    ExactPath { path: String },
+    CanonicalId { id: String },
+    QualifiedSymbol { symbol: String },
+}
+
+/// The sole compiler-side value allowed to retain the original wording.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(deny_unknown_fields)]
+pub struct RetrievalSeedPlanV1 {
+    pub contract_version: u16,
+    pub generic_query: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub exact_selectors: Vec<PacketSeedSelectorV1>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub free_queries: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type)]
@@ -106,6 +128,120 @@ pub struct PacketAdmissionGapV1 {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type)]
 #[serde(rename_all = "snake_case")]
+pub enum PacketParserCompletenessV1 {
+    Complete,
+    Partial,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(deny_unknown_fields)]
+pub struct PacketHydratedSourceRangeV1 {
+    pub stable_identity: String,
+    pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub symbol: Option<String>,
+    pub start_line: u32,
+    pub end_line: u32,
+    pub source: String,
+    pub parser_completeness: PacketParserCompletenessV1,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Type)]
+#[serde(rename_all = "snake_case")]
+pub enum PacketRelationCertaintyV1 {
+    Certain,
+    Probable,
+    Uncertain,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Type)]
+#[serde(rename_all = "snake_case")]
+pub enum PacketRelationKindV1 {
+    Member,
+    TypeUsage,
+    Usage,
+    Call,
+    Inheritance,
+    Override,
+    TypeArgument,
+    TemplateSpecialization,
+    Include,
+    Import,
+    MacroUsage,
+    AnnotationUsage,
+    Unknown,
+}
+
+impl PacketRelationKindV1 {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Member => "member",
+            Self::TypeUsage => "type_usage",
+            Self::Usage => "usage",
+            Self::Call => "call",
+            Self::Inheritance => "inheritance",
+            Self::Override => "override",
+            Self::TypeArgument => "type_argument",
+            Self::TemplateSpecialization => "template_specialization",
+            Self::Include => "include",
+            Self::Import => "import",
+            Self::MacroUsage => "macro_usage",
+            Self::AnnotationUsage => "annotation_usage",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(deny_unknown_fields)]
+pub struct PacketDirectedRelationV1 {
+    pub relation_id: String,
+    pub from_identity: String,
+    pub to_identity: String,
+    pub relation_kind: PacketRelationKindV1,
+    pub certainty: PacketRelationCertaintyV1,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(deny_unknown_fields)]
+pub struct PacketIdentityAmbiguityV1 {
+    pub selector: String,
+    #[serde(default)]
+    pub candidate_identities: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(deny_unknown_fields)]
+pub struct PacketCompilationPublicationV1 {
+    pub project_id: String,
+    pub core_generation_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retrieval_generation: Option<String>,
+}
+
+/// The pure compiler input. It intentionally cannot carry prompt text, task
+/// classes, obligations, coverage roles, or answer-stage labels.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(deny_unknown_fields)]
+pub struct PacketCompilationInputV1 {
+    pub contract_version: u16,
+    pub publication: PacketCompilationPublicationV1,
+    #[serde(default)]
+    pub admissions: Vec<PacketAdmissionReceiptV1>,
+    #[serde(default)]
+    pub sources: Vec<PacketHydratedSourceRangeV1>,
+    #[serde(default)]
+    pub relations: Vec<PacketDirectedRelationV1>,
+    #[serde(default)]
+    pub ambiguities: Vec<PacketIdentityAmbiguityV1>,
+    #[serde(default)]
+    pub admission_gaps: Vec<PacketAdmissionGapV1>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "snake_case")]
 pub enum PacketStructuralGapReasonV1 {
     CandidateCountExceeded,
     SourceBudgetExceeded,
@@ -149,20 +285,45 @@ mod tests {
     }
 
     #[test]
-    fn packet_descriptors_can_fail_closed_without_a_source_bound() {
-        let value = serde_json::to_value(PacketCandidateDescriptorV1 {
-            stable_identity: "node:7".into(),
-            path: "src/lib.rs".into(),
-            symbol: Some("crate::run".into()),
-            retrieval_lane: PacketRetrievalLaneV1::Lexical,
-            retrieval_score: VersionedRetrievalScoreV1 {
-                version: PACKET_RETRIEVAL_SCORE_VERSION_V1.into(),
-                value: 0.75,
+    fn compilation_input_cannot_serialize_prompt_policy() {
+        let input = PacketCompilationInputV1 {
+            contract_version: PACKET_COMPILATION_CONTRACT_VERSION_V1,
+            publication: PacketCompilationPublicationV1 {
+                project_id: "project".into(),
+                core_generation_id: "core".into(),
+                retrieval_generation: Some("retrieval".into()),
             },
-            source_bytes_upper_bound: None,
-            exact_selector_ordinal: None,
-        })
-        .unwrap();
-        assert!(value.get("source_bytes_upper_bound").is_none());
+            admissions: Vec::new(),
+            sources: Vec::new(),
+            relations: Vec::new(),
+            ambiguities: Vec::new(),
+            admission_gaps: Vec::new(),
+        };
+        let value = serde_json::to_value(input).unwrap();
+        for forbidden in [
+            "question",
+            "prompt",
+            "task_class",
+            "obligations",
+            "coverage_role",
+        ] {
+            assert!(
+                value.get(forbidden).is_none(),
+                "unexpected {forbidden}: {value}"
+            );
+        }
+    }
+
+    #[test]
+    fn directed_relation_kind_is_a_closed_typed_contract() {
+        let error = serde_json::from_value::<PacketDirectedRelationV1>(serde_json::json!({
+            "relation_id": "edge-1",
+            "from_identity": "node:1",
+            "to_identity": "node:2",
+            "relation_kind": "benchmark_shaped_relation",
+            "certainty": "certain"
+        }))
+        .expect_err("arbitrary relation labels must not enter compilation");
+        assert!(error.to_string().contains("unknown variant"), "{error}");
     }
 }

--- a/crates/codestory-contracts/src/compilation.rs
+++ b/crates/codestory-contracts/src/compilation.rs
@@ -50,6 +50,8 @@ pub enum PacketSeedSelectorV1 {
 pub struct RetrievalSeedPlanV1 {
     pub contract_version: u16,
     pub generic_query: String,
+    /// Exact selectors copied from typed probes. Raw question text has no
+    /// authority to populate this field.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub exact_selectors: Vec<PacketSeedSelectorV1>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/crates/codestory-retrieval/src/candidate.rs
+++ b/crates/codestory-retrieval/src/candidate.rs
@@ -171,17 +171,23 @@ pub fn fused_candidate_identity_matches(left: &CandidateHit, right: &CandidateHi
 }
 
 impl CandidateHit {
+    /// Stable descriptor identity available without opening core state.
+    pub fn packet_stable_identity(&self) -> Option<String> {
+        match self.node_id.as_deref() {
+            Some(identity) => {
+                let identity = identity.trim();
+                let identity = identity.parse::<i64>().ok()?;
+                Some(format!("node:{identity}"))
+            }
+            None => packet_path_identity(&self.file_path).map(|path| format!("path:{path}")),
+        }
+    }
+
     /// Convert sidecar output into the descriptor-only packet admission
     /// boundary. Missing identity or source bounds makes a candidate
     /// ineligible; callers must not hydrate core state to fill either field.
     pub fn packet_descriptor(&self) -> Option<PacketCandidateDescriptorV1> {
-        let stable_identity = self
-            .node_id
-            .as_deref()
-            .map(str::trim)
-            .filter(|identity| !identity.is_empty())
-            .map(|identity| format!("node:{identity}"))
-            .or_else(|| packet_path_identity(&self.file_path).map(|path| format!("path:{path}")))?;
+        let stable_identity = self.packet_stable_identity()?;
         let source_bytes_upper_bound = self.source_bytes_upper_bound?;
         if self.file_path.trim().is_empty()
             || source_bytes_upper_bound == 0
@@ -525,5 +531,44 @@ mod tests {
                 "unsafe path admitted: {path}"
             );
         }
+    }
+
+    #[test]
+    fn malformed_sidecar_node_identity_makes_the_descriptor_ineligible() {
+        let mut candidate = CandidateHit::lexical_stub("src/lib.rs", 0.8);
+        candidate.node_id = Some("not-an-id".into());
+        candidate.source_bytes_upper_bound = Some(512);
+
+        assert!(candidate.packet_descriptor().is_none());
+    }
+
+    #[test]
+    fn signed_sidecar_node_identity_uses_the_real_node_id_grammar() {
+        let mut candidate = CandidateHit::lexical_stub("src/lib.rs", 0.8);
+        candidate.node_id = Some("-42".into());
+        candidate.source_bytes_upper_bound = Some(512);
+
+        assert_eq!(
+            candidate
+                .packet_descriptor()
+                .expect("signed node id is valid")
+                .stable_identity,
+            "node:-42"
+        );
+    }
+
+    #[test]
+    fn sidecar_node_identity_is_canonicalized_before_admission() {
+        let mut candidate = CandidateHit::lexical_stub("src/lib.rs", 0.8);
+        candidate.node_id = Some(" +0042 ".into());
+        candidate.source_bytes_upper_bound = Some(512);
+
+        assert_eq!(
+            candidate
+                .packet_descriptor()
+                .expect("numeric node id is valid")
+                .stable_identity,
+            "node:42"
+        );
     }
 }

--- a/crates/codestory-runtime/src/agent/mod.rs
+++ b/crates/codestory-runtime/src/agent/mod.rs
@@ -80,9 +80,9 @@ pub fn plan_packet(
         .map_err(codestory_contracts::api::ApiError::invalid_argument)?;
     let probes = packet_probe::normalize_packet_probe_request(&request.probes);
     let free_queries = packet_probe::unresolved_packet_probe_queries(&probes);
-    Ok(packet_plan::build_packet_plan_with_extra(
-        question,
+    let seed_plan = packet_plan::build_retrieval_seed_plan(question, &free_queries);
+    Ok(packet_plan::build_packet_plan_from_seed_plan(
+        &seed_plan,
         request.budget,
-        &free_queries,
     ))
 }

--- a/crates/codestory-runtime/src/agent/mod.rs
+++ b/crates/codestory-runtime/src/agent/mod.rs
@@ -79,8 +79,7 @@ pub fn plan_packet(
     codestory_contracts::api::validate_packet_probe_request(&request.probes)
         .map_err(codestory_contracts::api::ApiError::invalid_argument)?;
     let probes = packet_probe::normalize_packet_probe_request(&request.probes);
-    let free_queries = packet_probe::unresolved_packet_probe_queries(&probes);
-    let seed_plan = packet_plan::build_retrieval_seed_plan(question, &free_queries);
+    let seed_plan = packet_plan::build_retrieval_seed_plan(question, &probes);
     Ok(packet_plan::build_packet_plan_from_seed_plan(
         &seed_plan,
         request.budget,

--- a/crates/codestory-runtime/src/agent/orchestrator.rs
+++ b/crates/codestory-runtime/src/agent/orchestrator.rs
@@ -7,7 +7,7 @@ use crate::agent::packet_candidate::{
     PacketProofSession, PacketSearchHit, install_packet_proof_session,
 };
 use crate::agent::packet_compiler::{
-    apply_compiled_evidence_for_project, directed_relations_from_graphs, drill_options_from_ids,
+    apply_frozen_packet_compilation, drill_options_from_ids, freeze_packet_compilation,
 };
 use crate::agent::packet_degradation::apply_packet_semantic_degradation_counters;
 use crate::agent::packet_evidence::decorate_citation_from_hit;
@@ -15,8 +15,8 @@ use crate::agent::packet_plan::{
     build_packet_plan_from_seed_plan, build_retrieval_seed_plan, packet_plan_annotation,
 };
 use crate::agent::packet_probe::{
-    exact_packet_probe_citations, exact_packet_probe_paths, normalize_packet_probe_request,
-    probes_from_seed_selectors, resolve_packet_probes, unresolved_packet_probe_queries,
+    exact_packet_probe_citations, normalize_packet_probe_request, probes_from_seed_selectors,
+    resolve_packet_probes, unresolved_packet_probe_queries,
 };
 use crate::agent::packet_scoring::{packet_display_path, packet_stage_citation_carry_limit};
 use crate::agent::packet_terms::prompt_search_terms;
@@ -39,14 +39,14 @@ use codestory_contracts::api::{
     AgentAnswerDto, AgentAskRequest, AgentCitationDto, AgentCustomRetrievalConfigDto,
     AgentHybridWeightsDto, AgentPacketDto, AgentPacketRequestDto, AgentResponseBlockDto,
     AgentResponseModeDto, AgentResponseSectionDto, AgentRetrievalPolicyModeDto,
-    AgentRetrievalPresetDto, AgentRetrievalProfileSelectionDto, AgentRetrievalStepDto,
-    AgentRetrievalStepKindDto, AgentRetrievalStepStatusDto, ApiError, EdgeKind, GraphArtifactDto,
-    GraphNodeDto, GraphRequest, GraphResponse, IndexFreshnessDto, IndexFreshnessStatusDto,
-    NodeDetailsDto, NodeDetailsRequest, NodeId, NodeKind, NodeOccurrencesRequest,
-    PACKET_DRILL_MAX_DEPTH, PACKET_DRILL_MAX_HITS, PacketBudgetLimitsDto, PacketBudgetModeDto,
-    PacketDispositionDto, PacketProbeDto, RetrievalAnnotationDto, RetrievalScoreBreakdownDto,
-    SearchHit, SearchHitOrigin, SearchRepoTextMode, SearchRequest, SupportUnitDto,
-    SupportUnitKindDto, TrailConfigDto, TrailFilterOptionsDto,
+    AgentRetrievalPresetDto, AgentRetrievalProfileSelectionDto, AgentRetrievalStepKindDto,
+    ApiError, EdgeKind, GraphArtifactDto, GraphNodeDto, GraphRequest, GraphResponse,
+    IndexFreshnessDto, IndexFreshnessStatusDto, NodeDetailsDto, NodeDetailsRequest, NodeId,
+    NodeKind, NodeOccurrencesRequest, PACKET_DRILL_MAX_DEPTH, PACKET_DRILL_MAX_HITS,
+    PacketBudgetLimitsDto, PacketBudgetModeDto, PacketDispositionDto, PacketProbeDto,
+    RetrievalAnnotationDto, RetrievalScoreBreakdownDto, SearchHit, SearchHitOrigin,
+    SearchRepoTextMode, SearchRequest, SupportUnitDto, SupportUnitKindDto, TrailConfigDto,
+    TrailFilterOptionsDto,
 };
 use codestory_contracts::compilation::INTERIM_MAX_ADMITTED_CANDIDATES;
 use std::cmp::Ordering;
@@ -466,37 +466,24 @@ pub(crate) fn agent_packet(
     apply_packet_semantic_degradation_counters(&mut answer);
     append_packet_non_trace_phase(&mut answer, "shadow_and_trace", phase_started);
 
-    let exact_probe_paths = exact_packet_probe_paths(&plan.probe_resolutions);
-
-    // Capture admitted repository evidence before presentation-only capping.
-    // The pure compiler, rather than legacy graph/citation budgets, decides
-    // which source ranges and directed edges enter the public packet.
-    let source_support = append_packet_source_evidence(controller, &mut answer);
-    let compilation_relations =
-        directed_relations_from_graphs(&answer.graphs, &proof_session.receipts());
-
-    // Coverage belongs only to exact selectors and deterministic source reads
-    // that survived admission. Prompt-ranked citations have no authority here.
-    let mut covered_paths = exact_probe_paths.clone();
-    covered_paths.extend(
-        source_support
-            .iter()
-            .filter_map(|source| source.path.clone()),
-    );
-    answer.source_coverage =
-        crate::source_coverage::observe_source_coverage(controller, &covered_paths);
-    let retained_coverage_paths = exact_probe_paths
-        .into_iter()
-        .chain(
-            source_support
-                .iter()
-                .filter_map(|source| source.path.clone()),
-        )
-        .map(|path| packet_display_path(&path))
-        .collect::<HashSet<_>>();
-    answer.source_coverage.retain(|observation| {
-        retained_coverage_paths.contains(&packet_display_path(&observation.path))
-    });
+    // The retrieval publication must be attached before compiler input is
+    // frozen. The compiler then hydrates source and the induced relation set
+    // directly from the admitted identities, never from legacy citations,
+    // graph views, or presentation sections.
+    let active_retrieval_publication =
+        crate::agent::retrieval_primary::active_pinned_retrieval_publication(controller);
+    if let Some(publication) = active_retrieval_publication.clone() {
+        answer.retrieval_trace.retrieval_publication = Some(publication);
+    }
+    let frozen_compilation = freeze_packet_compilation(
+        controller,
+        &project_id,
+        &plan.probe_resolutions,
+        active_retrieval_publication.as_ref(),
+        &proof_session,
+    )?;
+    answer.source_coverage = frozen_compilation.source_coverage.clone();
+    append_compiled_source_evidence(&mut answer, &frozen_compilation.product.support);
 
     let phase_started = Instant::now();
     let budget = apply_packet_budget(
@@ -516,16 +503,6 @@ pub(crate) fn agent_packet(
     order_packet_sections(&mut answer.sections);
     append_packet_non_trace_phase(&mut answer, "evidence_sections", phase_started);
 
-    // `agent_packet` executes inside one stable retrieval-publication scope. Compile the packet
-    // while that pin is still active so a one-shot drill carries the exact generations it must
-    // send back. Attaching publication only to the returned DTO was too late: the compiler had
-    // already emitted empty drill pins, and the continuation could not validate them.
-    if let Some(publication) =
-        crate::agent::retrieval_primary::active_pinned_retrieval_publication(controller)
-    {
-        answer.retrieval_trace.retrieval_publication = Some(publication);
-    }
-
     // Typed field, not `annotations`: readiness re-verification was previously
     // invisible, which is what let one packet pay for several full content
     // passes unnoticed. Publishing it here — before the trace summary is taken
@@ -543,13 +520,14 @@ pub(crate) fn agent_packet(
         question,
         plan,
         answer,
-        support: source_support,
+        support: Vec::new(),
         disposition: PacketDispositionDto::not_established("compile pending"),
         budget,
         retrieval_trace_summary,
         answer_sufficiency: Default::default(),
     };
     append_packet_non_trace_phase(&mut packet.answer, "packet_dto", phase_started);
+    apply_frozen_packet_compilation(&mut packet, Some(&req), frozen_compilation);
     enforce_packet_output_budget(&project_root, &mut packet);
 
     if let Some(diagnostic) = trace_export::write_packet_step_trace_from_env(&packet.answer) {
@@ -561,14 +539,6 @@ pub(crate) fn agent_packet(
             .push(RetrievalAnnotationDto::observation(diagnostic));
         enforce_packet_output_budget(&project_root, &mut packet);
     }
-    apply_compiled_evidence_for_project(
-        &mut packet,
-        Some(&req),
-        &project_id,
-        compilation_relations,
-    );
-    enforce_packet_output_budget(&project_root, &mut packet);
-
     Ok(packet)
 }
 
@@ -758,83 +728,25 @@ fn order_packet_sections(sections: &mut [AgentResponseSectionDto]) {
 /// bytes are bounded by the descriptor reservation contract.
 const PACKET_SOURCE_MAX_TOTAL_BYTES: usize = 14_336;
 
-struct PacketSourceRange {
-    path: String,
-    start_line: u32,
-    body: String,
-}
-
-/// Truncate on a UTF-8 character boundary, never mid-codepoint.
-fn truncate_packet_source(body: &str, max_bytes: usize) -> &str {
-    if body.len() <= max_bytes {
-        return body;
-    }
-    let mut end = max_bytes;
-    while end > 0 && !body.is_char_boundary(end) {
-        end -= 1;
-    }
-    &body[..end]
-}
-
-fn append_packet_source_evidence(
-    controller: &AppController,
-    answer: &mut AgentAnswerDto,
-) -> Vec<SupportUnitDto> {
-    if answer.citations.is_empty() {
-        return Vec::new();
-    }
-
+fn append_compiled_source_evidence(answer: &mut AgentAnswerDto, support: &[SupportUnitDto]) {
     let mut rendered = String::new();
-    let mut source_support = Vec::new();
-    let mut steps = Vec::new();
-    for citation in answer
-        .citations
+    for source in support
         .iter()
-        .take(INTERIM_MAX_ADMITTED_CANDIDATES)
+        .filter(|unit| unit.kind == SupportUnitKindDto::SourceRange)
     {
-        let started = Instant::now();
-        let Some(source) = repository_source_range(controller, citation) else {
+        let Some(body) = source.snippet.as_deref() else {
             continue;
         };
-        let retained = truncate_packet_source(
-            source.body.trim_end(),
-            codestory_contracts::compilation::INTERIM_SOURCE_ROW_UPPER_BOUND,
-        );
+        let retained = body.trim_end();
         if retained.is_empty() {
             continue;
         }
-        let entry = format!("### {}\n\n{}\n\n", citation.display_name, retained);
+        let entry = format!("### {}\n\n{}\n\n", source.summary, retained);
         if rendered.len().saturating_add(entry.len()) > PACKET_SOURCE_MAX_TOTAL_BYTES {
             break;
         }
         rendered.push_str(&entry);
-        let path = packet_display_path(&source.path);
-        let (start_line, end_line) = source_receipt_line_range(retained, source.start_line);
-        source_support.push(SupportUnitDto {
-            id: format!("source:{}:{start_line}", citation.node_id.0),
-            kind: SupportUnitKindDto::SourceRange,
-            summary: citation.display_name.clone(),
-            path: Some(path),
-            symbol_id: Some(citation.node_id.0.clone()),
-            start_line: Some(start_line),
-            end_line: Some(end_line),
-            snippet: Some(retained.to_string()),
-            edge_kind: None,
-            from_symbol: None,
-            to_symbol: None,
-            query: None,
-        });
-        steps.push(AgentRetrievalStepDto {
-            kind: AgentRetrievalStepKindDto::SourceRead,
-            status: AgentRetrievalStepStatusDto::Ok,
-            duration_ms: started.elapsed().as_millis().try_into().unwrap_or(u32::MAX),
-            input: Vec::new(),
-            output: Vec::new(),
-            message: Some(format!("bounded source for {}", citation.display_name)),
-        });
     }
-
-    answer.retrieval_trace.steps.extend(steps);
     if !rendered.is_empty() {
         answer.sections.push(AgentResponseSectionDto {
             id: "packet-source-evidence".to_string(),
@@ -842,82 +754,10 @@ fn append_packet_source_evidence(
             blocks: vec![AgentResponseBlockDto::Markdown { markdown: rendered }],
         });
     }
-    source_support
 }
 
-fn repository_source_range(
-    controller: &AppController,
-    citation: &AgentCitationDto,
-) -> Option<PacketSourceRange> {
-    let max_bytes = codestory_contracts::compilation::INTERIM_SOURCE_ROW_UPPER_BOUND;
-    if matches!(
-        citation.kind,
-        NodeKind::FUNCTION | NodeKind::METHOD | NodeKind::CLASS | NodeKind::STRUCT
-    ) && let Ok(snippet) = controller.snippet_function_body_context(citation.node_id.clone(), 0)
-    {
-        if let Some(end_line) = snippet.node.end_line.filter(|end| *end >= snippet.line)
-            && let Ok((path, bounded)) = controller.bounded_file_snippet_range(
-                &snippet.path,
-                crate::BoundedSnippetRangeOptions {
-                    focus_line: snippet.line,
-                    start_line: snippet.line,
-                    end_line,
-                    context_lines: 0,
-                    max_bytes,
-                    truncation_suffix: SOURCE_SNIPPET_TRUNCATION_SUFFIX,
-                },
-            )
-        {
-            return Some(PacketSourceRange {
-                path,
-                start_line: snippet.line,
-                body: bounded.markdown,
-            });
-        }
-        return Some(PacketSourceRange {
-            path: snippet.path,
-            start_line: snippet.line,
-            body: truncate_packet_source(&snippet.snippet, max_bytes).to_string(),
-        });
-    }
-
-    let path = citation.file_path.as_deref()?;
-    let line = citation.line?;
-    controller
-        .bounded_file_snippet(path, line, 4, max_bytes, SOURCE_SNIPPET_TRUNCATION_SUFFIX)
-        .ok()
-        .map(|(path, snippet)| PacketSourceRange {
-            path,
-            start_line: line.saturating_sub(4).max(1),
-            body: snippet.markdown,
-        })
-}
-
-fn source_receipt_line_range(markdown: &str, fallback_start: u32) -> (u32, u32) {
-    let numbered_lines = markdown.lines().filter_map(|line| {
-        let line = line
-            .trim_start()
-            .strip_prefix("> ")
-            .unwrap_or(line.trim_start());
-        let (line_number, _) = line.split_once(" | ")?;
-        line_number.trim().parse::<u32>().ok()
-    });
-    let mut start = None;
-    let mut end = None;
-    for line in numbered_lines {
-        start = Some(start.map_or(line, |current: u32| current.min(line)));
-        end = Some(end.map_or(line, |current: u32| current.max(line)));
-    }
-    (
-        start.unwrap_or(fallback_start),
-        end.unwrap_or(fallback_start),
-    )
-}
-
-/// A long function is rarely best represented by its prologue. Select at most three bounded,
-/// distinct windows whose source words match separate action clauses from the question.
-/// The ranges remain exact source receipts for the already selected symbol; this changes only
-/// which verified bytes spend the packet's fixed source budget.
+/// Render the legacy citation appendix. It remains diagnostic presentation and
+/// cannot select or protect evidence in the compiled packet.
 fn packet_evidence_ledger_markdown(
     answer: &AgentAnswerDto,
     limits: &PacketBudgetLimitsDto,

--- a/crates/codestory-runtime/src/agent/orchestrator.rs
+++ b/crates/codestory-runtime/src/agent/orchestrator.rs
@@ -6,13 +6,17 @@ use crate::agent::packet_budget::{
 use crate::agent::packet_candidate::{
     PacketProofSession, PacketSearchHit, install_packet_proof_session,
 };
-use crate::agent::packet_compiler::{drill_options_from_ids, finalize_interim_packet_evidence};
+use crate::agent::packet_compiler::{
+    apply_compiled_evidence_for_project, directed_relations_from_graphs, drill_options_from_ids,
+};
 use crate::agent::packet_degradation::apply_packet_semantic_degradation_counters;
 use crate::agent::packet_evidence::decorate_citation_from_hit;
-use crate::agent::packet_plan::{build_packet_plan_with_extra, packet_plan_annotation};
+use crate::agent::packet_plan::{
+    build_packet_plan_from_seed_plan, build_retrieval_seed_plan, packet_plan_annotation,
+};
 use crate::agent::packet_probe::{
     exact_packet_probe_citations, exact_packet_probe_paths, normalize_packet_probe_request,
-    resolve_packet_probes, unresolved_packet_probe_queries,
+    probes_from_seed_selectors, resolve_packet_probes, unresolved_packet_probe_queries,
 };
 use crate::agent::packet_scoring::{packet_display_path, packet_stage_citation_carry_limit};
 use crate::agent::packet_terms::prompt_search_terms;
@@ -337,6 +341,7 @@ pub(crate) fn agent_packet(
     }
     let is_drill_continuation = req.parent_packet_id.is_some() || !req.option_ids.is_empty();
     let free_queries = unresolved_packet_probe_queries(&req.probes);
+    let seed_plan = build_retrieval_seed_plan(&question, &free_queries);
     let mut probes = normalize_packet_probe_request(&req.probes);
     for option in drill_options_from_ids(&req.option_ids) {
         if let Some(path) = option.path {
@@ -345,11 +350,18 @@ pub(crate) fn agent_packet(
             probes.push(PacketProbeDto::SymbolId { id: symbol_id });
         }
     }
+    for probe in probes_from_seed_selectors(&seed_plan.exact_selectors) {
+        if !probes.contains(&probe) {
+            probes.push(probe);
+        }
+    }
     let probe_resolutions = resolve_packet_probes(controller, probes);
-    let mut plan = build_packet_plan_with_extra(&question, req.budget, &free_queries);
+    let mut plan = build_packet_plan_from_seed_plan(&seed_plan, req.budget);
     plan.probe_resolutions = probe_resolutions;
     let mut descriptor_queries = Vec::new();
-    for query in std::iter::once(question.as_str()).chain(free_queries.iter().map(String::as_str)) {
+    for query in std::iter::once(seed_plan.generic_query.as_str())
+        .chain(seed_plan.free_queries.iter().map(String::as_str))
+    {
         let query = query.trim();
         if !query.is_empty()
             && !descriptor_queries
@@ -455,18 +467,13 @@ pub(crate) fn agent_packet(
     append_packet_non_trace_phase(&mut answer, "shadow_and_trace", phase_started);
 
     let exact_probe_paths = exact_packet_probe_paths(&plan.probe_resolutions);
-    let phase_started = Instant::now();
-    let budget = apply_packet_budget(
-        &project_root,
-        &question,
-        req.budget,
-        limits.clone(),
-        &mut answer,
-    );
-    append_packet_non_trace_phase(&mut answer, "budget", phase_started);
 
-    // Hydrate deterministic bounded source only after identity admission.
-    let source_support = append_packet_source_evidence(controller, &mut answer, &limits);
+    // Capture admitted repository evidence before presentation-only capping.
+    // The pure compiler, rather than legacy graph/citation budgets, decides
+    // which source ranges and directed edges enter the public packet.
+    let source_support = append_packet_source_evidence(controller, &mut answer);
+    let compilation_relations =
+        directed_relations_from_graphs(&answer.graphs, &proof_session.receipts());
 
     // Coverage belongs only to exact selectors and deterministic source reads
     // that survived admission. Prompt-ranked citations have no authority here.
@@ -490,6 +497,16 @@ pub(crate) fn agent_packet(
     answer.source_coverage.retain(|observation| {
         retained_coverage_paths.contains(&packet_display_path(&observation.path))
     });
+
+    let phase_started = Instant::now();
+    let budget = apply_packet_budget(
+        &project_root,
+        &question,
+        req.budget,
+        limits.clone(),
+        &mut answer,
+    );
+    append_packet_non_trace_phase(&mut answer, "budget", phase_started);
 
     let phase_started = Instant::now();
     append_packet_evidence_sections(&mut answer, &limits);
@@ -544,7 +561,12 @@ pub(crate) fn agent_packet(
             .push(RetrievalAnnotationDto::observation(diagnostic));
         enforce_packet_output_budget(&project_root, &mut packet);
     }
-    finalize_interim_packet_evidence(&mut packet, Some(&req), &project_id);
+    apply_compiled_evidence_for_project(
+        &mut packet,
+        Some(&req),
+        &project_id,
+        compilation_relations,
+    );
     enforce_packet_output_budget(&project_root, &mut packet);
 
     Ok(packet)
@@ -757,16 +779,19 @@ fn truncate_packet_source(body: &str, max_bytes: usize) -> &str {
 fn append_packet_source_evidence(
     controller: &AppController,
     answer: &mut AgentAnswerDto,
-    limits: &PacketBudgetLimitsDto,
 ) -> Vec<SupportUnitDto> {
-    if answer.citations.is_empty() || limits.max_snippets == 0 {
+    if answer.citations.is_empty() {
         return Vec::new();
     }
 
     let mut rendered = String::new();
     let mut source_support = Vec::new();
     let mut steps = Vec::new();
-    for citation in answer.citations.iter().take(limits.max_snippets as usize) {
+    for citation in answer
+        .citations
+        .iter()
+        .take(INTERIM_MAX_ADMITTED_CANDIDATES)
+    {
         let started = Instant::now();
         let Some(source) = repository_source_range(controller, citation) else {
             continue;

--- a/crates/codestory-runtime/src/agent/orchestrator.rs
+++ b/crates/codestory-runtime/src/agent/orchestrator.rs
@@ -15,8 +15,7 @@ use crate::agent::packet_plan::{
     build_packet_plan_from_seed_plan, build_retrieval_seed_plan, packet_plan_annotation,
 };
 use crate::agent::packet_probe::{
-    exact_packet_probe_citations, normalize_packet_probe_request, probes_from_seed_selectors,
-    resolve_packet_probes, unresolved_packet_probe_queries,
+    exact_packet_probe_citations, normalize_packet_probe_request, resolve_packet_probes,
 };
 use crate::agent::packet_scoring::{packet_display_path, packet_stage_citation_carry_limit};
 use crate::agent::packet_terms::prompt_search_terms;
@@ -340,8 +339,6 @@ pub(crate) fn agent_packet(
         ));
     }
     let is_drill_continuation = req.parent_packet_id.is_some() || !req.option_ids.is_empty();
-    let free_queries = unresolved_packet_probe_queries(&req.probes);
-    let seed_plan = build_retrieval_seed_plan(&question, &free_queries);
     let mut probes = normalize_packet_probe_request(&req.probes);
     for option in drill_options_from_ids(&req.option_ids) {
         if let Some(path) = option.path {
@@ -350,11 +347,7 @@ pub(crate) fn agent_packet(
             probes.push(PacketProbeDto::SymbolId { id: symbol_id });
         }
     }
-    for probe in probes_from_seed_selectors(&seed_plan.exact_selectors) {
-        if !probes.contains(&probe) {
-            probes.push(probe);
-        }
-    }
+    let seed_plan = build_retrieval_seed_plan(&question, &probes);
     let probe_resolutions = resolve_packet_probes(controller, probes);
     let mut plan = build_packet_plan_from_seed_plan(&seed_plan, req.budget);
     plan.probe_resolutions = probe_resolutions;

--- a/crates/codestory-runtime/src/agent/packet_candidate.rs
+++ b/crates/codestory-runtime/src/agent/packet_candidate.rs
@@ -111,6 +111,11 @@ impl PacketProofSession {
         &self,
         descriptor: &PacketCandidateDescriptorV1,
     ) -> PacketAdmissionDecision {
+        let origin = if descriptor.exact_selector_ordinal.is_some() {
+            PacketAdmissionOriginV1::ExactTypedSelector
+        } else {
+            PacketAdmissionOriginV1::Retrieval
+        };
         if self
             .admitted_identities
             .borrow()
@@ -121,7 +126,7 @@ impl PacketProofSession {
         if *self.retrieval_admission_sealed.borrow() {
             self.record_gap(
                 PacketAdmissionGapKindV1::CandidateCountExceeded,
-                Some(descriptor.stable_identity.clone()),
+                unadmitted_gap_identity(origin, &descriptor.stable_identity),
                 descriptor.exact_selector_ordinal,
             );
             return PacketAdmissionDecision::CountBudgetExceeded;
@@ -129,7 +134,7 @@ impl PacketProofSession {
         let Some(source_bytes) = descriptor.source_bytes_upper_bound else {
             self.record_gap(
                 PacketAdmissionGapKindV1::SourceBoundMissing,
-                Some(descriptor.stable_identity.clone()),
+                unadmitted_gap_identity(origin, &descriptor.stable_identity),
                 descriptor.exact_selector_ordinal,
             );
             return PacketAdmissionDecision::SourceBudgetExceeded;
@@ -137,11 +142,7 @@ impl PacketProofSession {
         self.admit_with_receipt(
             &descriptor.stable_identity,
             source_bytes as usize,
-            if descriptor.exact_selector_ordinal.is_some() {
-                PacketAdmissionOriginV1::ExactTypedSelector
-            } else {
-                PacketAdmissionOriginV1::Retrieval
-            },
+            origin,
             &descriptor.retrieval_score.version,
             descriptor.exact_selector_ordinal,
         )
@@ -169,7 +170,7 @@ impl PacketProofSession {
         if self.remaining_hydration_slots() == 0 {
             self.record_gap(
                 PacketAdmissionGapKindV1::CandidateCountExceeded,
-                Some(stable_identity.to_string()),
+                unadmitted_gap_identity(origin, stable_identity),
                 exact_selector_ordinal,
             );
             return PacketAdmissionDecision::CountBudgetExceeded;
@@ -177,7 +178,7 @@ impl PacketProofSession {
         if source_bytes > self.remaining_source_bytes() {
             self.record_gap(
                 PacketAdmissionGapKindV1::SourceBudgetExceeded,
-                Some(stable_identity.to_string()),
+                unadmitted_gap_identity(origin, stable_identity),
                 exact_selector_ordinal,
             );
             return PacketAdmissionDecision::SourceBudgetExceeded;
@@ -279,6 +280,13 @@ impl PacketProofSession {
             }
         }
     }
+}
+
+fn unadmitted_gap_identity(
+    origin: PacketAdmissionOriginV1,
+    stable_identity: &str,
+) -> Option<String> {
+    (origin == PacketAdmissionOriginV1::ExactTypedSelector).then(|| stable_identity.to_string())
 }
 
 thread_local! {
@@ -648,6 +656,36 @@ mod tests {
             PacketAdmissionDecision::CountBudgetExceeded
         );
         assert!(session.receipts().is_empty());
+    }
+
+    #[test]
+    fn retrieval_overflow_never_exposes_an_unauthenticated_identity() {
+        let session = PacketProofSession::new();
+        for index in 0..INTERIM_MAX_ADMITTED_CANDIDATES {
+            assert_eq!(
+                session.admit(&format!("node:{index}"), 1),
+                PacketAdmissionDecision::Admitted
+            );
+        }
+        let stale = PacketCandidateDescriptorV1 {
+            stable_identity: "node:999999".into(),
+            path: "src/stale.rs".into(),
+            symbol: Some("stale".into()),
+            retrieval_lane: PacketRetrievalLaneV1::Lexical,
+            retrieval_score: VersionedRetrievalScoreV1 {
+                version: PACKET_RETRIEVAL_SCORE_VERSION_V1.to_string(),
+                value: 0.1,
+            },
+            source_bytes_upper_bound: Some(1),
+            exact_selector_ordinal: None,
+        };
+
+        assert_eq!(
+            session.admit_descriptor(&stale),
+            PacketAdmissionDecision::CountBudgetExceeded
+        );
+        assert_eq!(session.gaps().len(), 1);
+        assert_eq!(session.gaps()[0].stable_identity, None);
     }
 
     fn answer() -> AgentAnswerDto {

--- a/crates/codestory-runtime/src/agent/packet_compiler.rs
+++ b/crates/codestory-runtime/src/agent/packet_compiler.rs
@@ -1,137 +1,235 @@
-//! Finalize the bounded Horizon A packet without answer-planning policy.
+//! Runtime adapter for the pure repository-derived packet compiler.
 //!
-//! Retrieval, typed-probe resolution, descriptor admission, and exact
-//! hydration have already run. This interim boundary retains that evidence and
-//! converts objective admission or ambiguity gaps into stable continuations.
-//! Repository-derived selection belongs to Horizon B (`#2106`).
+//! Runtime owns publication checks and converts pinned repository records into
+//! [`PacketCompilationInputV1`]. Selection itself lives in
+//! `codestory-agent` and cannot see the question.
 
 use crate::agent::packet_candidate::{PacketProofSession, active_packet_proof_session};
 use crate::agent::packet_coverage::PacketCoverageInput;
 use crate::agent::packet_freshness::PacketFreshnessInput;
 use crate::agent::packet_scoring::packet_display_path;
+use codestory_agent::evidence_compiler::compile_repository_evidence;
 use codestory_contracts::api::{
     AgentPacketDto, AgentPacketRequestDto, BoundedDrillPlanDto, DrillGapKindDto, DrillOptionDto,
-    PACKET_DRILL_MAX_BYTES, PACKET_DRILL_MAX_DEPTH, PACKET_DRILL_MAX_HITS,
+    GraphArtifactDto, PACKET_DRILL_MAX_BYTES, PACKET_DRILL_MAX_DEPTH, PACKET_DRILL_MAX_HITS,
     PACKET_DRILL_MAX_OPTIONS, PacketDispositionDto, PacketProbeResolutionStatusDto,
-    SourceCoverageStatusDto, SupportUnitDto, SupportUnitKindDto, decode_drill_option_id,
+    SourceCoverageObservationDto, SourceCoverageStatusDto, SupportUnitDto, SupportUnitKindDto,
+    decode_drill_option_id,
 };
 use codestory_contracts::compilation::{
-    PacketAdmissionGapKindV1, PacketAdmissionReceiptV1, PacketContinuationSelectorV1,
-    PacketStructuralGapReasonV1,
+    PACKET_COMPILATION_CONTRACT_VERSION_V1, PacketAdmissionGapKindV1, PacketAdmissionGapV1,
+    PacketAdmissionOriginV1, PacketCompilationInputV1, PacketCompilationPublicationV1,
+    PacketContinuationSelectorV1, PacketDirectedRelationV1, PacketHydratedSourceRangeV1,
+    PacketIdentityAmbiguityV1, PacketParserCompletenessV1, PacketRelationCertaintyV1,
+    PacketRelationKindV1, PacketStructuralGapReasonV1,
 };
 use codestory_contracts::graph::FileCoverageReason;
-use std::collections::{BTreeSet, HashMap};
+use std::collections::BTreeSet;
 
-pub fn finalize_interim_packet_evidence(
+pub fn apply_compiled_evidence_for_project(
     packet: &mut AgentPacketDto,
     request: Option<&AgentPacketRequestDto>,
-    _project_id: &str,
+    project_id: &str,
+    relations: Vec<PacketDirectedRelationV1>,
 ) {
     let session = active_packet_proof_session();
-    if let Some(session) = session.as_deref() {
-        order_support_by_admission(&mut packet.support, &session.receipts());
-    }
-    let continuation = interim_continuations(packet, session.as_deref());
-    let publication = packet.answer.retrieval_trace.retrieval_publication.as_ref();
+    let input = packet_compilation_input(packet, project_id, session.as_deref(), relations);
+    let compiled = compile_repository_evidence(&input);
+    packet.support = compiled.support;
     packet.disposition = classify_packet_disposition(
         packet,
         request,
-        &continuation,
-        publication
-            .map(|publication| publication.core_generation_id.clone())
-            .unwrap_or_default(),
-        publication.map(|publication| publication.retrieval_generation.clone()),
+        &compiled.continuation,
+        input.publication.core_generation_id,
+        input.publication.retrieval_generation,
     );
 }
 
-fn order_support_by_admission(
-    support: &mut [SupportUnitDto],
-    admissions: &[PacketAdmissionReceiptV1],
-) {
-    let ordinals = admissions
-        .iter()
-        .map(|admission| (admission.stable_identity.as_str(), admission.packet_ordinal))
-        .collect::<HashMap<_, _>>();
-    support.sort_by_key(|unit| {
-        unit.symbol_id
-            .as_deref()
-            .and_then(|id| ordinals.get(format!("node:{id}").as_str()).copied())
-            .or_else(|| {
-                unit.path.as_deref().and_then(|path| {
-                    let path = packet_display_path(path);
-                    ordinals.get(format!("path:{path}").as_str()).copied()
-                })
-            })
-            .unwrap_or(u32::MAX)
-    });
-}
-
-fn interim_continuations(
+fn packet_compilation_input(
     packet: &AgentPacketDto,
+    project_id: &str,
     session: Option<&PacketProofSession>,
-) -> Vec<PacketContinuationSelectorV1> {
-    let mut continuation = Vec::new();
-    let mut seen = BTreeSet::new();
-
-    if let Some(session) = session {
-        for gap in session.gaps() {
-            let Some(stable_identity) = gap.stable_identity else {
-                continue;
-            };
-            let reason = match gap.kind {
-                PacketAdmissionGapKindV1::CandidateCountExceeded => {
-                    PacketStructuralGapReasonV1::CandidateCountExceeded
-                }
-                PacketAdmissionGapKindV1::SourceBudgetExceeded => {
-                    PacketStructuralGapReasonV1::SourceBudgetExceeded
-                }
-                PacketAdmissionGapKindV1::StableIdentityMissing
-                | PacketAdmissionGapKindV1::SourceBoundMissing
-                | PacketAdmissionGapKindV1::SourceUnavailable => {
-                    PacketStructuralGapReasonV1::SourceUnavailable
-                }
-            };
-            push_continuation(&mut continuation, &mut seen, stable_identity, reason);
+    relations: Vec<PacketDirectedRelationV1>,
+) -> PacketCompilationInputV1 {
+    let publication = packet.answer.retrieval_trace.retrieval_publication.as_ref();
+    let mut admission_gaps = session.map(PacketProofSession::gaps).unwrap_or_default();
+    let admissions = session
+        .map(PacketProofSession::receipts)
+        .unwrap_or_default();
+    let sources = hydrated_sources(&packet.support, &packet.answer.source_coverage, &admissions);
+    let source_identities = sources
+        .iter()
+        .map(|source| source.stable_identity.as_str())
+        .collect::<BTreeSet<_>>();
+    for admission in admissions
+        .iter()
+        .filter(|admission| admission.origin == PacketAdmissionOriginV1::ExactTypedSelector)
+    {
+        if !source_identities.contains(admission.stable_identity.as_str()) {
+            admission_gaps.push(PacketAdmissionGapV1 {
+                kind: PacketAdmissionGapKindV1::SourceUnavailable,
+                stable_identity: Some(admission.stable_identity.clone()),
+                exact_selector_ordinal: Some(admission.packet_ordinal),
+            });
         }
     }
 
-    for resolution in packet
+    PacketCompilationInputV1 {
+        contract_version: PACKET_COMPILATION_CONTRACT_VERSION_V1,
+        publication: PacketCompilationPublicationV1 {
+            project_id: project_id.to_string(),
+            core_generation_id: publication
+                .map(|publication| publication.core_generation_id.clone())
+                .unwrap_or_default(),
+            retrieval_generation: publication
+                .map(|publication| publication.retrieval_generation.clone()),
+        },
+        relations,
+        ambiguities: probe_ambiguities(packet),
+        admissions,
+        sources,
+        admission_gaps,
+    }
+}
+
+fn hydrated_sources(
+    support: &[SupportUnitDto],
+    source_coverage: &[SourceCoverageObservationDto],
+    admissions: &[codestory_contracts::compilation::PacketAdmissionReceiptV1],
+) -> Vec<PacketHydratedSourceRangeV1> {
+    support
+        .iter()
+        .filter(|unit| unit.kind == SupportUnitKindDto::SourceRange)
+        .filter_map(|unit| {
+            let path = unit.path.as_deref().map(packet_display_path)?;
+            let source = unit.snippet.clone()?;
+            let stable_identity = support_stable_identity(unit, &path, admissions)?;
+            let parser_completeness = source_coverage
+                .iter()
+                .find(|observation| packet_display_path(&observation.path) == path)
+                .map(|observation| match observation.status {
+                    SourceCoverageStatusDto::Indexed => PacketParserCompletenessV1::Complete,
+                    SourceCoverageStatusDto::Incomplete => PacketParserCompletenessV1::Partial,
+                    SourceCoverageStatusDto::PolicyExcluded
+                    | SourceCoverageStatusDto::NotEstablished => {
+                        PacketParserCompletenessV1::Unknown
+                    }
+                })
+                .unwrap_or(PacketParserCompletenessV1::Unknown);
+            Some(PacketHydratedSourceRangeV1 {
+                stable_identity,
+                path,
+                symbol: (!unit.summary.is_empty()).then_some(unit.summary.clone()),
+                start_line: unit.start_line.unwrap_or(1),
+                end_line: unit.end_line.or(unit.start_line).unwrap_or(1),
+                source,
+                parser_completeness,
+            })
+        })
+        .collect()
+}
+
+fn support_stable_identity(
+    unit: &SupportUnitDto,
+    path: &str,
+    admissions: &[codestory_contracts::compilation::PacketAdmissionReceiptV1],
+) -> Option<String> {
+    if let Some(symbol_id) = unit.symbol_id.as_deref() {
+        for candidate in [symbol_id.to_string(), format!("node:{symbol_id}")] {
+            if admissions
+                .iter()
+                .any(|admission| admission.stable_identity == candidate)
+            {
+                return Some(candidate);
+            }
+        }
+    }
+    admissions
+        .iter()
+        .find(|admission| admission.stable_identity == format!("path:{path}"))
+        .map(|admission| admission.stable_identity.clone())
+}
+
+pub(crate) fn directed_relations_from_graphs(
+    graphs: &[GraphArtifactDto],
+    admissions: &[codestory_contracts::compilation::PacketAdmissionReceiptV1],
+) -> Vec<PacketDirectedRelationV1> {
+    let admitted = admissions
+        .iter()
+        .map(|admission| admission.stable_identity.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut relations = Vec::new();
+    let mut seen = BTreeSet::new();
+    for artifact in graphs {
+        let GraphArtifactDto::Uml { graph, .. } = artifact else {
+            continue;
+        };
+        for edge in &graph.edges {
+            let from_identity = format!("node:{}", edge.source.0);
+            let to_identity = format!("node:{}", edge.target.0);
+            if !admitted.contains(from_identity.as_str())
+                || !admitted.contains(to_identity.as_str())
+            {
+                continue;
+            }
+            if !seen.insert(edge.id.0.clone()) {
+                continue;
+            }
+            relations.push(PacketDirectedRelationV1 {
+                relation_id: edge.id.0.clone(),
+                from_identity,
+                to_identity,
+                relation_kind: packet_relation_kind(edge.kind),
+                certainty: relation_certainty(edge.certainty.as_deref(), edge.confidence),
+            });
+        }
+    }
+    relations
+}
+
+fn packet_relation_kind(kind: codestory_contracts::api::EdgeKind) -> PacketRelationKindV1 {
+    use codestory_contracts::api::EdgeKind;
+    match kind {
+        EdgeKind::MEMBER => PacketRelationKindV1::Member,
+        EdgeKind::TYPE_USAGE => PacketRelationKindV1::TypeUsage,
+        EdgeKind::USAGE => PacketRelationKindV1::Usage,
+        EdgeKind::CALL => PacketRelationKindV1::Call,
+        EdgeKind::INHERITANCE => PacketRelationKindV1::Inheritance,
+        EdgeKind::OVERRIDE => PacketRelationKindV1::Override,
+        EdgeKind::TYPE_ARGUMENT => PacketRelationKindV1::TypeArgument,
+        EdgeKind::TEMPLATE_SPECIALIZATION => PacketRelationKindV1::TemplateSpecialization,
+        EdgeKind::INCLUDE => PacketRelationKindV1::Include,
+        EdgeKind::IMPORT => PacketRelationKindV1::Import,
+        EdgeKind::MACRO_USAGE => PacketRelationKindV1::MacroUsage,
+        EdgeKind::ANNOTATION_USAGE => PacketRelationKindV1::AnnotationUsage,
+        EdgeKind::UNKNOWN => PacketRelationKindV1::Unknown,
+    }
+}
+
+fn relation_certainty(label: Option<&str>, _confidence: Option<f32>) -> PacketRelationCertaintyV1 {
+    match label {
+        Some("certain") => PacketRelationCertaintyV1::Certain,
+        Some("probable") => PacketRelationCertaintyV1::Probable,
+        Some("uncertain") => PacketRelationCertaintyV1::Uncertain,
+        _ => PacketRelationCertaintyV1::Unknown,
+    }
+}
+
+fn probe_ambiguities(packet: &AgentPacketDto) -> Vec<PacketIdentityAmbiguityV1> {
+    packet
         .plan
         .probe_resolutions
         .iter()
         .filter(|resolution| resolution.status == PacketProbeResolutionStatusDto::Ambiguous)
-    {
-        for candidate in &resolution.candidates {
-            push_continuation(
-                &mut continuation,
-                &mut seen,
-                format!("node:{}", candidate.symbol_id),
-                PacketStructuralGapReasonV1::AmbiguousSelector,
-            );
-        }
-    }
-
-    continuation
-}
-
-fn push_continuation(
-    continuation: &mut Vec<PacketContinuationSelectorV1>,
-    seen: &mut BTreeSet<String>,
-    stable_identity: String,
-    reason: PacketStructuralGapReasonV1,
-) {
-    let key = format!("{reason:?}:{stable_identity}");
-    if !seen.insert(key) {
-        return;
-    }
-    let path = stable_identity.strip_prefix("path:").map(str::to_string);
-    let symbol_id = stable_identity.strip_prefix("node:").map(str::to_string);
-    continuation.push(PacketContinuationSelectorV1 {
-        stable_identity,
-        path,
-        symbol_id,
-        reason,
-    });
+        .map(|resolution| PacketIdentityAmbiguityV1 {
+            selector: format!("probe:{}", resolution.input_index),
+            candidate_identities: resolution
+                .candidates
+                .iter()
+                .map(|candidate| format!("node:{}", candidate.symbol_id))
+                .collect(),
+        })
+        .collect()
 }
 
 fn classify_packet_disposition(
@@ -313,6 +411,8 @@ pub fn drill_options_from_ids(option_ids: &[String]) -> Vec<DrillOptionDto> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use codestory_contracts::api::{EdgeId, EdgeKind, GraphEdgeDto, GraphResponse, NodeId};
+    use codestory_contracts::compilation::{PacketAdmissionOriginV1, PacketAdmissionReceiptV1};
 
     #[test]
     fn unknown_query_continuations_are_not_decoded() {
@@ -329,20 +429,132 @@ mod tests {
     }
 
     #[test]
-    fn admission_gaps_map_to_typed_structural_reasons() {
-        let mut continuation = Vec::new();
-        let mut seen = BTreeSet::new();
-        push_continuation(
-            &mut continuation,
-            &mut seen,
-            "path:src/lib.rs".into(),
-            PacketStructuralGapReasonV1::SourceBudgetExceeded,
-        );
-        assert_eq!(continuation.len(), 1);
-        assert_eq!(continuation[0].path.as_deref(), Some("src/lib.rs"));
+    fn uncertain_relation_is_not_compiler_evidence() {
         assert_eq!(
-            continuation[0].reason,
-            PacketStructuralGapReasonV1::SourceBudgetExceeded
+            relation_certainty(Some("uncertain"), Some(0.99)),
+            PacketRelationCertaintyV1::Uncertain
+        );
+    }
+
+    #[test]
+    fn numeric_confidence_cannot_upgrade_missing_certainty() {
+        assert_eq!(
+            relation_certainty(None, Some(0.99)),
+            PacketRelationCertaintyV1::Unknown
+        );
+    }
+
+    #[test]
+    fn adapter_forwards_every_admitted_hydrated_source_and_no_unadmitted_source() {
+        let admissions = (0..16)
+            .map(|index| PacketAdmissionReceiptV1 {
+                packet_ordinal: index,
+                stable_identity: format!("node:{index}"),
+                score_version: "retrieval-score/v1".into(),
+                reserved_source_bytes: 32,
+                origin: PacketAdmissionOriginV1::Retrieval,
+            })
+            .collect::<Vec<_>>();
+        let mut support = (0..16)
+            .map(|index| SupportUnitDto {
+                id: format!("source-{index}"),
+                kind: SupportUnitKindDto::SourceRange,
+                summary: format!("symbol-{index}"),
+                path: Some(format!("src/{index}.rs")),
+                symbol_id: Some(index.to_string()),
+                start_line: Some(1),
+                end_line: Some(1),
+                snippet: Some(format!("fn symbol_{index}() {{}}")),
+                edge_kind: None,
+                from_symbol: None,
+                to_symbol: None,
+                query: None,
+            })
+            .collect::<Vec<_>>();
+        support.push(SupportUnitDto {
+            id: "source-unadmitted".into(),
+            kind: SupportUnitKindDto::SourceRange,
+            summary: "unadmitted".into(),
+            path: Some("src/unadmitted.rs".into()),
+            symbol_id: Some("unadmitted".into()),
+            start_line: Some(1),
+            end_line: Some(1),
+            snippet: Some("fn unadmitted() {}".into()),
+            edge_kind: None,
+            from_symbol: None,
+            to_symbol: None,
+            query: None,
+        });
+
+        let hydrated = hydrated_sources(&support, &[], &admissions);
+        assert_eq!(hydrated.len(), 16);
+        assert!(
+            hydrated
+                .iter()
+                .all(|source| source.stable_identity.starts_with("node:"))
+        );
+        assert!(
+            hydrated
+                .iter()
+                .all(|source| source.path != "src/unadmitted.rs")
+        );
+    }
+
+    #[test]
+    fn compiler_relation_capture_precedes_presentation_edge_caps() {
+        let admissions = (0..16)
+            .map(|index| PacketAdmissionReceiptV1 {
+                packet_ordinal: index,
+                stable_identity: format!("node:{index}"),
+                score_version: "retrieval-score/v1".into(),
+                reserved_source_bytes: 32,
+                origin: PacketAdmissionOriginV1::Retrieval,
+            })
+            .collect::<Vec<_>>();
+        let mut edges = (0..20)
+            .map(|index| GraphEdgeDto {
+                id: EdgeId(format!("a-dense-{index:02}")),
+                source: NodeId("0".into()),
+                target: NodeId("0".into()),
+                kind: EdgeKind::CALL,
+                confidence: Some(1.0),
+                certainty: Some("certain".into()),
+                callsite_identity: None,
+                candidate_targets: Vec::new(),
+            })
+            .collect::<Vec<_>>();
+        edges.extend((1..16).map(|index| GraphEdgeDto {
+            id: EdgeId(format!("z-connect-{index:02}")),
+            source: NodeId((index - 1).to_string()),
+            target: NodeId(index.to_string()),
+            kind: EdgeKind::CALL,
+            confidence: Some(1.0),
+            certainty: Some("certain".into()),
+            callsite_identity: None,
+            candidate_targets: Vec::new(),
+        }));
+        let graphs = vec![GraphArtifactDto::Uml {
+            id: "graph".into(),
+            title: "graph".into(),
+            graph: GraphResponse {
+                center_id: NodeId("0".into()),
+                nodes: Vec::new(),
+                edges,
+                truncated: false,
+                omitted_edge_count: 0,
+                canonical_layout: None,
+            },
+        }];
+
+        let captured = directed_relations_from_graphs(&graphs, &admissions);
+        assert_eq!(captured.len(), 35);
+        assert_eq!(
+            captured
+                .iter()
+                .filter(|relation| relation.relation_id.starts_with("z-connect-"))
+                .count(),
+            15,
+            "dense early edge IDs must not hide the admitted-seed connecting forest"
         );
     }
 }

--- a/crates/codestory-runtime/src/agent/packet_compiler.rs
+++ b/crates/codestory-runtime/src/agent/packet_compiler.rs
@@ -14,23 +14,27 @@ use codestory_agent::evidence_compiler::{
 };
 use codestory_contracts::api::{
     AgentPacketDto, AgentPacketRequestDto, BoundedDrillPlanDto, DrillGapKindDto, DrillOptionDto,
-    EmbeddingVectorPublicationIdentityDto, NodeKind as ApiNodeKind, PACKET_DRILL_MAX_BYTES,
-    PACKET_DRILL_MAX_DEPTH, PACKET_DRILL_MAX_HITS, PACKET_DRILL_MAX_OPTIONS, PacketDispositionDto,
-    PacketProbeResolutionDto, PacketProbeResolutionStatusDto, SourceCoverageObservationDto,
-    SourceCoverageStatusDto, SupportUnitDto, SupportUnitKindDto, decode_drill_option_id,
+    EmbeddingVectorPublicationIdentityDto, PACKET_DRILL_MAX_BYTES, PACKET_DRILL_MAX_DEPTH,
+    PACKET_DRILL_MAX_HITS, PACKET_DRILL_MAX_OPTIONS, PacketDispositionDto,
+    PacketProbeResolutionDto, PacketProbeResolutionStatusDto, SourceCoverageNotEstablishedCauseDto,
+    SourceCoverageObservationDto, SourceCoverageStatusDto, SupportUnitDto, SupportUnitKindDto,
+    decode_drill_option_id,
 };
 use codestory_contracts::compilation::{
     INTERIM_SOURCE_ROW_UPPER_BOUND, PACKET_COMPILATION_CONTRACT_VERSION_V1,
     PacketAdmissionGapKindV1, PacketAdmissionGapV1, PacketAdmissionOriginV1,
-    PacketCompilationInputV1, PacketCompilationPublicationV1, PacketContinuationSelectorV1,
-    PacketDirectedRelationV1, PacketHydratedSourceRangeV1, PacketIdentityAmbiguityV1,
-    PacketParserCompletenessV1, PacketRelationCertaintyV1, PacketRelationKindV1,
-    PacketStructuralGapReasonV1,
+    PacketAdmissionReceiptV1, PacketCompilationInputV1, PacketCompilationPublicationV1,
+    PacketContinuationSelectorV1, PacketDirectedRelationV1, PacketHydratedSourceRangeV1,
+    PacketIdentityAmbiguityV1, PacketParserCompletenessV1, PacketRelationCertaintyV1,
+    PacketRelationKindV1, PacketStructuralGapReasonV1,
 };
 use codestory_contracts::graph::{
-    EdgeKind as CoreEdgeKind, FileCoverageReason, NodeId as CoreNodeId, ResolutionCertainty,
+    EdgeKind as CoreEdgeKind, FileCoverageReason, Node as CoreNode, NodeId as CoreNodeId,
+    NodeKind as CoreNodeKind, ResolutionCertainty,
 };
+use codestory_store::{FileInfo, Store};
 use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
 
 const COMPILER_SOURCE_TRUNCATION_SUFFIX: &str = "\n// ... source truncated by packet row cap\n```";
 
@@ -52,17 +56,18 @@ pub(crate) fn freeze_packet_compilation(
 ) -> Result<FrozenPacketCompilationV1, codestory_contracts::api::ApiError> {
     let admissions = session.receipts();
     let mut admission_gaps = session.gaps();
-    let mut sources = hydrate_admitted_sources(controller, &admissions, &mut admission_gaps);
+    let storage = controller.open_storage_read_only()?;
+    let (admissions, mut sources) =
+        hydrate_admitted_sources(controller, &storage, &admissions, &mut admission_gaps)?;
     let source_paths = sources
         .iter()
         .map(|source| source.path.clone())
         .collect::<Vec<_>>();
-    let source_coverage =
-        crate::source_coverage::observe_source_coverage(controller, &source_paths);
+    let source_coverage = observe_admitted_source_coverage(controller, &storage, &source_paths);
     for source in &mut sources {
         source.parser_completeness = parser_completeness_for_path(&source.path, &source_coverage);
     }
-    let relations = hydrate_induced_relations(controller, &admissions)?;
+    let relations = hydrate_induced_relations(&storage, &admissions)?;
     let publication = PacketCompilationPublicationV1 {
         project_id: project_id.to_string(),
         core_generation_id: publication
@@ -105,58 +110,113 @@ pub(crate) fn apply_frozen_packet_compilation(
 
 fn hydrate_admitted_sources(
     controller: &AppController,
-    admissions: &[codestory_contracts::compilation::PacketAdmissionReceiptV1],
+    storage: &Store,
+    admissions: &[PacketAdmissionReceiptV1],
     admission_gaps: &mut Vec<PacketAdmissionGapV1>,
-) -> Vec<PacketHydratedSourceRangeV1> {
+) -> Result<
+    (
+        Vec<PacketAdmissionReceiptV1>,
+        Vec<PacketHydratedSourceRangeV1>,
+    ),
+    codestory_contracts::api::ApiError,
+> {
+    let project_root = controller.require_project_root()?;
+    let mut authenticated = Vec::new();
     let mut sources = Vec::new();
     for admission in admissions {
         let result = if let Some(raw_id) = admission.stable_identity.strip_prefix("node:") {
-            hydrate_admitted_node_source(controller, admission, raw_id)
+            let Some(node) = authenticated_node(storage, raw_id)? else {
+                push_admission_gap(
+                    admission_gaps,
+                    admission,
+                    PacketAdmissionGapKindV1::StableIdentityMissing,
+                    false,
+                );
+                continue;
+            };
+            authenticated.push(admission.clone());
+            hydrate_admitted_node_source(controller, storage, admission, &node)
         } else if let Some(path) = admission.stable_identity.strip_prefix("path:") {
-            hydrate_admitted_path_source(controller, admission, path)
+            let Some(file) = find_admitted_file(storage, &project_root, path)? else {
+                push_admission_gap(
+                    admission_gaps,
+                    admission,
+                    PacketAdmissionGapKindV1::StableIdentityMissing,
+                    false,
+                );
+                continue;
+            };
+            authenticated.push(admission.clone());
+            hydrate_admitted_file_source(controller, admission, &file)
         } else {
-            Err(PacketAdmissionGapKindV1::StableIdentityMissing)
+            push_admission_gap(
+                admission_gaps,
+                admission,
+                PacketAdmissionGapKindV1::StableIdentityMissing,
+                false,
+            );
+            continue;
         };
         match result {
             Ok(source) => sources.push(source),
-            Err(kind) => admission_gaps.push(PacketAdmissionGapV1 {
-                kind,
-                stable_identity: Some(admission.stable_identity.clone()),
-                exact_selector_ordinal: (admission.origin
-                    == PacketAdmissionOriginV1::ExactTypedSelector)
-                    .then_some(admission.packet_ordinal),
-            }),
+            Err(kind) => push_admission_gap(admission_gaps, admission, kind, true),
         }
     }
-    sources
+    Ok((authenticated, sources))
+}
+
+fn push_admission_gap(
+    admission_gaps: &mut Vec<PacketAdmissionGapV1>,
+    admission: &PacketAdmissionReceiptV1,
+    kind: PacketAdmissionGapKindV1,
+    expose_authenticated_identity: bool,
+) {
+    admission_gaps.push(PacketAdmissionGapV1 {
+        kind,
+        stable_identity: expose_authenticated_identity.then(|| admission.stable_identity.clone()),
+        exact_selector_ordinal: (admission.origin == PacketAdmissionOriginV1::ExactTypedSelector)
+            .then_some(admission.packet_ordinal),
+    });
+}
+
+fn authenticated_node(
+    storage: &Store,
+    raw_id: &str,
+) -> Result<Option<CoreNode>, codestory_contracts::api::ApiError> {
+    let Ok(node_id) = raw_id.parse::<i64>() else {
+        return Ok(None);
+    };
+    storage.get_node(CoreNodeId(node_id)).map_err(|error| {
+        codestory_contracts::api::ApiError::internal(format!(
+            "Failed to authenticate admitted packet node: {error}"
+        ))
+    })
 }
 
 fn hydrate_admitted_node_source(
     controller: &AppController,
-    admission: &codestory_contracts::compilation::PacketAdmissionReceiptV1,
-    raw_id: &str,
+    storage: &Store,
+    admission: &PacketAdmissionReceiptV1,
+    node: &CoreNode,
 ) -> Result<PacketHydratedSourceRangeV1, PacketAdmissionGapKindV1> {
-    let details = controller
-        .node_details(codestory_contracts::api::NodeDetailsRequest {
-            id: codestory_contracts::api::NodeId(raw_id.to_string()),
-        })
-        .map_err(|_| PacketAdmissionGapKindV1::SourceUnavailable)?;
-    if let Some(path) = file_node_source_path(
-        details.kind,
-        details.file_path.as_deref(),
-        &details.serialized_name,
-    ) {
-        return hydrate_admitted_path_source(controller, admission, path);
+    let file_id = if node.kind == CoreNodeKind::FILE {
+        node.id
+    } else {
+        node.file_node_id
+            .ok_or(PacketAdmissionGapKindV1::SourceBoundMissing)?
+    };
+    let file = storage
+        .get_file_by_id(file_id.0)
+        .map_err(|_| PacketAdmissionGapKindV1::SourceUnavailable)?
+        .ok_or(PacketAdmissionGapKindV1::SourceUnavailable)?;
+    if node.kind == CoreNodeKind::FILE {
+        return hydrate_admitted_file_source(controller, admission, &file);
     }
-    let path = details
-        .file_path
-        .as_deref()
-        .ok_or(PacketAdmissionGapKindV1::SourceBoundMissing)?;
-    let (start_line, end_line) = valid_source_bounds(details.start_line, details.end_line)
+    let (start_line, end_line) = valid_source_bounds(node.start_line, node.end_line)
         .ok_or(PacketAdmissionGapKindV1::SourceBoundMissing)?;
     let (_, bounded) = controller
         .bounded_file_snippet_range(
-            path,
+            &file.path.to_string_lossy(),
             BoundedSnippetRangeOptions {
                 focus_line: start_line,
                 start_line,
@@ -169,41 +229,32 @@ fn hydrate_admitted_node_source(
         .map_err(|_| PacketAdmissionGapKindV1::SourceUnavailable)?;
     hydrated_source(
         admission,
-        path,
-        Some(details.display_name),
+        &file.path.to_string_lossy(),
+        Some(
+            node.qualified_name
+                .clone()
+                .unwrap_or_else(|| node.serialized_name.clone()),
+        ),
         &bounded.markdown,
     )
 }
 
-fn file_node_source_path<'a>(
-    kind: ApiNodeKind,
-    file_path: Option<&'a str>,
-    serialized_name: &'a str,
-) -> Option<&'a str> {
-    (kind == ApiNodeKind::FILE)
-        .then(|| {
-            file_path
-                .filter(|path| !path.is_empty())
-                .unwrap_or(serialized_name)
-        })
-        .filter(|path| !path.is_empty())
-}
-
-fn hydrate_admitted_path_source(
+fn hydrate_admitted_file_source(
     controller: &AppController,
-    admission: &codestory_contracts::compilation::PacketAdmissionReceiptV1,
-    path: &str,
+    admission: &PacketAdmissionReceiptV1,
+    file: &FileInfo,
 ) -> Result<PacketHydratedSourceRangeV1, PacketAdmissionGapKindV1> {
+    let path = file.path.to_string_lossy();
     let (_, bounded) = controller
         .bounded_file_snippet(
-            path,
+            &path,
             1,
             8,
             source_byte_cap(admission),
             COMPILER_SOURCE_TRUNCATION_SUFFIX,
         )
         .map_err(|_| PacketAdmissionGapKindV1::SourceUnavailable)?;
-    hydrated_source(admission, path, None, &bounded.markdown)
+    hydrated_source(admission, &path, None, &bounded.markdown)
 }
 
 fn hydrated_source(
@@ -228,10 +279,38 @@ fn hydrated_source(
     })
 }
 
-fn source_byte_cap(
-    admission: &codestory_contracts::compilation::PacketAdmissionReceiptV1,
-) -> usize {
+fn source_byte_cap(admission: &PacketAdmissionReceiptV1) -> usize {
     (admission.reserved_source_bytes as usize).clamp(1, INTERIM_SOURCE_ROW_UPPER_BOUND)
+}
+
+fn find_admitted_file(
+    storage: &Store,
+    project_root: &Path,
+    path: &str,
+) -> Result<Option<FileInfo>, codestory_contracts::api::ApiError> {
+    for candidate in admitted_file_lookup_paths(project_root, path) {
+        let file = storage.get_file_by_path(&candidate).map_err(|error| {
+            codestory_contracts::api::ApiError::internal(format!(
+                "Failed to authenticate admitted packet path: {error}"
+            ))
+        })?;
+        if file.is_some() {
+            return Ok(file);
+        }
+    }
+    Ok(None)
+}
+
+fn admitted_file_lookup_paths(project_root: &Path, path: &str) -> Vec<PathBuf> {
+    let candidate = PathBuf::from(path);
+    let mut paths = vec![candidate.clone()];
+    if !candidate.is_absolute() {
+        let joined = project_root.join(candidate);
+        if !paths.contains(&joined) {
+            paths.push(joined);
+        }
+    }
+    paths
 }
 
 fn valid_source_bounds(start_line: Option<u32>, end_line: Option<u32>) -> Option<(u32, u32)> {
@@ -260,6 +339,104 @@ fn source_receipt_line_range(markdown: &str) -> Option<(u32, u32)> {
     start.zip(end)
 }
 
+fn observe_admitted_source_coverage(
+    controller: &AppController,
+    storage: &Store,
+    paths: &[String],
+) -> Vec<SourceCoverageObservationDto> {
+    let Ok(project_root) = controller.require_project_root() else {
+        return paths
+            .iter()
+            .map(|path| source_coverage_not_established(path))
+            .collect();
+    };
+    let mut seen = BTreeSet::new();
+    paths
+        .iter()
+        .filter(|path| seen.insert(packet_display_path(path)))
+        .map(|path| {
+            observe_one_admitted_source_coverage(storage, &project_root, path)
+                .unwrap_or_else(|_| source_coverage_not_established(path))
+        })
+        .collect()
+}
+
+fn observe_one_admitted_source_coverage(
+    storage: &Store,
+    project_root: &Path,
+    path: &str,
+) -> Result<SourceCoverageObservationDto, codestory_store::StorageError> {
+    let mut file = None;
+    for candidate in admitted_file_lookup_paths(project_root, path) {
+        if let Some(found) = storage.get_file_by_path(&candidate)? {
+            file = Some(found);
+            break;
+        }
+    }
+    let Some(file) = file else {
+        return Ok(source_coverage_not_established(path));
+    };
+    let relative_path = codestory_workspace::workspace_relative_path(project_root, &file.path)
+        .unwrap_or_else(|| file.path.clone())
+        .to_string_lossy()
+        .replace('\\', "/");
+    if storage.has_source_policy_exclusion_path(&relative_path)? {
+        return Ok(SourceCoverageObservationDto {
+            path: path.to_string(),
+            status: SourceCoverageStatusDto::PolicyExcluded,
+            reason: None,
+            not_established_cause: None,
+            observed_size: None,
+            byte_cap: None,
+        });
+    }
+
+    let verified_source = storage.get_file_content_hash(file.id)?.is_some();
+    let structural_projection = if file.language == "openapi" {
+        storage.has_file_owned_openapi_endpoint_projection(file.id)?
+    } else if codestory_indexer::structural::is_structural_candidate_path(&file.path) {
+        storage.has_structural_text_projection_for_file(file.id)?
+    } else {
+        true
+    };
+    let errors = storage.get_file_coverage_reasons(file.id)?;
+    let reason = if !file.complete || !file.indexed || !verified_source || !structural_projection {
+        errors
+            .first()
+            .copied()
+            .or_else(|| {
+                (file.indexed && verified_source && !file.complete)
+                    .then_some(FileCoverageReason::ParserPartial)
+            })
+            .or(Some(FileCoverageReason::CollectorFailure))
+    } else {
+        None
+    };
+    Ok(SourceCoverageObservationDto {
+        path: path.to_string(),
+        status: if reason.is_some() {
+            SourceCoverageStatusDto::Incomplete
+        } else {
+            SourceCoverageStatusDto::Indexed
+        },
+        reason,
+        not_established_cause: None,
+        observed_size: None,
+        byte_cap: None,
+    })
+}
+
+fn source_coverage_not_established(path: &str) -> SourceCoverageObservationDto {
+    SourceCoverageObservationDto {
+        path: path.to_string(),
+        status: SourceCoverageStatusDto::NotEstablished,
+        reason: None,
+        not_established_cause: Some(SourceCoverageNotEstablishedCauseDto::LookupUnavailable),
+        observed_size: None,
+        byte_cap: None,
+    }
+}
+
 fn parser_completeness_for_path(
     path: &str,
     source_coverage: &[SourceCoverageObservationDto],
@@ -278,8 +455,8 @@ fn parser_completeness_for_path(
 }
 
 fn hydrate_induced_relations(
-    controller: &AppController,
-    admissions: &[codestory_contracts::compilation::PacketAdmissionReceiptV1],
+    storage: &Store,
+    admissions: &[PacketAdmissionReceiptV1],
 ) -> Result<Vec<PacketDirectedRelationV1>, codestory_contracts::api::ApiError> {
     let node_ids = admissions
         .iter()
@@ -290,7 +467,6 @@ fn hydrate_induced_relations(
     if node_ids.is_empty() {
         return Ok(Vec::new());
     }
-    let storage = controller.open_storage_read_only()?;
     storage
         .get_certain_edge_representatives_between_node_ids(&node_ids)
         .map_err(|error| {
@@ -581,20 +757,33 @@ mod tests {
     }
 
     #[test]
-    fn file_nodes_use_their_indexed_path_without_fabricating_symbol_bounds() {
-        assert_eq!(
-            file_node_source_path(ApiNodeKind::FILE, None, "src/lib.rs"),
-            Some("src/lib.rs")
+    fn public_symbol_identity_requires_a_node_in_the_pinned_core() {
+        let mut storage = Store::new_in_memory().expect("store");
+        assert!(
+            authenticated_node(&storage, "not-an-id")
+                .expect("invalid identities are rejected")
+                .is_none()
         );
-        assert_eq!(
-            file_node_source_path(ApiNodeKind::FILE, Some("src/canonical.rs"), "src/stale.rs"),
-            Some("src/canonical.rs")
+        assert!(
+            authenticated_node(&storage, "-42")
+                .expect("missing identities are rejected")
+                .is_none()
         );
+        storage
+            .insert_nodes_batch(&[CoreNode {
+                id: CoreNodeId(-42),
+                kind: CoreNodeKind::FUNCTION,
+                serialized_name: "crate::real".into(),
+                ..Default::default()
+            }])
+            .expect("insert authenticated node");
         assert_eq!(
-            file_node_source_path(ApiNodeKind::FUNCTION, None, "run"),
-            None
+            authenticated_node(&storage, "-42")
+                .expect("lookup")
+                .expect("authenticated node")
+                .id,
+            CoreNodeId(-42)
         );
-        assert_eq!(file_node_source_path(ApiNodeKind::FILE, None, ""), None);
     }
 
     #[test]

--- a/crates/codestory-runtime/src/agent/packet_compiler.rs
+++ b/crates/codestory-runtime/src/agent/packet_compiler.rs
@@ -33,7 +33,7 @@ use codestory_contracts::graph::{
     NodeKind as CoreNodeKind, ResolutionCertainty,
 };
 use codestory_store::{FileInfo, Store};
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 
 const COMPILER_SOURCE_TRUNCATION_SUFFIX: &str = "\n// ... source truncated by packet row cap\n```";
@@ -42,6 +42,12 @@ pub(crate) struct FrozenPacketCompilationV1 {
     pub(crate) product: RepositoryDerivedCompilationV1,
     pub(crate) source_coverage: Vec<SourceCoverageObservationDto>,
     publication: PacketCompilationPublicationV1,
+}
+
+#[derive(Debug, Clone)]
+struct AuthenticatedPacketAdmissionV1 {
+    receipt: PacketAdmissionReceiptV1,
+    core_node_id: CoreNodeId,
 }
 
 /// Hydrate exactly the packet-wide admitted identities and compile their
@@ -57,7 +63,7 @@ pub(crate) fn freeze_packet_compilation(
     let admissions = session.receipts();
     let mut admission_gaps = session.gaps();
     let storage = controller.open_storage_read_only()?;
-    let (admissions, mut sources) =
+    let (authenticated_admissions, mut sources) =
         hydrate_admitted_sources(controller, &storage, &admissions, &mut admission_gaps)?;
     let source_paths = sources
         .iter()
@@ -67,7 +73,11 @@ pub(crate) fn freeze_packet_compilation(
     for source in &mut sources {
         source.parser_completeness = parser_completeness_for_path(&source.path, &source_coverage);
     }
-    let relations = hydrate_induced_relations(&storage, &admissions)?;
+    let relations = hydrate_induced_relations(&storage, &authenticated_admissions)?;
+    let admissions = authenticated_admissions
+        .into_iter()
+        .map(|admission| admission.receipt)
+        .collect();
     let publication = PacketCompilationPublicationV1 {
         project_id: project_id.to_string(),
         core_generation_id: publication
@@ -115,7 +125,7 @@ fn hydrate_admitted_sources(
     admission_gaps: &mut Vec<PacketAdmissionGapV1>,
 ) -> Result<
     (
-        Vec<PacketAdmissionReceiptV1>,
+        Vec<AuthenticatedPacketAdmissionV1>,
         Vec<PacketHydratedSourceRangeV1>,
     ),
     codestory_contracts::api::ApiError,
@@ -134,7 +144,10 @@ fn hydrate_admitted_sources(
                 );
                 continue;
             };
-            authenticated.push(admission.clone());
+            authenticated.push(AuthenticatedPacketAdmissionV1 {
+                receipt: admission.clone(),
+                core_node_id: node.id,
+            });
             hydrate_admitted_node_source(controller, storage, admission, &node)
         } else if let Some(path) = admission.stable_identity.strip_prefix("path:") {
             let Some(file) = find_admitted_file(storage, &project_root, path)? else {
@@ -146,7 +159,10 @@ fn hydrate_admitted_sources(
                 );
                 continue;
             };
-            authenticated.push(admission.clone());
+            authenticated.push(AuthenticatedPacketAdmissionV1 {
+                receipt: admission.clone(),
+                core_node_id: CoreNodeId(file.id),
+            });
             hydrate_admitted_file_source(controller, admission, &file)
         } else {
             push_admission_gap(
@@ -456,13 +472,19 @@ fn parser_completeness_for_path(
 
 fn hydrate_induced_relations(
     storage: &Store,
-    admissions: &[PacketAdmissionReceiptV1],
+    admissions: &[AuthenticatedPacketAdmissionV1],
 ) -> Result<Vec<PacketDirectedRelationV1>, codestory_contracts::api::ApiError> {
+    let mut stable_identity_by_node = HashMap::new();
+    for admission in admissions {
+        stable_identity_by_node
+            .entry(admission.core_node_id)
+            .or_insert_with(|| admission.receipt.stable_identity.clone());
+    }
     let node_ids = admissions
         .iter()
-        .filter_map(|admission| admission.stable_identity.strip_prefix("node:"))
-        .filter_map(|raw_id| raw_id.parse::<i64>().ok())
-        .map(CoreNodeId)
+        .map(|admission| admission.core_node_id)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
         .collect::<Vec<_>>();
     if node_ids.is_empty() {
         return Ok(Vec::new());
@@ -477,15 +499,15 @@ fn hydrate_induced_relations(
         .map(|edges| {
             edges
                 .into_iter()
-                .map(|edge| {
+                .filter_map(|edge| {
                     let (from, to) = edge.effective_endpoints();
-                    PacketDirectedRelationV1 {
+                    Some(PacketDirectedRelationV1 {
                         relation_id: edge.id.0.to_string(),
-                        from_identity: format!("node:{}", from.0),
-                        to_identity: format!("node:{}", to.0),
+                        from_identity: stable_identity_by_node.get(&from)?.clone(),
+                        to_identity: stable_identity_by_node.get(&to)?.clone(),
                         relation_kind: packet_relation_kind(edge.kind),
                         certainty: relation_certainty(edge.certainty),
-                    }
+                    })
                 })
                 .collect()
         })
@@ -715,6 +737,7 @@ pub fn drill_options_from_ids(option_ids: &[String]) -> Vec<DrillOptionDto> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use codestory_contracts::graph::{Edge as CoreEdge, EdgeId as CoreEdgeId};
 
     #[test]
     fn unknown_query_continuations_are_not_decoded() {
@@ -784,6 +807,95 @@ mod tests {
                 .id,
             CoreNodeId(-42)
         );
+    }
+
+    #[test]
+    fn path_admissions_participate_in_the_induced_relation_graph() {
+        let mut storage = Store::new_in_memory().expect("store");
+        storage
+            .insert_nodes_batch(&[
+                CoreNode {
+                    id: CoreNodeId(1),
+                    kind: CoreNodeKind::FILE,
+                    serialized_name: "src/a.rs".into(),
+                    ..Default::default()
+                },
+                CoreNode {
+                    id: CoreNodeId(2),
+                    kind: CoreNodeKind::FILE,
+                    serialized_name: "src/b.rs".into(),
+                    ..Default::default()
+                },
+                CoreNode {
+                    id: CoreNodeId(3),
+                    kind: CoreNodeKind::FUNCTION,
+                    serialized_name: "crate::run".into(),
+                    ..Default::default()
+                },
+            ])
+            .expect("insert file nodes");
+        storage
+            .insert_edges_batch(&[
+                CoreEdge {
+                    id: CoreEdgeId(10),
+                    source: CoreNodeId(1),
+                    target: CoreNodeId(2),
+                    kind: CoreEdgeKind::IMPORT,
+                    certainty: Some(ResolutionCertainty::Certain),
+                    ..Default::default()
+                },
+                CoreEdge {
+                    id: CoreEdgeId(11),
+                    source: CoreNodeId(1),
+                    target: CoreNodeId(3),
+                    kind: CoreEdgeKind::MEMBER,
+                    certainty: Some(ResolutionCertainty::Certain),
+                    ..Default::default()
+                },
+            ])
+            .expect("insert import edge");
+        let admissions = [
+            AuthenticatedPacketAdmissionV1 {
+                receipt: PacketAdmissionReceiptV1 {
+                    packet_ordinal: 0,
+                    stable_identity: "path:src/a.rs".into(),
+                    score_version: "test".into(),
+                    reserved_source_bytes: 1,
+                    origin: PacketAdmissionOriginV1::Retrieval,
+                },
+                core_node_id: CoreNodeId(1),
+            },
+            AuthenticatedPacketAdmissionV1 {
+                receipt: PacketAdmissionReceiptV1 {
+                    packet_ordinal: 1,
+                    stable_identity: "path:src/b.rs".into(),
+                    score_version: "test".into(),
+                    reserved_source_bytes: 1,
+                    origin: PacketAdmissionOriginV1::Retrieval,
+                },
+                core_node_id: CoreNodeId(2),
+            },
+            AuthenticatedPacketAdmissionV1 {
+                receipt: PacketAdmissionReceiptV1 {
+                    packet_ordinal: 2,
+                    stable_identity: "node:3".into(),
+                    score_version: "test".into(),
+                    reserved_source_bytes: 1,
+                    origin: PacketAdmissionOriginV1::Retrieval,
+                },
+                core_node_id: CoreNodeId(3),
+            },
+        ];
+
+        let relations = hydrate_induced_relations(&storage, &admissions).expect("relations");
+
+        assert_eq!(relations.len(), 2);
+        assert_eq!(relations[0].from_identity, "path:src/a.rs");
+        assert_eq!(relations[0].to_identity, "path:src/b.rs");
+        assert_eq!(relations[0].relation_kind, PacketRelationKindV1::Import);
+        assert_eq!(relations[1].from_identity, "path:src/a.rs");
+        assert_eq!(relations[1].to_identity, "node:3");
+        assert_eq!(relations[1].relation_kind, PacketRelationKindV1::Member);
     }
 
     #[test]

--- a/crates/codestory-runtime/src/agent/packet_compiler.rs
+++ b/crates/codestory-runtime/src/agent/packet_compiler.rs
@@ -4,191 +4,319 @@
 //! [`PacketCompilationInputV1`]. Selection itself lives in
 //! `codestory-agent` and cannot see the question.
 
-use crate::agent::packet_candidate::{PacketProofSession, active_packet_proof_session};
+use crate::agent::packet_candidate::PacketProofSession;
 use crate::agent::packet_coverage::PacketCoverageInput;
 use crate::agent::packet_freshness::PacketFreshnessInput;
 use crate::agent::packet_scoring::packet_display_path;
-use codestory_agent::evidence_compiler::compile_repository_evidence;
+use crate::{AppController, BoundedSnippetRangeOptions};
+use codestory_agent::evidence_compiler::{
+    RepositoryDerivedCompilationV1, compile_repository_evidence,
+};
 use codestory_contracts::api::{
     AgentPacketDto, AgentPacketRequestDto, BoundedDrillPlanDto, DrillGapKindDto, DrillOptionDto,
-    GraphArtifactDto, PACKET_DRILL_MAX_BYTES, PACKET_DRILL_MAX_DEPTH, PACKET_DRILL_MAX_HITS,
-    PACKET_DRILL_MAX_OPTIONS, PacketDispositionDto, PacketProbeResolutionStatusDto,
-    SourceCoverageObservationDto, SourceCoverageStatusDto, SupportUnitDto, SupportUnitKindDto,
-    decode_drill_option_id,
+    EmbeddingVectorPublicationIdentityDto, NodeKind as ApiNodeKind, PACKET_DRILL_MAX_BYTES,
+    PACKET_DRILL_MAX_DEPTH, PACKET_DRILL_MAX_HITS, PACKET_DRILL_MAX_OPTIONS, PacketDispositionDto,
+    PacketProbeResolutionDto, PacketProbeResolutionStatusDto, SourceCoverageObservationDto,
+    SourceCoverageStatusDto, SupportUnitDto, SupportUnitKindDto, decode_drill_option_id,
 };
 use codestory_contracts::compilation::{
-    PACKET_COMPILATION_CONTRACT_VERSION_V1, PacketAdmissionGapKindV1, PacketAdmissionGapV1,
-    PacketAdmissionOriginV1, PacketCompilationInputV1, PacketCompilationPublicationV1,
-    PacketContinuationSelectorV1, PacketDirectedRelationV1, PacketHydratedSourceRangeV1,
-    PacketIdentityAmbiguityV1, PacketParserCompletenessV1, PacketRelationCertaintyV1,
-    PacketRelationKindV1, PacketStructuralGapReasonV1,
+    INTERIM_SOURCE_ROW_UPPER_BOUND, PACKET_COMPILATION_CONTRACT_VERSION_V1,
+    PacketAdmissionGapKindV1, PacketAdmissionGapV1, PacketAdmissionOriginV1,
+    PacketCompilationInputV1, PacketCompilationPublicationV1, PacketContinuationSelectorV1,
+    PacketDirectedRelationV1, PacketHydratedSourceRangeV1, PacketIdentityAmbiguityV1,
+    PacketParserCompletenessV1, PacketRelationCertaintyV1, PacketRelationKindV1,
+    PacketStructuralGapReasonV1,
 };
-use codestory_contracts::graph::FileCoverageReason;
+use codestory_contracts::graph::{
+    EdgeKind as CoreEdgeKind, FileCoverageReason, NodeId as CoreNodeId, ResolutionCertainty,
+};
 use std::collections::BTreeSet;
 
-pub fn apply_compiled_evidence_for_project(
+const COMPILER_SOURCE_TRUNCATION_SUFFIX: &str = "\n// ... source truncated by packet row cap\n```";
+
+pub(crate) struct FrozenPacketCompilationV1 {
+    pub(crate) product: RepositoryDerivedCompilationV1,
+    pub(crate) source_coverage: Vec<SourceCoverageObservationDto>,
+    publication: PacketCompilationPublicationV1,
+}
+
+/// Hydrate exactly the packet-wide admitted identities and compile their
+/// repository evidence while the core/retrieval publication is pinned. This
+/// runs before any presentation or output-budget mutation.
+pub(crate) fn freeze_packet_compilation(
+    controller: &AppController,
+    project_id: &str,
+    probe_resolutions: &[PacketProbeResolutionDto],
+    publication: Option<&EmbeddingVectorPublicationIdentityDto>,
+    session: &PacketProofSession,
+) -> Result<FrozenPacketCompilationV1, codestory_contracts::api::ApiError> {
+    let admissions = session.receipts();
+    let mut admission_gaps = session.gaps();
+    let mut sources = hydrate_admitted_sources(controller, &admissions, &mut admission_gaps);
+    let source_paths = sources
+        .iter()
+        .map(|source| source.path.clone())
+        .collect::<Vec<_>>();
+    let source_coverage =
+        crate::source_coverage::observe_source_coverage(controller, &source_paths);
+    for source in &mut sources {
+        source.parser_completeness = parser_completeness_for_path(&source.path, &source_coverage);
+    }
+    let relations = hydrate_induced_relations(controller, &admissions)?;
+    let publication = PacketCompilationPublicationV1 {
+        project_id: project_id.to_string(),
+        core_generation_id: publication
+            .map(|publication| publication.core_generation_id.clone())
+            .unwrap_or_default(),
+        retrieval_generation: publication
+            .map(|publication| publication.retrieval_generation.clone()),
+    };
+    let input = PacketCompilationInputV1 {
+        contract_version: PACKET_COMPILATION_CONTRACT_VERSION_V1,
+        publication: publication.clone(),
+        admissions,
+        sources,
+        relations,
+        ambiguities: probe_ambiguities(probe_resolutions),
+        admission_gaps,
+    };
+    let product = compile_repository_evidence(&input);
+    Ok(FrozenPacketCompilationV1 {
+        product,
+        source_coverage,
+        publication,
+    })
+}
+
+pub(crate) fn apply_frozen_packet_compilation(
     packet: &mut AgentPacketDto,
     request: Option<&AgentPacketRequestDto>,
-    project_id: &str,
-    relations: Vec<PacketDirectedRelationV1>,
+    frozen: FrozenPacketCompilationV1,
 ) {
-    let session = active_packet_proof_session();
-    let input = packet_compilation_input(packet, project_id, session.as_deref(), relations);
-    let compiled = compile_repository_evidence(&input);
-    packet.support = compiled.support;
+    packet.support = frozen.product.support;
     packet.disposition = classify_packet_disposition(
         packet,
         request,
-        &compiled.continuation,
-        input.publication.core_generation_id,
-        input.publication.retrieval_generation,
+        &frozen.product.continuation,
+        frozen.publication.core_generation_id,
+        frozen.publication.retrieval_generation,
     );
 }
 
-fn packet_compilation_input(
-    packet: &AgentPacketDto,
-    project_id: &str,
-    session: Option<&PacketProofSession>,
-    relations: Vec<PacketDirectedRelationV1>,
-) -> PacketCompilationInputV1 {
-    let publication = packet.answer.retrieval_trace.retrieval_publication.as_ref();
-    let mut admission_gaps = session.map(PacketProofSession::gaps).unwrap_or_default();
-    let admissions = session
-        .map(PacketProofSession::receipts)
-        .unwrap_or_default();
-    let sources = hydrated_sources(&packet.support, &packet.answer.source_coverage, &admissions);
-    let source_identities = sources
-        .iter()
-        .map(|source| source.stable_identity.as_str())
-        .collect::<BTreeSet<_>>();
-    for admission in admissions
-        .iter()
-        .filter(|admission| admission.origin == PacketAdmissionOriginV1::ExactTypedSelector)
-    {
-        if !source_identities.contains(admission.stable_identity.as_str()) {
-            admission_gaps.push(PacketAdmissionGapV1 {
-                kind: PacketAdmissionGapKindV1::SourceUnavailable,
-                stable_identity: Some(admission.stable_identity.clone()),
-                exact_selector_ordinal: Some(admission.packet_ordinal),
-            });
-        }
-    }
-
-    PacketCompilationInputV1 {
-        contract_version: PACKET_COMPILATION_CONTRACT_VERSION_V1,
-        publication: PacketCompilationPublicationV1 {
-            project_id: project_id.to_string(),
-            core_generation_id: publication
-                .map(|publication| publication.core_generation_id.clone())
-                .unwrap_or_default(),
-            retrieval_generation: publication
-                .map(|publication| publication.retrieval_generation.clone()),
-        },
-        relations,
-        ambiguities: probe_ambiguities(packet),
-        admissions,
-        sources,
-        admission_gaps,
-    }
-}
-
-fn hydrated_sources(
-    support: &[SupportUnitDto],
-    source_coverage: &[SourceCoverageObservationDto],
+fn hydrate_admitted_sources(
+    controller: &AppController,
     admissions: &[codestory_contracts::compilation::PacketAdmissionReceiptV1],
+    admission_gaps: &mut Vec<PacketAdmissionGapV1>,
 ) -> Vec<PacketHydratedSourceRangeV1> {
-    support
-        .iter()
-        .filter(|unit| unit.kind == SupportUnitKindDto::SourceRange)
-        .filter_map(|unit| {
-            let path = unit.path.as_deref().map(packet_display_path)?;
-            let source = unit.snippet.clone()?;
-            let stable_identity = support_stable_identity(unit, &path, admissions)?;
-            let parser_completeness = source_coverage
-                .iter()
-                .find(|observation| packet_display_path(&observation.path) == path)
-                .map(|observation| match observation.status {
-                    SourceCoverageStatusDto::Indexed => PacketParserCompletenessV1::Complete,
-                    SourceCoverageStatusDto::Incomplete => PacketParserCompletenessV1::Partial,
-                    SourceCoverageStatusDto::PolicyExcluded
-                    | SourceCoverageStatusDto::NotEstablished => {
-                        PacketParserCompletenessV1::Unknown
-                    }
-                })
-                .unwrap_or(PacketParserCompletenessV1::Unknown);
-            Some(PacketHydratedSourceRangeV1 {
-                stable_identity,
-                path,
-                symbol: (!unit.summary.is_empty()).then_some(unit.summary.clone()),
-                start_line: unit.start_line.unwrap_or(1),
-                end_line: unit.end_line.or(unit.start_line).unwrap_or(1),
-                source,
-                parser_completeness,
-            })
-        })
-        .collect()
-}
-
-fn support_stable_identity(
-    unit: &SupportUnitDto,
-    path: &str,
-    admissions: &[codestory_contracts::compilation::PacketAdmissionReceiptV1],
-) -> Option<String> {
-    if let Some(symbol_id) = unit.symbol_id.as_deref() {
-        for candidate in [symbol_id.to_string(), format!("node:{symbol_id}")] {
-            if admissions
-                .iter()
-                .any(|admission| admission.stable_identity == candidate)
-            {
-                return Some(candidate);
-            }
+    let mut sources = Vec::new();
+    for admission in admissions {
+        let result = if let Some(raw_id) = admission.stable_identity.strip_prefix("node:") {
+            hydrate_admitted_node_source(controller, admission, raw_id)
+        } else if let Some(path) = admission.stable_identity.strip_prefix("path:") {
+            hydrate_admitted_path_source(controller, admission, path)
+        } else {
+            Err(PacketAdmissionGapKindV1::StableIdentityMissing)
+        };
+        match result {
+            Ok(source) => sources.push(source),
+            Err(kind) => admission_gaps.push(PacketAdmissionGapV1 {
+                kind,
+                stable_identity: Some(admission.stable_identity.clone()),
+                exact_selector_ordinal: (admission.origin
+                    == PacketAdmissionOriginV1::ExactTypedSelector)
+                    .then_some(admission.packet_ordinal),
+            }),
         }
     }
-    admissions
-        .iter()
-        .find(|admission| admission.stable_identity == format!("path:{path}"))
-        .map(|admission| admission.stable_identity.clone())
+    sources
 }
 
-pub(crate) fn directed_relations_from_graphs(
-    graphs: &[GraphArtifactDto],
-    admissions: &[codestory_contracts::compilation::PacketAdmissionReceiptV1],
-) -> Vec<PacketDirectedRelationV1> {
-    let admitted = admissions
-        .iter()
-        .map(|admission| admission.stable_identity.as_str())
-        .collect::<BTreeSet<_>>();
-    let mut relations = Vec::new();
-    let mut seen = BTreeSet::new();
-    for artifact in graphs {
-        let GraphArtifactDto::Uml { graph, .. } = artifact else {
+fn hydrate_admitted_node_source(
+    controller: &AppController,
+    admission: &codestory_contracts::compilation::PacketAdmissionReceiptV1,
+    raw_id: &str,
+) -> Result<PacketHydratedSourceRangeV1, PacketAdmissionGapKindV1> {
+    let details = controller
+        .node_details(codestory_contracts::api::NodeDetailsRequest {
+            id: codestory_contracts::api::NodeId(raw_id.to_string()),
+        })
+        .map_err(|_| PacketAdmissionGapKindV1::SourceUnavailable)?;
+    if let Some(path) = file_node_source_path(
+        details.kind,
+        details.file_path.as_deref(),
+        &details.serialized_name,
+    ) {
+        return hydrate_admitted_path_source(controller, admission, path);
+    }
+    let path = details
+        .file_path
+        .as_deref()
+        .ok_or(PacketAdmissionGapKindV1::SourceBoundMissing)?;
+    let (start_line, end_line) = valid_source_bounds(details.start_line, details.end_line)
+        .ok_or(PacketAdmissionGapKindV1::SourceBoundMissing)?;
+    let (_, bounded) = controller
+        .bounded_file_snippet_range(
+            path,
+            BoundedSnippetRangeOptions {
+                focus_line: start_line,
+                start_line,
+                end_line,
+                context_lines: 0,
+                max_bytes: source_byte_cap(admission),
+                truncation_suffix: COMPILER_SOURCE_TRUNCATION_SUFFIX,
+            },
+        )
+        .map_err(|_| PacketAdmissionGapKindV1::SourceUnavailable)?;
+    hydrated_source(
+        admission,
+        path,
+        Some(details.display_name),
+        &bounded.markdown,
+    )
+}
+
+fn file_node_source_path<'a>(
+    kind: ApiNodeKind,
+    file_path: Option<&'a str>,
+    serialized_name: &'a str,
+) -> Option<&'a str> {
+    (kind == ApiNodeKind::FILE)
+        .then(|| {
+            file_path
+                .filter(|path| !path.is_empty())
+                .unwrap_or(serialized_name)
+        })
+        .filter(|path| !path.is_empty())
+}
+
+fn hydrate_admitted_path_source(
+    controller: &AppController,
+    admission: &codestory_contracts::compilation::PacketAdmissionReceiptV1,
+    path: &str,
+) -> Result<PacketHydratedSourceRangeV1, PacketAdmissionGapKindV1> {
+    let (_, bounded) = controller
+        .bounded_file_snippet(
+            path,
+            1,
+            8,
+            source_byte_cap(admission),
+            COMPILER_SOURCE_TRUNCATION_SUFFIX,
+        )
+        .map_err(|_| PacketAdmissionGapKindV1::SourceUnavailable)?;
+    hydrated_source(admission, path, None, &bounded.markdown)
+}
+
+fn hydrated_source(
+    admission: &codestory_contracts::compilation::PacketAdmissionReceiptV1,
+    path: &str,
+    symbol: Option<String>,
+    source: &str,
+) -> Result<PacketHydratedSourceRangeV1, PacketAdmissionGapKindV1> {
+    if source.trim().is_empty() {
+        return Err(PacketAdmissionGapKindV1::SourceUnavailable);
+    }
+    let (start_line, end_line) =
+        source_receipt_line_range(source).ok_or(PacketAdmissionGapKindV1::SourceBoundMissing)?;
+    Ok(PacketHydratedSourceRangeV1 {
+        stable_identity: admission.stable_identity.clone(),
+        path: packet_display_path(path),
+        symbol,
+        start_line,
+        end_line,
+        source: source.to_string(),
+        parser_completeness: PacketParserCompletenessV1::Unknown,
+    })
+}
+
+fn source_byte_cap(
+    admission: &codestory_contracts::compilation::PacketAdmissionReceiptV1,
+) -> usize {
+    (admission.reserved_source_bytes as usize).clamp(1, INTERIM_SOURCE_ROW_UPPER_BOUND)
+}
+
+fn valid_source_bounds(start_line: Option<u32>, end_line: Option<u32>) -> Option<(u32, u32)> {
+    let start_line = start_line.filter(|line| *line > 0)?;
+    let end_line = end_line.filter(|line| *line >= start_line)?;
+    Some((start_line, end_line))
+}
+
+fn source_receipt_line_range(markdown: &str) -> Option<(u32, u32)> {
+    let mut start = None;
+    let mut end = None;
+    for line in markdown.lines() {
+        let line = line
+            .trim_start()
+            .strip_prefix("> ")
+            .unwrap_or(line.trim_start());
+        let Some((line_number, _)) = line.split_once(" | ") else {
             continue;
         };
-        for edge in &graph.edges {
-            let from_identity = format!("node:{}", edge.source.0);
-            let to_identity = format!("node:{}", edge.target.0);
-            if !admitted.contains(from_identity.as_str())
-                || !admitted.contains(to_identity.as_str())
-            {
-                continue;
-            }
-            if !seen.insert(edge.id.0.clone()) {
-                continue;
-            }
-            relations.push(PacketDirectedRelationV1 {
-                relation_id: edge.id.0.clone(),
-                from_identity,
-                to_identity,
-                relation_kind: packet_relation_kind(edge.kind),
-                certainty: relation_certainty(edge.certainty.as_deref(), edge.confidence),
-            });
-        }
+        let Ok(line_number) = line_number.trim().parse::<u32>() else {
+            continue;
+        };
+        start = Some(start.map_or(line_number, |current: u32| current.min(line_number)));
+        end = Some(end.map_or(line_number, |current: u32| current.max(line_number)));
     }
-    relations
+    start.zip(end)
 }
 
-fn packet_relation_kind(kind: codestory_contracts::api::EdgeKind) -> PacketRelationKindV1 {
-    use codestory_contracts::api::EdgeKind;
+fn parser_completeness_for_path(
+    path: &str,
+    source_coverage: &[SourceCoverageObservationDto],
+) -> PacketParserCompletenessV1 {
+    source_coverage
+        .iter()
+        .find(|observation| packet_display_path(&observation.path) == packet_display_path(path))
+        .map(|observation| match observation.status {
+            SourceCoverageStatusDto::Indexed => PacketParserCompletenessV1::Complete,
+            SourceCoverageStatusDto::Incomplete => PacketParserCompletenessV1::Partial,
+            SourceCoverageStatusDto::PolicyExcluded | SourceCoverageStatusDto::NotEstablished => {
+                PacketParserCompletenessV1::Unknown
+            }
+        })
+        .unwrap_or(PacketParserCompletenessV1::Unknown)
+}
+
+fn hydrate_induced_relations(
+    controller: &AppController,
+    admissions: &[codestory_contracts::compilation::PacketAdmissionReceiptV1],
+) -> Result<Vec<PacketDirectedRelationV1>, codestory_contracts::api::ApiError> {
+    let node_ids = admissions
+        .iter()
+        .filter_map(|admission| admission.stable_identity.strip_prefix("node:"))
+        .filter_map(|raw_id| raw_id.parse::<i64>().ok())
+        .map(CoreNodeId)
+        .collect::<Vec<_>>();
+    if node_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let storage = controller.open_storage_read_only()?;
+    storage
+        .get_certain_edge_representatives_between_node_ids(&node_ids)
+        .map_err(|error| {
+            codestory_contracts::api::ApiError::internal(format!(
+                "Failed to load admitted packet relations: {error}"
+            ))
+        })
+        .map(|edges| {
+            edges
+                .into_iter()
+                .map(|edge| {
+                    let (from, to) = edge.effective_endpoints();
+                    PacketDirectedRelationV1 {
+                        relation_id: edge.id.0.to_string(),
+                        from_identity: format!("node:{}", from.0),
+                        to_identity: format!("node:{}", to.0),
+                        relation_kind: packet_relation_kind(edge.kind),
+                        certainty: relation_certainty(edge.certainty),
+                    }
+                })
+                .collect()
+        })
+}
+
+fn packet_relation_kind(kind: CoreEdgeKind) -> PacketRelationKindV1 {
+    use CoreEdgeKind as EdgeKind;
     match kind {
         EdgeKind::MEMBER => PacketRelationKindV1::Member,
         EdgeKind::TYPE_USAGE => PacketRelationKindV1::TypeUsage,
@@ -206,19 +334,19 @@ fn packet_relation_kind(kind: codestory_contracts::api::EdgeKind) -> PacketRelat
     }
 }
 
-fn relation_certainty(label: Option<&str>, _confidence: Option<f32>) -> PacketRelationCertaintyV1 {
-    match label {
-        Some("certain") => PacketRelationCertaintyV1::Certain,
-        Some("probable") => PacketRelationCertaintyV1::Probable,
-        Some("uncertain") => PacketRelationCertaintyV1::Uncertain,
+fn relation_certainty(certainty: Option<ResolutionCertainty>) -> PacketRelationCertaintyV1 {
+    match certainty {
+        Some(ResolutionCertainty::Certain) => PacketRelationCertaintyV1::Certain,
+        Some(ResolutionCertainty::Probable) => PacketRelationCertaintyV1::Probable,
+        Some(ResolutionCertainty::Uncertain) => PacketRelationCertaintyV1::Uncertain,
         _ => PacketRelationCertaintyV1::Unknown,
     }
 }
 
-fn probe_ambiguities(packet: &AgentPacketDto) -> Vec<PacketIdentityAmbiguityV1> {
-    packet
-        .plan
-        .probe_resolutions
+fn probe_ambiguities(
+    probe_resolutions: &[PacketProbeResolutionDto],
+) -> Vec<PacketIdentityAmbiguityV1> {
+    probe_resolutions
         .iter()
         .filter(|resolution| resolution.status == PacketProbeResolutionStatusDto::Ambiguous)
         .map(|resolution| PacketIdentityAmbiguityV1 {
@@ -411,8 +539,6 @@ pub fn drill_options_from_ids(option_ids: &[String]) -> Vec<DrillOptionDto> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use codestory_contracts::api::{EdgeId, EdgeKind, GraphEdgeDto, GraphResponse, NodeId};
-    use codestory_contracts::compilation::{PacketAdmissionOriginV1, PacketAdmissionReceiptV1};
 
     #[test]
     fn unknown_query_continuations_are_not_decoded() {
@@ -431,130 +557,52 @@ mod tests {
     #[test]
     fn uncertain_relation_is_not_compiler_evidence() {
         assert_eq!(
-            relation_certainty(Some("uncertain"), Some(0.99)),
+            relation_certainty(Some(ResolutionCertainty::Uncertain)),
             PacketRelationCertaintyV1::Uncertain
         );
     }
 
     #[test]
     fn numeric_confidence_cannot_upgrade_missing_certainty() {
-        assert_eq!(
-            relation_certainty(None, Some(0.99)),
-            PacketRelationCertaintyV1::Unknown
-        );
+        assert_eq!(relation_certainty(None), PacketRelationCertaintyV1::Unknown);
     }
 
     #[test]
-    fn adapter_forwards_every_admitted_hydrated_source_and_no_unadmitted_source() {
-        let admissions = (0..16)
-            .map(|index| PacketAdmissionReceiptV1 {
-                packet_ordinal: index,
-                stable_identity: format!("node:{index}"),
-                score_version: "retrieval-score/v1".into(),
-                reserved_source_bytes: 32,
-                origin: PacketAdmissionOriginV1::Retrieval,
-            })
-            .collect::<Vec<_>>();
-        let mut support = (0..16)
-            .map(|index| SupportUnitDto {
-                id: format!("source-{index}"),
-                kind: SupportUnitKindDto::SourceRange,
-                summary: format!("symbol-{index}"),
-                path: Some(format!("src/{index}.rs")),
-                symbol_id: Some(index.to_string()),
-                start_line: Some(1),
-                end_line: Some(1),
-                snippet: Some(format!("fn symbol_{index}() {{}}")),
-                edge_kind: None,
-                from_symbol: None,
-                to_symbol: None,
-                query: None,
-            })
-            .collect::<Vec<_>>();
-        support.push(SupportUnitDto {
-            id: "source-unadmitted".into(),
-            kind: SupportUnitKindDto::SourceRange,
-            summary: "unadmitted".into(),
-            path: Some("src/unadmitted.rs".into()),
-            symbol_id: Some("unadmitted".into()),
-            start_line: Some(1),
-            end_line: Some(1),
-            snippet: Some("fn unadmitted() {}".into()),
-            edge_kind: None,
-            from_symbol: None,
-            to_symbol: None,
-            query: None,
-        });
-
-        let hydrated = hydrated_sources(&support, &[], &admissions);
-        assert_eq!(hydrated.len(), 16);
-        assert!(
-            hydrated
-                .iter()
-                .all(|source| source.stable_identity.starts_with("node:"))
-        );
-        assert!(
-            hydrated
-                .iter()
-                .all(|source| source.path != "src/unadmitted.rs")
-        );
+    fn missing_or_invalid_source_bounds_never_become_line_one_source() {
+        for (start_line, end_line) in [
+            (None, Some(3)),
+            (Some(3), None),
+            (Some(0), Some(3)),
+            (Some(4), Some(3)),
+        ] {
+            assert_eq!(valid_source_bounds(start_line, end_line), None);
+        }
+        assert_eq!(valid_source_bounds(Some(3), Some(4)), Some((3, 4)));
     }
 
     #[test]
-    fn compiler_relation_capture_precedes_presentation_edge_caps() {
-        let admissions = (0..16)
-            .map(|index| PacketAdmissionReceiptV1 {
-                packet_ordinal: index,
-                stable_identity: format!("node:{index}"),
-                score_version: "retrieval-score/v1".into(),
-                reserved_source_bytes: 32,
-                origin: PacketAdmissionOriginV1::Retrieval,
-            })
-            .collect::<Vec<_>>();
-        let mut edges = (0..20)
-            .map(|index| GraphEdgeDto {
-                id: EdgeId(format!("a-dense-{index:02}")),
-                source: NodeId("0".into()),
-                target: NodeId("0".into()),
-                kind: EdgeKind::CALL,
-                confidence: Some(1.0),
-                certainty: Some("certain".into()),
-                callsite_identity: None,
-                candidate_targets: Vec::new(),
-            })
-            .collect::<Vec<_>>();
-        edges.extend((1..16).map(|index| GraphEdgeDto {
-            id: EdgeId(format!("z-connect-{index:02}")),
-            source: NodeId((index - 1).to_string()),
-            target: NodeId(index.to_string()),
-            kind: EdgeKind::CALL,
-            confidence: Some(1.0),
-            certainty: Some("certain".into()),
-            callsite_identity: None,
-            candidate_targets: Vec::new(),
-        }));
-        let graphs = vec![GraphArtifactDto::Uml {
-            id: "graph".into(),
-            title: "graph".into(),
-            graph: GraphResponse {
-                center_id: NodeId("0".into()),
-                nodes: Vec::new(),
-                edges,
-                truncated: false,
-                omitted_edge_count: 0,
-                canonical_layout: None,
-            },
-        }];
-
-        let captured = directed_relations_from_graphs(&graphs, &admissions);
-        assert_eq!(captured.len(), 35);
+    fn file_nodes_use_their_indexed_path_without_fabricating_symbol_bounds() {
         assert_eq!(
-            captured
-                .iter()
-                .filter(|relation| relation.relation_id.starts_with("z-connect-"))
-                .count(),
-            15,
-            "dense early edge IDs must not hide the admitted-seed connecting forest"
+            file_node_source_path(ApiNodeKind::FILE, None, "src/lib.rs"),
+            Some("src/lib.rs")
+        );
+        assert_eq!(
+            file_node_source_path(ApiNodeKind::FILE, Some("src/canonical.rs"), "src/stale.rs"),
+            Some("src/canonical.rs")
+        );
+        assert_eq!(
+            file_node_source_path(ApiNodeKind::FUNCTION, None, "run"),
+            None
+        );
+        assert_eq!(file_node_source_path(ApiNodeKind::FILE, None, ""), None);
+    }
+
+    #[test]
+    fn source_receipts_require_observed_numbered_lines() {
+        assert_eq!(source_receipt_line_range("source without a receipt"), None);
+        assert_eq!(
+            source_receipt_line_range("```text\n>    7 | fn run() {}\n     8 | }\n```"),
+            Some((7, 8))
         );
     }
 }

--- a/crates/codestory-runtime/src/agent/packet_probe.rs
+++ b/crates/codestory-runtime/src/agent/packet_probe.rs
@@ -3,7 +3,6 @@ use crate::agent::citation::to_citation_from_hit;
 use crate::agent::packet_candidate::{PacketAdmissionDecision, active_packet_proof_session};
 use crate::agent::retrieval_primary::active_pinned_retrieval_publication;
 use crate::target_resolution::{TargetResolution, TargetSelection};
-pub(crate) use codestory_agent::packet_probes::exact_packet_probe_paths;
 use codestory_agent::{PinnedReader, admit_continuation_probe};
 use codestory_contracts::api::{
     AgentCitationDto, NodeId, NodeKind, PacketEvidenceResolutionDto, PacketEvidenceTierDto,

--- a/crates/codestory-runtime/src/agent/packet_probe.rs
+++ b/crates/codestory-runtime/src/agent/packet_probe.rs
@@ -11,7 +11,7 @@ use codestory_contracts::api::{
     PacketProbeRejectionDto, PacketProbeResolutionDto, PacketProbeResolutionStatusDto,
     SearchHitOrigin,
 };
-use codestory_contracts::compilation::PacketContinuationSelectorV1;
+use codestory_contracts::compilation::{PacketContinuationSelectorV1, PacketSeedSelectorV1};
 use codestory_workspace::{
     ProjectRelativePathResolution, project_identity_v3, resolve_project_relative_path,
 };
@@ -29,6 +29,25 @@ pub(crate) fn unresolved_packet_probe_queries(probes: &[PacketProbeDto]) -> Vec<
             _ => None,
         })
         .filter(|query| !query.trim().is_empty())
+        .collect()
+}
+
+pub(crate) fn probes_from_seed_selectors(
+    selectors: &[PacketSeedSelectorV1],
+) -> Vec<PacketProbeDto> {
+    selectors
+        .iter()
+        .map(|selector| match selector {
+            PacketSeedSelectorV1::ExactPath { path } => {
+                PacketProbeDto::ExactPath { path: path.clone() }
+            }
+            PacketSeedSelectorV1::CanonicalId { id } => PacketProbeDto::SymbolId {
+                id: id.strip_prefix("node:").unwrap_or(id).to_string(),
+            },
+            PacketSeedSelectorV1::QualifiedSymbol { symbol } => PacketProbeDto::QualifiedSymbol {
+                symbol: symbol.clone(),
+            },
+        })
         .collect()
 }
 
@@ -780,6 +799,33 @@ mod tests {
         assert_eq!(
             unresolved_packet_probe_queries(&probes),
             ["publication recovery"]
+        );
+    }
+
+    #[test]
+    fn seed_selectors_convert_without_textual_reinterpretation() {
+        let selectors = vec![
+            PacketSeedSelectorV1::ExactPath {
+                path: "src/lib.rs".into(),
+            },
+            PacketSeedSelectorV1::CanonicalId {
+                id: "node:7".into(),
+            },
+            PacketSeedSelectorV1::QualifiedSymbol {
+                symbol: "crate::run".into(),
+            },
+        ];
+        assert_eq!(
+            probes_from_seed_selectors(&selectors),
+            vec![
+                PacketProbeDto::ExactPath {
+                    path: "src/lib.rs".into(),
+                },
+                PacketProbeDto::SymbolId { id: "7".into() },
+                PacketProbeDto::QualifiedSymbol {
+                    symbol: "crate::run".into(),
+                },
+            ]
         );
     }
 

--- a/crates/codestory-runtime/src/agent/packet_probe.rs
+++ b/crates/codestory-runtime/src/agent/packet_probe.rs
@@ -10,7 +10,7 @@ use codestory_contracts::api::{
     PacketProbeRejectionDto, PacketProbeResolutionDto, PacketProbeResolutionStatusDto,
     SearchHitOrigin,
 };
-use codestory_contracts::compilation::{PacketContinuationSelectorV1, PacketSeedSelectorV1};
+use codestory_contracts::compilation::PacketContinuationSelectorV1;
 use codestory_workspace::{
     ProjectRelativePathResolution, project_identity_v3, resolve_project_relative_path,
 };
@@ -18,36 +18,6 @@ use std::path::Path;
 
 pub(crate) fn normalize_packet_probe_request(probes: &[PacketProbeDto]) -> Vec<PacketProbeDto> {
     probes.to_vec()
-}
-
-pub(crate) fn unresolved_packet_probe_queries(probes: &[PacketProbeDto]) -> Vec<String> {
-    probes
-        .iter()
-        .filter_map(|probe| match probe {
-            PacketProbeDto::FreeQuery { query } => Some(query.trim().to_string()),
-            _ => None,
-        })
-        .filter(|query| !query.trim().is_empty())
-        .collect()
-}
-
-pub(crate) fn probes_from_seed_selectors(
-    selectors: &[PacketSeedSelectorV1],
-) -> Vec<PacketProbeDto> {
-    selectors
-        .iter()
-        .map(|selector| match selector {
-            PacketSeedSelectorV1::ExactPath { path } => {
-                PacketProbeDto::ExactPath { path: path.clone() }
-            }
-            PacketSeedSelectorV1::CanonicalId { id } => PacketProbeDto::SymbolId {
-                id: id.strip_prefix("node:").unwrap_or(id).to_string(),
-            },
-            PacketSeedSelectorV1::QualifiedSymbol { symbol } => PacketProbeDto::QualifiedSymbol {
-                symbol: symbol.clone(),
-            },
-        })
-        .collect()
 }
 
 pub(crate) fn resolve_packet_probes(
@@ -780,52 +750,6 @@ mod tests {
             source_bytes_upper_bound: Some(1),
             exact_selector_ordinal: None,
         }
-    }
-
-    #[test]
-    fn only_typed_free_queries_enter_generic_subquery_seeds() {
-        let probes = vec![
-            PacketProbeDto::ExactPath {
-                path: "src/lib.rs".into(),
-            },
-            PacketProbeDto::QualifiedSymbol {
-                symbol: "runtime::Publisher.commit".into(),
-            },
-            PacketProbeDto::FreeQuery {
-                query: "publication recovery".into(),
-            },
-        ];
-        assert_eq!(
-            unresolved_packet_probe_queries(&probes),
-            ["publication recovery"]
-        );
-    }
-
-    #[test]
-    fn seed_selectors_convert_without_textual_reinterpretation() {
-        let selectors = vec![
-            PacketSeedSelectorV1::ExactPath {
-                path: "src/lib.rs".into(),
-            },
-            PacketSeedSelectorV1::CanonicalId {
-                id: "node:7".into(),
-            },
-            PacketSeedSelectorV1::QualifiedSymbol {
-                symbol: "crate::run".into(),
-            },
-        ];
-        assert_eq!(
-            probes_from_seed_selectors(&selectors),
-            vec![
-                PacketProbeDto::ExactPath {
-                    path: "src/lib.rs".into(),
-                },
-                PacketProbeDto::SymbolId { id: "7".into() },
-                PacketProbeDto::QualifiedSymbol {
-                    symbol: "crate::run".into(),
-                },
-            ]
-        );
     }
 
     #[test]

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -997,15 +997,13 @@ fn admit_packet_candidate_descriptors<'a>(
         if let Some(descriptor) = candidate.packet_descriptor() {
             descriptors.push(descriptor);
         } else {
-            let kind = if candidate.node_id.as_deref().is_none_or(str::is_empty) {
-                PacketAdmissionGapKindV1::StableIdentityMissing
-            } else {
+            let stable_identity = candidate.packet_stable_identity();
+            let kind = if stable_identity.is_some() {
                 PacketAdmissionGapKindV1::SourceBoundMissing
+            } else {
+                PacketAdmissionGapKindV1::StableIdentityMissing
             };
-            session.record_ineligible_candidate(
-                kind,
-                candidate.node_id.as_deref().map(|id| format!("node:{id}")),
-            );
+            session.record_ineligible_candidate(kind, None);
         }
     }
     descriptors.sort_by(|left, right| {
@@ -2667,15 +2665,13 @@ fn resolve_sidecar_candidates_in_storage(
             match candidate.packet_descriptor() {
                 Some(descriptor) => Some(descriptor),
                 None => {
-                    let kind = if candidate.node_id.as_deref().is_none_or(str::is_empty) {
-                        PacketAdmissionGapKindV1::StableIdentityMissing
-                    } else {
+                    let stable_identity = candidate.packet_stable_identity();
+                    let kind = if stable_identity.is_some() {
                         PacketAdmissionGapKindV1::SourceBoundMissing
+                    } else {
+                        PacketAdmissionGapKindV1::StableIdentityMissing
                     };
-                    identity_scope.record_ineligible_candidate(
-                        kind,
-                        candidate.node_id.as_deref().map(|id| format!("node:{id}")),
-                    );
+                    identity_scope.record_ineligible_candidate(kind, None);
                     unresolved_candidates.push((
                         candidate,
                         if matches!(kind, PacketAdmissionGapKindV1::StableIdentityMissing) {
@@ -3961,6 +3957,40 @@ mod tests {
             session.admit_descriptor(&low.packet_descriptor().expect("complete low descriptor")),
             PacketAdmissionDecision::CountBudgetExceeded,
             "the sealed session must not admit a late lower-scoring query candidate"
+        );
+    }
+
+    #[test]
+    fn ineligible_sidecar_descriptor_never_exports_an_unauthenticated_identity() {
+        use crate::agent::packet_candidate::PacketProofSession;
+
+        let session = PacketProofSession::new();
+        let mut malformed = CandidateHit::with_source(
+            "src/malformed.rs",
+            Some("Malformed".to_string()),
+            0.9,
+            CandidateSource::Lexical,
+        );
+        malformed.node_id = Some("not-an-id".to_string());
+        malformed.source_bytes_upper_bound = Some(64);
+        let mut missing_bound = CandidateHit::with_source(
+            "src/missing.rs",
+            Some("Missing".to_string()),
+            0.8,
+            CandidateSource::Lexical,
+        );
+        missing_bound.node_id = Some("42".to_string());
+
+        admit_packet_candidate_descriptors(&session, [&malformed, &missing_bound]);
+
+        assert!(session.receipts().is_empty());
+        assert_eq!(session.gaps().len(), 2);
+        assert!(
+            session
+                .gaps()
+                .iter()
+                .all(|gap| gap.stable_identity.is_none()),
+            "unverified sidecar identities leaked into public continuation input"
         );
     }
 

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -376,9 +376,12 @@ pub(crate) fn with_stable_retrieval_publication<T: RetrievalPublicationResponse>
 pub(crate) fn with_stable_packet_retrieval_publication<T: RetrievalPublicationResponse>(
     controller: &AppController,
     operation: &str,
+    expected_core_generation_id: &str,
+    expected_core_run_id: &str,
     mut build: impl FnMut() -> Result<T, ApiError>,
 ) -> Result<T, ApiError> {
     if let Some(pinned) = active_pinned_retrieval_read(controller) {
+        ensure_pinned_core_publication(&pinned, expected_core_generation_id, expected_core_run_id)?;
         let mut response = build()?;
         response.attach_retrieval_publication(publication_dto(&pinned));
         return Ok(response);
@@ -390,7 +393,17 @@ pub(crate) fn with_stable_packet_retrieval_publication<T: RetrievalPublicationRe
         controller,
         operation,
         PinnedRetrievalScope::PacketDescriptor,
-        build,
+        || {
+            let pinned = active_pinned_retrieval_read(controller).ok_or_else(|| {
+                ApiError::internal("packet descriptor retrieval ran without its publication pin")
+            })?;
+            ensure_pinned_core_publication(
+                &pinned,
+                expected_core_generation_id,
+                expected_core_run_id,
+            )?;
+            build()
+        },
         |_| Ok(()),
     )
 }
@@ -3290,6 +3303,34 @@ mod tests {
             .expect("nested operation");
 
         assert_eq!(response.publication, Some(expected));
+    }
+
+    #[test]
+    fn packet_descriptor_pin_refuses_a_different_core_before_building() {
+        let fixture = pinned_operation_fixture();
+        let mut build_calls = 0;
+        let pinned = Rc::new(
+            PinnedRetrievalRead::begin_packet_descriptor(&fixture.controller)
+                .expect("begin packet descriptor pin"),
+        );
+
+        let error =
+            with_active_pinned_retrieval_read(&fixture.controller, Rc::clone(&pinned), || {
+                with_stable_packet_retrieval_publication(
+                    &fixture.controller,
+                    "packet response",
+                    "ffffffff-ffff-4fff-8fff-ffffffffffff",
+                    "foreign-run",
+                    || {
+                        build_calls += 1;
+                        Ok(TestPublicationResponse::default())
+                    },
+                )
+            })
+            .expect_err("a descriptor publication from another core must be rejected");
+
+        assert_eq!(error.code, "publication_changed");
+        assert_eq!(build_calls, 0);
     }
 
     /// Every helper that can reuse an operation's pin must actually reuse it.

--- a/crates/codestory-runtime/src/cache_rehydrate.rs
+++ b/crates/codestory-runtime/src/cache_rehydrate.rs
@@ -1529,7 +1529,7 @@ mod tests {
                 .is_some_and(|reason| reason.contains("insufficient space for compact rehydrate")),
             "unexpected reason: {output:?}"
         );
-        assert_eq!(output.copied, false);
+        assert!(!output.copied);
         assert!(
             output
                 .peak_space_required_bytes

--- a/crates/codestory-runtime/src/call_path_kernel.rs
+++ b/crates/codestory-runtime/src/call_path_kernel.rs
@@ -5634,8 +5634,7 @@ mod tests {
                 Vec::new(),
             ),
         );
-        let root = complete_root(&integration);
-        root
+        complete_root(&integration)
     }
 
     #[test]

--- a/crates/codestory-runtime/src/controller_symbols.rs
+++ b/crates/codestory-runtime/src/controller_symbols.rs
@@ -381,11 +381,13 @@ impl AppController {
     /// descriptor-only; source and graph evidence may be opened only after the
     /// packet-wide admission session is sealed.
     pub fn agent_packet(&self, req: AgentPacketRequestDto) -> Result<AgentPacketDto, ApiError> {
-        agent::retrieval_primary::with_stable_packet_retrieval_publication(
-            self,
-            "packet output",
-            || agent::agent_packet(self, req.clone()),
-        )
+        self.with_complete_core_snapshot(|_| {
+            agent::retrieval_primary::with_stable_packet_retrieval_publication(
+                self,
+                "packet output",
+                || agent::agent_packet(self, req.clone()),
+            )
+        })
     }
 
     pub fn graph_neighborhood(&self, req: GraphRequest) -> Result<GraphResponse, ApiError> {

--- a/crates/codestory-runtime/src/controller_symbols.rs
+++ b/crates/codestory-runtime/src/controller_symbols.rs
@@ -381,10 +381,12 @@ impl AppController {
     /// descriptor-only; source and graph evidence may be opened only after the
     /// packet-wide admission session is sealed.
     pub fn agent_packet(&self, req: AgentPacketRequestDto) -> Result<AgentPacketDto, ApiError> {
-        self.with_complete_core_snapshot(|_| {
+        self.with_complete_core_snapshot(|publication| {
             agent::retrieval_primary::with_stable_packet_retrieval_publication(
                 self,
                 "packet output",
+                &publication.generation_id,
+                &publication.run_id,
                 || agent::agent_packet(self, req.clone()),
             )
         })

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -117,6 +117,7 @@ mod search_terms;
 mod semantic_projection;
 mod semantic_republish;
 mod snippets;
+#[cfg(test)]
 mod source_coverage;
 #[cfg(feature = "v3-evidence-separation-support")]
 #[doc(hidden)]
@@ -576,7 +577,10 @@ impl Runtime {
     }
 
     pub fn agent_service(&self) -> AgentService {
-        AgentService::new(self.controller.clone())
+        AgentService::new_with_public_operation(
+            self.controller.clone(),
+            self.public_operation.clone(),
+        )
     }
 
     pub fn bookmark_service(&self) -> BookmarkService {

--- a/crates/codestory-runtime/src/services.rs
+++ b/crates/codestory-runtime/src/services.rs
@@ -2957,11 +2957,26 @@ impl TrailService {
 #[derive(Clone)]
 pub struct AgentService {
     controller: AppController,
+    public_operation: PublicOperationService,
 }
 
 impl AgentService {
     pub(crate) fn new(controller: AppController) -> Self {
-        Self { controller }
+        let public_operation = PublicOperationService::new(controller.clone());
+        Self {
+            controller,
+            public_operation,
+        }
+    }
+
+    pub(crate) fn new_with_public_operation(
+        controller: AppController,
+        public_operation: PublicOperationService,
+    ) -> Self {
+        Self {
+            controller,
+            public_operation,
+        }
     }
 
     pub fn ask(&self, req: AgentAskRequest) -> Result<AgentAnswerDto, ApiError> {
@@ -2969,7 +2984,13 @@ impl AgentService {
     }
 
     pub fn packet(&self, req: AgentPacketRequestDto) -> Result<AgentPacketDto, ApiError> {
-        self.controller.agent_packet(req)
+        let cancelled = active_public_operation_cancellation()
+            .unwrap_or_else(|| Arc::new(AtomicBool::new(false)));
+        self.public_operation
+            .run_with_cancel("packet", cancelled, || {
+                self.controller.agent_packet(req.clone())
+            })
+            .map(|operation| operation.value)
     }
 }
 
@@ -3870,6 +3891,30 @@ pub(crate) mod activation_tests {
             core_generation_id: None,
             retrieval_generation: None,
         }
+    }
+
+    #[test]
+    fn exported_agent_packet_pins_core_before_retrieval() {
+        let fixture = ready_activation_fixture();
+        let agent = fixture.runtime.agent_service();
+        let controller = fixture.runtime.controller.clone();
+        let observed = Arc::new(AtomicBool::new(false));
+        let observed_in_hook = Arc::clone(&observed);
+        set_before_retrieval_pin_test_hook(move || {
+            assert!(
+                controller.active_core_publication().is_some(),
+                "retrieval began outside the exported service's core snapshot"
+            );
+            observed_in_hook.store(true, Ordering::Release);
+        });
+
+        agent
+            .packet(warm_packet_request())
+            .expect("exported agent packet");
+        assert!(
+            observed.load(Ordering::Acquire),
+            "exported agent service bypassed the public-operation boundary"
+        );
     }
 
     /// The first packet on a ready lease performs exactly one fingerprint pass.

--- a/crates/codestory-store/src/core_generation.rs
+++ b/crates/codestory-store/src/core_generation.rs
@@ -452,7 +452,7 @@ pub(crate) fn clone_file_copy_on_write(
     {
         fs::copy(source, destination)
             .map_err(|error| core_path_error("test-only full copy stage", destination, error))?;
-        return Ok(true);
+        Ok(true)
     }
     #[cfg(not(any(test, feature = "test-support")))]
     Ok(false)

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -6125,6 +6125,30 @@ impl Storage {
             .map_err(StorageError::from)
     }
 
+    /// Whether one file owns the current structural-text projection row.
+    ///
+    /// Packet coverage uses this bounded identity lookup after admission. It
+    /// must not materialize the repository-wide projection inventory.
+    pub fn has_structural_text_projection_for_file(
+        &self,
+        file_id: i64,
+    ) -> Result<bool, StorageError> {
+        self.conn
+            .query_row(
+                "SELECT EXISTS(
+                    SELECT 1
+                    FROM structural_text_projection
+                    WHERE file_id = ?1
+                      AND descriptor_version = ?2
+                    LIMIT 1
+                 )",
+                params![file_id, STRUCTURAL_TEXT_UNIT_DESCRIPTOR_VERSION as i64],
+                |row| row.get::<_, i64>(0),
+            )
+            .map(|found| found != 0)
+            .map_err(StorageError::from)
+    }
+
     /// Whether one file owns a complete dedicated OpenAPI endpoint projection.
     ///
     /// This stays file-scoped and bounded in SQLite rather than loading graph
@@ -8058,8 +8082,8 @@ impl Storage {
         Ok(BoundedRawIncidentEdges { edges, truncated })
     }
 
-    /// Return one certain typed edge representative for every directed pair
-    /// whose effective endpoints are both in `node_ids`.
+    /// Return one certain edge representative for every directed pair and
+    /// relation kind whose effective endpoints are both in `node_ids`.
     ///
     /// This is an induced-edge read: it never opens endpoint nodes or file
     /// records, and dense parallel edges for one pair cannot consume the rows
@@ -8094,9 +8118,10 @@ impl Storage {
                         ROW_NUMBER() OVER (
                             PARTITION BY
                                 COALESCE(e.resolved_source_node_id, e.source_node_id),
-                                COALESCE(e.resolved_target_node_id, e.target_node_id)
-                            ORDER BY e.kind ASC, e.id ASC
-                        ) AS pair_rank
+                                COALESCE(e.resolved_target_node_id, e.target_node_id),
+                                e.kind
+                            ORDER BY e.id ASC
+                        ) AS typed_pair_rank
                  FROM edge e
                  JOIN admitted source_node
                    ON source_node.id = COALESCE(e.resolved_source_node_id, e.source_node_id)
@@ -8108,7 +8133,7 @@ impl Storage {
                     resolved_source_node_id, resolved_target_node_id, confidence,
                     callsite_identity, certainty, candidate_target_node_ids
              FROM ranked
-             WHERE pair_rank = 1
+             WHERE typed_pair_rank = 1
              ORDER BY CASE WHEN effective_source = effective_target THEN 1 ELSE 0 END ASC,
                       effective_source ASC, effective_target ASC, kind ASC, id ASC"
         );
@@ -10238,6 +10263,27 @@ impl Storage {
         &self,
     ) -> Result<Vec<SourcePolicyExclusionRecord>, StorageError> {
         read_source_policy_exclusions(&self.conn)
+    }
+
+    /// Check one normalized source-policy path without reading the complete
+    /// exclusion publication into memory.
+    pub fn has_source_policy_exclusion_path(
+        &self,
+        normalized_path: &str,
+    ) -> Result<bool, StorageError> {
+        self.conn
+            .query_row(
+                "SELECT EXISTS(
+                    SELECT 1
+                    FROM source_policy_exclusion
+                    WHERE normalized_path = ?1
+                    LIMIT 1
+                 )",
+                params![normalized_path],
+                |row| row.get::<_, i64>(0),
+            )
+            .map(|found| found != 0)
+            .map_err(StorageError::from)
     }
 
     pub fn get_source_policy_exclusion_manifest(
@@ -13243,6 +13289,31 @@ impl Storage {
         }
     }
 
+    /// Read one file record by its graph/file identity.
+    pub fn get_file_by_id(&self, file_id: i64) -> Result<Option<FileInfo>, StorageError> {
+        self.conn
+            .query_row(
+                "SELECT id, path, language, modification_time, indexed, complete, line_count, file_role
+                 FROM file
+                 WHERE id = ?1",
+                params![file_id],
+                |row| {
+                    Ok(FileInfo {
+                        id: row.get(0)?,
+                        path: PathBuf::from(row.get::<_, String>(1)?),
+                        language: row.get(2)?,
+                        modification_time: row.get(3)?,
+                        indexed: row.get::<_, i32>(4)? != 0,
+                        complete: row.get::<_, i32>(5)? != 0,
+                        line_count: row.get(6)?,
+                        file_role: FileRole::from_db_value(&row.get::<_, String>(7)?),
+                    })
+                },
+            )
+            .optional()
+            .map_err(StorageError::from)
+    }
+
     pub fn get_node_kinds_for_files(
         &self,
         file_ids: &[i64],
@@ -13854,6 +13925,26 @@ impl Storage {
             });
         }
         Ok(errors)
+    }
+
+    /// Read only the coverage reasons attached to one admitted file.
+    pub fn get_file_coverage_reasons(
+        &self,
+        file_id: i64,
+    ) -> Result<Vec<FileCoverageReason>, StorageError> {
+        let mut stmt = self.conn.prepare(
+            "SELECT coverage_reason
+             FROM error
+             WHERE file_id = ?1
+               AND coverage_reason IS NOT NULL
+             ORDER BY id ASC",
+        )?;
+        let rows = stmt.query_map(params![file_id], |row| row.get::<_, String>(0))?;
+        rows.map(|row| {
+            let reason = row?;
+            FileCoverageReason::try_from(reason.as_str()).map_err(StorageError::from)
+        })
+        .collect()
     }
 
     /// Clear all errors

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -8058,6 +8058,71 @@ impl Storage {
         Ok(BoundedRawIncidentEdges { edges, truncated })
     }
 
+    /// Return one certain typed edge representative for every directed pair
+    /// whose effective endpoints are both in `node_ids`.
+    ///
+    /// This is an induced-edge read: it never opens endpoint nodes or file
+    /// records, and dense parallel edges for one pair cannot consume the rows
+    /// needed to expose a different admitted pair.
+    pub fn get_certain_edge_representatives_between_node_ids(
+        &self,
+        node_ids: &[NodeId],
+    ) -> Result<Vec<Edge>, StorageError> {
+        let unique_node_ids = node_ids.iter().copied().collect::<BTreeSet<_>>();
+        if unique_node_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        if unique_node_ids.len() > EDGE_NODE_LOOKUP_BATCH_SIZE {
+            return Err(StorageError::Other(format!(
+                "induced edge lookup accepts at most {EDGE_NODE_LOOKUP_BATCH_SIZE} node ids"
+            )));
+        }
+
+        let admitted_values = (1..=unique_node_ids.len())
+            .map(|index| format!("(?{index})"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let query = format!(
+            "WITH admitted(id) AS (VALUES {admitted_values}),
+             ranked AS (
+                 SELECT e.id, e.source_node_id, e.target_node_id, e.kind, e.file_node_id,
+                        e.line, e.resolved_source_node_id, e.resolved_target_node_id,
+                        e.confidence, e.callsite_identity, e.certainty,
+                        e.candidate_target_node_ids,
+                        COALESCE(e.resolved_source_node_id, e.source_node_id) AS effective_source,
+                        COALESCE(e.resolved_target_node_id, e.target_node_id) AS effective_target,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY
+                                COALESCE(e.resolved_source_node_id, e.source_node_id),
+                                COALESCE(e.resolved_target_node_id, e.target_node_id)
+                            ORDER BY e.kind ASC, e.id ASC
+                        ) AS pair_rank
+                 FROM edge e
+                 JOIN admitted source_node
+                   ON source_node.id = COALESCE(e.resolved_source_node_id, e.source_node_id)
+                 JOIN admitted target_node
+                   ON target_node.id = COALESCE(e.resolved_target_node_id, e.target_node_id)
+                 WHERE e.certainty = 'certain'
+             )
+             SELECT id, source_node_id, target_node_id, kind, file_node_id, line,
+                    resolved_source_node_id, resolved_target_node_id, confidence,
+                    callsite_identity, certainty, candidate_target_node_ids
+             FROM ranked
+             WHERE pair_rank = 1
+             ORDER BY CASE WHEN effective_source = effective_target THEN 1 ELSE 0 END ASC,
+                      effective_source ASC, effective_target ASC, kind ASC, id ASC"
+        );
+        let mut stmt = self.conn.prepare(&query)?;
+        let mut rows = stmt.query(params_from_iter(
+            unique_node_ids.iter().map(|node_id| Value::from(node_id.0)),
+        ))?;
+        let mut edges = Vec::new();
+        while let Some(row) = rows.next()? {
+            edges.push(Self::edge_from_row(row)?);
+        }
+        Ok(edges)
+    }
+
     pub fn get_edges_for_node_ids(
         &self,
         node_ids: &[NodeId],

--- a/crates/codestory-store/src/storage_impl/tests/mod.rs
+++ b/crates/codestory-store/src/storage_impl/tests/mod.rs
@@ -8943,6 +8943,71 @@ fn induced_certain_edge_representatives_keep_connectors_after_dense_early_edges(
 }
 
 #[test]
+fn induced_certain_edge_representatives_preserve_distinct_kinds_for_one_pair()
+-> Result<(), StorageError> {
+    let mut storage = Storage::new_in_memory()?;
+    storage.insert_nodes_batch(&[
+        Node {
+            id: NodeId(1),
+            kind: NodeKind::FUNCTION,
+            serialized_name: "source".to_string(),
+            ..Default::default()
+        },
+        Node {
+            id: NodeId(2),
+            kind: NodeKind::FUNCTION,
+            serialized_name: "target".to_string(),
+            ..Default::default()
+        },
+    ])?;
+    storage.insert_edges_batch(&[
+        Edge {
+            id: EdgeId(1),
+            source: NodeId(1),
+            target: NodeId(2),
+            kind: EdgeKind::CALL,
+            certainty: Some(ResolutionCertainty::Certain),
+            ..Default::default()
+        },
+        Edge {
+            id: EdgeId(2),
+            source: NodeId(1),
+            target: NodeId(2),
+            kind: EdgeKind::CALL,
+            certainty: Some(ResolutionCertainty::Certain),
+            ..Default::default()
+        },
+        Edge {
+            id: EdgeId(3),
+            source: NodeId(1),
+            target: NodeId(2),
+            kind: EdgeKind::MEMBER,
+            certainty: Some(ResolutionCertainty::Certain),
+            ..Default::default()
+        },
+    ])?;
+
+    let selected =
+        storage.get_certain_edge_representatives_between_node_ids(&[NodeId(1), NodeId(2)])?;
+    assert_eq!(selected.len(), 2);
+    assert_eq!(
+        selected
+            .iter()
+            .filter(|edge| edge.kind == EdgeKind::CALL)
+            .count(),
+        1
+    );
+    assert_eq!(
+        selected
+            .iter()
+            .filter(|edge| edge.kind == EdgeKind::MEMBER)
+            .count(),
+        1
+    );
+    Ok(())
+}
+
+#[test]
 fn file_error_replacement_deletes_the_unique_file_set_with_a_batched_predicate()
 -> Result<(), StorageError> {
     let mut storage = Storage::new_in_memory()?;

--- a/crates/codestory-store/src/storage_impl/tests/mod.rs
+++ b/crates/codestory-store/src/storage_impl/tests/mod.rs
@@ -8887,6 +8887,62 @@ fn bounded_raw_incident_edges_do_not_open_endpoint_nodes_or_files() -> Result<()
 }
 
 #[test]
+fn induced_certain_edge_representatives_keep_connectors_after_dense_early_edges()
+-> Result<(), StorageError> {
+    let mut storage = Storage::new_in_memory()?;
+    storage.insert_nodes_batch(
+        &(1..=16)
+            .map(|id| Node {
+                id: NodeId(id),
+                kind: NodeKind::FUNCTION,
+                serialized_name: format!("node_{id}"),
+                ..Default::default()
+            })
+            .collect::<Vec<_>>(),
+    )?;
+    let mut edges = (1..=20)
+        .map(|id| Edge {
+            id: EdgeId(id),
+            source: NodeId(1),
+            target: NodeId(1),
+            kind: EdgeKind::CALL,
+            certainty: Some(ResolutionCertainty::Certain),
+            ..Default::default()
+        })
+        .collect::<Vec<_>>();
+    edges.extend((2..=16).map(|target| Edge {
+        id: EdgeId(100 + target),
+        source: NodeId(target - 1),
+        target: NodeId(target),
+        kind: EdgeKind::MEMBER,
+        certainty: Some(ResolutionCertainty::Certain),
+        ..Default::default()
+    }));
+    storage.insert_edges_batch(&edges)?;
+
+    let selected = storage.get_certain_edge_representatives_between_node_ids(
+        &(1..=16).map(NodeId).collect::<Vec<_>>(),
+    )?;
+    assert_eq!(
+        selected
+            .iter()
+            .filter(|edge| edge.source != edge.target)
+            .count(),
+        15,
+        "dense self edges hid the connecting forest"
+    );
+    assert_eq!(
+        selected
+            .iter()
+            .filter(|edge| edge.source == edge.target)
+            .count(),
+        1,
+        "parallel self edges were not represented once"
+    );
+    Ok(())
+}
+
+#[test]
 fn file_error_replacement_deletes_the_unique_file_set_with_a_batched_predicate()
 -> Result<(), StorageError> {
     let mut storage = Storage::new_in_memory()?;

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -140,12 +140,12 @@ flowchart LR
   the same engine.
 - `codestory-retrieval` owns immutable lexical/vector/SCIP generations,
   manifests, engine integration, health, retention, and fail-closed queries.
-- [`codestory-agent`](subsystems/agent.md) owns prompt-blind generic retrieval
-  planning and pure evidence-policy helpers. It forwards the unchanged question
-  and caller-supplied free-query seeds without inferring answer shapes or
-  traversal policy. It owns no activation, storage, retrieval execution,
-  admission, hydration, publication retry, or mutable readiness authority.
-  Repository-derived compilation lands separately under #2106.
+- [`codestory-agent`](subsystems/agent.md) owns syntactic retrieval-seed planning
+  and pure repository-derived compilation over admitted typed evidence. Only
+  the seed plan may retain the unchanged question; compilation receives no
+  prompt text, task class, obligation, role, carrier, or sufficiency policy. It
+  owns no activation, storage, retrieval execution, admission, hydration,
+  publication retry, or mutable readiness authority.
 - `codestory-runtime` is the only product orchestration layer.
 - `codestory-cli` parses and renders CLI, HTTP, and stdio adapters.
 - `codestory-bench` measures product paths without defining product behavior.

--- a/docs/architecture/packet-generalization.md
+++ b/docs/architecture/packet-generalization.md
@@ -1,11 +1,11 @@
 # Packet generalization
 
 Packet compilation is repository-derived. The original question may seed
-generic lexical and semantic retrieval, and syntactic planning may extract
-only repository paths, canonical IDs, and qualified symbols delimited as
-inline code. Typed free-query probes remain ordinary generic retrieval seeds.
-Once retrieval returns candidate descriptors, neither the question nor any
-prompt-derived policy crosses the compiler boundary.
+generic lexical and semantic retrieval, but no part of its wording has exact
+selector authority. Repository paths, canonical IDs, and qualified symbols
+enter only through typed probes. Typed free-query probes remain ordinary
+generic retrieval seeds. Once retrieval returns candidate descriptors, neither
+the question nor any prompt-derived policy crosses the compiler boundary.
 
 ## Required sequence
 
@@ -20,7 +20,8 @@ question + typed probes
   -> 16-row / 16-KiB public projection
 ```
 
-Exact typed selectors are resolved through identity indexes and admitted first.
+Exact typed selectors are copied without interpreting the question, resolved
+through identity indexes, and admitted first.
 Remaining candidates are admitted in versioned retrieval-score order. One
 packet-scoped session admits at most sixteen stable identities and reserves at
 most 16 KiB of conservative source bounds before any candidate source, graph

--- a/docs/architecture/packet-generalization.md
+++ b/docs/architecture/packet-generalization.md
@@ -2,9 +2,10 @@
 
 Packet compilation is repository-derived. The original question may seed
 generic lexical and semantic retrieval, and syntactic planning may extract
-only explicit repository paths, canonical IDs, qualified symbols, and typed
-free-query probes. Once retrieval returns candidate descriptors, neither the
-question nor any prompt-derived policy crosses the compiler boundary.
+only repository paths, canonical IDs, and qualified symbols delimited as
+inline code. Typed free-query probes remain ordinary generic retrieval seeds.
+Once retrieval returns candidate descriptors, neither the question nor any
+prompt-derived policy crosses the compiler boundary.
 
 ## Required sequence
 

--- a/docs/architecture/packet-generalization.md
+++ b/docs/architecture/packet-generalization.md
@@ -1,20 +1,21 @@
 # Packet generalization
 
-Horizon A is a prompt-blind, retrieval-first interim packet path. The original
-question reaches generic lexical and semantic retrieval unchanged. Typed
-exact probes constrain identity resolution, and typed free-query probes add
-ordinary retrieval queries. No wording is translated into an answer shape or
-structural traversal policy. Repository-derived compilation lands separately
-under #2106.
+Packet compilation is repository-derived. The original question may seed
+generic lexical and semantic retrieval, and syntactic planning may extract
+only explicit repository paths, canonical IDs, qualified symbols, and typed
+free-query probes. Once retrieval returns candidate descriptors, neither the
+question nor any prompt-derived policy crosses the compiler boundary.
 
 ## Required sequence
 
 ```text
 question + typed probes
-  -> unchanged-question generic query plan
+  -> RetrievalSeedPlanV1
   -> descriptor-only retrieval
   -> packet-wide admission
   -> admitted source and relation hydration
+  -> PacketCompilationInputV1
+  -> repository-derived selection
   -> 16-row / 16-KiB public projection
 ```
 
@@ -25,10 +26,12 @@ most 16 KiB of conservative source bounds before any candidate source, graph
 neighbourhood, node body, or file record is loaded. Initial retrieval, typed
 probes, batches, and continuations share that session.
 
-The interim finalizer retains only evidence that passed packet-wide admission
-and exact hydration. It converts objective admission and ambiguity gaps into
-typed stable continuations. It does not infer which evidence would answer the
-question.
+The compiler receives admitted identities, hydrated source ranges, certain
+directed relations, parser completeness, ambiguity, and one pinned publication
+identity. It may prefer distinct paths, remove contained source ranges, retain
+a bounded connecting forest, add one certain incident relation for a
+disconnected seed, prefer source witnesses over symbol-only locations, and
+apply deterministic byte costs. It cannot receive the raw question.
 
 ## Forbidden production shapes
 
@@ -70,5 +73,4 @@ those shapes is permitted only in tests, tooling, and checker fixtures.
 
 The public packet reports bounded source and indexed structural evidence,
 typed gaps, ambiguity, truncation, and its pinned publication identity. It
-always reports `answer_sufficiency: not_asserted`. Horizon A establishes this
-substrate contract only; it is not product-usefulness evidence.
+always reports `answer_sufficiency: not_asserted`.

--- a/docs/architecture/subsystems/agent.md
+++ b/docs/architecture/subsystems/agent.md
@@ -2,12 +2,12 @@
 
 `codestory-agent` owns the pure halves of packet compilation: syntactic seed
 planning and repository-derived evidence selection. The seed plan may pass the
-unchanged question to generic retrieval and recognize explicit paths, canonical
-IDs, and qualified symbols only when the caller delimits them as inline code.
-Typed free-query probes remain generic retrieval seeds. The compiler receives
-no question text. It selects only from admitted identities, hydrated source,
-certain directed relations, ambiguity, parser completeness, and publication
-identity.
+unchanged question to generic retrieval, but raw wording never creates an exact
+selector. Exact paths, canonical IDs, and qualified symbols enter only through
+typed probes. Typed free-query probes remain generic retrieval seeds. The
+compiler receives no question text. It selects only from admitted identities,
+hydrated source, certain directed relations, ambiguity, parser completeness,
+and publication identity.
 
 The crate depends on `codestory-contracts` alone. It cannot activate a
 project, open or write storage, execute retrieval, retry a publication, or
@@ -44,8 +44,9 @@ retrieval, or filesystem access.
 
 ## Extension rules
 
-- keep question interpretation inside `RetrievalSeedPlanV1`; compiler rules
-  must be functions of typed repository evidence only;
+- keep the unchanged question confined to the generic query in
+  `RetrievalSeedPlanV1`; copy exact selectors only from typed probes, and make
+  compiler rules functions of typed repository evidence only;
 - add retrieval, admission, hydration, publication retry, and assembly in
   runtime;
 - never import `codestory-runtime`, `codestory-store`, `codestory-retrieval`,

--- a/docs/architecture/subsystems/agent.md
+++ b/docs/architecture/subsystems/agent.md
@@ -3,8 +3,9 @@
 `codestory-agent` owns the pure halves of packet compilation: syntactic seed
 planning and repository-derived evidence selection. The seed plan may pass the
 unchanged question to generic retrieval and recognize explicit paths, canonical
-IDs, qualified symbols, and typed free-query probes. The compiler receives no
-question text. It selects only from admitted identities, hydrated source,
+IDs, and qualified symbols only when the caller delimits them as inline code.
+Typed free-query probes remain generic retrieval seeds. The compiler receives
+no question text. It selects only from admitted identities, hydrated source,
 certain directed relations, ambiguity, parser completeness, and publication
 identity.
 

--- a/docs/architecture/subsystems/agent.md
+++ b/docs/architecture/subsystems/agent.md
@@ -1,11 +1,12 @@
 # Agent Subsystem
 
-`codestory-agent` owns Horizon A's prompt-blind packet seed planning and pure
-evidence-policy helpers. It passes the unchanged question to generic retrieval
-and records typed free-query probes as additional generic queries. It does not
-infer paths, symbols, relations, answer stages, material roles, or sufficiency
-from prompt wording. Repository-derived evidence selection lands separately
-under #2106.
+`codestory-agent` owns the pure halves of packet compilation: syntactic seed
+planning and repository-derived evidence selection. The seed plan may pass the
+unchanged question to generic retrieval and recognize explicit paths, canonical
+IDs, qualified symbols, and typed free-query probes. The compiler receives no
+question text. It selects only from admitted identities, hydrated source,
+certain directed relations, ambiguity, parser completeness, and publication
+identity.
 
 The crate depends on `codestory-contracts` alone. It cannot activate a
 project, open or write storage, execute retrieval, retry a publication, or
@@ -14,15 +15,19 @@ pinned, through the `PinnedReader` trait implemented by runtime.
 
 ## Ownership
 
-- the unchanged-question generic retrieval plan;
+- `RetrievalSeedPlanV1`, the sole post-request object allowed to retain the
+  original wording;
 - deterministic query deduplication without English or domain taxonomies;
+- repository-derived source containment, path diversity, relation-forest, and
+  byte-bound selection over `PacketCompilationInputV1`;
 - `PinnedReader`, the only allowed view of pinned runtime state.
 
 ## Entry points
 
 - `src/lib.rs`: crate contract and module map
-- `src/packet_plan.rs` and `src/planning.rs`: unchanged-question retrieval
+- `src/packet_plan.rs` and `src/planning.rs`: unchanged-question retrieval seed
   planning and literal query deduplication
+- `src/evidence_compiler.rs`: pure repository-derived packet compilation
 - `src/citation.rs` and `src/packet_evidence.rs`: compatibility metadata for
   non-compiler search/citation surfaces; these fields have no admission,
   ranking, protection, or sufficiency authority in packet compilation
@@ -31,15 +36,15 @@ pinned, through the `PinnedReader` trait implemented by runtime.
 ## What stays in runtime
 
 Runtime owns generic retrieval, packet-wide descriptor admission, exact-probe
-resolution, hydration, publication retry, interim packet finalization, public
+resolution, hydration, publication retry, compilation-input assembly, public
 projection, and budgets. Those modules live under
 `crates/codestory-runtime/src/agent/` because they need `AppController`, store,
 retrieval, or filesystem access.
 
 ## Extension rules
 
-- keep question handling to unchanged generic retrieval and caller-supplied
-  typed probes;
+- keep question interpretation inside `RetrievalSeedPlanV1`; compiler rules
+  must be functions of typed repository evidence only;
 - add retrieval, admission, hydration, publication retry, and assembly in
   runtime;
 - never import `codestory-runtime`, `codestory-store`, `codestory-retrieval`,
@@ -48,11 +53,11 @@ retrieval, or filesystem access.
 
 ## Failure signatures
 
-- prompt tokens, task classes, obligations, roles, carriers, or answer stages
-  steer planning, admission, hydration, finalization, or capping;
+- the raw question, prompt tokens, task classes, obligations, roles, carriers,
+  or answer stages cross into `PacketCompilationInputV1`;
 - this crate starts retrieval, indexing, or a publication retry;
 - a planner reads ambient process state instead of a pin;
-- packet output asserts answer sufficiency.
+- compiler output asserts answer sufficiency.
 
 See [runtime](runtime.md) for assembly and retry, and
 [retrieval](retrieval.md) for fail-closed query execution.

--- a/docs/architecture/subsystems/retrieval.md
+++ b/docs/architecture/subsystems/retrieval.md
@@ -82,9 +82,9 @@ a live publication fence and is not persisted as vector compatibility.
 
 - add artifact formats and identity fields here before teaching runtime about
   them;
-- keep generic retrieval and descriptor metadata here, prompt-blind seed
-  planning in `codestory-agent`, and admission, hydration, interim assembly,
-  pin, and bounded product retry in `codestory-runtime`;
+- keep generic retrieval and descriptor metadata here, pure repository-derived
+  compilation in `codestory-agent`, and admission, hydration, assembly, pin,
+  and bounded product retry in `codestory-runtime`;
 - keep model execution mechanics and capability reporting in
   `codestory-llama-sys`, while keeping product model/vector/backend policy here;
 - preserve stable `sidecar_*` DTO fields only as compatibility vocabulary, not

--- a/docs/architecture/subsystems/runtime.md
+++ b/docs/architecture/subsystems/runtime.md
@@ -20,7 +20,8 @@ adapter syntax, SQLite mechanics, parsers, or model execution.
   generation-bound continuations;
 - one descriptor-only admission pass across the unchanged question and all
   typed free queries before candidate source or graph hydration;
-- prompt-blind interim finalization of admitted and hydrated packet evidence;
+- assembly of `PacketCompilationInputV1` and projection of the pure compiler's
+  bounded evidence product;
 - managed retrieval preparation and user-facing gap mapping;
 - generation-coherent candidate resolution and one bounded publication retry.
 

--- a/plugins/codestory/skills/codestory-grounding/SKILL.md
+++ b/plugins/codestory/skills/codestory-grounding/SKILL.md
@@ -136,7 +136,7 @@ plugin package to locate a documented field or excerpt.
   IDs from `publication`. Then answer from the combined evidence and the
   continuation result's remaining gaps. A first-pass continuation-required gap
   is resolved when it is absent from that result; retain other first-pass gaps
-  only when the continuation still reports them. The bounded packet
+  only when the continuation still reports them. The bounded compiler
   continuation is distinct from ordinary exact navigation after the packet.
 - `no_useful_evidence` and `unavailable` describe the packet result, not the
   repository. Preserve that outcome while using exact navigation when it can

--- a/plugins/codestory/skills/codestory-grounding/references/packet.md
+++ b/plugins/codestory/skills/codestory-grounding/references/packet.md
@@ -15,9 +15,9 @@ CLI flags. Every call requires `project` (absolute repository root).
 |------|---------|-----------------|
 | Normal path | MCP `packet` with `question` and optional `budget` / tagged `probes`. | Schema-3 evidence rows, gaps, retrieval state, diagnostics capability, and optional continuation. |
 | `available` | Use the returned evidence rows first. Follow an exact identity with `snippet`, `context`, or an explicit graph operation when the task still needs it. | The packet never asserts answer sufficiency. |
-| `continuation_available` | Repeat the question with `parent_packet_id=continuation.continuation_id`, `option_ids=continuation.gap_ids.map((item) => item.gap_id)`, and the core/retrieval generation IDs from `publication.core.generation_id` and `publication.retrieval.retrieval_generation`. | One bounded packet continuation; ordinary exact navigation remains available afterward. |
+| `continuation_available` | Repeat the question with `parent_packet_id=continuation.continuation_id`, `option_ids=continuation.gap_ids.map((item) => item.gap_id)`, and the core/retrieval generation IDs from `publication.core.generation_id` and `publication.retrieval.retrieval_generation`. | One bounded compiler continuation; ordinary exact navigation remains available afterward. |
 | `no_useful_evidence` / `unavailable` | Preserve the reported gap and use exact search, source, or relations if the task can still be grounded. | Do not turn absence of packet evidence into an absence claim. |
-| Explicit target | `search`, `context`, `trail`, or `snippet` may be used directly when the user or prior evidence identifies the target. | These are the packet substrate and fallback. |
+| Explicit target | `search`, `context`, `trail`, or `snippet` may be used directly when the user or prior evidence identifies the target. | These are the packet compiler's substrate and fallback. |
 | Integration edge | Use JSON/MCP structured content. Preserve exact paths, symbol IDs, ranges, evidence IDs, and gap IDs. | The public result carries no proof disposition. |
 
 ## Notes
@@ -54,7 +54,7 @@ CLI flags. Every call requires `project` (absolute repository root).
   `source_range` from the same file. That range supports only what its source
   text directly shows; the coverage warning still forbids file-wide absence or
   completeness claims.
-- A packet continuation is bounded to one round. It names stable selectors
+- A compiler continuation is bounded to one round. It names stable selectors
   and a structural gap, never a claim that the current packet is insufficient
   for the answer. After that round, let the task determine whether exact
   navigation is useful rather than manufacturing another packet policy.


### PR DESCRIPTION
Closes #2106
Refs #2098

## Context

PR #2103 repaired the Horizon A substrate and removed benchmark-shaped packet policy. This separate Horizon B slice wires the repository-derived compiler promised by the frozen 0.18 evidence-compiler plan. It does not establish product usefulness or authorize a release.

Base: `7794d6e2696450a683163b3926842b44f7aa4b38`

Head: `e51b6389f43eb1196ae711b702defa110720464b`

Tree: `14416957638a8f749a3b669872bd882b1292dd6b`

## What changed

- Added the typed `RetrievalSeedPlanV1 -> PacketCandidateDescriptorV1 -> PacketAdmissionReceiptV1 -> PacketCompilationInputV1 -> PacketEvidenceProductV3` boundary.
- Kept the unchanged question only as a generic retrieval seed. Raw question text has no exact-selector authority: only typed path, canonical-ID, qualified-symbol, file-symbol, and continuation probes can create exact selectors. Typed free queries remain generic retrieval seeds.
- Added a pure compiler over admitted identities, hydrated source, certain typed relations, ambiguity, gaps, and one publication identity.
- Made selection repository-derived: exact admission order, versioned retrieval order, distinct paths, source containment, a bounded directed relation forest, parser completeness, and deterministic byte cost.
- Hydrates source and the induced certain relation set directly from all and only admitted identities before presentation or output-budget mutation. Legacy citations and graph projections cannot select compiler evidence.
- Authenticates admitted sidecar identities against the same pinned core before they may appear in source, relations, gaps, or continuations. Malformed and stale identities fail closed without exposing their spelling.
- Reads source coverage one admitted file at a time. Packet compilation no longer opens broad node neighborhoods or repository-wide coverage inventories.
- Preserves one representative of every certain typed relation kind for each directed admitted pair.
- Rejects self-loops and missing symbol bounds, prevents opaque relation IDs or identity spelling from steering semantic selection, and lets file nodes hydrate through their indexed path without invented symbol coordinates.
- Projects raw public node IDs that round-trip through existing context surfaces; path identities never masquerade as symbol IDs.
- Keeps continuations stable and typed. Inline code, diagnostic prose, arbitrary Markdown containers, and fenced logs never become exact selectors or continuation queries, and production still reports `answer_sufficiency: not_asserted`.
- Pins every exported packet route across retrieval, admission, hydration, compilation, and projection.
- Updated architecture documentation to the typed-probe-only selector boundary.

## How to review

Start at:

1. `crates/codestory-contracts/src/compilation.rs`
2. `crates/codestory-agent/src/packet_plan.rs`
3. `crates/codestory-agent/src/evidence_compiler.rs`
4. `crates/codestory-runtime/src/agent/orchestrator.rs`
5. `crates/codestory-runtime/src/agent/packet_compiler.rs`
6. `crates/codestory-store/src/storage_impl/mod.rs`
7. `crates/codestory-agent/tests/repository_evidence_metamorphic.rs`

The critical boundary is that `PacketCompilationInputV1` cannot carry the question, prompt terms, task class, obligations, roles, carriers, answer stages, or sufficiency policy. With frozen admitted evidence, paraphrase, bijective rename, opaque edge-ID changes, and input permutation cannot change selection shape.

## Focused verification

- Agent suites: 78 unit, 5 black-box boundary, 2 production-scoring, and 14 metamorphic tests passed.
- `cargo test --locked -p codestory-runtime --lib`: 832 passed, 4 ignored.
- CLI architecture contracts: 56 passed.
- stdio protocol contracts: 66 passed.
- Strict all-target clippy for agent, runtime, and CLI: passed.
- Routing, A/B analyzer, plugin, and hostile generalization matrix: 404 passed, 1 Windows-only skip.
- Live packet generalization scan: 103 production files passed.
- Retrieval generalization scan: 368 production files and 1,724 forbidden patterns passed.
- Documentation links, formatting, and `git diff --check`: passed.
- The independent verifier reran seven selected hostile cases against this exact head and found no remaining counterexample. It confirmed that raw question markup cannot create exact selectors, typed probes remain functional, admitted paths participate in induced relations, rejected retrieval identities stay hidden, and core/retrieval mismatch stops before packet construction.
- All required GitHub checks passed on the exact head.

Earlier unchanged component checks on this branch also passed: contracts 124, store 284, retrieval 406 with 3 ignored, CLI golden path 18, both proof-feature transport profiles, evidence-only conformance, and strict library clippy for retrieval/indexer.

## Risk

This deliberately changes packet evidence ordering and removes legacy presentation artifacts as selection authority. The main semantic risk is losing useful evidence that old fitted policy happened to preserve. The next gate is the builder-visible five-arm ablation; this PR itself makes no accuracy claim.

## Non-claims

- No version bump, calibration, broad source qualification, packaging, marketplace, or release work was run.
- Historical 18-task, Q2, Dart, and 45/54 results remain contaminated development evidence only.
- This does not prove the packet beats native tools or CodeStory primitives.
- Graph and semantic retrieval have not yet earned default status through ablation.
- The branch remains at 0.17.5.
