### PR TITLE
[codex] qualify the evidence compiler against primitives

### DIFF
--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -18,6 +18,7 @@ name = "codestory-cli-runtime"
 path = "src/runtime_main.rs"
 
 [features]
+benchmark-support = ["codestory-runtime/benchmark-support"]
 proof-qualification-support = ["codestory-runtime/proof-qualification-support"]
 v3-evidence-separation-support = ["codestory-runtime/v3-evidence-separation-support"]
 

--- a/crates/codestory-cli/src/app/agent_context/packet.rs
+++ b/crates/codestory-cli/src/app/agent_context/packet.rs
@@ -17,12 +17,27 @@ use codestory_contracts::api::{AgentPacketDto, PacketBudgetModeDto, PacketDispos
 use codestory_contracts::packet_projection_v3::{
     EvidenceAvailabilityV3Dto, PacketProjectionV3Dto, RetrievalStateV3Dto,
 };
+#[cfg(feature = "benchmark-support")]
+use sha2::{Digest, Sha256};
 use std::fmt::Write as _;
+
+#[cfg(feature = "benchmark-support")]
+fn benchmark_request_receipt(request: &AgentPacketRequestDto) -> serde_json::Value {
+    serde_json::json!({
+        "question_sha256": format!("{:x}", Sha256::digest(request.question.as_bytes())),
+        "parent_packet_id": request.parent_packet_id.as_deref(),
+        "option_ids": &request.option_ids,
+        "core_generation_id": request.core_generation_id.as_deref(),
+        "retrieval_generation": request.retrieval_generation.as_deref(),
+    })
+}
 
 pub(in crate::app) fn run_packet(cmd: PacketCommand) -> Result<()> {
     ensure_dot_only_for_trail(cmd.format, "packet")?;
     preflight_output_file(cmd.output_file.as_deref())?;
     preflight_output_file(cmd.diagnostics_out.as_deref())?;
+    #[cfg(feature = "benchmark-support")]
+    preflight_output_file(cmd.benchmark_retrieval_proof_out.as_deref())?;
     args::validate_packet_probe_arguments(&cmd.probes).map_err(anyhow::Error::msg)?;
     let OpenedAgentSurface { runtime, .. } = open_agent_surface(
         &cmd.project,
@@ -33,7 +48,45 @@ pub(in crate::app) fn run_packet(cmd: PacketCommand) -> Result<()> {
     )?;
 
     let request = packet_request_from_command(&cmd);
+    #[cfg(feature = "benchmark-support")]
+    let benchmark_disable_dense_semantic = cmd.benchmark_disable_dense_semantic;
+    #[cfg(feature = "benchmark-support")]
+    let benchmark_retrieval_proof_out = cmd.benchmark_retrieval_proof_out.clone();
     let mut operation = runtime.run_public_operation("packet", || {
+        #[cfg(feature = "benchmark-support")]
+        let packet = {
+            let execution = runtime
+                .browser
+                .packet_for_benchmark(request.clone(), !benchmark_disable_dense_semantic)
+                .map_err(map_api_error)?;
+            if let Some(path) = benchmark_retrieval_proof_out.as_deref() {
+                let publication = execution
+                    .packet
+                    .answer
+                    .retrieval_trace
+                    .retrieval_publication
+                    .as_ref();
+                let proof = serde_json::json!({
+                    "contract": "codestory.packet-builder-ablation-receipt/v1",
+                    "requested_dense_semantic": !benchmark_disable_dense_semantic,
+                    "request": benchmark_request_receipt(&request),
+                    "retrieval_proof": execution.retrieval_proof,
+                    "core_generation_id": publication.map(|value| value.core_generation_id.as_str()),
+                    "core_run_id": publication.map(|value| value.core_run_id.as_str()),
+                    "retrieval_generation": publication.map(|value| value.retrieval_generation.as_str()),
+                    "semantic_generation": publication.map(|value| value.semantic_generation.as_str()),
+                });
+                let bytes = serde_json::to_vec_pretty(&proof)?;
+                codestory_workspace::atomic_file::publish_new_private_file_atomic(
+                    path,
+                    "codestory-packet-builder-ablation-proof",
+                    &bytes,
+                )
+                .map_err(anyhow::Error::new)?;
+            }
+            execution.packet
+        };
+        #[cfg(not(feature = "benchmark-support"))]
         let packet = runtime
             .browser
             .packet(request.clone())
@@ -384,6 +437,8 @@ pub(crate) fn packet_disposition_label(kind: PacketDispositionKindDto) -> &'stat
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "benchmark-support")]
+    use super::benchmark_request_receipt;
     use super::packet_request_from_command;
     use crate::args::{Cli, Command};
     use clap::Parser;
@@ -419,5 +474,41 @@ mod tests {
         assert_eq!(request.core_generation_id.as_deref(), Some("core-1"));
         assert_eq!(request.retrieval_generation.as_deref(), Some("retrieval-1"));
         assert_eq!(request.question, "explain indexing");
+    }
+
+    #[cfg(feature = "benchmark-support")]
+    #[test]
+    fn benchmark_receipt_binds_the_exact_packet_request() {
+        let cli = Cli::try_parse_from([
+            "codestory-cli",
+            "packet",
+            "--project",
+            "/tmp/project",
+            "--question",
+            "explain indexing",
+            "--parent-packet-id",
+            "packet-1",
+            "--option-id",
+            "gap-1",
+            "--core-generation-id",
+            "core-1",
+            "--retrieval-generation",
+            "retrieval-1",
+        ])
+        .expect("parse packet request");
+        let Command::Packet(cmd) = cli.command else {
+            panic!("expected packet command");
+        };
+        let request = packet_request_from_command(&cmd);
+        assert_eq!(
+            benchmark_request_receipt(&request),
+            serde_json::json!({
+                "question_sha256": "467ace0f0ea2c522ed79a393b5c1258c96c5a10fc8740d736fab1d3aca8dad7c",
+                "parent_packet_id": "packet-1",
+                "option_ids": ["gap-1"],
+                "core_generation_id": "core-1",
+                "retrieval_generation": "retrieval-1",
+            }),
+        );
     }
 }

--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -589,6 +589,12 @@ pub(crate) struct PacketCommand {
         help = "Write the immutable packet diagnostic projection atomically to this path."
     )]
     pub(crate) diagnostics_out: Option<PathBuf>,
+    #[cfg(feature = "benchmark-support")]
+    #[arg(long, hide = true)]
+    pub(crate) benchmark_disable_dense_semantic: bool,
+    #[cfg(feature = "benchmark-support")]
+    #[arg(long, value_name = "PATH", hide = true)]
+    pub(crate) benchmark_retrieval_proof_out: Option<PathBuf>,
 }
 
 #[derive(Args, Debug)]
@@ -2956,6 +2962,50 @@ mod tests {
         assert!(help.contains("--option-id <ID>"));
         assert!(help.contains("--core-generation-id <ID>"));
         assert!(help.contains("--retrieval-generation <ID>"));
+        assert!(!help.contains("benchmark-disable-dense-semantic"));
+    }
+
+    #[cfg(not(feature = "benchmark-support"))]
+    #[test]
+    fn product_packet_rejects_dense_semantic_ablation_flag() {
+        let error = Cli::try_parse_from([
+            "codestory-cli",
+            "packet",
+            "--project",
+            "/tmp/project",
+            "--question",
+            "explain indexing",
+            "--benchmark-disable-dense-semantic",
+        ])
+        .expect_err("product builds must not expose the benchmark-only ablation switch");
+        assert_eq!(error.kind(), clap::error::ErrorKind::UnknownArgument);
+    }
+
+    #[cfg(feature = "benchmark-support")]
+    #[test]
+    fn packet_parses_hidden_dense_semantic_ablation_flag() {
+        let packet = Cli::try_parse_from([
+            "codestory-cli",
+            "packet",
+            "--project",
+            "/tmp/project",
+            "--question",
+            "explain indexing",
+            "--benchmark-disable-dense-semantic",
+            "--benchmark-retrieval-proof-out",
+            "/tmp/retrieval-proof.json",
+        ])
+        .expect("benchmark build should parse the hidden packet ablation flag");
+        match packet.command {
+            Command::Packet(cmd) => {
+                assert!(cmd.benchmark_disable_dense_semantic);
+                assert_eq!(
+                    cmd.benchmark_retrieval_proof_out.as_deref(),
+                    Some(std::path::Path::new("/tmp/retrieval-proof.json")),
+                );
+            }
+            _ => panic!("expected packet command"),
+        }
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/executor.rs
+++ b/crates/codestory-retrieval/src/executor.rs
@@ -146,11 +146,18 @@ pub(crate) enum CandidatePayloadMode {
 }
 
 impl CandidatePayloadMode {
-    fn cache_fingerprint(self, fingerprint: String) -> String {
+    fn cache_fingerprint(self, fingerprint: String, include_dense_semantic: bool) -> String {
         match self {
             Self::Full => fingerprint,
-            Self::DescriptorOnly => format!("packet-descriptor/v1:{fingerprint}"),
+            Self::DescriptorOnly if include_dense_semantic => {
+                format!("packet-descriptor/v1:dense-on:{fingerprint}")
+            }
+            Self::DescriptorOnly => format!("packet-descriptor/v1:dense-off:{fingerprint}"),
         }
+    }
+
+    fn is_descriptor(self) -> bool {
+        self == Self::DescriptorOnly
     }
 }
 
@@ -160,7 +167,7 @@ impl<'a> QueryExecutor<'a> {
     /// `total_budget_ms` caps retrieval work only; it does not include runtime candidate
     /// resolution, packet sufficiency checks, or answer composition.
     pub fn execute(&mut self, query: &str, total_budget_ms: Option<u64>) -> Result<QueryResult> {
-        self.execute_with_payload(query, total_budget_ms, CandidatePayloadMode::Full)
+        self.execute_with_payload(query, total_budget_ms, CandidatePayloadMode::Full, true)
     }
 
     pub(crate) fn execute_packet_descriptors(
@@ -168,7 +175,31 @@ impl<'a> QueryExecutor<'a> {
         query: &str,
         total_budget_ms: Option<u64>,
     ) -> Result<QueryResult> {
-        self.execute_with_payload(query, total_budget_ms, CandidatePayloadMode::DescriptorOnly)
+        self.execute_with_payload(
+            query,
+            total_budget_ms,
+            CandidatePayloadMode::DescriptorOnly,
+            true,
+        )
+    }
+
+    /// Execute the production descriptor path with the dense semantic stage
+    /// removed for the builder-visible packet ablation.
+    ///
+    /// Full publication health is still required. This changes one retrieval
+    /// lane for measurement; it is unavailable to product builds.
+    #[cfg(feature = "benchmark-support")]
+    pub(crate) fn execute_packet_descriptors_without_dense_semantic_for_benchmark(
+        &mut self,
+        query: &str,
+        total_budget_ms: Option<u64>,
+    ) -> Result<QueryResult> {
+        self.execute_with_payload(
+            query,
+            total_budget_ms,
+            CandidatePayloadMode::DescriptorOnly,
+            false,
+        )
     }
 
     fn execute_with_payload(
@@ -176,10 +207,14 @@ impl<'a> QueryExecutor<'a> {
         query: &str,
         total_budget_ms: Option<u64>,
         payload: CandidatePayloadMode,
+        include_dense_semantic: bool,
     ) -> Result<QueryResult> {
         let request_started = Instant::now();
         let features = classify_query(query);
-        let fingerprint = payload.cache_fingerprint(query_fingerprint(&features.raw_query));
+        let fingerprint = payload.cache_fingerprint(
+            query_fingerprint(&features.raw_query),
+            include_dense_semantic,
+        );
 
         let (mode, degraded_reason) = self.resolve_mode(payload);
         if mode != RetrievalDegradedMode::Full {
@@ -223,7 +258,7 @@ impl<'a> QueryExecutor<'a> {
         }
 
         let mut plan = crate::planner::plan_query(&features, mode);
-        if payload == CandidatePayloadMode::DescriptorOnly {
+        if payload.is_descriptor() {
             // Both SCIP stages open the graph query view. The anchor stage
             // constructs its adjacency map even when it returns only anchors,
             // while expansion materializes neighbor evidence. Packet
@@ -235,6 +270,11 @@ impl<'a> QueryExecutor<'a> {
                     RetrievalStageKind::Stage0ScipAnchor | RetrievalStageKind::Stage2ScipExpand
                 )
             });
+        }
+        if !include_dense_semantic {
+            debug_assert!(payload.is_descriptor());
+            plan.stages
+                .retain(|stage| stage.kind != RetrievalStageKind::Stage1bSemantic);
         }
         let planned_budget_ms = plan.stages.iter().map(|stage| stage.budget_ms).sum::<u64>();
         if let Some(budget) = total_budget_ms {
@@ -325,7 +365,7 @@ impl<'a> QueryExecutor<'a> {
                     Some("sidecar_layout_missing".into()),
                 );
             };
-            let report = if payload == CandidatePayloadMode::DescriptorOnly {
+            let report = if payload.is_descriptor() {
                 if let (Some(embedding_device), Some(runtime)) = (
                     self.sidecars.embedding_device_readiness(),
                     self.sidecars.runtime_config(),
@@ -372,7 +412,7 @@ impl<'a> QueryExecutor<'a> {
             } else {
                 probe_sidecar_health(layout, &manifest.project_id, Some(manifest.clone()))
             };
-            return if payload == CandidatePayloadMode::DescriptorOnly {
+            return if payload.is_descriptor() {
                 crate::mode::derive_descriptor_mode(&report.lexical, &report.semantic)
             } else {
                 derive_degraded_mode(&report.lexical, &report.semantic, &report.scip)
@@ -398,7 +438,7 @@ impl<'a> QueryExecutor<'a> {
                 sidecars.scip_anchor_with_context(query, stage.top_k, context)
             }
             RetrievalStageKind::Stage1Lexical => {
-                if payload == CandidatePayloadMode::DescriptorOnly {
+                if payload.is_descriptor() {
                     sidecars.lexical_descriptor_search_with_context(query, stage.top_k, context)
                 } else {
                     sidecars.lexical_search_with_context(query, stage.top_k, context)
@@ -1394,6 +1434,84 @@ mod tests {
                 .hits
                 .iter()
                 .all(|hit| hit.source_excerpt.is_none() && hit.target.is_none())
+        );
+    }
+
+    #[cfg(feature = "benchmark-support")]
+    #[test]
+    fn benchmark_packet_descriptor_control_executes_no_dense_semantic_stage() {
+        struct DenseSemanticTripwire;
+
+        impl SidecarSearch for DenseSemanticTripwire {
+            fn lexical_search(&self, _query: &str, _limit: usize) -> Result<Vec<CandidateHit>> {
+                let mut hit = CandidateHit::with_source(
+                    "src/lexical.rs",
+                    Some("lexical_anchor".into()),
+                    0.9,
+                    CandidateSource::Lexical,
+                );
+                hit.node_id = Some("17".into());
+                hit.source_bytes_upper_bound = Some(512);
+                Ok(vec![hit])
+            }
+
+            fn semantic_search(&self, _query: &str, _limit: usize) -> Result<Vec<CandidateHit>> {
+                panic!("dense semantic retrieval must not execute in the benchmark control")
+            }
+
+            fn scip_anchor(&self, _query: &str, _limit: usize) -> Result<Vec<CandidateHit>> {
+                Ok(Vec::new())
+            }
+
+            fn scip_expand(
+                &self,
+                _anchors: &[CandidateHit],
+                _limit: usize,
+            ) -> Result<Vec<CandidateHit>> {
+                Ok(Vec::new())
+            }
+        }
+
+        let query = "explain the unfamiliar subsystem";
+        let manifest = sample_manifest();
+        let mut cache = RetrievalCache::new();
+        let dense_on_key = RetrievalCacheKey::from_manifest(
+            &manifest,
+            CandidatePayloadMode::DescriptorOnly.cache_fingerprint(query_fingerprint(query), true),
+        );
+        cache.insert(
+            dense_on_key,
+            vec![CandidateHit::lexical_stub("src/stale-dense-on.rs", 1.0)],
+        );
+        let mut executor = QueryExecutor {
+            sidecars: Arc::new(DenseSemanticTripwire),
+            cache: &mut cache,
+            manifest: Some(manifest),
+            file_roles: Arc::new(HashMap::new()),
+            cancelled: cancellation_flag(),
+            mode_override: Some(RetrievalDegradedMode::Full),
+        };
+
+        let result = executor
+            .execute_packet_descriptors_without_dense_semantic_for_benchmark(query, Some(800))
+            .expect("lexical descriptor control");
+
+        assert!(
+            !result.trace.cache_hit,
+            "dense-on cache entries must not cross into the control"
+        );
+        assert!(
+            result
+                .hits
+                .iter()
+                .any(|hit| hit.file_path == "src/lexical.rs")
+        );
+        assert!(
+            result
+                .trace
+                .stages
+                .iter()
+                .all(|stage| { stage.stage != RetrievalStageKind::Stage1bSemantic })
         );
     }
 

--- a/crates/codestory-retrieval/src/query.rs
+++ b/crates/codestory-retrieval/src/query.rs
@@ -400,6 +400,28 @@ impl PinnedQuerySession {
         cancelled: Option<Arc<AtomicBool>>,
         cache: &mut RetrievalCache,
     ) -> Result<QueryResult> {
+        self.execute_packet_descriptors_with_cache_policy(query, budget_ms, cancelled, cache, true)
+    }
+
+    #[cfg(feature = "benchmark-support")]
+    pub fn execute_packet_descriptors_without_dense_semantic_for_benchmark_with_cache(
+        &self,
+        query: &str,
+        budget_ms: Option<u64>,
+        cancelled: Option<Arc<AtomicBool>>,
+        cache: &mut RetrievalCache,
+    ) -> Result<QueryResult> {
+        self.execute_packet_descriptors_with_cache_policy(query, budget_ms, cancelled, cache, false)
+    }
+
+    fn execute_packet_descriptors_with_cache_policy(
+        &self,
+        query: &str,
+        budget_ms: Option<u64>,
+        cancelled: Option<Arc<AtomicBool>>,
+        cache: &mut RetrievalCache,
+        include_dense_semantic: bool,
+    ) -> Result<QueryResult> {
         let cancelled = cancelled.unwrap_or_else(cancellation_flag);
         if cancelled.load(Ordering::Acquire) {
             bail!("retrieval query cancelled before preflight");
@@ -413,7 +435,18 @@ impl PinnedQuerySession {
             cancelled,
             mode_override: None,
         };
-        let mut result = executor.execute_packet_descriptors(query, budget_ms)?;
+        let mut result = if include_dense_semantic {
+            executor.execute_packet_descriptors(query, budget_ms)?
+        } else {
+            #[cfg(feature = "benchmark-support")]
+            {
+                executor.execute_packet_descriptors_without_dense_semantic_for_benchmark(
+                    query, budget_ms,
+                )?
+            }
+            #[cfg(not(feature = "benchmark-support"))]
+            unreachable!("dense semantic packet control requires benchmark-support")
+        };
         sanitize_packet_candidate_descriptors(&mut result.hits);
         Ok(result.with_publication_identity(&self.publication_identity))
     }
@@ -469,6 +502,26 @@ impl PinnedQuerySession {
         cancelled: Option<Arc<AtomicBool>>,
         cache: &mut RetrievalCache,
     ) -> Result<Vec<QueryResult>> {
+        self.execute_packet_descriptor_batch_with_cache_policy(queries, cancelled, cache, true)
+    }
+
+    #[cfg(feature = "benchmark-support")]
+    pub fn execute_packet_descriptor_batch_without_dense_semantic_for_benchmark_with_cache(
+        &self,
+        queries: &[QueryBatchItem<'_>],
+        cancelled: Option<Arc<AtomicBool>>,
+        cache: &mut RetrievalCache,
+    ) -> Result<Vec<QueryResult>> {
+        self.execute_packet_descriptor_batch_with_cache_policy(queries, cancelled, cache, false)
+    }
+
+    fn execute_packet_descriptor_batch_with_cache_policy(
+        &self,
+        queries: &[QueryBatchItem<'_>],
+        cancelled: Option<Arc<AtomicBool>>,
+        cache: &mut RetrievalCache,
+        include_dense_semantic: bool,
+    ) -> Result<Vec<QueryResult>> {
         if queries.is_empty() {
             return Ok(Vec::new());
         }
@@ -499,6 +552,7 @@ impl PinnedQuerySession {
             queries,
             cache,
             strict_batch_worker_limit(queries.len()),
+            include_dense_semantic,
         )?;
         for result in &mut results {
             sanitize_packet_candidate_descriptors(&mut result.hits);
@@ -747,6 +801,7 @@ fn execute_strict_retrieval_query_batch_against_sidecars(
         cache,
         worker_limit,
         CandidatePayloadMode::Full,
+        true,
     )
 }
 
@@ -760,6 +815,7 @@ fn execute_strict_retrieval_descriptor_batch_against_sidecars(
     queries: &[QueryBatchItem<'_>],
     cache: &mut RetrievalCache,
     worker_limit: usize,
+    include_dense_semantic: bool,
 ) -> Result<Vec<QueryResult>> {
     execute_strict_retrieval_query_batch_against_sidecars_with_payload(
         sidecars,
@@ -771,6 +827,7 @@ fn execute_strict_retrieval_descriptor_batch_against_sidecars(
         cache,
         worker_limit,
         CandidatePayloadMode::DescriptorOnly,
+        include_dense_semantic,
     )
 }
 
@@ -785,6 +842,7 @@ fn execute_strict_retrieval_query_batch_against_sidecars_with_payload(
     cache: &mut RetrievalCache,
     worker_limit: usize,
     payload: CandidatePayloadMode,
+    include_dense_semantic: bool,
 ) -> Result<Vec<QueryResult>> {
     if mode != RetrievalDegradedMode::Full {
         bail!(
@@ -846,8 +904,19 @@ fn execute_strict_retrieval_query_batch_against_sidecars_with_payload(
                         CandidatePayloadMode::Full => {
                             executor.execute(query, Some(remaining_budget_ms))
                         }
+                        CandidatePayloadMode::DescriptorOnly if include_dense_semantic => executor
+                            .execute_packet_descriptors(query, Some(remaining_budget_ms)),
                         CandidatePayloadMode::DescriptorOnly => {
-                            executor.execute_packet_descriptors(query, Some(remaining_budget_ms))
+                            #[cfg(feature = "benchmark-support")]
+                            {
+                                executor
+                                    .execute_packet_descriptors_without_dense_semantic_for_benchmark(
+                                        query,
+                                        Some(remaining_budget_ms),
+                                    )
+                            }
+                            #[cfg(not(feature = "benchmark-support"))]
+                            unreachable!("dense semantic packet control requires benchmark-support")
                         }
                     }
                     .map(|mut result| {
@@ -1637,6 +1706,69 @@ mod tests {
             ]
         );
         assert_eq!(sidecars.max_active.load(Ordering::SeqCst), 2);
+    }
+
+    #[cfg(feature = "benchmark-support")]
+    #[test]
+    fn benchmark_descriptor_batch_executes_no_dense_semantic_stage() {
+        struct DenseSemanticTripwire;
+
+        impl SidecarSearch for DenseSemanticTripwire {
+            fn lexical_search(&self, query: &str, _limit: usize) -> Result<Vec<CandidateHit>> {
+                Ok(vec![CandidateHit::lexical_stub(
+                    format!("src/{query}.rs"),
+                    1.0,
+                )])
+            }
+
+            fn semantic_search(&self, _query: &str, _limit: usize) -> Result<Vec<CandidateHit>> {
+                panic!("dense semantic retrieval must not execute in the descriptor batch control")
+            }
+
+            fn scip_anchor(&self, _query: &str, _limit: usize) -> Result<Vec<CandidateHit>> {
+                Ok(Vec::new())
+            }
+
+            fn scip_expand(
+                &self,
+                _anchors: &[CandidateHit],
+                _limit: usize,
+            ) -> Result<Vec<CandidateHit>> {
+                Ok(Vec::new())
+            }
+        }
+
+        let queries = [
+            QueryBatchItem {
+                query: "alpha flow",
+                budget_ms: Some(500),
+            },
+            QueryBatchItem {
+                query: "beta flow",
+                budget_ms: Some(500),
+            },
+        ];
+        let results = execute_strict_retrieval_descriptor_batch_against_sidecars(
+            Arc::new(DenseSemanticTripwire),
+            Some(manifest_for("testproj", "descriptor-control", 2)),
+            Arc::new(HashMap::new()),
+            cancellation_flag(),
+            RetrievalDegradedMode::Full,
+            &queries,
+            &mut RetrievalCache::new(),
+            2,
+            false,
+        )
+        .expect("descriptor batch control");
+
+        assert_eq!(results.len(), 2);
+        assert!(results.iter().all(|result| {
+            result
+                .trace
+                .stages
+                .iter()
+                .all(|stage| stage.stage != crate::planner::RetrievalStageKind::Stage1bSemantic)
+        }));
     }
 
     #[test]

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [features]
 default = ["proof-qualification-support"]
-benchmark-support = []
+benchmark-support = ["codestory-retrieval/benchmark-support"]
 proof-qualification-support = []
 v3-evidence-separation-support = ["codestory-agent/v3-evidence-separation-support"]
 # The runtime test hooks now partly live in codestory-agent (fresh_index_observation

--- a/crates/codestory-runtime/src/agent/mod.rs
+++ b/crates/codestory-runtime/src/agent/mod.rs
@@ -61,6 +61,8 @@ pub(crate) use codestory_agent::{
     packet_freshness, packet_plan, packet_scoring, packet_terms, planning, profiles,
 };
 
+#[cfg(feature = "benchmark-support")]
+pub(crate) use orchestrator::agent_packet_for_benchmark;
 pub(crate) use orchestrator::{agent_ask, agent_packet};
 pub use packet_budget::enforce_packet_output_budget_for_representation;
 pub use packet_follow_up::bind_packet_follow_up_program;

--- a/crates/codestory-runtime/src/agent/orchestrator.rs
+++ b/crates/codestory-runtime/src/agent/orchestrator.rs
@@ -3,6 +3,8 @@ use crate::agent::packet_batch::{PacketLatencyBudget, run_packet_planned_subquer
 use crate::agent::packet_budget::{
     apply_packet_budget, enforce_packet_output_budget, packet_budget_limits,
 };
+#[cfg(feature = "benchmark-support")]
+use crate::agent::packet_candidate::BenchmarkPacketRetrievalProof;
 use crate::agent::packet_candidate::{
     PacketProofSession, PacketSearchHit, install_packet_proof_session,
 };
@@ -321,6 +323,38 @@ pub(crate) fn agent_packet(
     controller: &AppController,
     req: AgentPacketRequestDto,
 ) -> Result<AgentPacketDto, ApiError> {
+    agent_packet_with_session(controller, req, std::rc::Rc::new(PacketProofSession::new()))
+}
+
+#[cfg(feature = "benchmark-support")]
+pub(crate) struct BenchmarkPacketExecution {
+    pub(crate) packet: AgentPacketDto,
+    pub(crate) retrieval_proof: BenchmarkPacketRetrievalProof,
+}
+
+#[cfg(feature = "benchmark-support")]
+pub(crate) fn agent_packet_for_benchmark(
+    controller: &AppController,
+    req: AgentPacketRequestDto,
+    include_dense_semantic: bool,
+) -> Result<BenchmarkPacketExecution, ApiError> {
+    let proof_session = std::rc::Rc::new(if include_dense_semantic {
+        PacketProofSession::new()
+    } else {
+        PacketProofSession::without_dense_semantic_for_benchmark()
+    });
+    let packet = agent_packet_with_session(controller, req, std::rc::Rc::clone(&proof_session))?;
+    Ok(BenchmarkPacketExecution {
+        packet,
+        retrieval_proof: proof_session.benchmark_retrieval_proof(),
+    })
+}
+
+fn agent_packet_with_session(
+    controller: &AppController,
+    req: AgentPacketRequestDto,
+    proof_session: std::rc::Rc<PacketProofSession>,
+) -> Result<AgentPacketDto, ApiError> {
     let question = req.question.trim().to_string();
     if question.is_empty() {
         return Err(ApiError::invalid_argument("Question cannot be empty."));
@@ -330,7 +364,6 @@ pub(crate) fn agent_packet(
     let project_root = controller.require_project_root()?;
     let project_id = codestory_workspace::project_identity_v3(&project_root).project_id;
     controller.begin_packet_retrieval();
-    let proof_session = std::rc::Rc::new(PacketProofSession::new());
     let _proof_session_guard = install_packet_proof_session(std::rc::Rc::clone(&proof_session));
 
     if !req.option_ids.is_empty() && req.parent_packet_id.is_none() {

--- a/crates/codestory-runtime/src/agent/packet_candidate.rs
+++ b/crates/codestory-runtime/src/agent/packet_candidate.rs
@@ -14,7 +14,11 @@ use codestory_contracts::compilation::{
 };
 use codestory_contracts::graph::NodeId as CoreNodeId;
 use sha2::{Digest, Sha256};
+#[cfg(feature = "benchmark-support")]
+use std::cell::Cell;
 use std::cell::RefCell;
+#[cfg(feature = "benchmark-support")]
+use std::collections::BTreeMap;
 use std::collections::{HashMap, HashSet};
 use std::ops::Deref;
 use std::rc::Rc;
@@ -35,7 +39,7 @@ pub(crate) enum PacketGraphDirection {
 /// Formula hydration, trail-scan ledgers, and promotion need-sets no longer
 /// live here. The session only bounds how many candidates may hydrate and how
 /// many source bytes they may charge before exact hydration.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub(crate) struct PacketProofSession {
     /// Packet-scoped count of candidates selected for source/graph hydration.
     /// Horizon A admits at most [`INTERIM_MAX_ADMITTED_CANDIDATES`] across the
@@ -47,6 +51,34 @@ pub(crate) struct PacketProofSession {
     receipts: RefCell<Vec<PacketAdmissionReceiptV1>>,
     gaps: RefCell<Vec<PacketAdmissionGapV1>>,
     retrieval_admission_sealed: RefCell<bool>,
+    #[cfg(feature = "benchmark-support")]
+    include_dense_semantic: bool,
+    #[cfg(feature = "benchmark-support")]
+    descriptor_query_count: Cell<u32>,
+    #[cfg(feature = "benchmark-support")]
+    descriptor_cache_hit_count: Cell<u32>,
+    #[cfg(feature = "benchmark-support")]
+    descriptor_stage_invocations: RefCell<BTreeMap<String, u32>>,
+    #[cfg(feature = "benchmark-support")]
+    descriptor_stage_candidates: RefCell<BTreeMap<String, u64>>,
+}
+
+impl Default for PacketProofSession {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(feature = "benchmark-support")]
+#[derive(Debug, Clone, serde::Serialize)]
+pub(crate) struct BenchmarkPacketRetrievalProof {
+    pub contract: &'static str,
+    pub requested_policy: &'static str,
+    pub descriptor_query_count: u32,
+    pub descriptor_cache_hit_count: u32,
+    pub descriptor_stage_invocations: BTreeMap<String, u32>,
+    pub descriptor_stage_candidates: BTreeMap<String, u64>,
+    pub dense_semantic_stage_invocations: u32,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -66,6 +98,72 @@ impl PacketProofSession {
             receipts: RefCell::new(Vec::new()),
             gaps: RefCell::new(Vec::new()),
             retrieval_admission_sealed: RefCell::new(false),
+            #[cfg(feature = "benchmark-support")]
+            include_dense_semantic: true,
+            #[cfg(feature = "benchmark-support")]
+            descriptor_query_count: Cell::new(0),
+            #[cfg(feature = "benchmark-support")]
+            descriptor_cache_hit_count: Cell::new(0),
+            #[cfg(feature = "benchmark-support")]
+            descriptor_stage_invocations: RefCell::new(BTreeMap::new()),
+            #[cfg(feature = "benchmark-support")]
+            descriptor_stage_candidates: RefCell::new(BTreeMap::new()),
+        }
+    }
+
+    #[cfg(feature = "benchmark-support")]
+    pub(crate) fn without_dense_semantic_for_benchmark() -> Self {
+        Self {
+            include_dense_semantic: false,
+            ..Self::new()
+        }
+    }
+
+    #[cfg(feature = "benchmark-support")]
+    pub(crate) fn includes_dense_semantic(&self) -> bool {
+        self.include_dense_semantic
+    }
+
+    #[cfg(feature = "benchmark-support")]
+    pub(crate) fn record_descriptor_trace(&self, trace: &codestory_retrieval::QueryTrace) {
+        self.descriptor_query_count
+            .set(self.descriptor_query_count.get().saturating_add(1));
+        if trace.cache_hit {
+            self.descriptor_cache_hit_count
+                .set(self.descriptor_cache_hit_count.get().saturating_add(1));
+        }
+        let mut invocations = self.descriptor_stage_invocations.borrow_mut();
+        let mut candidates = self.descriptor_stage_candidates.borrow_mut();
+        for stage in &trace.stages {
+            if stage.completion_status != codestory_retrieval::StageCompletionStatus::Completed {
+                continue;
+            }
+            let label = stage.stage.label().to_string();
+            let invocation_count = invocations.entry(label.clone()).or_default();
+            *invocation_count = invocation_count.saturating_add(1);
+            let candidate_count = candidates.entry(label).or_default();
+            *candidate_count = candidate_count.saturating_add(stage.candidates_added as u64);
+        }
+    }
+
+    #[cfg(feature = "benchmark-support")]
+    pub(crate) fn benchmark_retrieval_proof(&self) -> BenchmarkPacketRetrievalProof {
+        let descriptor_stage_invocations = self.descriptor_stage_invocations.borrow().clone();
+        BenchmarkPacketRetrievalProof {
+            contract: "codestory.packet-dense-candidate-ablation-proof/v1",
+            requested_policy: if self.include_dense_semantic {
+                "repository_graph_lexical_dense_candidate_stage_enabled_v1"
+            } else {
+                "repository_graph_lexical_dense_candidate_stage_disabled_v1"
+            },
+            descriptor_query_count: self.descriptor_query_count.get(),
+            descriptor_cache_hit_count: self.descriptor_cache_hit_count.get(),
+            dense_semantic_stage_invocations: descriptor_stage_invocations
+                .get("stage1b_semantic")
+                .copied()
+                .unwrap_or(0),
+            descriptor_stage_invocations,
+            descriptor_stage_candidates: self.descriptor_stage_candidates.borrow().clone(),
         }
     }
 
@@ -551,6 +649,72 @@ mod tests {
         PacketEvidenceResolutionDto, PacketEvidenceTierDto, SearchHitOrigin,
     };
     use codestory_contracts::compilation::{PacketRetrievalLaneV1, VersionedRetrievalScoreV1};
+
+    #[cfg(feature = "benchmark-support")]
+    #[test]
+    fn benchmark_retrieval_proof_records_executed_descriptor_stages() {
+        assert!(
+            PacketProofSession::default().includes_dense_semantic(),
+            "enabling benchmark support must not change the normal packet default"
+        );
+        let session = PacketProofSession::without_dense_semantic_for_benchmark();
+        session.record_descriptor_trace(&codestory_retrieval::QueryTrace {
+            retrieval_mode: "full".into(),
+            degraded_reason: None,
+            total_budget_ms: 800,
+            elapsed_ms: 4,
+            cancel_reason: None,
+            cache_hit: false,
+            stages: vec![
+                codestory_retrieval::StageTrace {
+                    stage: codestory_retrieval::RetrievalStageKind::Stage1Lexical,
+                    budget_ms: 200,
+                    elapsed_ms: 4,
+                    admission_wait_ms: 0,
+                    queue_wait_ms: Some(0),
+                    execution_ms: Some(4),
+                    candidates_added: 3,
+                    marginal_gain: 1.0,
+                    cancel_reason: None,
+                    cache_hit: false,
+                    degraded: false,
+                    stub_reason: None,
+                    completion_status: codestory_retrieval::StageCompletionStatus::Completed,
+                },
+                codestory_retrieval::StageTrace {
+                    stage: codestory_retrieval::RetrievalStageKind::Stage1bSemantic,
+                    budget_ms: 200,
+                    elapsed_ms: 0,
+                    admission_wait_ms: 0,
+                    queue_wait_ms: None,
+                    execution_ms: None,
+                    candidates_added: 0,
+                    marginal_gain: 0.0,
+                    cancel_reason: Some("unique_exact_definition".into()),
+                    cache_hit: false,
+                    degraded: false,
+                    stub_reason: None,
+                    completion_status: codestory_retrieval::StageCompletionStatus::Skipped,
+                },
+            ],
+        });
+
+        let proof = session.benchmark_retrieval_proof();
+        assert_eq!(proof.descriptor_query_count, 1);
+        assert_eq!(proof.descriptor_cache_hit_count, 0);
+        assert_eq!(proof.dense_semantic_stage_invocations, 0);
+        assert!(
+            !proof
+                .descriptor_stage_invocations
+                .contains_key("stage1b_semantic")
+        );
+        assert_eq!(proof.descriptor_stage_invocations["stage1_lexical"], 1);
+        assert_eq!(proof.descriptor_stage_candidates["stage1_lexical"], 3);
+        assert_eq!(
+            proof.requested_policy,
+            "repository_graph_lexical_dense_candidate_stage_disabled_v1"
+        );
+    }
 
     #[test]
     fn admission_is_packet_wide_identity_deduplicated_and_count_bounded() {

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -137,6 +137,13 @@ impl RetrievalPublicationResponse for AgentPacketDto {
     }
 }
 
+#[cfg(feature = "benchmark-support")]
+impl RetrievalPublicationResponse for super::orchestrator::BenchmarkPacketExecution {
+    fn attach_retrieval_publication(&mut self, publication: EmbeddingVectorPublicationIdentityDto) {
+        self.packet.attach_retrieval_publication(publication);
+    }
+}
+
 fn publication_dto(pinned: &PinnedRetrievalRead) -> EmbeddingVectorPublicationIdentityDto {
     let publication = pinned.session.publication_identity();
     EmbeddingVectorPublicationIdentityDto {
@@ -951,7 +958,19 @@ pub(crate) fn preadmit_packet_descriptor_queries(
                 budget_ms: Some(per_query_budget),
             })
             .collect::<Vec<_>>();
+        #[cfg(feature = "benchmark-support")]
+        let include_dense_semantic = session.includes_dense_semantic();
         let query_results = with_detached_sidecar_query_cache(controller, |cache| {
+            #[cfg(feature = "benchmark-support")]
+            if !include_dense_semantic {
+                return pinned
+                    .session
+                    .execute_packet_descriptor_batch_without_dense_semantic_for_benchmark_with_cache(
+                        &batch_items,
+                        crate::services::active_public_operation_cancellation(),
+                        cache,
+                    );
+            }
             pinned.session.execute_packet_descriptor_batch_with_cache(
                 &batch_items,
                 crate::services::active_public_operation_cancellation(),
@@ -959,6 +978,10 @@ pub(crate) fn preadmit_packet_descriptor_queries(
             )
         })
         .map_err(map_pinned_query_error)?;
+        #[cfg(feature = "benchmark-support")]
+        for result in &query_results {
+            session.record_descriptor_trace(&result.trace);
+        }
         if query_results.len() != queries.len() {
             return Err(sidecar_retrieval_unavailable_error(
                 controller,
@@ -1053,7 +1076,18 @@ pub(crate) fn run_and_resolve_sidecar_query(
 ) -> Result<(QueryResult, SidecarCandidateResolutionOutcome), ApiError> {
     with_pinned_retrieval_read(controller, |pinned| {
         let query_result = with_detached_sidecar_query_cache(controller, |cache| {
-            if crate::agent::packet_candidate::active_packet_proof_session().is_some() {
+            if let Some(_session) = crate::agent::packet_candidate::active_packet_proof_session() {
+                #[cfg(feature = "benchmark-support")]
+                if !_session.includes_dense_semantic() {
+                    return pinned
+                        .session
+                        .execute_packet_descriptors_without_dense_semantic_for_benchmark_with_cache(
+                            query,
+                            Some(sidecar_budget_ms(latency_budget_ms)),
+                            crate::services::active_public_operation_cancellation(),
+                            cache,
+                        );
+                }
                 pinned.session.execute_packet_descriptors_with_cache(
                     query,
                     Some(sidecar_budget_ms(latency_budget_ms)),
@@ -1070,6 +1104,10 @@ pub(crate) fn run_and_resolve_sidecar_query(
             }
         })
         .map_err(map_pinned_query_error)?;
+        #[cfg(feature = "benchmark-support")]
+        if let Some(session) = crate::agent::packet_candidate::active_packet_proof_session() {
+            session.record_descriptor_trace(&query_result.trace);
+        }
         pinned.ensure_query_identity(&query_result, "resolving sidecar candidates")?;
         let resolution = resolve_sidecar_candidates_in_read(
             controller,
@@ -1344,6 +1382,18 @@ fn search_sidecar_packet_batch_inner(
             })
             .collect::<Vec<_>>();
         let query_results = with_detached_sidecar_query_cache(controller, |cache| {
+            #[cfg(feature = "benchmark-support")]
+            if active_packet_proof_session()
+                .is_some_and(|session| !session.includes_dense_semantic())
+            {
+                return pinned
+                    .session
+                    .execute_packet_descriptor_batch_without_dense_semantic_for_benchmark_with_cache(
+                        &batch_items,
+                        crate::services::active_public_operation_cancellation(),
+                        cache,
+                    );
+            }
             pinned.session.execute_packet_descriptor_batch_with_cache(
                 &batch_items,
                 crate::services::active_public_operation_cancellation(),
@@ -1351,6 +1401,12 @@ fn search_sidecar_packet_batch_inner(
             )
         })
         .map_err(map_pinned_query_error)?;
+        #[cfg(feature = "benchmark-support")]
+        if let Some(session) = active_packet_proof_session() {
+            for result in &query_results {
+                session.record_descriptor_trace(&result.trace);
+            }
+        }
         for result in &query_results {
             pinned.ensure_query_identity(result, "resolving sidecar packet batch")?;
         }

--- a/crates/codestory-runtime/src/browser.rs
+++ b/crates/codestory-runtime/src/browser.rs
@@ -41,6 +41,13 @@ pub struct BrowserQueryItem {
     pub source: String,
 }
 
+#[cfg(feature = "benchmark-support")]
+#[derive(Debug, Clone)]
+pub struct BenchmarkPacketExecution {
+    pub packet: AgentPacketDto,
+    pub retrieval_proof: serde_json::Value,
+}
+
 /// Runtime-owned read-only codebase browser boundary.
 ///
 /// This facade intentionally exposes repository lookup, grounding, and DB-first
@@ -157,6 +164,32 @@ impl ReadOnlyBrowserService {
 
     pub fn packet(&self, req: AgentPacketRequestDto) -> Result<AgentPacketDto, ApiError> {
         self.run_public("packet", || self.controller.agent_packet(req.clone()))
+    }
+
+    /// Measurement-only packet control that executes the same compiler while
+    /// recording whether the dense descriptor stage actually ran.
+    #[cfg(feature = "benchmark-support")]
+    #[doc(hidden)]
+    pub fn packet_for_benchmark(
+        &self,
+        req: AgentPacketRequestDto,
+        include_dense_semantic: bool,
+    ) -> Result<BenchmarkPacketExecution, ApiError> {
+        self.run_public("packet", || {
+            let execution = self
+                .controller
+                .agent_packet_for_benchmark(req.clone(), include_dense_semantic)?;
+            Ok(BenchmarkPacketExecution {
+                packet: execution.packet,
+                retrieval_proof: serde_json::to_value(execution.retrieval_proof).map_err(
+                    |error| {
+                        ApiError::internal(format!(
+                            "serialize benchmark packet retrieval proof: {error}"
+                        ))
+                    },
+                )?,
+            })
+        })
     }
 
     pub fn search(&self, req: SearchRequest) -> Result<Vec<SearchHit>, ApiError> {

--- a/crates/codestory-runtime/src/controller_symbols.rs
+++ b/crates/codestory-runtime/src/controller_symbols.rs
@@ -392,6 +392,23 @@ impl AppController {
         })
     }
 
+    #[cfg(feature = "benchmark-support")]
+    pub(crate) fn agent_packet_for_benchmark(
+        &self,
+        req: AgentPacketRequestDto,
+        include_dense_semantic: bool,
+    ) -> Result<agent::orchestrator::BenchmarkPacketExecution, ApiError> {
+        self.with_complete_core_snapshot(|publication| {
+            agent::retrieval_primary::with_stable_packet_retrieval_publication(
+                self,
+                "packet output",
+                &publication.generation_id,
+                &publication.run_id,
+                || agent::agent_packet_for_benchmark(self, req.clone(), include_dense_semantic),
+            )
+        })
+    }
+
     pub fn graph_neighborhood(&self, req: GraphRequest) -> Result<GraphResponse, ApiError> {
         graph_builders::graph_neighborhood(self, req)
     }

--- a/docs/testing/agent-benchmark-harness-verification.md
+++ b/docs/testing/agent-benchmark-harness-verification.md
@@ -5,6 +5,11 @@
 Scope: transcript analysis and manifest-backed quality scoring for
 `scripts/codestory-agent-ab-benchmark.mjs`.
 
+The historical 18-task language-expansion corpus is builder-visible and
+contaminated. Runs against it can diagnose the harness and guide one general
+compiler revision; they cannot authorize a release or support product-facing
+accuracy claims.
+
 The harness exposes pure analyzer/scorer functions and keeps a built-in
 fixture smoke test:
 
@@ -17,6 +22,12 @@ The focused Node fixture lives at
 
 ```sh
 node --test ./scripts/tests/codestory-agent-ab-analyzer.test.mjs
+```
+
+The evidence-compiler ablation has a separate frozen contract test:
+
+```sh
+node --test ./scripts/tests/codestory-evidence-compiler-ablation.test.mjs
 ```
 
 The fixture verifies:
@@ -56,7 +67,88 @@ owns query planning.
 Keep `node ./scripts/codestory-agent-ab-benchmark.mjs --list` as the cheapest
 configuration smoke check.
 
-The language-support promotion packet-runtime suite is:
+The five-arm builder-visible evidence-compiler ablation is:
+
+```sh
+cargo build --locked --release -p codestory-cli --features benchmark-support
+node scripts/codestory-agent-ab-benchmark.mjs \
+  --builder-ablation \
+  --materialize-repos \
+  --codestory-cli target/release/codestory-cli \
+  --out-dir target/agent-benchmark/evidence-compiler-builder
+```
+
+It runs three fresh repeats of native tools, exact identity/source, exact plus
+explicit relations, packet without dense candidates, and packet with dense
+candidates. The agent may inspect source and adapt in every arm. The two packet
+arms use one benchmark-only binary and record whether the dense candidate stage
+actually executed. The harness never follows a continuation automatically.
+Each agent session has an opaque, treatment-blind ephemeral Codex home with no
+MCP configuration. Exact-operation arguments are allowlisted and bind the
+pinned project plus prepared agent namespace; cache, refresh, and output-path
+overrides invalidate the row. If the agent chooses the one permitted typed
+continuation, it must use the same checksum-bound CLI and write a second
+execution receipt; the join rejects a failed call, an option not offered by the
+initial packet, a changed request or publication, or a changed dense-stage
+policy. The agent sees neither the initial harness command nor its task-shaped
+artifact paths. Typed
+continuations hold dense retrieval disabled in both packet arms, so only the
+withheld initial packet prelude differs between the dense treatments.
+Packet exploration is the median paired ratio of observed local
+repository-context actions after the matched first successful CodeStory action
+begins. The slice starts at the action boundary rather than the result boundary,
+so context gathered in parallel while CodeStory runs cannot disappear between
+the first-action fence and the exploration metric. A
+known local search, source-read, Git, build/test, or CodeStory command is an
+observed action even when it produces no output. Any other command is an
+observed action when it emits non-whitespace output while running in the pinned
+repository. Non-command tool calls are observed actions as well. Exit status
+does not erase context that already reached the agent, so a failing command
+that printed source still counts. The first-action fence uses this same
+observed-action boundary. This deliberately overcounts ambiguous output rather
+than letting an unfamiliar reader, extensionless file, glob, or failing shell
+pipeline make a treatment look better. Command-shaped source reads and output
+bytes remain diagnostic only. Equal zero-work rows count as equal, not as a
+packet reduction.
+
+Prepare the arm-blinded case bundle and keep the case map from the independent
+reviewer:
+
+```sh
+node scripts/codestory-evidence-compiler-ablation-adjudication.mjs \
+  --prepare \
+  --run-dir target/agent-benchmark/evidence-compiler-builder \
+  --output-dir target/agent-benchmark/evidence-compiler-builder/adjudication
+```
+
+The independent reviewer adjudicates all 96 CodeStory-arm answers for critical
+factual and unsupported relation claims, without the map or experimental arm
+names. Join
+the returned judgments to the withheld map, then evaluate the receipt:
+
+```sh
+node scripts/codestory-evidence-compiler-ablation-adjudication.mjs \
+  --finalize \
+  --run-dir target/agent-benchmark/evidence-compiler-builder \
+  --cases target/agent-benchmark/evidence-compiler-builder/adjudication/blinded-cases.json \
+  --map target/agent-benchmark/evidence-compiler-builder/adjudication/private-case-map.json \
+  --judgments <blinded-judgments.json> \
+  --output target/agent-benchmark/evidence-compiler-builder/adjudication.json
+node scripts/codestory-evidence-compiler-ablation-evaluate.mjs \
+  --run-dir target/agent-benchmark/evidence-compiler-builder \
+  --adjudication target/agent-benchmark/evidence-compiler-builder/adjudication.json \
+  --attempt initial
+```
+
+The resulting receipt is development evidence only. A failed packet gate
+must be classified by rerunning evaluation with
+`--causal-classification new|equivalent`. A new causal class permits one
+general compiler revision; an equivalent failure or any failed
+`--attempt general_revision` emits the machine `stop` decision. The same
+receipt explicitly keeps or disables graph and dense-semantic defaults from
+their independently adjudicated marginal comparisons.
+
+The legacy language-support packet-runtime diagnostic is:
 
 ```powershell
 $env:CODESTORY_EMBED_MODEL_SOURCE = (node scripts/prepare-embedded-model.mjs).Trim()
@@ -72,16 +164,16 @@ node scripts/codestory-agent-ab-benchmark.mjs `
   --codestory-cli target/release/codestory-cli.exe `
   --out-dir target/agent-benchmark/language-expansion-publishable-full-form-command-shapes `
   --timeout-ms 180000 `
-  --max-source-reads-after-packet 0 `
-  --publishable
+  --max-source-reads-after-packet 0
 ```
 
 The run ledger records per-run `wall_ms`, token usage, estimated cost when
 `CODESTORY_BENCH_INPUT_COST_PER_MTOK` and
 `CODESTORY_BENCH_OUTPUT_COST_PER_MTOK` are configured, observed tool calls, tool
 categories, web searches, command counts, command categories, direct source
-reads, ordinary source reads after the first CodeStory command, ordinary source
-reads after the first packet, duplicate file reads, and manifest quality scores.
+reads, observed repository-context actions after the first CodeStory action,
+ordinary source reads after the first packet, duplicate file reads, and
+manifest quality scores.
 For the `without_codestory` arm, the harness mechanically runs a strictly
 no-CodeStory local-context prelude before starting the nested agent. It derives
 plain `rg` search terms from the prompt, reads bounded snippets from selected
@@ -230,9 +322,9 @@ with the harness's trusted-checkout mode and confirm the summary shows local
 command/tool counts and zero web searches.
 
 Do not make public savings claims from these fixtures. They only prove
-transcript analyzer/parser and scorer behavior. Promotion evidence still
-requires real benchmark runs with raw transcripts, repeated medians, and quality
-thresholds.
+transcript analyzer/parser and scorer behavior. Release acceptance requires the
+separately owned sealed task set, fresh installed sessions, raw transcripts,
+repeated task-level results, and its preregistered gates.
 
 ## README with/without row
 

--- a/scripts/codestory-agent-ab-benchmark.mjs
+++ b/scripts/codestory-agent-ab-benchmark.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import assert from "node:assert/strict";
-import { createHash } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import { spawn } from "node:child_process";
 import { existsSync, realpathSync, statSync } from "node:fs";
 import { chmod, copyFile, mkdir, mkdtemp, open, readdir, readFile, rm, writeFile } from "node:fs/promises";
@@ -30,6 +30,19 @@ import {
   isTrustedPublishableRepoUrl,
   repoProvenanceBlockers,
 } from "./codestory-evidence-provenance.mjs";
+import {
+  BUILDER_ABLATION_ARMS,
+  BUILDER_ABLATION_TASK_IDS,
+  builderOperationViolations,
+  builderPacketRetrievalPolicy,
+  codeStoryInvocationsFromCommand,
+  codeStoryOperationFromCommand,
+  codeStoryOperationFromMcpTool,
+  isBuilderAblationArm,
+  isBuilderCodeStoryArm,
+  isBuilderPacketArm,
+  planBuilderAblationRuns,
+} from "./lib/evidence-compiler-ablation.mjs";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const benchmarkHarnessPath = fileURLToPath(import.meta.url);
@@ -222,10 +235,21 @@ const ARMS = {
     CODESTORY_ARM_INSTRUCTION,
   published_0_17_5: CODESTORY_ARM_INSTRUCTION,
   candidate_0_18: CODESTORY_ARM_INSTRUCTION,
+  native_tools: "Use ordinary local repository exploration only.",
+  exact_identity_source: "Use CodeStory exact identity and source operations before ordinary local exploration.",
+  exact_plus_relations: "Use CodeStory exact identity, source, and explicit relation operations before ordinary local exploration.",
+  packet_semantic_off: "Start from the harness packet with dense semantic candidates disabled, then investigate adaptively with ordinary local tools.",
+  packet_semantic_on: "Start from the harness packet with dense semantic candidates enabled, then investigate adaptively with ordinary local tools.",
 };
 
 function isCodeStoryArm(arm) {
-  return arm === "with_codestory" || arm === "published_0_17_5" || arm === "candidate_0_18";
+  return arm === "with_codestory" || arm === "published_0_17_5" || arm === "candidate_0_18" ||
+    isBuilderCodeStoryArm(arm);
+}
+
+function isPacketArm(arm) {
+  return arm === "with_codestory" || arm === "published_0_17_5" || arm === "candidate_0_18" ||
+    isBuilderPacketArm(arm);
 }
 
 function isPacketProjectionV3(packet) {
@@ -244,6 +268,7 @@ function usage() {
   node scripts/codestory-agent-ab-benchmark.mjs --self-test
   node scripts/codestory-agent-ab-benchmark.mjs --reanalyze-dir target/agent-benchmark/<run-dir>
   node scripts/codestory-agent-ab-benchmark.mjs --packet-runtime --task-suite <suite> [--materialize-repos] [--repeats n]
+  node scripts/codestory-agent-ab-benchmark.mjs --builder-ablation --codestory-cli <benchmark-enabled-cli> [--materialize-repos] [--out-dir path]
   node scripts/codestory-agent-ab-benchmark.mjs [--quick] [--repos names] [--arms names] [--task-suite name] [--task-ids ids] [--task-manifest path] [--include-local-repos] [--repeats n] [--runner codex] [--model model] [--sandbox mode] [--out-dir path] [--timeout-ms ms] [--prepare-codestory-cache] [--canary-task-id id] [--shard-count n --shard-index n] [--allow-failures] [--publishable]
   node scripts/codestory-agent-ab-benchmark.mjs --exact-candidate --task-suite language-expansion-holdout --published-archive <path> --published-checksum-manifest <path> --published-checksum-sha256 <sha256> --candidate-source-root <path>
 
@@ -289,6 +314,8 @@ Options:
                   External SHA-256 binding for the comparator source artifact bundle.
   --exact-candidate
                   Run the fresh 18-task, three-repeat comparison of no CodeStory, published 0.17.5, and the frozen 0.18 candidate.
+  --builder-ablation
+                  Run the frozen five-arm, three-repeat builder-visible evidence-compiler ablation. This mode never supplies release evidence.
   --published-archive
                   Published CodeStory 0.17.5 native archive named by the authenticated checksum manifest.
   --published-checksum-manifest
@@ -375,6 +402,7 @@ function parseArgs(argv) {
       "reuse-comparators-ledger-sha256": { type: "string" },
       "reuse-comparators-artifacts-sha256": { type: "string" },
       "exact-candidate": { type: "boolean" },
+      "builder-ablation": { type: "boolean" },
       "published-archive": { type: "string" },
       "published-checksum-manifest": { type: "string" },
       "published-checksum-sha256": { type: "string" },
@@ -423,6 +451,7 @@ function parseArgs(argv) {
     reuseComparatorsLedgerSha256: null,
     reuseComparatorsArtifactsSha256: null,
     exactCandidate: false,
+    builderAblation: false,
     publishedArchive: null,
     publishedChecksumManifest: null,
     publishedChecksumSha256: null,
@@ -492,6 +521,7 @@ function parseArgs(argv) {
   opts.reuseComparatorsLedgerSha256 = values["reuse-comparators-ledger-sha256"] ?? null;
   opts.reuseComparatorsArtifactsSha256 = values["reuse-comparators-artifacts-sha256"] ?? null;
   opts.exactCandidate = values["exact-candidate"] === true;
+  opts.builderAblation = values["builder-ablation"] === true;
   opts.publishedArchive = values["published-archive"] ?? null;
   opts.publishedChecksumManifest = values["published-checksum-manifest"] ?? null;
   opts.publishedChecksumSha256 = values["published-checksum-sha256"] ?? null;
@@ -514,7 +544,10 @@ function parseArgs(argv) {
     throw new Error("--task-suite and --task-manifest are mutually exclusive");
   }
 
-  if (!opts.reanalyzeDir && !opts.repos && !opts.taskSuite && !opts.taskManifest && !opts.exactCandidate) {
+  if (
+    !opts.reanalyzeDir && !opts.repos && !opts.taskSuite && !opts.taskManifest &&
+    !opts.exactCandidate && !opts.builderAblation
+  ) {
     opts.repos = opts.quick
       ? ["codestory"]
       : [
@@ -584,6 +617,39 @@ function parseArgs(argv) {
       "--published-checksum-sha256",
     );
   }
+  if (opts.builderAblation) {
+    const builderOptionAllowlist = new Set([
+      "builder-ablation",
+      "materialize-repos",
+      "repo-cache-dir",
+      "out-dir",
+      "codestory-cli",
+    ]);
+    const forbiddenOptions = [...providedOptions].filter((name) => !builderOptionAllowlist.has(name));
+    if (forbiddenOptions.length) {
+      throw new Error(`builder-ablation mode forbids option(s): ${forbiddenOptions.sort().join(", ")}`);
+    }
+    if (opts.exactCandidate || opts.packetRuntime || opts.aggregateShards) {
+      throw new Error("builder-ablation mode is mutually exclusive with exact-candidate, packet-runtime, and aggregation");
+    }
+    if (!opts.codestoryCli) {
+      throw new Error("builder-ablation mode requires --codestory-cli built with benchmark-support");
+    }
+    opts.taskSuite = "language-expansion-holdout";
+    opts.taskIds = [...BUILDER_ABLATION_TASK_IDS];
+    opts.arms = [...BUILDER_ABLATION_ARMS];
+    opts.repeats = 3;
+    opts.model = DEFAULT_BENCHMARK_MODEL;
+    opts.runner = "codex";
+    opts.sandbox = "workspace-write";
+    opts.jobs = 1;
+    opts.prepareCodestoryCache = true;
+    opts.shardCount = 1;
+    opts.shardIndex = 0;
+    opts.publishable = false;
+    opts.allowFailures = false;
+    opts.diagnosticExtraProbesFromManifest = false;
+  }
   opts.arms ??= ["without_codestory", "with_codestory"];
   if (!opts.arms.length) {
     throw new Error("--arms must include at least one arm");
@@ -595,12 +661,15 @@ function parseArgs(argv) {
     if (!opts.exactCandidate && EXACT_CANDIDATE_ARMS.includes(arm) && arm !== "without_codestory") {
       throw new Error(`Arm '${arm}' is available only with --exact-candidate`);
     }
+    if (!opts.builderAblation && isBuilderAblationArm(arm)) {
+      throw new Error(`Arm '${arm}' is available only with --builder-ablation`);
+    }
   }
   if (!opts.repeats) {
     opts.repeats = opts.quick ? 1 : 3;
   }
   if (opts.prepareCodestoryCache == null) {
-    opts.prepareCodestoryCache = opts.packetRuntime || opts.arms.includes("with_codestory");
+    opts.prepareCodestoryCache = opts.packetRuntime || opts.arms.some(isCodeStoryArm);
   }
   if (!Number.isInteger(opts.repeats) || opts.repeats < 1) {
     throw new Error("--repeats must be a positive integer");
@@ -848,6 +917,30 @@ async function initializeExactCandidateState(opts, dependencies = {}) {
   }
 }
 
+async function initializeBuilderAblationState(opts, dependencies = {}) {
+  const createPrivateStateRoot = dependencies.createPrivateStateRoot
+    ?? createExactCandidatePrivateStateRoot;
+  opts.builderAblationStateRoot = await createPrivateStateRoot(
+    "codestory-agent-builder-ablation-",
+  );
+}
+
+function opaqueBuilderContinuationProofPath(stateRoot, entropy = randomBytes) {
+  const nonce = entropy(24);
+  if (!Buffer.isBuffer(nonce) || nonce.length !== 24) {
+    throw new Error("builder continuation proof entropy must return exactly 24 bytes");
+  }
+  return path.join(stateRoot, "continuation-proofs", `${nonce.toString("hex")}.json`);
+}
+
+function opaqueBuilderAgentHome(stateRoot, entropy = randomBytes) {
+  const nonce = entropy(24);
+  if (!Buffer.isBuffer(nonce) || nonce.length !== 24) {
+    throw new Error("builder agent-home entropy must return exactly 24 bytes");
+  }
+  return path.join(stateRoot, "agent-sessions", nonce.toString("hex"), "host");
+}
+
 async function finalizeBenchmarkResources(opts, ledger, preparationLedger, dependencies = {}) {
   const remove = dependencies.remove ?? rm;
   const failures = [...(opts.exactCandidateInitializationCleanupFailures ?? [])];
@@ -870,6 +963,7 @@ async function finalizeBenchmarkResources(opts, ledger, preparationLedger, depen
   for (const [resource, root] of [
     ["exact_candidate_state", opts.exactCandidateStateRoot],
     ["exact_candidate_baseline_state", opts.exactCandidateBaselineContainerRoot],
+    ["builder_ablation_state", opts.builderAblationStateRoot],
   ]) {
     if (!root) continue;
     const failure = await removeOwnedBenchmarkRoot(remove, resource, root);
@@ -878,6 +972,7 @@ async function finalizeBenchmarkResources(opts, ledger, preparationLedger, depen
   delete opts.exactCandidateStateRoot;
   delete opts.exactCandidateBaselineContainerRoot;
   delete opts.exactCandidateBaselineStateRoot;
+  delete opts.builderAblationStateRoot;
   delete opts.exactCandidateInitializationCleanupFailures;
   return failures;
 }
@@ -1040,15 +1135,18 @@ async function prepareAgentCodexIsolation(outDir, opts = {}) {
     runner_config: PINNED_CODEX_RUNNER_CONFIG,
   };
   let homes = null;
-  if (opts.exactCandidate) {
+  if (opts.exactCandidate || opts.builderAblation) {
     homes = {};
-    for (const arm of EXACT_CANDIDATE_ARMS) {
-      const armRoot = arm === "without_codestory"
-        ? opts.exactCandidateBaselineStateRoot
-        : path.join(opts.exactCandidateStateRoot, arm);
+    const arms = opts.builderAblation ? BUILDER_ABLATION_ARMS : EXACT_CANDIDATE_ARMS;
+    for (const arm of arms) {
+      const armRoot = opts.builderAblation
+        ? path.dirname(opaqueBuilderAgentHome(opts.builderAblationStateRoot))
+        : arm === "without_codestory"
+          ? opts.exactCandidateBaselineStateRoot
+          : path.join(opts.exactCandidateStateRoot, arm);
       const codexHome = path.join(armRoot, "host");
       await mkdir(codexHome, { recursive: true });
-      if (arm === "without_codestory") {
+      if (!opts.builderAblation && arm === "without_codestory") {
         for (const directory of [
           "home", "tmp", "xdg-cache", "xdg-config", "xdg-data",
         ]) {
@@ -1057,6 +1155,7 @@ async function prepareAgentCodexIsolation(outDir, opts = {}) {
       }
       await copyFile(authPath, path.join(codexHome, "auth.json"));
       homes[arm] = codexHome;
+      if (opts.builderAblation) continue;
       for (const value of Object.values(
         exactCandidateArmEnvironmentGroups(opts, arm).directories,
       )) {
@@ -1071,11 +1170,21 @@ async function prepareAgentCodexIsolation(outDir, opts = {}) {
         );
       }
     }
-    receipt.contract = "codestory.agent-benchmark-codex-isolation/v3";
-    receipt.with_codestory_config = "arm_specific_checksum_bound_cli";
+    receipt.contract = opts.builderAblation
+      ? "codestory.agent-benchmark-codex-isolation/v4"
+      : "codestory.agent-benchmark-codex-isolation/v3";
+    receipt.with_codestory_config = opts.builderAblation
+      ? "isolated_ephemeral_home_checksum_bound_cli_only"
+      : "arm_specific_checksum_bound_cli";
     receipt.homes = Object.fromEntries(
-      EXACT_CANDIDATE_ARMS.map((arm) => [arm, path.relative(outDir, homes[arm])]),
+      arms.map((arm) => [arm, path.relative(outDir, homes[arm])]),
     );
+    if (opts.builderAblation) {
+      receipt.codestory_surface = "checksum_bound_cli_only";
+      receipt.without_codestory_config = "isolated_ephemeral_home_no_codestory";
+      receipt.host_config_files = "none";
+      return await writeAgentCodexIsolationReceipt(outDir, receipt, homes, opts);
+    }
     receipt.cache_roots = Object.fromEntries(
       EXACT_CANDIDATE_ARMS.map((arm) => [
         arm,
@@ -1107,6 +1216,21 @@ async function prepareAgentCodexIsolation(outDir, opts = {}) {
   );
   return {
     root: opts.exactCandidate ? opts.exactCandidateStateRoot : null,
+    homes,
+    receipt,
+  };
+}
+
+async function writeAgentCodexIsolationReceipt(outDir, receipt, homes, opts) {
+  await writeFile(
+    path.join(outDir, "codex-agent-isolation.json"),
+    `${JSON.stringify(receipt, null, 2)}\n`,
+    "utf8",
+  );
+  return {
+    root: opts.exactCandidate
+      ? opts.exactCandidateStateRoot
+      : opts.builderAblationStateRoot ?? null,
     homes,
     receipt,
   };
@@ -1675,6 +1799,33 @@ function validateExactCandidateShape(opts, tasks) {
   }
   if (opts.reuseBaselineFrom) {
     throw new Error("baseline reuse is forbidden in exact-candidate mode");
+  }
+}
+
+function validateBuilderAblationShape(opts, tasks) {
+  if (!opts.builderAblation) return;
+  if (
+    tasks.length !== BUILDER_ABLATION_TASK_IDS.length ||
+    tasks.map((task) => task.id).join(",") !== BUILDER_ABLATION_TASK_IDS.join(",")
+  ) {
+    throw new Error("builder-ablation tasks differ from the frozen builder-visible development set");
+  }
+  if (
+    opts.taskSuite !== "language-expansion-holdout" ||
+    opts.repeats !== 3 ||
+    opts.arms.join(",") !== BUILDER_ABLATION_ARMS.join(",")
+  ) {
+    throw new Error("builder-ablation mode requires its frozen suite, five arms, and three repeats");
+  }
+  if (
+    opts.reuseBaselineFrom || opts.resumePrefixFrom || opts.reuseComparatorsFrom ||
+    opts.diagnosticExtraProbesFromManifest || opts.publishable || opts.shardCount !== 1
+  ) {
+    throw new Error("builder-ablation rows must be fresh, unsharded, and free of manifest probe injection");
+  }
+  const cli = path.resolve(opts.codestoryCli);
+  if (!existsSync(cli) || !statSync(cli).isFile()) {
+    throw new Error(`builder-ablation CodeStory CLI does not exist: ${cli}`);
   }
 }
 
@@ -2626,7 +2777,59 @@ async function materializeRepos(tasks, opts) {
   }
 }
 
+function builderAblationPacketBlock(prelude) {
+  if (!prelude?.packet) return "";
+  return `
+The harness ran the initial packet before your turn. Its command and private
+measurement paths are deliberately withheld.
+
+Initial packet JSON:
+\`\`\`json
+${JSON.stringify(packetForAgentPrompt(prelude.packet), null, 2)}
+\`\`\``;
+}
+
+function builderAblationArmInstruction(arm, continuationContract = null) {
+  if (arm === "native_tools") {
+    return "Do not use CodeStory. Investigate with ordinary local search and source reads.";
+  }
+  if (arm === "exact_identity_source") {
+    return "Your first repository-context action must be a successful CodeStory exact operation. With $CODESTORY_CLI, use only search with --repo-text off, files, symbol, or snippet. Every CodeStory command must include the exact --project path shown above; search must also include --profile agent --run-id shared-agent. Do not pass cache, refresh, or output-file overrides. After the first CodeStory output, investigate adaptively with ordinary local search and source reads. Any other CodeStory operation invalidates the row.";
+  }
+  if (arm === "exact_plus_relations") {
+    return "Your first repository-context action must be a successful CodeStory exact operation. With $CODESTORY_CLI, use search with --repo-text off, files, symbol, snippet, context, trail, callers, callees, or trace. Every CodeStory command must include the exact --project path shown above; search must also include --profile agent --run-id shared-agent. Do not pass cache, refresh, or output-file overrides. After the first CodeStory output, investigate adaptively with ordinary local search and source reads. Any other CodeStory operation invalidates the row.";
+  }
+  const continuation = continuationContract
+    ? ` The packet offers one optional continuation. If you use it, run this exact command as a separate repository-context action and do not run another CodeStory command:
+\`\`\`${packetFirstCommandFenceLanguage()}
+${continuationContract.command}
+\`\`\``
+    : " The packet offers no continuation. Do not call CodeStory during your turn.";
+  return `Use the initial packet as bounded source-backed evidence, not as an answer or sufficiency verdict. You may investigate adaptively with ordinary local search and source reads.${continuation} Preserve uncertainty and do not claim runtime execution, absence, or a relationship that the cited source does not establish.`;
+}
+
+function composeBuilderAblationPrompt(repoName, repoConfig, armName, task, context = {}) {
+  const packetBlock = isBuilderPacketArm(armName)
+    ? builderAblationPacketBlock(context.codestoryPrelude)
+    : "";
+  return `You are running a builder-visible development ablation for CodeStory.
+
+Repository: ${repoName}
+Project path: ${repoConfig.path}
+Task: ${task?.prompt ?? repoConfig.prompt}
+
+Instruction: ${builderAblationArmInstruction(armName, context.builderContinuationContract)}
+${packetBlock}
+
+Return a concise answer with the files, symbols, and source evidence that support it.
+Do not edit source files. Use read-only inspection commands only; CodeStory may read its already-prepared cache.
+Do not use web search, browser tools, remote URLs, or upstream mirrors. Inspect only this pinned local checkout.`;
+}
+
 function composePrompt(repoName, repoConfig, armName, task = null, context = {}) {
+  if (context.builderAblation) {
+    return composeBuilderAblationPrompt(repoName, repoConfig, armName, task, context);
+  }
   const taskPrompt = task?.prompt ?? repoConfig.prompt;
   const taskHeader = task
     ? `Task id: ${task.id}
@@ -3149,32 +3352,23 @@ function isCommandEvent(event) {
 function commandCategory(command) {
   const text = String(command ?? "");
   const shellText = text.replace(/\\"/g, '"');
-  const codestoryCommands =
-    "\\b(index|ground|doctor|search|symbol|trail|snippet|query|explore|bookmark|context|drill|files|affected|setup|serve|packet)\\b";
+  const codestoryCommands = "\\b[a-z][a-z0-9-]*\\b";
+  const knownCodestoryCommands =
+    "\\b(index|ground|doctor|ready|search|symbol|trail|callers|callees|trace|snippet|query|explore|bookmark|context|drill|files|affected|impact|test-map|setup|serve|packet|verify-indexed-direct-calls|retrieval|cache|agent|report)\\b";
   const codestoryExecutablePath =
     String.raw`['"]?(?:[A-Z]:)?(?:[^;&|\r\n"']*[\\/])*codestory-cli(?:\.exe)?['"]?\s+${codestoryCommands}`;
-  if (/^\s*(?:rg|grep|findstr|select-string)\b/i.test(text)) {
-    return "shell_search";
-  }
-  if (/^\s*(?:get-content|cat|type|sed|nl)\b/i.test(text)) {
-    return "direct_file_read";
-  }
   if (
     /^\s*codestory-cli(?:\.exe)?(?:\s|$)/i.test(shellText) ||
     new RegExp(`^\\s*${codestoryExecutablePath}`, "i").test(shellText) ||
     new RegExp(`[;&|]\\s*${codestoryExecutablePath}`, "i").test(shellText) ||
     /&\s*["']*\$env:CODESTORY_CLI\s+/i.test(shellText) ||
     new RegExp(`(?:^|[;&|]\\s*)["']?\\$CODESTORY_CLI["']?\\s+${codestoryCommands}`, "i").test(shellText) ||
-    new RegExp(`&\\s*["']*\\$[a-z_][a-z0-9_]*\\s+${codestoryCommands}`, "i").test(shellText)
+    new RegExp(`&\\s*["']*\\$[a-z_][a-z0-9_]*\\s+${knownCodestoryCommands}`, "i").test(shellText)
   ) {
     return "codestory_cli";
   }
-  if (/\b(rg|grep|findstr|select-string)\b/i.test(command)) {
-    return "shell_search";
-  }
-  if (/\b(get-content|cat|type|sed|nl)\b/i.test(command)) {
-    return "direct_file_read";
-  }
+  const sourceCategory = sourceProducingCommandCategory(text);
+  if (sourceCategory) return sourceCategory;
   if (/\bgit\b/i.test(command)) {
     return "git";
   }
@@ -3182,6 +3376,49 @@ function commandCategory(command) {
     return "build_test";
   }
   return "other";
+}
+
+function gitSourceProducingCommand(command) {
+  const segments = String(command ?? "").split(/[;&|\r\n]+/u);
+  for (const segment of segments) {
+    const words = segment.trim().split(/\s+/u).filter(Boolean);
+    const gitIndex = words.findIndex((word) =>
+      /^(?:["']?)(?:(?:[^\s"'\\/]+)[\\/])*git(?:\.exe)?["']?$/iu.test(word)
+    );
+    if (gitIndex < 0) continue;
+    let index = gitIndex + 1;
+    while (index < words.length && words[index].startsWith("-")) {
+      const option = words[index].split("=", 1)[0];
+      const consumesValue = ["-C", "-c", "--git-dir", "--work-tree", "--namespace"].includes(option) &&
+        !words[index].includes("=");
+      index += consumesValue ? 2 : 1;
+    }
+    const subcommand = String(words[index] ?? "")
+      .replace(/^["']|["']$/gu, "")
+      .toLowerCase();
+    if (["show", "grep", "blame", "diff"].includes(subcommand)) return true;
+    if (subcommand === "log" && words.slice(index + 1).some((word) => word === "-p" || word === "--patch")) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function sourceProducingCommandCategory(command) {
+  const text = String(command ?? "");
+  if (/\b(?:rg|grep|findstr|select-string)\b/iu.test(text)) {
+    return "shell_search";
+  }
+  if (
+    /\b(?:get-content|cat|type|sed|nl|head|tail|awk|bat|less|dd|strings|jq)\b/iu.test(text) ||
+    /\b(?:read_text|read_to_string|readlines?|readFile(?:Sync)?|readTextFile|createReadStream|File\.read|IO\.read|Pathname\.read|Bun\.file)\b/iu.test(text) ||
+    /\bopen\s*\(|\bPath\s*\([^)]*\)\.read_/iu.test(text) ||
+    /\b(?:perl|ruby)\s+[^;&|]*(?:-[A-Za-z]*[np]|-e)\b/iu.test(text) ||
+    /(?:^|[\s'"=:])[^\s'";&|]+\.(?:rs|js|jsx|mjs|cjs|ts|tsx|mts|cts|py|pyi|go|java|kt|kts|cs|cpp|cc|cxx|c|h|hpp|hh|hxx|rb|php|swift|dart|sh|bash|html|htm|css|sql|md|toml|json|yaml|yml)(?=$|[\s'";&|])/iu.test(text)
+  ) {
+    return "direct_file_read";
+  }
+  return gitSourceProducingCommand(text) ? "git" : null;
 }
 
 function isCodestoryPacketCommand(command) {
@@ -3231,6 +3468,51 @@ function isSuccessfulContextCommand(command) {
     return true;
   }
   return ["codestory_cli", "shell_search", "direct_file_read", "git", "build_test"].includes(command.category);
+}
+
+const REPOSITORY_CONTEXT_COMMAND_CATEGORIES = new Set([
+  "codestory_cli",
+  "shell_search",
+  "direct_file_read",
+  "git",
+  "build_test",
+]);
+
+function isObservedRepositoryContextCommand(command) {
+  return REPOSITORY_CONTEXT_COMMAND_CATEGORIES.has(command.category) ||
+    String(command.aggregated_output ?? "").trim().length > 0;
+}
+
+function observedRepositoryContextActions(commands, events) {
+  const actions = commands
+    .filter(isObservedRepositoryContextCommand)
+    .map((command) => ({
+      action_key: `command:${command.id}`,
+      kind: "command",
+      id: command.id,
+      category: command.category,
+      codestory: command.category === "codestory_cli",
+      event_index: command.started_event_index ?? command.completed_event_index ?? -1,
+    }));
+
+  events.forEach((event, eventIndex) => {
+    if (!isToolCallStartEvent(event)) return;
+    const category = toolCallCategory(event);
+    if (category === "command_execution") return;
+    const item = itemOf(event);
+    const id = String(item.id ?? event.id ?? `tool_${eventIndex}`);
+    const codestory = isCodeStoryMcpToolCallEvent(event);
+    actions.push({
+      action_key: `${codestory ? "mcp" : "tool"}:${id}`,
+      kind: "tool",
+      id,
+      category,
+      codestory,
+      event_index: eventIndex,
+    });
+  });
+
+  return actions.sort((left, right) => left.event_index - right.event_index);
 }
 
 function normalizePathLike(value) {
@@ -3391,7 +3673,8 @@ function extractCommandExecutions(events) {
 
   for (const command of byId.values()) {
     command.category = command.harness_semantics?.category ?? commandCategory(command.command);
-    command.codestory_operation = command.harness_semantics?.operation ?? null;
+    command.codestory_operation = command.harness_semantics?.operation ??
+      (command.category === "codestory_cli" ? codeStoryOperationFromCommand(command.command) : null);
     command.pattern = commandPattern(command.command);
     commands.push(command);
   }
@@ -3400,6 +3683,77 @@ function extractCommandExecutions(events) {
       (a.started_event_index ?? a.completed_event_index ?? 0) -
       (b.started_event_index ?? b.completed_event_index ?? 0),
   );
+}
+
+function codeStoryMcpToolName(event) {
+  const item = itemOf(event);
+  return item.tool ?? item.name ?? item.tool_name ?? event.tool ?? event.name ?? null;
+}
+
+function orderedCodeStoryOperations(commands, events) {
+  const operations = commands
+    .flatMap((command) => {
+      if (command.harness_semantics) {
+        return [{
+          operation: command.harness_semantics.operation,
+          transport: "cli",
+          source: "harness_packet_prelude",
+          checksum_bound: true,
+          successful: command.exit_code === 0 && String(command.status ?? "completed").toLowerCase() !== "failed",
+          event_index: command.completed_event_index ?? command.started_event_index ?? -1,
+          result_event_index: command.completed_event_index ?? command.started_event_index ?? -1,
+          action_key: `command:${command.id}`,
+          raw: { command: command.command },
+        }];
+      }
+      return codeStoryInvocationsFromCommand(command.command).map((invocation, invocationIndex) => ({
+        operation: invocation.operation,
+        transport: "cli",
+        source: "agent_cli",
+        checksum_bound: invocation.checksum_bound,
+        successful: command.exit_code === 0 && String(command.status ?? "completed").toLowerCase() !== "failed",
+        event_index: (command.completed_event_index ?? command.started_event_index ?? -1) + invocationIndex / 1000,
+        result_event_index: command.completed_event_index ?? command.started_event_index ?? -1,
+        action_key: `command:${command.id}`,
+        raw: { command: command.command },
+      }));
+    });
+  const mcpById = new Map();
+  events.forEach((event, eventIndex) => {
+    if (!isCodeStoryMcpToolCallEvent(event)) return;
+    const item = itemOf(event);
+    const id = String(item.id ?? event.id ?? `mcp_${eventIndex}`);
+    const current = mcpById.get(id) ?? {
+      operation: codeStoryOperationFromMcpTool(codeStoryMcpToolName(event)),
+      transport: "mcp",
+      source: "agent_mcp",
+      successful: false,
+      event_index: eventIndex,
+      result_event_index: null,
+      action_key: `mcp:${id}`,
+      raw: { arguments: item.arguments ?? event.arguments ?? null },
+    };
+    current.operation ??= codeStoryOperationFromMcpTool(codeStoryMcpToolName(event));
+    current.event_index = Math.min(current.event_index, eventIndex);
+    if (isSuccessfulCodeStoryMcpToolCallEvent(event)) {
+      current.successful = true;
+      current.result_event_index = eventIndex;
+    }
+    mcpById.set(id, current);
+  });
+  operations.push(...mcpById.values());
+  return operations.sort((left, right) => left.event_index - right.event_index);
+}
+
+function isOrdinarySourceProducingCommand(command) {
+  return sourceProducingCommandCategory(command.command) != null;
+}
+
+function isRemoteContextCommand(command) {
+  const text = String(command?.command ?? command ?? "");
+  return /(?:^|[;&|]\s*)(?:curl|wget|Invoke-WebRequest|Invoke-RestMethod)\b/i.test(text) ||
+    /(?:^|[;&|]\s*)git\s+(?:clone|fetch|pull|ls-remote)\b/i.test(text) ||
+    /(?:^|[;&|]\s*)gh\s+(?:api|repo|pr|issue|search)\b/i.test(text);
 }
 
 function extractFinalAnswer(events) {
@@ -3656,6 +4010,7 @@ function directSourceReadAuthorization(read, commands, events, projectRoot, cont
 
 function analyzeTranscript(events, projectRoot = null, context = {}) {
   const commands = extractCommandExecutions(events);
+  const codestoryOperations = orderedCodeStoryOperations(commands, events);
   const toolCategories = toolCallCategories(events);
   const codestoryMcpToolCalls = events.filter(isCodeStoryMcpToolCallStartEvent);
   const codestoryMcpCompletedCalls = events.filter(isSuccessfulCodeStoryMcpToolCallEvent);
@@ -3687,16 +4042,20 @@ function analyzeTranscript(events, projectRoot = null, context = {}) {
   const firstSuccessfulCodeStory = commands.find(
     (command) => command.category === "codestory_cli" && command.exit_code === 0,
   );
+  const firstSuccessfulCodeStoryOperation = codestoryOperations.find((operation) => operation.successful);
   const firstSuccessfulPacket = commands.find(
     (command) =>
       command.category === "codestory_cli" &&
       command.exit_code === 0 &&
-      (command.codestory_operation === "packet" || isCodestoryPacketCommand(command.command)),
+      (command.harness_semantics?.operation === "packet" ||
+        isCodestoryPacketCommand(command.command)),
   );
   const codestoryIndexCommands = commands.filter(
     (command) => command.category === "codestory_cli" && isCodestoryIndexCommand(command.command),
   );
   const firstSuccessfulContextCommand = commands.find(isSuccessfulContextCommand);
+  const observedContextActions = observedRepositoryContextActions(commands, events);
+  const firstObservedContextAction = observedContextActions[0] ?? null;
   const sourceReads = directFileReads.filter((read) => read.source_like && read.repo_like);
   const authorizedSourceReads = sourceReads.map((read) => ({
     ...read,
@@ -3706,7 +4065,35 @@ function analyzeTranscript(events, projectRoot = null, context = {}) {
     first == null
       ? null
       : sourceReads.filter((read) => (read.event_index ?? -1) > (first.completed_event_index ?? first.started_event_index ?? -1)).length;
-
+  const firstCodeStoryEventIndex = firstSuccessfulCodeStoryOperation?.result_event_index ??
+    firstSuccessfulCodeStoryOperation?.event_index ??
+    null;
+  const firstCodeStoryActionPosition = firstSuccessfulCodeStoryOperation == null
+    ? -1
+    : observedContextActions.findIndex(
+      (action) => action.action_key === firstSuccessfulCodeStoryOperation.action_key,
+    );
+  const ordinarySourceActionsAfterFirstCodeStory = firstCodeStoryEventIndex == null
+    ? []
+    : commands.filter((command) =>
+      (command.started_event_index ?? command.completed_event_index ?? -1) > firstCodeStoryEventIndex &&
+      command.category !== "codestory_cli" &&
+      isOrdinarySourceProducingCommand(command)
+    );
+  const exploratoryRepositoryContextActionsAfterFirstCodeStory = firstCodeStoryActionPosition < 0
+    ? []
+    : observedContextActions
+      .slice(firstCodeStoryActionPosition + 1)
+      .filter((action) => action.codestory !== true);
+  const exploratoryRepositoryContextCommandKeys = new Set(
+    exploratoryRepositoryContextActionsAfterFirstCodeStory
+      .filter((action) => action.kind === "command")
+      .map((action) => action.action_key),
+  );
+  const exploratoryRepositoryContextCommandsAfterFirstCodeStory = commands.filter(
+    (command) => exploratoryRepositoryContextCommandKeys.has(`command:${command.id}`),
+  );
+  const remoteContextCommands = commands.filter(isRemoteContextCommand);
   return {
     interaction_turns: interactionTurnTelemetry(events),
     tool_categories: toolCategories,
@@ -3717,6 +4104,7 @@ function analyzeTranscript(events, projectRoot = null, context = {}) {
     command_categories: commandCategories,
     command_count: commands.length,
     command_patterns_duplicated: duplicateCounts(commands.map((command) => command.pattern)),
+    codestory_operations: codestoryOperations,
     output_chars_by_category: outputCharsByCategory,
     direct_file_reads_total: directFileReads.length,
     direct_source_reads_total: sourceReads.length,
@@ -3743,22 +4131,49 @@ function analyzeTranscript(events, projectRoot = null, context = {}) {
           category: firstSuccessfulContextCommand.category,
         }
       : null,
+    first_observed_repository_context_action: firstObservedContextAction
+      ? {
+          kind: firstObservedContextAction.kind,
+          id: firstObservedContextAction.id,
+          category: firstObservedContextAction.category,
+        }
+      : null,
     packet_was_first_context_command:
       firstSuccessfulPacket != null &&
-      firstSuccessfulContextCommand != null &&
-      firstSuccessfulPacket.id === firstSuccessfulContextCommand.id,
+      firstObservedContextAction != null &&
+      `command:${firstSuccessfulPacket.id}` === firstObservedContextAction.action_key,
     codestory_index_commands_observed: codestoryIndexCommands.length,
     ordinary_source_reads_after_first_codestory: afterIndex(firstSuccessfulCodeStory),
     ordinary_source_reads_after_first_packet: afterIndex(firstSuccessfulPacket),
+    ordinary_source_actions_after_first_codestory: ordinarySourceActionsAfterFirstCodeStory.length,
+    exploratory_source_reads_after_first_codestory: ordinarySourceActionsAfterFirstCodeStory.length,
+    observed_repository_context_actions: observedContextActions.length,
+    exploratory_repository_context_actions_after_first_codestory:
+      exploratoryRepositoryContextActionsAfterFirstCodeStory.length,
+    ordinary_source_output_bytes_after_first_codestory: ordinarySourceActionsAfterFirstCodeStory
+      .reduce((sum, command) => sum + Buffer.byteLength(String(command.aggregated_output ?? ""), "utf8"), 0),
+    observed_repository_context_output_bytes_after_first_codestory:
+      exploratoryRepositoryContextCommandsAfterFirstCodeStory
+        .reduce((sum, command) => sum + Buffer.byteLength(String(command.aggregated_output ?? ""), "utf8"), 0),
+    remote_context_commands: remoteContextCommands.map((command) => command.command),
+    codestory_was_first_context_command:
+      firstSuccessfulCodeStoryOperation != null &&
+      firstObservedContextAction != null &&
+      firstSuccessfulCodeStoryOperation.action_key === firstObservedContextAction.action_key,
+    codestory_was_first_repository_context_action:
+      firstSuccessfulCodeStoryOperation != null &&
+      firstObservedContextAction != null &&
+      firstSuccessfulCodeStoryOperation.action_key === firstObservedContextAction.action_key,
     final_answer_chars: extractFinalAnswer(events).length,
   };
 }
 
 function isCodeStoryMcpToolCallEvent(event) {
   const item = itemOf(event);
+  const server = String(item.server ?? event?.server ?? "").trim().toLowerCase();
   return (
     String(item.type ?? "").toLowerCase() === "mcp_tool_call" &&
-    String(item.server ?? event?.server ?? "").trim().toLowerCase() === "codestory"
+    (server === "codestory" || /(?:^|[-_])codestory$/u.test(server))
   );
 }
 
@@ -4690,7 +5105,10 @@ function retrievalIndexCommandArgs(project) {
   ];
 }
 
-function packetCommandArgs(repoConfig, task, opts = {}) {
+function packetCommandArgs(repoConfig, task, opts = {}, arm = null) {
+  if (opts.builderAblation && opts.diagnosticExtraProbesFromManifest) {
+    throw new Error("builder ablation forbids manifest-derived packet probes");
+  }
   const args = [
     "packet",
     "--project",
@@ -4703,13 +5121,16 @@ function packetCommandArgs(repoConfig, task, opts = {}) {
     "--format",
     "json",
   ];
+  if (arm === "packet_semantic_off") {
+    args.push("--benchmark-disable-dense-semantic");
+  }
   for (const probe of packetCommandExtraProbes(task, opts)) {
     args.push("--extra-probe", probe);
   }
   return args;
 }
 
-function drillPacketCommandArgs(repoConfig, task, opts, packet) {
+function drillPacketCommandArgs(repoConfig, task, opts, packet, arm = null) {
   const drill = packet?.disposition?.drill;
   const continuation = isPacketProjectionV3(packet) ? packet.continuation : null;
   const parentPacketId = String(
@@ -4724,7 +5145,10 @@ function drillPacketCommandArgs(repoConfig, task, opts, packet) {
   if (!parentPacketId || optionIds.length === 0) {
     return null;
   }
-  const args = packetCommandArgs(repoConfig, task, opts);
+  const continuationArm = opts.builderAblation && isBuilderPacketArm(arm)
+    ? "packet_semantic_off"
+    : arm;
+  const args = packetCommandArgs(repoConfig, task, opts, continuationArm);
   args.push("--parent-packet-id", parentPacketId);
   for (const optionId of optionIds) {
     args.push("--option-id", optionId);
@@ -4744,6 +5168,54 @@ function drillPacketCommandArgs(repoConfig, task, opts, packet) {
     args.push("--retrieval-generation", retrievalGeneration);
   }
   return args;
+}
+
+function builderContinuationContract(repoConfig, task, opts, packet, arm, proofPath) {
+  if (!proofPath || !isPacketProjectionV3(packet)) return null;
+  const continuation = packet.continuation;
+  const parentPacketId = String(continuation?.continuation_id ?? "").trim();
+  const allowedOptionIds = (Array.isArray(continuation?.gap_ids) ? continuation.gap_ids : [])
+    .map((identity) => String(identity?.gap_id ?? "").trim())
+    .filter(Boolean);
+  const coreGenerationId = String(packet?.publication?.core?.generation_id ?? "").trim();
+  const retrievalGeneration = String(
+    packet?.publication?.retrieval?.retrieval_generation ?? "",
+  ).trim();
+  if (
+    packet.status !== "continuation_available" ||
+    !parentPacketId ||
+    !allowedOptionIds.length ||
+    new Set(allowedOptionIds).size !== allowedOptionIds.length ||
+    !coreGenerationId ||
+    !retrievalGeneration
+  ) {
+    return null;
+  }
+  const args = drillPacketCommandArgs(repoConfig, task, opts, packet, arm);
+  if (!args) return null;
+  args.push("--benchmark-retrieval-proof-out", proofPath);
+  return {
+    parent_packet_id: parentPacketId,
+    allowed_option_ids: allowedOptionIds,
+    core_generation_id: coreGenerationId,
+    retrieval_generation: retrievalGeneration,
+    project: repoConfig.path,
+    question: task?.prompt ?? repoConfig.prompt,
+    question_sha256: sha256Bytes(task?.prompt ?? repoConfig.prompt),
+    proof_path: proofPath,
+    command: ["$CODESTORY_CLI", ...args.map((value) => shellSingleQuoted(value))].join(" "),
+  };
+}
+
+function builderContinuationOfferReceipt(contract) {
+  if (!contract) return null;
+  return {
+    parent_packet_id: contract.parent_packet_id,
+    allowed_option_ids: contract.allowed_option_ids,
+    core_generation_id: contract.core_generation_id,
+    retrieval_generation: contract.retrieval_generation,
+    question_sha256: contract.question_sha256,
+  };
 }
 
 function displayShellArg(value) {
@@ -4799,6 +5271,9 @@ function preludePublicFields(prelude) {
     packet_contract_runtime: prelude.packet_contract_runtime ?? null,
     packet_extra_probe_count: prelude.packet_extra_probe_count ?? null,
     packet_extra_probe_strategy: prelude.packet_extra_probe_strategy ?? null,
+    packet_retrieval_policy: prelude.packet_retrieval_policy ?? null,
+    packet_retrieval_proof: prelude.packet_retrieval_proof ?? null,
+    packet_retrieval_proof_path: prelude.packet_retrieval_proof_path ?? null,
     packet_drill_continuation: prelude.packet_drill_continuation === true,
     packet_contract_blockers: prelude.packet_contract_blockers ?? [],
     ...(prelude.packet_command_failure == null
@@ -5982,8 +6457,65 @@ function packetCommandFailureReason(envelope) {
   ].filter(Boolean).join("; ");
 }
 
+function builderPacketRetrievalProofErrors(receipt, arm, expectedRequest = null) {
+  const errors = [];
+  const expectedDense = expectedRequest?.requested_dense_semantic ?? arm === "packet_semantic_on";
+  const expectedPolicy = builderPacketRetrievalPolicy(
+    expectedDense ? "packet_semantic_on" : "packet_semantic_off",
+  );
+  const proof = receipt?.retrieval_proof;
+  const semanticInvocations = proof?.dense_semantic_stage_invocations;
+  const stageInvocations = proof?.descriptor_stage_invocations?.stage1b_semantic ?? 0;
+  if (
+    receipt?.contract !== "codestory.packet-builder-ablation-receipt/v1" ||
+    receipt?.requested_dense_semantic !== expectedDense ||
+    proof?.contract !== "codestory.packet-dense-candidate-ablation-proof/v1" ||
+    proof?.requested_policy !== expectedPolicy ||
+    !Number.isInteger(proof?.descriptor_query_count) || proof.descriptor_query_count < 1 ||
+    !Number.isInteger(semanticInvocations) || semanticInvocations < 0 ||
+    !Number.isInteger(stageInvocations) || stageInvocations !== semanticInvocations ||
+    (!expectedDense && semanticInvocations !== 0)
+  ) {
+    errors.push("packet retrieval proof does not establish the requested dense candidate-stage policy");
+  }
+  for (const field of [
+    "core_generation_id",
+    "core_run_id",
+    "retrieval_generation",
+    "semantic_generation",
+  ]) {
+    if (typeof receipt?.[field] !== "string" || !receipt[field].trim()) {
+      errors.push(`packet retrieval proof is missing ${field}`);
+    }
+  }
+  if (expectedRequest) {
+    const request = receipt?.request;
+    const optionIds = request?.option_ids;
+    const expectedOptions = new Set(expectedRequest.allowed_option_ids ?? []);
+    if (
+      request?.question_sha256 !== expectedRequest.question_sha256 ||
+      request?.parent_packet_id !== (expectedRequest.parent_packet_id ?? null) ||
+      request?.core_generation_id !== (expectedRequest.core_generation_id ?? null) ||
+      request?.retrieval_generation !== (expectedRequest.retrieval_generation ?? null) ||
+      !Array.isArray(optionIds) ||
+      new Set(optionIds).size !== optionIds.length ||
+      optionIds.some((value) => !expectedOptions.has(value)) ||
+      (expectedRequest.parent_packet_id ? optionIds.length === 0 : optionIds.length !== 0)
+    ) {
+      errors.push("packet retrieval proof is not bound to the exact benchmark request");
+    }
+  }
+  return errors;
+}
+
 async function runCodeStoryPacketPrelude(opts, run, repoConfig, outDir, runId, codestoryCli, env) {
-  const args = packetCommandArgs(repoConfig, run.task, opts);
+  const args = packetCommandArgs(repoConfig, run.task, opts, run.arm);
+  const retrievalProofPath = opts.builderAblation
+    ? path.join(outDir, `${runId}.packet-retrieval-proof.json`)
+    : null;
+  if (retrievalProofPath) {
+    args.push("--benchmark-retrieval-proof-out", retrievalProofPath);
+  }
   const extraProbes = packetCommandExtraProbes(run.task, opts);
   let command = displayCommand(codestoryCli, args);
   let activeArgs = args;
@@ -6022,6 +6554,7 @@ async function runCodeStoryPacketPrelude(opts, run, repoConfig, outDir, runId, c
   let activeStderrPath = stderrPath;
   let drillContinuation = false;
   if (
+    !opts.builderAblation &&
     result.status === "pass" &&
     !parseError &&
     (
@@ -6029,7 +6562,7 @@ async function runCodeStoryPacketPrelude(opts, run, repoConfig, outDir, runId, c
       (isPacketProjectionV3(packet) && packet?.status === "continuation_available")
     )
   ) {
-    const drillArgs = drillPacketCommandArgs(repoConfig, run.task, opts, packet);
+    const drillArgs = drillPacketCommandArgs(repoConfig, run.task, opts, packet, run.arm);
     if (drillArgs) {
       const drillStdoutPath = path.join(outDir, `${runId}.codestory-packet-drill.stdout.json`);
       const drillStderrPath = path.join(outDir, `${runId}.codestory-packet-drill.stderr.txt`);
@@ -6067,8 +6600,26 @@ async function runCodeStoryPacketPrelude(opts, run, repoConfig, outDir, runId, c
   }
 
   const wallMs = Math.round((performance.now() - started) * 1000) / 1000;
+  let retrievalProof = null;
+  let retrievalProofError = null;
+  if (retrievalProofPath) {
+    try {
+      retrievalProof = JSON.parse(await readFile(retrievalProofPath, "utf8"));
+      retrievalProofError = builderPacketRetrievalProofErrors(retrievalProof, run.arm, {
+        question_sha256: sha256Bytes(run.task?.prompt ?? repoConfig.prompt),
+        parent_packet_id: null,
+        allowed_option_ids: [],
+        core_generation_id: null,
+        retrieval_generation: null,
+      })[0] ?? null;
+    } catch (error) {
+      retrievalProofError = `packet retrieval proof failed: ${error.message}`;
+    }
+  }
   const manifestQuality = packetManifestQualitySummary(packet, run.task);
-  const contractBlockers = parseError
+  const contractBlockers = retrievalProofError
+    ? [retrievalProofError]
+    : parseError
     ? [`packet JSON parse failed: ${parseError}`]
     : commandFailureReason
       ? [commandFailureReason]
@@ -6126,6 +6677,9 @@ async function runCodeStoryPacketPrelude(opts, run, repoConfig, outDir, runId, c
     packet_contract_runtime: packet?._meta?.codestory_publication?.contract_runtime ?? null,
     packet_extra_probe_count: extraProbes.length,
     packet_extra_probe_strategy: packetExtraProbeStrategy(extraProbes),
+    packet_retrieval_policy: builderPacketRetrievalPolicy(run.arm),
+    packet_retrieval_proof: retrievalProof,
+    packet_retrieval_proof_path: retrievalProofPath,
     packet_drill_continuation: drillContinuation,
     packet_contract_blockers: contractBlockers,
     packet_command_failure: commandFailure,
@@ -6192,15 +6746,20 @@ async function runOne(opts, run, outDir) {
   const env = agentRunnerEnv(
     selectedBenchmarkChildEnv(opts, run.arm),
     opts.agentCodexHomes?.[run.arm] ?? null,
-    !opts.exactCandidate || isCodeStoryArm(run.arm),
+    opts.builderAblation
+      ? isCodeStoryArm(run.arm)
+      : (!opts.exactCandidate || isCodeStoryArm(run.arm)),
   );
+  if (opts.builderAblation && isCodeStoryArm(run.arm)) {
+    env.CODESTORY_CLI = codestoryPreludeCli;
+  }
   const interactionStarted = performance.now();
   const baselinePrelude =
     run.arm === "without_codestory"
       ? await runBaselinePrelude(opts, run, repoConfig, outDir, runId)
       : null;
   const codestoryPrelude =
-    isCodeStoryArm(run.arm)
+    isPacketArm(run.arm)
       ? await runCodeStoryPacketPrelude(
           opts,
           run,
@@ -6211,9 +6770,26 @@ async function runOne(opts, run, outDir) {
           env,
         )
       : null;
+  const opaqueContinuationProofPath = opts.builderAblation && isBuilderPacketArm(run.arm)
+    ? opaqueBuilderContinuationProofPath(opts.builderAblationStateRoot)
+    : null;
+  const builderContinuation = builderContinuationContract(
+    repoConfig,
+    run.task,
+    opts,
+    codestoryPrelude?.packet,
+    run.arm,
+    opaqueContinuationProofPath,
+  );
+  const builderContinuationProofPath = builderContinuation?.proof_path ?? null;
+  if (builderContinuationProofPath) {
+    await mkdir(path.dirname(builderContinuationProofPath), { recursive: true, mode: 0o700 });
+  }
   const prompt = composePrompt(run.repo, repoConfig, run.arm, run.task, {
     baselinePrelude,
     codestoryPrelude,
+    builderAblation: opts.builderAblation,
+    builderContinuationContract: builderContinuation,
   });
   const { command, args, stdin, killProcessTree } = runnerCommand(
     opts,
@@ -6300,10 +6876,61 @@ async function runOne(opts, run, outDir) {
     "exact_match",
   ].includes(codestoryBinaryIdentity.status);
   const provenance = await repoProvenance(repoConfig, opts.signal);
-  const packetFirstRequired = isCodeStoryArm(run.arm);
+  const packetFirstRequired = isPacketArm(run.arm);
   const packetFirstPass =
     !packetFirstRequired || Boolean(analysis.packet_was_first_context_command);
   const quality = scoreQuality(analysisEvents, run.task);
+  const builderOperationErrors = opts.builderAblation
+    ? builderOperationViolations(run.arm, analysis.codestory_operations, {
+        continuationContract: builderContinuation,
+        expectedProject: repoConfig.path,
+      })
+    : [];
+  let builderContinuationRetrievalProof = null;
+  if (builderContinuationProofPath && existsSync(builderContinuationProofPath)) {
+    try {
+      builderContinuationRetrievalProof = JSON.parse(
+        await readFile(builderContinuationProofPath, "utf8"),
+      );
+      const proofErrors = builderPacketRetrievalProofErrors(
+        builderContinuationRetrievalProof,
+        run.arm,
+        { ...builderContinuation, requested_dense_semantic: false },
+      );
+      if (proofErrors.length) builderOperationErrors.push(...proofErrors.map((error) => `continuation ${error}`));
+      const initialIdentity = codestoryPrelude?.public?.packet_retrieval_proof;
+      for (const field of [
+        "core_generation_id",
+        "core_run_id",
+        "retrieval_generation",
+        "semantic_generation",
+      ]) {
+        if (builderContinuationRetrievalProof?.[field] !== initialIdentity?.[field]) {
+          builderOperationErrors.push(`continuation packet changed ${field}`);
+        }
+      }
+    } catch (error) {
+      builderOperationErrors.push(`continuation retrieval proof failed: ${error.message}`);
+    }
+  }
+  const agentPacketContinuations = analysis.codestory_operations.filter(
+    (operation) => operation.source === "agent_cli" && operation.operation === "packet",
+  );
+  if (builderContinuationProofPath && agentPacketContinuations.length > 0 && !builderContinuationRetrievalProof) {
+    builderOperationErrors.push("packet continuation did not produce an execution proof");
+  }
+  if (builderContinuationProofPath && agentPacketContinuations.length === 0 && builderContinuationRetrievalProof) {
+    builderOperationErrors.push("unexpected continuation execution proof without a recorded continuation");
+  }
+  if (opts.builderAblation && analysis.external_context_tool_calls > 0) {
+    builderOperationErrors.push("external context tool use is forbidden");
+  }
+  if (opts.builderAblation && analysis.remote_context_commands.length > 0) {
+    builderOperationErrors.push("remote repository or HTTP command use is forbidden");
+  }
+  const builderFirstCodeStoryRequired = opts.builderAblation && isCodeStoryArm(run.arm);
+  const builderFirstCodeStoryPass = !builderFirstCodeStoryRequired ||
+    analysis.codestory_was_first_context_command === true;
   const cacheProvenance = isCodeStoryArm(run.arm)
     ? await codestoryCacheProvenance(
         opts,
@@ -6387,6 +7014,26 @@ async function runOne(opts, run, outDir) {
     transcript_analysis: analysis,
     packet_first_required: packetFirstRequired,
     packet_first_pass: packetFirstPass,
+    builder_ablation: opts.builderAblation
+      ? {
+          contract: "codestory.evidence-compiler-builder-row/v1",
+          development_only: true,
+          release_authority: false,
+          fresh: true,
+          first_codestory_required: builderFirstCodeStoryRequired,
+          first_codestory_pass: builderFirstCodeStoryPass,
+          packet_retrieval_policy: builderPacketRetrievalPolicy(run.arm),
+          continuation_offer: builderContinuationOfferReceipt(builderContinuation),
+          continuation_retrieval_proof: builderContinuationRetrievalProof,
+          intervention_scope: isBuilderPacketArm(run.arm)
+            ? "dense_candidate_stage_only_model_residency_and_full_publication_health_retained"
+            : null,
+          operation_violations: [
+            ...builderOperationErrors,
+            ...(builderFirstCodeStoryPass ? [] : ["first repository-context action was not CodeStory"]),
+          ],
+        }
+      : null,
     quality,
     event_types: eventTypeCounts(analysisEvents),
     json_events: parsed.length,
@@ -6573,6 +7220,8 @@ function retrievalStatusSnapshotFromOutput(result, output, parseError, wallMs) {
     degraded_reason: output?.degraded_reason ?? null,
     manifest_embedding_backend: output?.manifest?.embedding_backend ?? null,
     manifest_embedding_dim: output?.manifest?.embedding_dim ?? null,
+    sidecar_input_hash: output?.manifest?.sidecar_input_hash ?? null,
+    sidecar_generation: output?.manifest?.sidecar_generation ?? null,
     semantic_generation: output?.manifest?.semantic_generation ?? null,
     embedding_device_policy: output?.embedding_device_policy ?? null,
     embedding_device_state: output?.embedding_device_state ?? null,
@@ -7703,7 +8352,7 @@ async function prepareCodeStoryCaches(opts, tasks) {
       },
     }));
   }
-  if (!opts.arms.includes("with_codestory")) {
+  if (!opts.arms.some(isCodeStoryArm)) {
     return [];
   }
   const repoNames = [...new Set(tasks.map((task) => task.repo))];
@@ -10396,6 +11045,12 @@ function resourceAccountingForResult(result) {
     direct_source_reads_total: presentFiniteNumber(analysis.direct_source_reads_total),
     ordinary_source_reads_after_first_codestory:
       presentFiniteNumber(analysis.ordinary_source_reads_after_first_codestory),
+    exploratory_source_reads_after_first_codestory:
+      presentFiniteNumber(analysis.exploratory_source_reads_after_first_codestory),
+    exploratory_repository_context_actions_after_first_codestory:
+      presentFiniteNumber(
+        analysis.exploratory_repository_context_actions_after_first_codestory,
+      ),
     ordinary_source_reads_after_first_packet:
       presentFiniteNumber(analysis.ordinary_source_reads_after_first_packet),
   };
@@ -10485,6 +11140,15 @@ function summarizeArmCostAccounting(rows) {
       ),
       ordinary_source_reads_after_first_codestory: sumFinite(
         rows.map((row) => row.transcript_analysis?.ordinary_source_reads_after_first_codestory),
+      ),
+      exploratory_source_reads_after_first_codestory: sumFinite(
+        rows.map((row) => row.transcript_analysis?.exploratory_source_reads_after_first_codestory),
+      ),
+      exploratory_repository_context_actions_after_first_codestory: sumFinite(
+        rows.map(
+          (row) => row.transcript_analysis
+            ?.exploratory_repository_context_actions_after_first_codestory,
+        ),
       ),
       ordinary_source_reads_after_first_packet: sumFinite(
         rows.map((row) => row.transcript_analysis?.ordinary_source_reads_after_first_packet),
@@ -11669,6 +12333,9 @@ function runSelfTest() {
 }
 
 function planAgentRuns(opts, tasks) {
+  if (opts.builderAblation) {
+    return planBuilderAblationRuns(tasks, opts.repeats);
+  }
   const plannedRuns = [];
   if (opts.exactCandidate) {
     for (const [taskIndex, task] of tasks.entries()) {
@@ -13275,7 +13942,7 @@ async function benchmarkShardAttestation(
     throw new Error("Benchmark shard attestation requires a clean tracked source checkout");
   }
   let cliSha256 = dependencies.cliSha256 ?? null;
-  if (!Object.hasOwn(dependencies, "cliSha256") && opts.arms.includes("with_codestory")) {
+  if (!Object.hasOwn(dependencies, "cliSha256") && opts.arms.some(isCodeStoryArm)) {
     const cli = resolveCodeStoryCli(opts);
     if (path.isAbsolute(cli) && existsSync(cli) && statSync(cli).isFile()) {
       cliSha256 = sha256Bytes(await readFile(cli));
@@ -13305,6 +13972,7 @@ async function benchmarkShardAttestation(
     canary_task_id: opts.canaryTaskId ?? opts.manifestCanaryTaskId ?? null,
     diagnostic_extra_probes_from_manifest: Boolean(opts.diagnosticExtraProbesFromManifest),
     collect_all_failures: Boolean(opts.collectAllFailures),
+    builder_ablation: Boolean(opts.builderAblation),
     shard_count: opts.shardCount,
   };
   const rowContractEnvironmentDigests = new Set(
@@ -13819,6 +14487,98 @@ async function runExactCandidatePipeline({
   };
 }
 
+async function runBuilderAblationPipeline({
+  opts,
+  tasks,
+  plannedRuns,
+  executeRun,
+  outDir,
+  materializeGroup,
+  prepareGroup,
+  prepareIsolation,
+  recordResult,
+  recordPreparation,
+  recordPreparationState,
+  recordFirstFailure,
+}) {
+  const cachePreparation = [];
+  opts.cachePreparationByRepo ??= new Map();
+  const groups = [...groupTasksByRepo(tasks)].map(([repo, repoTasks]) => ({ repo, tasks: repoTasks }));
+  for (const group of groups) {
+    try {
+      await materializeGroup(group, null);
+      await recordPreparationState({ kind: "materialized", repo: group.repo });
+      const rows = await prepareGroup(group, null);
+      if (!Array.isArray(rows) || rows.length !== 1 || rows[0]?.repo !== group.repo) {
+        throw new Error(`builder ablation preparation must return exactly one row for ${group.repo}`);
+      }
+      const blockers = cachePreparationCanaryBlockers(
+        rows[0],
+        selectedBenchmarkChildEnv(opts),
+      );
+      if (blockers.length) {
+        throw new Error(`builder ablation preparation is ineligible: ${blockers.join("; ")}`);
+      }
+      await recordPreparation(rows[0]);
+      cachePreparation.push(rows[0]);
+      opts.cachePreparationByRepo.set(group.repo, rows[0]);
+      await recordPreparationState({ kind: "prepared", repo: group.repo });
+    } catch (error) {
+      if (error?.preparation) await recordPreparation(error.preparation);
+      const failure = pipelineStageFailure("preparation", group, error);
+      await recordFirstFailure(failure);
+      return {
+        results: [],
+        firstFailure: failure,
+        comparativeFailure: null,
+        comparativePublishable: false,
+        cachePreparation,
+        agentCodexIsolation: null,
+        aborted: true,
+      };
+    }
+  }
+
+  let agentCodexIsolation;
+  try {
+    agentCodexIsolation = await prepareIsolation();
+  } catch (error) {
+    const failure = pipelineStageFailure("agent_isolation", null, error);
+    await recordFirstFailure(failure);
+    return {
+      results: [],
+      firstFailure: failure,
+      comparativeFailure: null,
+      comparativePublishable: false,
+      cachePreparation,
+      agentCodexIsolation: null,
+      aborted: true,
+    };
+  }
+
+  const outcome = await runPlannedAgentRuns(
+    { ...opts, jobs: 1 },
+    plannedRuns,
+    new Map(),
+    outDir,
+    {
+      runOne: executeRun,
+      failFast: false,
+      onResult: recordResult,
+      onFirstFailure: recordFirstFailure,
+    },
+  );
+  return {
+    results: outcome.results,
+    firstFailure: outcome.firstFailure,
+    comparativeFailure: null,
+    comparativePublishable: outcome.firstFailure == null,
+    cachePreparation,
+    agentCodexIsolation,
+    aborted: false,
+  };
+}
+
 async function runAgentBenchmarkPipeline({
   opts,
   tasks,
@@ -13835,6 +14595,22 @@ async function runAgentBenchmarkPipeline({
   recordFirstFailure = async () => {},
   recordComparativeFailure = async () => {},
 }) {
+  if (opts.builderAblation) {
+    return await runBuilderAblationPipeline({
+      opts,
+      tasks,
+      plannedRuns,
+      executeRun,
+      outDir,
+      materializeGroup,
+      prepareGroup,
+      prepareIsolation,
+      recordResult,
+      recordPreparation,
+      recordPreparationState,
+      recordFirstFailure,
+    });
+  }
   if (opts.exactCandidate) {
     return await runExactCandidatePipeline({
       opts,
@@ -14199,6 +14975,7 @@ async function main() {
   }
   const allTasks = await loadTasks(opts);
   validateExactCandidateShape(opts, allTasks);
+  validateBuilderAblationShape(opts, allTasks);
   opts.exactCandidateCostRates = opts.exactCandidate
     ? exactCandidateCostRates(process.env)
     : null;
@@ -14259,6 +15036,9 @@ async function main() {
   const plannedRuns = planAgentRuns(opts, tasks);
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
   const outDir = path.resolve(opts.outDir ?? path.join(repoRoot, "target", "agent-benchmark", timestamp));
+  if (opts.builderAblation) {
+    opts.timingExecutionWindowId = `builder-ablation-${timestamp}-${process.pid}`;
+  }
   await mkdir(outDir, { recursive: true });
   const runsPath = path.join(outDir, "runs.jsonl");
   if (existsSync(runsPath)) {
@@ -14301,6 +15081,8 @@ async function main() {
           ...row,
         });
       }
+    } else if (opts.builderAblation) {
+      await initializeBuilderAblationState(opts);
     }
     pipeline = await runAgentBenchmarkPipeline({
       opts,
@@ -14420,6 +15202,19 @@ async function main() {
   );
   const summaryPayload = {
     generated_at: new Date().toISOString(),
+    evidence_status: opts.builderAblation ? "builder_visible_development_only" : null,
+    release_authority: opts.builderAblation ? false : null,
+    builder_ablation: opts.builderAblation
+      ? {
+          contract: "codestory.evidence-compiler-builder-harness/v1",
+          historical_corpus_burned: true,
+          adaptive_local_investigation_allowed: true,
+          packet_continuation_selected_by_agent: true,
+          packet_semantic_off_scope:
+            "dense_candidate_stage_only_model_residency_and_full_publication_health_retained",
+          critical_claim_adjudication: "required_external_blinded_receipt",
+        }
+      : null,
     runner: opts.runner,
     model: opts.model,
     repos: opts.repos ?? [...new Set(tasks.map((task) => task.repo))],
@@ -14455,6 +15250,7 @@ async function main() {
     comparator_reuse: comparatorReuse.provenance,
     allow_failures: opts.allowFailures,
     timeout_ms: opts.timeoutMs,
+    timing_execution_window_id: opts.timingExecutionWindowId ?? null,
     sandbox: opts.sandbox,
     output_dir: outDir,
     retrieval_env: retrievalEnv(),
@@ -14565,6 +15361,7 @@ export {
   parseJsonLines,
   cachePolicyForRun,
   codeStoryArmInstruction,
+  composeBuilderAblationPrompt,
   cachePreparationCanaryBlockers,
   cachePreparationIdentityBlockers,
   candidateIncrementalRetrievalWorkBlockers,
@@ -14577,6 +15374,9 @@ export {
   finalizeBenchmarkResources,
   finalBenchmarkFailure,
   initializeExactCandidateState,
+  initializeBuilderAblationState,
+  opaqueBuilderAgentHome,
+  opaqueBuilderContinuationProofPath,
   benchmarkAgentScopeArgs,
   retrievalIndexCommandArgs,
   retrievalIndexWorkEvidence,
@@ -14585,6 +15385,7 @@ export {
   packetComposition,
   packetCommandArgs,
   drillPacketCommandArgs,
+  builderContinuationContract,
   packetForAgentPrompt,
   packetManifestExtraProbes,
   packetManifestQualitySummary,
@@ -14627,6 +15428,7 @@ export {
   packetV3EvidenceGapAccountingError,
   withExactSourceMutation,
   validateExactCandidateShape,
+  validateBuilderAblationShape,
   validateExactCandidateResumePrefixRows,
   validateExactCandidateComparatorPrefixRows,
   validateExactComparatorLedgerSha256,

--- a/scripts/codestory-evidence-compiler-ablation-adjudication.mjs
+++ b/scripts/codestory-evidence-compiler-ablation-adjudication.mjs
@@ -1,0 +1,338 @@
+#!/usr/bin/env node
+import { createHash, randomBytes } from "node:crypto";
+import { existsSync, lstatSync, realpathSync, statSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseArgs as parseNodeArgs } from "node:util";
+
+const CASES_CONTRACT = "codestory.evidence-compiler-builder-blinded-cases/v1";
+const MAP_CONTRACT = "codestory.evidence-compiler-builder-blinded-map/v1";
+const JUDGMENTS_CONTRACT = "codestory.evidence-compiler-builder-blinded-judgments/v1";
+const ADJUDICATION_CONTRACT = "codestory.evidence-compiler-builder-adjudication/v1";
+const ADJUDICATED_ARMS = new Set([
+  "exact_identity_source",
+  "exact_plus_relations",
+  "packet_semantic_off",
+  "packet_semantic_on",
+]);
+const EXPECTED_CASES = 96;
+const MAX_TRANSCRIPT_BYTES = 16 * 1024 * 1024;
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function parseJsonl(text, label) {
+  return text.split(/\r?\n/u).filter(Boolean).map((line, index) => {
+    try {
+      return JSON.parse(line);
+    } catch (error) {
+      throw new Error(`invalid ${label} row ${index + 1}: ${error.message}`);
+    }
+  });
+}
+
+function pathInside(root, candidate, label) {
+  const resolvedRoot = path.resolve(root);
+  const resolved = path.resolve(candidate);
+  const relative = path.relative(resolvedRoot, resolved);
+  if (!relative || relative === "." || relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`${label} must be a file inside ${resolvedRoot}`);
+  }
+  return resolved;
+}
+
+function artifactPath(runDir, value, label) {
+  const raw = String(value ?? "").trim();
+  if (!raw) throw new Error(`${label} is missing`);
+  const candidate = pathInside(
+    runDir,
+    path.isAbsolute(raw) ? raw : path.join(runDir, raw),
+    label,
+  );
+  const metadata = lstatSync(candidate);
+  if (!metadata.isFile() || metadata.isSymbolicLink()) {
+    throw new Error(`${label} must name a regular non-symlink file`);
+  }
+  return pathInside(realpathSync(runDir), realpathSync(candidate), label);
+}
+
+function extractFinalAnswer(events) {
+  let answer = null;
+  for (const event of events) {
+    const eventType = String(event?.type ?? event?.event ?? "").toLowerCase();
+    const item = event?.item && typeof event.item === "object" ? event.item : {};
+    if (
+      (eventType === "item.completed" || eventType.endsWith(".completed")) &&
+      item.type === "agent_message" &&
+      typeof item.text === "string"
+    ) {
+      answer = item.text;
+    }
+  }
+  if (!answer?.trim()) throw new Error("runner transcript contains no final agent answer");
+  return answer;
+}
+
+async function answerFromRow(runDir, row) {
+  const transcriptPath = artifactPath(runDir, row.stdout_path, "row stdout_path");
+  const size = statSync(transcriptPath).size;
+  if (size > MAX_TRANSCRIPT_BYTES) {
+    throw new Error(`runner transcript exceeds ${MAX_TRANSCRIPT_BYTES} bytes: ${transcriptPath}`);
+  }
+  return extractFinalAnswer(parseJsonl(await readFile(transcriptPath, "utf8"), "runner transcript"));
+}
+
+function opaqueCaseId(used) {
+  for (;;) {
+    const candidate = randomBytes(12).toString("hex");
+    if (!used.has(candidate)) {
+      used.add(candidate);
+      return candidate;
+    }
+  }
+}
+
+async function prepareBlindedCases({ runDir, outputDir }) {
+  const runsPath = path.join(runDir, "runs.jsonl");
+  if (!existsSync(runsPath)) throw new Error(`missing ${runsPath}`);
+  const runBytes = await readFile(runsPath);
+  const sourceRunsSha256 = sha256(runBytes);
+  const rows = parseJsonl(runBytes.toString("utf8"), "runs.jsonl")
+    .filter((row) => ADJUDICATED_ARMS.has(row.arm));
+  if (rows.length !== EXPECTED_CASES) {
+    throw new Error(`expected ${EXPECTED_CASES} CodeStory rows for blinded adjudication; received ${rows.length}`);
+  }
+  const keys = new Set(rows.map((row) => `${row.task_id}\t${row.arm}\t${row.repeat}`));
+  if (keys.size !== rows.length) throw new Error("packet/control rows are not unique");
+
+  const usedIds = new Set();
+  const cases = [];
+  const entries = [];
+  for (const row of rows) {
+    const answer = await answerFromRow(runDir, row);
+    const caseId = opaqueCaseId(usedIds);
+    const answerSha256 = sha256(Buffer.from(answer, "utf8"));
+    cases.push({
+      case_id: caseId,
+      repository: row.repo,
+      repository_path: row.repo_path,
+      repository_commit: row.repo_provenance?.git_head ?? null,
+      question: row.task_manifest_snapshot?.prompt ?? null,
+      answer,
+      answer_sha256: answerSha256,
+    });
+    entries.push({
+      case_id: caseId,
+      task_id: row.task_id,
+      arm: row.arm,
+      repeat: row.repeat,
+      answer_sha256: answerSha256,
+    });
+  }
+  cases.sort((left, right) => left.case_id.localeCompare(right.case_id));
+  entries.sort((left, right) => left.case_id.localeCompare(right.case_id));
+  const casesPayload = {
+    contract: CASES_CONTRACT,
+    source_runs_sha256: sourceRunsSha256,
+    instructions: {
+      critical_factual_error: "Count each unique materially wrong statement about the requested code behavior that could change the answer's conclusion.",
+      unsupported_relation_claim: "Count each unique material call, import, implementation, data-flow, or control-flow claim that is not established by the answer's cited source or the pinned repository source.",
+      output: "Return the judgments contract with every case_id exactly once. Include nonnegative integer counts plus unique critical_factual_finding_ids and unsupported_relation_finding_ids arrays of the same lengths. Reuse one stable finding id when two answers make the same error. Add concise source-backed notes. Do not identify or infer experimental arms.",
+    },
+    cases,
+  };
+  const casesBytes = Buffer.from(`${JSON.stringify(casesPayload, null, 2)}\n`);
+  const casesSha256 = sha256(casesBytes);
+  const mapPayload = {
+    contract: MAP_CONTRACT,
+    source_runs_sha256: sourceRunsSha256,
+    source_cases_sha256: casesSha256,
+    entries,
+  };
+  await mkdir(outputDir, { recursive: true });
+  const casesPath = path.join(outputDir, "blinded-cases.json");
+  const mapPath = path.join(outputDir, "private-case-map.json");
+  await writeFile(casesPath, casesBytes, { mode: 0o600 });
+  await writeFile(mapPath, `${JSON.stringify(mapPayload, null, 2)}\n`, { mode: 0o600 });
+  return { casesPath, mapPath, casesSha256, sourceRunsSha256 };
+}
+
+function integerCount(value, label) {
+  if (!Number.isInteger(value) || value < 0) throw new Error(`${label} must be a nonnegative integer`);
+  return value;
+}
+
+function findingIds(value, expectedCount, label) {
+  if (!Array.isArray(value) || value.length !== expectedCount) {
+    throw new Error(`${label} must contain exactly ${expectedCount} finding ids`);
+  }
+  const ids = value.map((entry) => String(entry ?? "").trim());
+  if (
+    ids.some((entry) => !entry || entry.length > 256) ||
+    new Set(ids).size !== ids.length
+  ) {
+    throw new Error(`${label} must contain unique nonempty ids of at most 256 characters`);
+  }
+  return ids;
+}
+
+async function finalizeAdjudication({ runDir, casesPath, mapPath, judgmentsPath, outputPath }) {
+  const runBytes = await readFile(path.join(runDir, "runs.jsonl"));
+  const sourceRunsSha256 = sha256(runBytes);
+  const casesBytes = await readFile(casesPath);
+  const cases = JSON.parse(casesBytes.toString("utf8"));
+  const mapping = JSON.parse(await readFile(mapPath, "utf8"));
+  const judgmentBytes = await readFile(judgmentsPath);
+  const judgments = JSON.parse(judgmentBytes.toString("utf8"));
+  const sourceCasesSha256 = sha256(casesBytes);
+  if (
+    cases.contract !== CASES_CONTRACT ||
+    mapping.contract !== MAP_CONTRACT ||
+    judgments.contract !== JUDGMENTS_CONTRACT
+  ) {
+    throw new Error("blinded adjudication contract mismatch");
+  }
+  if (
+    cases.source_runs_sha256 !== sourceRunsSha256 ||
+    mapping.source_runs_sha256 !== sourceRunsSha256 ||
+    mapping.source_cases_sha256 !== sourceCasesSha256 ||
+    judgments.source_cases_sha256 !== sourceCasesSha256
+  ) {
+    throw new Error("blinded adjudication inputs do not bind the exact run and case bytes");
+  }
+  if (!judgments.independent_reviewer || !Array.isArray(judgments.rows)) {
+    throw new Error("judgments must name an independent reviewer and contain rows");
+  }
+  const caseIds = new Set(cases.cases?.map((entry) => entry.case_id) ?? []);
+  const mapById = new Map(mapping.entries?.map((entry) => [entry.case_id, entry]) ?? []);
+  const judgmentById = new Map(judgments.rows.map((entry) => [entry.case_id, entry]));
+  if (
+    caseIds.size !== EXPECTED_CASES ||
+    mapById.size !== EXPECTED_CASES ||
+    judgmentById.size !== EXPECTED_CASES ||
+    judgments.rows.length !== EXPECTED_CASES ||
+    [...caseIds].some((caseId) => !mapById.has(caseId) || !judgmentById.has(caseId))
+  ) {
+    throw new Error(`blinded cases, private map, and judgments must contain the same ${EXPECTED_CASES} unique case ids`);
+  }
+  const rows = [...caseIds].map((caseId) => {
+    const mapped = mapById.get(caseId);
+    const judgment = judgmentById.get(caseId);
+    const answer = cases.cases.find((entry) => entry.case_id === caseId);
+    if (
+      mapped.answer_sha256 !== answer?.answer_sha256 ||
+      answer?.answer_sha256 !== sha256(Buffer.from(String(answer?.answer ?? ""), "utf8"))
+    ) {
+      throw new Error(`answer identity mismatch for blinded case ${caseId}`);
+    }
+    const criticalFactualErrors = integerCount(
+      judgment.critical_factual_errors,
+      `${caseId} critical_factual_errors`,
+    );
+    const unsupportedRelationClaims = integerCount(
+      judgment.unsupported_relation_claims,
+      `${caseId} unsupported_relation_claims`,
+    );
+    return {
+      task_id: mapped.task_id,
+      arm: mapped.arm,
+      repeat: mapped.repeat,
+      critical_factual_errors: criticalFactualErrors,
+      critical_factual_finding_ids: findingIds(
+        judgment.critical_factual_finding_ids,
+        criticalFactualErrors,
+        `${caseId} critical_factual_finding_ids`,
+      ),
+      unsupported_relation_claims: unsupportedRelationClaims,
+      unsupported_relation_finding_ids: findingIds(
+        judgment.unsupported_relation_finding_ids,
+        unsupportedRelationClaims,
+        `${caseId} unsupported_relation_finding_ids`,
+      ),
+      notes: String(judgment.notes ?? "").trim() || null,
+    };
+  }).sort((left, right) =>
+    left.task_id.localeCompare(right.task_id) ||
+    left.arm.localeCompare(right.arm) ||
+    left.repeat - right.repeat
+  );
+  const output = {
+    contract: ADJUDICATION_CONTRACT,
+    blinded: true,
+    independent_reviewer: judgments.independent_reviewer,
+    source_runs_sha256: sourceRunsSha256,
+    source_cases_sha256: sourceCasesSha256,
+    source_judgments_sha256: sha256(judgmentBytes),
+    rows,
+  };
+  await writeFile(outputPath, `${JSON.stringify(output, null, 2)}\n`, { mode: 0o600 });
+  return output;
+}
+
+function parseArgs(argv) {
+  const { values } = parseNodeArgs({
+    args: argv,
+    allowPositionals: false,
+    strict: true,
+    options: {
+      prepare: { type: "boolean" },
+      finalize: { type: "boolean" },
+      "run-dir": { type: "string" },
+      "output-dir": { type: "string" },
+      cases: { type: "string" },
+      map: { type: "string" },
+      judgments: { type: "string" },
+      output: { type: "string" },
+    },
+  });
+  if (Boolean(values.prepare) === Boolean(values.finalize) || !values["run-dir"]) {
+    throw new Error("select exactly one of --prepare or --finalize and provide --run-dir");
+  }
+  if (values.prepare && !values["output-dir"]) {
+    throw new Error("--prepare requires --output-dir");
+  }
+  if (values.finalize && (!values.cases || !values.map || !values.judgments || !values.output)) {
+    throw new Error("--finalize requires --cases, --map, --judgments, and --output");
+  }
+  return {
+    mode: values.prepare ? "prepare" : "finalize",
+    runDir: path.resolve(values["run-dir"]),
+    outputDir: values["output-dir"] ? path.resolve(values["output-dir"]) : null,
+    casesPath: values.cases ? path.resolve(values.cases) : null,
+    mapPath: values.map ? path.resolve(values.map) : null,
+    judgmentsPath: values.judgments ? path.resolve(values.judgments) : null,
+    outputPath: values.output ? path.resolve(values.output) : null,
+  };
+}
+
+async function main(argv) {
+  const opts = parseArgs(argv);
+  if (opts.mode === "prepare") {
+    const receipt = await prepareBlindedCases(opts);
+    console.log(`wrote ${receipt.casesPath}`);
+    console.log(`withheld ${receipt.mapPath}`);
+    return;
+  }
+  await finalizeAdjudication(opts);
+  console.log(`wrote ${opts.outputPath}`);
+}
+
+export {
+  ADJUDICATION_CONTRACT,
+  CASES_CONTRACT,
+  JUDGMENTS_CONTRACT,
+  MAP_CONTRACT,
+  extractFinalAnswer,
+  finalizeAdjudication,
+  parseArgs,
+  prepareBlindedCases,
+};
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  main(process.argv.slice(2)).catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}

--- a/scripts/codestory-evidence-compiler-ablation-evaluate.mjs
+++ b/scripts/codestory-evidence-compiler-ablation-evaluate.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseArgs as parseNodeArgs } from "node:util";
+
+import {
+  BUILDER_ABLATION_ARMS,
+  BUILDER_ABLATION_TASK_IDS,
+  evidenceCompilerBuilderAcceptance,
+  marginalValue,
+} from "./lib/evidence-compiler-ablation.mjs";
+
+function parseArgs(argv) {
+  const { values } = parseNodeArgs({
+    args: argv,
+    allowPositionals: false,
+    strict: true,
+    options: {
+      "run-dir": { type: "string" },
+      adjudication: { type: "string" },
+      attempt: { type: "string" },
+      "causal-classification": { type: "string" },
+    },
+  });
+  if (!values["run-dir"] || !values.adjudication || !values.attempt) {
+    throw new Error("usage: codestory-evidence-compiler-ablation-evaluate.mjs --run-dir <dir> --adjudication <json> --attempt <initial|general_revision> [--causal-classification <new|equivalent>]");
+  }
+  if (!["initial", "general_revision"].includes(values.attempt)) {
+    throw new Error("--attempt must be initial or general_revision");
+  }
+  if (
+    values["causal-classification"] != null &&
+    !["new", "equivalent"].includes(values["causal-classification"])
+  ) {
+    throw new Error("--causal-classification must be new or equivalent");
+  }
+  return {
+    runDir: path.resolve(values["run-dir"]),
+    adjudication: path.resolve(values.adjudication),
+    attempt: values.attempt,
+    causalClassification: values["causal-classification"] ?? null,
+  };
+}
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function parseJsonl(text) {
+  return text.split(/\r?\n/u).filter(Boolean).map((line, index) => {
+    try {
+      return JSON.parse(line);
+    } catch (error) {
+      throw new Error(`invalid runs.jsonl row ${index + 1}: ${error.message}`);
+    }
+  });
+}
+
+function formatRatio(value) {
+  if (value == null) return "missing";
+  if (!Number.isFinite(value)) return "infinite";
+  return `${(value * 100).toFixed(2)}%`;
+}
+
+function markdownReceipt(receipt) {
+  const acceptance = receipt.packet_acceptance;
+  const graph = receipt.default_layer_decisions.graph_relations;
+  const semantic = receipt.default_layer_decisions.dense_semantic_candidates;
+  return `# Evidence compiler builder ablation
+
+Next action: **${receipt.packet_decision}**
+
+- Packet versus explicit primitives task-pass difference: ${acceptance.mean_task_pass_difference?.toFixed(4) ?? "missing"}
+- Exploratory repository-context-action ratio: ${formatRatio(acceptance.exploratory_repository_context_action_ratio)}
+- Whole-task wall ratio: ${formatRatio(acceptance.whole_task_wall_ratio)}
+- Input-context ratio: ${formatRatio(acceptance.input_context_ratio)}
+- Independent critical-claim adjudication complete: ${acceptance.adjudication_complete}
+- Graph relations default: ${graph}
+- Dense packet candidates default: ${semantic}
+
+${acceptance.reasons.length ? `## Blocking reasons\n\n${acceptance.reasons.map((reason) => `- ${reason}`).join("\n")}\n` : ""}
+This is builder-visible development evidence. It cannot be used as sealed release evidence.
+`;
+}
+
+function packetNextAction(packetPassed, attempt, causalClassification) {
+  if (packetPassed) {
+    if (causalClassification != null) {
+      throw new Error("a passing packet gate cannot carry a failure causal classification");
+    }
+    return "advance";
+  }
+  if (attempt === "general_revision") return "stop";
+  if (causalClassification === "new") return "revise_once";
+  if (causalClassification === "equivalent") return "stop";
+  return "failed_needs_causal_classification";
+}
+
+async function evaluate(opts) {
+  const attempt = opts.attempt ?? "initial";
+  const causalClassification = opts.causalClassification ?? null;
+  if (!["initial", "general_revision"].includes(attempt)) {
+    throw new Error("attempt must be initial or general_revision");
+  }
+  const runsPath = path.join(opts.runDir, "runs.jsonl");
+  if (!existsSync(runsPath)) throw new Error(`missing ${runsPath}`);
+  const runBytes = await readFile(runsPath);
+  const rows = parseJsonl(runBytes.toString("utf8"));
+  const adjudication = JSON.parse(await readFile(opts.adjudication, "utf8"));
+  const runsSha256 = sha256(runBytes);
+  if (adjudication.source_runs_sha256 !== runsSha256) {
+    throw new Error("adjudication source_runs_sha256 does not match runs.jsonl");
+  }
+  const packetAcceptance = evidenceCompilerBuilderAcceptance(rows, adjudication);
+  const graphRelations = marginalValue(
+    rows,
+    "exact_plus_relations",
+    "exact_identity_source",
+    adjudication,
+  );
+  const denseSemanticCandidates = marginalValue(
+    rows,
+    "packet_semantic_on",
+    "packet_semantic_off",
+    adjudication,
+  );
+  const packetDecision = packetNextAction(
+    packetAcceptance.pass,
+    attempt,
+    causalClassification,
+  );
+  const summaryPath = path.join(opts.runDir, "summary.json");
+  const summary = existsSync(summaryPath)
+    ? JSON.parse(await readFile(summaryPath, "utf8"))
+    : null;
+  const receipt = {
+    generated_at: new Date().toISOString(),
+    evidence_status: "builder_visible_development_only",
+    release_authority: false,
+    historical_corpus_burned: true,
+    experiment_attempt: attempt,
+    causal_classification: causalClassification,
+    packet_decision: packetDecision,
+    source_runs_sha256: runsSha256,
+    adjudication_sha256: sha256(await readFile(opts.adjudication)),
+    source_commit: summary?.source_commit ?? summary?.shard?.attestation?.source_commit ?? null,
+    source_tree: summary?.source_tree ?? summary?.shard?.attestation?.source_tree ?? null,
+    arms: BUILDER_ABLATION_ARMS,
+    task_ids: BUILDER_ABLATION_TASK_IDS,
+    packet_acceptance: packetAcceptance,
+    marginal_value: {
+      graph_relations: graphRelations,
+      dense_semantic_candidates: denseSemanticCandidates,
+    },
+    default_layer_decisions: {
+      graph_relations: graphRelations.positive ? "keep_default" : "disable_default",
+      dense_semantic_candidates: denseSemanticCandidates.positive
+        ? "keep_default"
+        : "disable_default",
+    },
+  };
+  await writeFile(
+    path.join(opts.runDir, "builder-ablation.json"),
+    `${JSON.stringify(receipt, null, 2)}\n`,
+    "utf8",
+  );
+  await writeFile(
+    path.join(opts.runDir, "builder-ablation.md"),
+    markdownReceipt(receipt),
+    "utf8",
+  );
+  console.log(`wrote ${path.join(opts.runDir, "builder-ablation.json")}`);
+  return receipt;
+}
+
+export { evaluate, markdownReceipt, packetNextAction, parseArgs, parseJsonl };
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  evaluate(parseArgs(process.argv.slice(2))).then((receipt) => {
+    if (receipt.packet_decision !== "advance") process.exitCode = 1;
+  }).catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}

--- a/scripts/lib/evidence-compiler-ablation.mjs
+++ b/scripts/lib/evidence-compiler-ablation.mjs
@@ -1,0 +1,1039 @@
+import { createHash } from "node:crypto";
+
+const BUILDER_ABLATION_CONTRACT = "codestory.evidence-compiler-builder-ablation/v1";
+
+const BUILDER_ABLATION_ARMS = Object.freeze([
+  "native_tools",
+  "exact_identity_source",
+  "exact_plus_relations",
+  "packet_semantic_off",
+  "packet_semantic_on",
+]);
+
+const BUILDER_ABLATION_TASK_IDS = Object.freeze([
+  "python-requests-session-flow",
+  "rust-ripgrep-search-pipeline",
+  "javascript-express-routing-flow",
+  "typescript-swr-hook-flow",
+  "c-redis-command-loop",
+  "go-gin-route-dispatch",
+  "swift-alamofire-request-flow",
+  "dart-http-client-flow",
+]);
+
+const EXACT_IDENTITY_SOURCE_OPERATIONS = new Set([
+  "search",
+  "files",
+  "symbol",
+  "symbols",
+  "get_node",
+  "definition",
+  "snippet",
+]);
+
+const EXPLICIT_RELATION_OPERATIONS = new Set([
+  ...EXACT_IDENTITY_SOURCE_OPERATIONS,
+  "context",
+  "references",
+  "trail",
+  "callers",
+  "callees",
+  "trace",
+  "neighbors",
+  "shortest_path",
+  "query_subgraph",
+]);
+
+const PACKET_OPERATIONS = new Set(["packet", "agent_packet"]);
+
+function isBuilderAblationArm(arm) {
+  return BUILDER_ABLATION_ARMS.includes(arm);
+}
+
+function isBuilderCodeStoryArm(arm) {
+  return isBuilderAblationArm(arm) && arm !== "native_tools";
+}
+
+function isBuilderPacketArm(arm) {
+  return arm === "packet_semantic_off" || arm === "packet_semantic_on";
+}
+
+function builderPacketRetrievalPolicy(arm) {
+  if (arm === "packet_semantic_off") {
+    return "repository_graph_lexical_dense_candidate_stage_disabled_v1";
+  }
+  if (arm === "packet_semantic_on") {
+    return "repository_graph_lexical_dense_candidate_stage_enabled_v1";
+  }
+  return null;
+}
+
+function planBuilderAblationRuns(tasks, repeats = 3) {
+  if (repeats !== 3) {
+    throw new Error("builder ablation requires exactly three repeats");
+  }
+  const planned = [];
+  for (const [taskIndex, task] of tasks.entries()) {
+    for (let repeat = 1; repeat <= repeats; repeat += 1) {
+      const rotation = (taskIndex * repeats + repeat - 1) % BUILDER_ABLATION_ARMS.length;
+      for (let position = 0; position < BUILDER_ABLATION_ARMS.length; position += 1) {
+        const arm = BUILDER_ABLATION_ARMS[(rotation + position) % BUILDER_ABLATION_ARMS.length];
+        planned.push({ repo: task.repo, task, arm, repeat });
+      }
+    }
+  }
+  return planned;
+}
+
+function normalizeCodeStoryOperation(value) {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/^mcp__.*__/, "")
+    .replaceAll("-", "_");
+}
+
+function hasUnquotedShellComposition(command) {
+  const text = String(command ?? "");
+  let quote = null;
+  let escaped = false;
+  for (let index = 0; index < text.length; index += 1) {
+    const character = text[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === "\\" && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if (quote === "'") {
+      if (character === "'") quote = null;
+      continue;
+    }
+    if (character === "`") return true;
+    if (character === "$" && text[index + 1] === "(") return true;
+    if (quote === '"') {
+      if (character === '"') quote = null;
+      continue;
+    }
+    if (character === "'" || character === '"') {
+      quote = character;
+      continue;
+    }
+    if (
+      character === ";" || character === "|" || character === "&" ||
+      character === "<" || character === ">" || character === "\n" ||
+      character === "\r"
+    ) {
+      return true;
+    }
+  }
+  return escaped || quote != null;
+}
+
+function shellWords(command) {
+  if (hasUnquotedShellComposition(command)) return null;
+  const text = String(command ?? "");
+  const words = [];
+  let word = "";
+  let wordStarted = false;
+  let quote = null;
+  let escaped = false;
+  const finishWord = () => {
+    if (!wordStarted) return;
+    words.push(word);
+    word = "";
+    wordStarted = false;
+  };
+  for (let index = 0; index < text.length; index += 1) {
+    const character = text[index];
+    if (escaped) {
+      word += character;
+      wordStarted = true;
+      escaped = false;
+      continue;
+    }
+    if (character === "\\" && quote !== "'") {
+      escaped = true;
+      wordStarted = true;
+      continue;
+    }
+    if (quote) {
+      if (character === quote) {
+        quote = null;
+      } else {
+        word += character;
+      }
+      wordStarted = true;
+      continue;
+    }
+    if (character === "'" || character === '"') {
+      quote = character;
+      wordStarted = true;
+      continue;
+    }
+    if (/\s/u.test(character)) {
+      finishWord();
+      continue;
+    }
+    word += character;
+    wordStarted = true;
+  }
+  if (escaped || quote) return null;
+  finishWord();
+  return words;
+}
+
+function directBenchmarkCliInvocation(command) {
+  const text = String(command ?? "");
+  const executable = String.raw`(?:"\$(?:CODESTORY_CLI|\{CODESTORY_CLI\})"|\$(?:CODESTORY_CLI|\{CODESTORY_CLI\}))`;
+  if (!new RegExp(`^\\s*${executable}(?=\\s)`, "u").test(text)) return null;
+  const words = shellWords(text);
+  if (!words || words.length < 2) return null;
+  if (!["$CODESTORY_CLI", "${CODESTORY_CLI}"].includes(words[0])) return null;
+  if (!/^[a-z][a-z0-9-]*$/iu.test(words[1])) return null;
+  return {
+    operation: normalizeCodeStoryOperation(words[1]),
+    args: words.slice(2),
+  };
+}
+
+function codeStoryInvocationsFromCommand(command) {
+  const direct = directBenchmarkCliInvocation(command);
+  if (direct) {
+    return [{ operation: direct.operation, checksum_bound: true }];
+  }
+  const text = String(command ?? "").replace(/\\"/g, '"');
+  const pinnedVariable = String.raw`\$(?:\{(?:env:)?CODESTORY_CLI\}|(?:env:)?CODESTORY_CLI)`;
+  const directExecutable = String.raw`(?:codestory-cli(?:\.exe)?|(?:[^\s;&|"']+[\\/])+codestory-cli(?:\.exe)?|"[^"]*[\\/]codestory-cli(?:\.exe)?"|'[^']*[\\/]codestory-cli(?:\.exe)?')`;
+  const executable = `(?:(?<pinned>["']?${pinnedVariable}["']?)|(?<direct>${directExecutable}))`;
+  const matches = [...text.matchAll(new RegExp(`${executable}\\s+([a-z][a-z0-9-]*)\\b`, "gi"))]
+    .map((match) => ({
+      operation: normalizeCodeStoryOperation(match[3]),
+      checksum_bound: Boolean(match.groups?.pinned),
+    }));
+  if (matches.length) return matches;
+  if (new RegExp(`${pinnedVariable}|\\bCODESTORY_CLI\\b|codestory-cli(?:\\.exe)?`, "i").test(text)) {
+    return [{ operation: null, checksum_bound: false }];
+  }
+  return [];
+}
+
+function codeStoryOperationFromCommand(command) {
+  return codeStoryInvocationsFromCommand(command)[0]?.operation ?? null;
+}
+
+function codeStoryOperationFromMcpTool(toolName) {
+  const normalized = normalizeCodeStoryOperation(toolName);
+  return normalized || null;
+}
+
+const TRAIL_ARGUMENTS = Object.freeze({
+  values: new Set([
+    "--project", "--id", "--query", "--file", "--choose", "--mode", "--depth",
+    "--direction", "--max-nodes", "--layout", "--format",
+  ]),
+  booleans: new Set([
+    "--include-tests", "--show-utility-calls", "--hide-speculative", "--story", "--mermaid",
+  ]),
+});
+
+const EXACT_OPERATION_ARGUMENTS = Object.freeze({
+  search: {
+    values: new Set([
+      "--project", "--query", "--limit", "--repo-text", "--profile", "--run-id",
+      "--format",
+    ]),
+    booleans: new Set(["--why", "--plan-details"]),
+  },
+  files: {
+    values: new Set(["--project", "--path", "--language", "--role", "--limit", "--format"]),
+    booleans: new Set(),
+  },
+  symbol: {
+    values: new Set(["--project", "--id", "--query", "--file", "--choose", "--format"]),
+    booleans: new Set(["--mermaid"]),
+  },
+  snippet: {
+    values: new Set([
+      "--project", "--id", "--query", "--file", "--choose", "--context", "--lines",
+      "--format",
+    ]),
+    booleans: new Set(["--function-body"]),
+  },
+  context: {
+    values: new Set([
+      "--project", "--id", "--query", "--bookmark", "--max-results", "--format",
+    ]),
+    booleans: new Set(["--no-evidence"]),
+  },
+  trail: TRAIL_ARGUMENTS,
+  callers: TRAIL_ARGUMENTS,
+  callees: TRAIL_ARGUMENTS,
+  trace: TRAIL_ARGUMENTS,
+});
+
+function exactOperationArgumentViolations(operation, command, expectedProject) {
+  const parsed = directBenchmarkCliInvocation(command);
+  const schema = EXACT_OPERATION_ARGUMENTS[operation];
+  if (!parsed || parsed.operation !== operation || !schema) {
+    return [`CLI ${operation} has no permitted direct argument shape`];
+  }
+  if (typeof expectedProject !== "string" || !expectedProject) {
+    return ["builder harness did not bind the expected project"];
+  }
+
+  const seen = new Map();
+  const violations = [];
+  for (let index = 0; index < parsed.args.length; index += 1) {
+    const token = parsed.args[index];
+    if (!token.startsWith("--")) {
+      violations.push(`CLI ${operation} contains an unbound positional argument`);
+      continue;
+    }
+    const equals = token.indexOf("=");
+    const flag = equals >= 0 ? token.slice(0, equals) : token;
+    const inlineValue = equals >= 0 ? token.slice(equals + 1) : null;
+    if (schema.booleans.has(flag)) {
+      if (inlineValue != null || seen.has(flag)) {
+        violations.push(`CLI ${operation} has an invalid or duplicate ${flag}`);
+      }
+      seen.set(flag, true);
+      continue;
+    }
+    if (!schema.values.has(flag)) {
+      violations.push(`CLI ${operation} argument ${flag} is not permitted in the pinned ablation`);
+      continue;
+    }
+    const value = inlineValue ?? parsed.args[index + 1];
+    if (inlineValue == null) index += 1;
+    if (!value || value.startsWith("--") || seen.has(flag)) {
+      violations.push(`CLI ${operation} has a missing or duplicate ${flag}`);
+      continue;
+    }
+    seen.set(flag, value);
+  }
+
+  if (seen.get("--project") !== expectedProject) {
+    violations.push(`CLI ${operation} must bind --project to the pinned repository`);
+  }
+  if (operation === "search") {
+    if (seen.get("--repo-text") !== "off") {
+      violations.push("CLI search must declare --repo-text off in exact/relations arms");
+    }
+    if (seen.get("--profile") !== "agent" || seen.get("--run-id") !== "shared-agent") {
+      violations.push("CLI search must bind the prepared agent profile and run id");
+    }
+  }
+  return violations;
+}
+
+function commandUsesBenchmarkCli(command) {
+  return directBenchmarkCliInvocation(command) != null;
+}
+
+function optionValues(args, name) {
+  const values = [];
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] === name) {
+      if (index + 1 >= args.length || args[index + 1].startsWith("--")) return null;
+      values.push(args[index + 1]);
+      index += 1;
+    } else if (args[index].startsWith(`${name}=`)) {
+      const value = args[index].slice(name.length + 1);
+      if (!value) return null;
+      values.push(value);
+    }
+  }
+  return values;
+}
+
+function singleOption(args, name) {
+  const values = optionValues(args, name);
+  return values?.length === 1 ? values[0] : null;
+}
+
+function packetContinuationShape(operation, arm, options = {}) {
+  const raw = operation?.raw ?? {};
+  const expected = options.continuationContract;
+  const parsed = directBenchmarkCliInvocation(raw.command);
+  if (operation?.transport !== "cli" || operation?.successful !== true || !expected || !parsed) {
+    return false;
+  }
+  if (parsed.operation !== "packet") return false;
+  const args = parsed.args;
+  const allowedFlags = new Set([
+    "--project",
+    "--profile",
+    "--run-id",
+    "--question",
+    "--budget",
+    "--format",
+    "--parent-packet-id",
+    "--option-id",
+    "--core-generation-id",
+    "--retrieval-generation",
+    "--benchmark-retrieval-proof-out",
+    "--benchmark-disable-dense-semantic",
+  ]);
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (!token.startsWith("--")) return false;
+    const flag = token.split("=", 1)[0];
+    if (!allowedFlags.has(flag)) return false;
+    if (flag !== "--benchmark-disable-dense-semantic" && !token.includes("=")) index += 1;
+  }
+  const optionIds = optionValues(args, "--option-id");
+  const allowedOptionIds = new Set(expected.allowed_option_ids ?? []);
+  if (
+    !optionIds?.length ||
+    new Set(optionIds).size !== optionIds.length ||
+    optionIds.some((value) => !allowedOptionIds.has(value))
+  ) {
+    return false;
+  }
+  for (const [flag, value] of [
+    ["--project", expected.project],
+    ["--profile", "agent"],
+    ["--run-id", "shared-agent"],
+    ["--question", expected.question],
+    ["--budget", "standard"],
+    ["--format", "json"],
+    ["--parent-packet-id", expected.parent_packet_id],
+    ["--core-generation-id", expected.core_generation_id],
+    ["--retrieval-generation", expected.retrieval_generation],
+    ["--benchmark-retrieval-proof-out", expected.proof_path],
+  ]) {
+    if (singleOption(args, flag) !== value) return false;
+  }
+  const denseDisabled = args.filter((arg) => arg === "--benchmark-disable-dense-semantic").length;
+  if (args.some((arg) => arg.startsWith("--benchmark-disable-dense-semantic="))) {
+    return false;
+  }
+  // A typed continuation is an exact-selector follow-up, so both packet arms
+  // hold its dense stage disabled. The only semantic treatment difference is
+  // the hidden initial packet prelude.
+  return denseDisabled === 1;
+}
+
+function builderOperationViolations(arm, operations, options = {}) {
+  const violations = [];
+  if (!isBuilderAblationArm(arm)) {
+    return [`unknown builder ablation arm: ${arm}`];
+  }
+  const attempted = operations ?? [];
+  const successful = attempted.filter((entry) => entry?.successful === true);
+  if (arm === "native_tools") {
+    if (attempted.length) {
+      violations.push(`native arm attempted CodeStory operation(s): ${attempted.map((entry) => entry.operation ?? "unknown").join(", ")}`);
+    }
+    return violations;
+  }
+
+  if (!successful.length) {
+    return ["CodeStory arm executed no successful CodeStory operation"];
+  }
+  for (const entry of attempted) {
+    if (entry.source !== "harness_packet_prelude" && entry.transport !== "cli") {
+      violations.push("builder ablation permits only the checksum-bound CodeStory CLI");
+    }
+    if (
+      entry.transport === "cli" &&
+      entry.source !== "harness_packet_prelude" &&
+      !commandUsesBenchmarkCli(entry.raw?.command)
+    ) {
+      violations.push("agent CLI operation did not execute the checksum-bound $CODESTORY_CLI");
+    }
+    if (entry.transport === "cli" && entry.source !== "harness_packet_prelude") {
+      if (hasUnquotedShellComposition(entry.raw?.command)) {
+        violations.push("agent CLI operation must be one uncomposed command");
+      }
+      const remainingCodeStoryEnvironment = String(entry.raw?.command ?? "")
+        .replace(/\$(?:\{(?:env:)?CODESTORY_CLI\}|(?:env:)?CODESTORY_CLI)/gi, "");
+      if (/\bCODESTORY_[A-Z0-9_]+\b/i.test(remainingCodeStoryEnvironment)) {
+        violations.push("agent CLI operation attempted to inspect or override CodeStory benchmark state");
+      }
+    }
+  }
+  if (arm === "exact_identity_source" || arm === "exact_plus_relations") {
+    const allowed = arm === "exact_identity_source"
+      ? EXACT_IDENTITY_SOURCE_OPERATIONS
+      : EXPLICIT_RELATION_OPERATIONS;
+    for (const entry of attempted) {
+      if (!entry.operation || !allowed.has(entry.operation)) {
+        violations.push(`operation ${entry.operation ?? "unknown"} is forbidden in ${arm}`);
+        continue;
+      }
+      violations.push(...exactOperationArgumentViolations(
+        entry.operation,
+        entry.raw?.command,
+        options.expectedProject,
+      ));
+    }
+    return violations;
+  }
+
+  if (attempted.length > 2) {
+    violations.push(`packet arm attempted ${attempted.length} CodeStory operations; maximum is two`);
+  }
+  for (const entry of attempted) {
+    if (!entry.operation || !PACKET_OPERATIONS.has(entry.operation)) {
+      violations.push(`operation ${entry.operation ?? "unknown"} is forbidden in ${arm}`);
+    }
+  }
+  if (attempted.length >= 1 && attempted[0].source !== "harness_packet_prelude") {
+    violations.push("packet arm did not begin with the harness packet prelude");
+  }
+  if (attempted.length === 2 && !packetContinuationShape(attempted[1], arm, options)) {
+    violations.push("packet continuation is missing generation-bound typed selectors, execution proof, or the requested dense policy");
+  }
+  if (attempted.length === 2 && !options.continuationContract) {
+    violations.push("packet continuation was not offered by the initial packet");
+  }
+  return violations;
+}
+
+function finiteNonnegative(value) {
+  return Number.isFinite(value) && value >= 0;
+}
+
+function mean(values) {
+  return values.length ? values.reduce((sum, value) => sum + value, 0) / values.length : null;
+}
+
+function median(values) {
+  if (!values.length) return null;
+  const ordered = [...values].sort((left, right) => left - right);
+  const midpoint = Math.floor(ordered.length / 2);
+  return ordered.length % 2 === 0
+    ? (ordered[midpoint - 1] + ordered[midpoint]) / 2
+    : ordered[midpoint];
+}
+
+function ratio(numerator, denominator) {
+  if (!finiteNonnegative(numerator) || !finiteNonnegative(denominator)) return null;
+  if (denominator === 0) return numerator === 0 ? 1 : Number.POSITIVE_INFINITY;
+  return numerator / denominator;
+}
+
+function receiptRatio(value) {
+  return value === Number.POSITIVE_INFINITY ? "infinite" : value;
+}
+
+function pairedRows(rows, candidateArm, controlArm) {
+  const control = new Map(
+    rows
+      .filter((row) => row.arm === controlArm)
+      .map((row) => [`${row.task_id}\t${row.repeat}`, row]),
+  );
+  return rows
+    .filter((row) => row.arm === candidateArm)
+    .map((candidate) => ({
+      candidate,
+      control: control.get(`${candidate.task_id}\t${candidate.repeat}`) ?? null,
+    }));
+}
+
+function timingPairIsEligible({ candidate, control }) {
+  const candidateCohort = candidate?.installed_agent_timing?.timing_cohort_id;
+  const controlCohort = control?.installed_agent_timing?.timing_cohort_id;
+  return Boolean(
+    control &&
+    candidate?.installed_agent_timing_eligible === true &&
+    control?.installed_agent_timing_eligible === true &&
+    /^[0-9a-f]{64}$/u.test(String(candidateCohort ?? "")) &&
+    candidateCohort === controlCohort,
+  );
+}
+
+function taskPassCounts(rows, arm) {
+  const byTask = new Map();
+  for (const row of rows.filter((entry) => entry.arm === arm)) {
+    const current = byTask.get(row.task_id) ?? { passes: 0, rows: 0 };
+    current.rows += 1;
+    if (row.quality?.pass === true) current.passes += 1;
+    byTask.set(row.task_id, current);
+  }
+  return byTask;
+}
+
+function adjudicationKey(row) {
+  return `${row.task_id}\t${row.arm}\t${row.repeat}`;
+}
+
+function normalizeAdjudication(adjudication) {
+  if (adjudication?.contract !== "codestory.evidence-compiler-builder-adjudication/v1") {
+    return { complete: false, byKey: new Map(), reason: "missing or invalid independent adjudication contract" };
+  }
+  const digest = /^[0-9a-f]{64}$/u;
+  if (
+    adjudication.blinded !== true ||
+    typeof adjudication.independent_reviewer !== "string" ||
+    !adjudication.independent_reviewer.trim() ||
+    !digest.test(String(adjudication.source_cases_sha256 ?? "")) ||
+    !digest.test(String(adjudication.source_judgments_sha256 ?? "")) ||
+    !Array.isArray(adjudication.rows)
+  ) {
+    return {
+      complete: false,
+      byKey: new Map(),
+      reason: "adjudication must carry blinded case, judgment, and independent-reviewer receipts",
+    };
+  }
+  const byKey = new Map(adjudication.rows.map((row) => [adjudicationKey(row), row]));
+  if (byKey.size !== adjudication.rows.length) {
+    return { complete: false, byKey, reason: "adjudication contains duplicate task/arm/repeat rows" };
+  }
+  const adjudicatedArms = BUILDER_ABLATION_ARMS.filter((arm) => arm !== "native_tools");
+  const expectedKeys = new Set(BUILDER_ABLATION_TASK_IDS.flatMap((taskId) =>
+    adjudicatedArms.flatMap((arm) => [1, 2, 3].map(
+      (repeat) => `${taskId}\t${arm}\t${repeat}`,
+    )),
+  ));
+  if (
+    byKey.size !== expectedKeys.size ||
+    [...byKey.keys()].some((key) => !expectedKeys.has(key))
+  ) {
+    return {
+      complete: false,
+      byKey,
+      reason: `adjudication must contain exactly ${expectedKeys.size} CodeStory-arm rows`,
+    };
+  }
+  return {
+    complete: true,
+    byKey,
+    reason: null,
+  };
+}
+
+function criticalCount(adjudicatedRow) {
+  const factual = Number(adjudicatedRow?.critical_factual_errors);
+  const relations = Number(adjudicatedRow?.unsupported_relation_claims);
+  const factualIds = adjudicatedRow?.critical_factual_finding_ids;
+  const relationIds = adjudicatedRow?.unsupported_relation_finding_ids;
+  if (
+    !Number.isInteger(factual) || factual < 0 ||
+    !Number.isInteger(relations) || relations < 0 ||
+    !Array.isArray(factualIds) || factualIds.length !== factual ||
+    !Array.isArray(relationIds) || relationIds.length !== relations ||
+    new Set(factualIds).size !== factualIds.length ||
+    new Set(relationIds).size !== relationIds.length
+  ) {
+    return null;
+  }
+  return factual + relations;
+}
+
+function criticalFindingIds(adjudicatedRow) {
+  if (criticalCount(adjudicatedRow) == null) return null;
+  return new Set([
+    ...adjudicatedRow.critical_factual_finding_ids.map((id) => `factual:${id}`),
+    ...adjudicatedRow.unsupported_relation_finding_ids.map((id) => `relation:${id}`),
+  ]);
+}
+
+function sha256Text(value) {
+  return createHash("sha256").update(String(value ?? ""), "utf8").digest("hex");
+}
+
+function requestReceiptMatchesInitial(receipt, question) {
+  const request = receipt?.request;
+  return Boolean(
+    request &&
+    request.question_sha256 === sha256Text(question) &&
+    request.parent_packet_id == null &&
+    Array.isArray(request.option_ids) &&
+    request.option_ids.length === 0 &&
+    request.core_generation_id == null &&
+    request.retrieval_generation == null
+  );
+}
+
+function requestReceiptMatchesContinuation(receipt, offer) {
+  const request = receipt?.request;
+  const selected = request?.option_ids;
+  const allowed = new Set(offer?.allowed_option_ids ?? []);
+  return Boolean(
+    offer &&
+    request &&
+    request.question_sha256 === offer.question_sha256 &&
+    request.parent_packet_id === offer.parent_packet_id &&
+    request.core_generation_id === offer.core_generation_id &&
+    request.retrieval_generation === offer.retrieval_generation &&
+    Array.isArray(selected) &&
+    selected.length > 0 &&
+    new Set(selected).size === selected.length &&
+    selected.every((value) => allowed.has(value))
+  );
+}
+
+function candidateOnlyCriticalForPairs(pairs, normalizedAdjudication) {
+  const missing = [];
+  const candidateOnly = [];
+  for (const { candidate, control } of pairs) {
+    if (!control) {
+      missing.push(`${candidate.task_id}/${candidate.repeat}`);
+      continue;
+    }
+    const candidateJudgment = normalizedAdjudication.byKey.get(adjudicationKey(candidate));
+    const controlJudgment = normalizedAdjudication.byKey.get(adjudicationKey(control));
+    const candidateCount = criticalCount(candidateJudgment);
+    const controlCount = criticalCount(controlJudgment);
+    const candidateIds = criticalFindingIds(candidateJudgment);
+    const controlIds = criticalFindingIds(controlJudgment);
+    if (candidateCount == null || controlCount == null) {
+      missing.push(`${candidate.task_id}/${candidate.repeat}`);
+      continue;
+    }
+    const onlyIds = [...candidateIds].filter((id) => !controlIds.has(id));
+    if (onlyIds.length) {
+      candidateOnly.push({
+        task_id: candidate.task_id,
+        repeat: candidate.repeat,
+        candidate_critical: candidateCount,
+        control_critical: controlCount,
+        candidate_only_finding_ids: onlyIds,
+      });
+    }
+  }
+  return {
+    complete: normalizedAdjudication.complete && missing.length === 0,
+    missing,
+    candidate_only: candidateOnly,
+  };
+}
+
+function aggregateRatio(pairs, selector) {
+  const eligible = pairs.filter(({ candidate, control }) => control && selector(candidate) != null && selector(control) != null);
+  if (!eligible.length) return null;
+  return ratio(
+    eligible.reduce((sum, { candidate }) => sum + selector(candidate), 0),
+    eligible.reduce((sum, { control }) => sum + selector(control), 0),
+  );
+}
+
+function medianPairedRatio(pairs, selector) {
+  const ratios = pairs.flatMap(({ candidate, control }) => {
+    if (!control) return [];
+    const candidateValue = selector(candidate);
+    const controlValue = selector(control);
+    const value = ratio(candidateValue, controlValue);
+    return value == null ? [] : [value];
+  });
+  return median(ratios);
+}
+
+function denseStageProofInvocations(receipt, arm) {
+  const proof = receipt?.retrieval_proof;
+  const expectedDense = arm === "packet_semantic_on";
+  const invocations = proof?.dense_semantic_stage_invocations;
+  const stageInvocations = proof?.descriptor_stage_invocations?.stage1b_semantic ?? 0;
+  const identities = [
+    receipt?.core_generation_id,
+    receipt?.core_run_id,
+    receipt?.retrieval_generation,
+    receipt?.semantic_generation,
+  ];
+  if (
+    receipt?.contract !== "codestory.packet-builder-ablation-receipt/v1" ||
+    receipt?.requested_dense_semantic !== expectedDense ||
+    proof?.contract !== "codestory.packet-dense-candidate-ablation-proof/v1" ||
+    proof?.requested_policy !== builderPacketRetrievalPolicy(arm) ||
+    !Number.isInteger(proof?.descriptor_query_count) || proof.descriptor_query_count < 1 ||
+    !Number.isInteger(invocations) || invocations < 0 ||
+    !Number.isInteger(stageInvocations) || stageInvocations !== invocations ||
+    (!expectedDense && invocations !== 0) ||
+    identities.some((value) => typeof value !== "string" || !value.trim())
+  ) {
+    return null;
+  }
+  return invocations;
+}
+
+function evidenceCompilerBuilderAcceptance(rows, adjudication, options = {}) {
+  const reasons = [];
+  const expectedTaskIds = options.taskIds ?? BUILDER_ABLATION_TASK_IDS;
+  const expectedRepeats = options.repeats ?? 3;
+  const expectedRows = expectedTaskIds.length * BUILDER_ABLATION_ARMS.length * expectedRepeats;
+  const expectedKeys = new Set(expectedTaskIds.flatMap((taskId) =>
+    BUILDER_ABLATION_ARMS.flatMap((arm) =>
+      Array.from({ length: expectedRepeats }, (_, index) => `${taskId}\t${arm}\t${index + 1}`)
+    )
+  ));
+  const actualKeys = new Set(rows.map((row) => `${row.task_id}\t${row.arm}\t${row.repeat}`));
+  if (
+    rows.length !== expectedRows ||
+    actualKeys.size !== expectedRows ||
+    [...actualKeys].some((key) => !expectedKeys.has(key))
+  ) {
+    reasons.push(`expected ${expectedRows} unique frozen rows; received ${rows.length} rows and ${actualKeys.size} unique keys`);
+  }
+  for (const row of rows) {
+    if (row.status !== "pass") reasons.push(`row ${row.task_id}/${row.arm}/${row.repeat} status=${row.status}`);
+    const violations = row.builder_ablation?.operation_violations;
+    if (!Array.isArray(violations) || violations.length) {
+      reasons.push(`row ${row.task_id}/${row.arm}/${row.repeat} has missing or forbidden operation telemetry`);
+    }
+    if (row.comparator_reuse_provenance || row.resume_provenance || row.reused_from) {
+      reasons.push(`row ${row.task_id}/${row.arm}/${row.repeat} is not fresh`);
+    }
+    if (
+      row.repo_provenance?.git_dirty !== false ||
+      !/^[0-9a-f]{40}$/u.test(String(row.repo_provenance?.git_head ?? ""))
+    ) {
+      reasons.push(`row ${row.task_id}/${row.arm}/${row.repeat} lacks a clean pinned repository receipt`);
+    }
+    if (isBuilderCodeStoryArm(row.arm) && (
+      row.builder_ablation?.first_codestory_required !== true ||
+      row.builder_ablation?.first_codestory_pass !== true ||
+      row.transcript_analysis?.codestory_was_first_repository_context_action !== true ||
+      !Number.isInteger(
+        row.transcript_analysis
+          ?.exploratory_repository_context_actions_after_first_codestory,
+      ) ||
+      row.transcript_analysis
+        .exploratory_repository_context_actions_after_first_codestory < 0
+    )) {
+      reasons.push(
+        `row ${row.task_id}/${row.arm}/${row.repeat} lacks valid observed repository-context accounting`,
+      );
+    }
+  }
+  const codeStoryRows = rows.filter((row) => isBuilderCodeStoryArm(row.arm));
+  const cliDigests = new Set(codeStoryRows.map((row) => row.codestory_prelude_cli_sha256).filter(Boolean));
+  if (cliDigests.size !== 1 || codeStoryRows.some((row) => !row.codestory_prelude_cli_sha256)) {
+    reasons.push("all four CodeStory arms must execute one identical benchmark CLI digest");
+  }
+  for (const taskId of expectedTaskIds) {
+    const taskPacketRows = rows.filter((row) => row.task_id === taskId && isBuilderPacketArm(row.arm));
+    const publications = new Set(taskPacketRows.map((row) => {
+      const proof = row.codestory_harness_prelude?.packet_retrieval_proof;
+      return [
+        proof?.core_generation_id,
+        proof?.core_run_id,
+        proof?.retrieval_generation,
+        proof?.semantic_generation,
+      ].join("\t");
+    }));
+    if (
+      taskPacketRows.length !== expectedRepeats * 2 ||
+      publications.size !== 1 ||
+      [...publications].some((identity) => identity.split("\t").some((part) => !part))
+    ) {
+      reasons.push(`${taskId} packet arms do not share one complete core/retrieval publication identity`);
+    }
+    const packetPublication = taskPacketRows[0]?.codestory_harness_prelude?.packet_retrieval_proof;
+    const taskCodeStoryRows = rows.filter(
+      (row) => row.task_id === taskId && isBuilderCodeStoryArm(row.arm),
+    );
+    const storagePaths = new Set(taskCodeStoryRows.map(
+      (row) => row.codestory_cache_provenance?.storage_path,
+    ));
+    if (
+      taskCodeStoryRows.length !== expectedRepeats * 4 ||
+      storagePaths.size !== 1 ||
+      [...storagePaths].some((value) => typeof value !== "string" || !value.trim()) ||
+      taskCodeStoryRows.some((row) => {
+        const retrieval = row.codestory_cache_provenance?.retrieval_status;
+        return retrieval?.sidecar_generation !== packetPublication?.retrieval_generation ||
+          retrieval?.semantic_generation !== packetPublication?.semantic_generation;
+      })
+    ) {
+      reasons.push(`${taskId} CodeStory arms do not bind one prepared retrieval publication`);
+    }
+  }
+  let denseSemanticOnInvocations = 0;
+  for (const row of rows.filter((entry) => isBuilderPacketArm(entry.arm))) {
+    const receipt = row.codestory_harness_prelude?.packet_retrieval_proof;
+    const invocations = denseStageProofInvocations(receipt, row.arm);
+    if (invocations == null) {
+      reasons.push(`row ${row.task_id}/${row.arm}/${row.repeat} has invalid dense candidate-stage execution proof`);
+      continue;
+    }
+    if (!requestReceiptMatchesInitial(receipt, row.task_manifest_snapshot?.prompt)) {
+      reasons.push(`row ${row.task_id}/${row.arm}/${row.repeat} initial proof is not bound to its packet request`);
+    }
+    if (row.arm === "packet_semantic_on") denseSemanticOnInvocations += invocations;
+    const continuationOperation = row.transcript_analysis?.codestory_operations?.find(
+      (operation) => operation?.source === "agent_cli" && operation?.operation === "packet",
+    ) ?? null;
+    const continuationAttempted = continuationOperation != null;
+    const continuationOffer = row.builder_ablation?.continuation_offer ?? null;
+    const continuationReceipt = row.builder_ablation?.continuation_retrieval_proof ?? null;
+    if (continuationAttempted) {
+      const continuationInvocations = denseStageProofInvocations(continuationReceipt, row.arm);
+      if (
+        continuationOperation.successful !== true ||
+        continuationInvocations == null ||
+        !requestReceiptMatchesContinuation(continuationReceipt, continuationOffer) ||
+        ["core_generation_id", "core_run_id", "retrieval_generation", "semantic_generation"]
+          .some((field) => continuationReceipt?.[field] !== receipt?.[field])
+      ) {
+        reasons.push(`row ${row.task_id}/${row.arm}/${row.repeat} has invalid continuation execution proof`);
+      } else if (row.arm === "packet_semantic_on") {
+        denseSemanticOnInvocations += continuationInvocations;
+      }
+    } else if (continuationReceipt != null) {
+      reasons.push(`row ${row.task_id}/${row.arm}/${row.repeat} has an unbound continuation execution proof`);
+    }
+    if (continuationOffer == null && continuationAttempted) {
+      reasons.push(`row ${row.task_id}/${row.arm}/${row.repeat} executed a continuation the initial packet did not offer`);
+    }
+  }
+  if (denseSemanticOnInvocations < 1) {
+    reasons.push("semantic-on packet rows contain no executed dense candidate stage");
+  }
+
+  const packetArm = "packet_semantic_off";
+  const controlArm = "exact_plus_relations";
+  const packetCounts = taskPassCounts(rows, packetArm);
+  const controlCounts = taskPassCounts(rows, controlArm);
+  const taskQualityDeltas = expectedTaskIds.map((taskId) => ({
+    task_id: taskId,
+    packet_passes: packetCounts.get(taskId)?.passes ?? 0,
+    control_passes: controlCounts.get(taskId)?.passes ?? 0,
+    packet_q: (packetCounts.get(taskId)?.passes ?? 0) / expectedRepeats,
+    control_q: (controlCounts.get(taskId)?.passes ?? 0) / expectedRepeats,
+  })).map((entry) => ({ ...entry, difference: entry.packet_q - entry.control_q }));
+  const meanTaskPassDifference = mean(taskQualityDeltas.map((entry) => entry.difference));
+  if (meanTaskPassDifference == null || meanTaskPassDifference < -0.05) {
+    reasons.push(`packet mean task-pass difference ${meanTaskPassDifference ?? "missing"} is below -0.05`);
+  }
+  for (const entry of taskQualityDeltas) {
+    if (entry.packet_passes === 0 && entry.control_passes >= 2) {
+      reasons.push(`${entry.task_id} is packet 0/${expectedRepeats} while primitives are ${entry.control_passes}/${expectedRepeats}`);
+    }
+  }
+
+  const pairs = pairedRows(rows, packetArm, controlArm);
+  if (pairs.length !== expectedTaskIds.length * expectedRepeats || pairs.some((pair) => !timingPairIsEligible(pair))) {
+    reasons.push("packet and primitive timing rows do not share complete eligible cohort identities");
+  }
+  const exploratoryRepositoryContextActionRatio = medianPairedRatio(
+    pairs,
+    (row) => row.transcript_analysis
+      ?.exploratory_repository_context_actions_after_first_codestory,
+  );
+  if (
+    exploratoryRepositoryContextActionRatio == null ||
+    exploratoryRepositoryContextActionRatio > 0.8
+  ) {
+    reasons.push(
+      `packet exploratory repository-context-action ratio ${exploratoryRepositoryContextActionRatio ?? "missing"} exceeds 0.80`,
+    );
+  }
+  const wholeTaskWallRatio = aggregateRatio(
+    pairs,
+    (row) => row.installed_agent_timing?.whole_task_wall_ms,
+  );
+  if (wholeTaskWallRatio == null || wholeTaskWallRatio > 1.05) {
+    reasons.push(`packet whole-task wall ratio ${wholeTaskWallRatio ?? "missing"} exceeds 1.05`);
+  }
+  const inputContextRatio = aggregateRatio(pairs, (row) => row.usage?.input_tokens);
+  if (inputContextRatio == null || inputContextRatio > 1.05) {
+    reasons.push(`packet input-context ratio ${inputContextRatio ?? "missing"} exceeds 1.05`);
+  }
+
+  const normalizedAdjudication = normalizeAdjudication(adjudication);
+  const packetCriticalComparison = candidateOnlyCriticalForPairs(pairs, normalizedAdjudication);
+  if (!packetCriticalComparison.complete) {
+    reasons.push(
+      normalizedAdjudication.reason ??
+      `independent critical-claim adjudication is incomplete for ${packetCriticalComparison.missing.join(", ")}`,
+    );
+  }
+  if (packetCriticalComparison.candidate_only.length) {
+    reasons.push(`packet-only critical factual or unsupported-relation claims=${packetCriticalComparison.candidate_only.length}`);
+  }
+
+  return {
+    contract: BUILDER_ABLATION_CONTRACT,
+    pass: reasons.length === 0,
+    reasons: [...new Set(reasons)],
+    packet_arm: packetArm,
+    control_arm: controlArm,
+    expected_rows: expectedRows,
+    observed_rows: rows.length,
+    task_quality_deltas: taskQualityDeltas,
+    mean_task_pass_difference: meanTaskPassDifference,
+    exploratory_repository_context_metric:
+      "exploratory_repository_context_actions_after_first_codestory",
+    exploratory_repository_context_aggregation: "median_paired_ratio",
+    exploratory_repository_context_action_ratio:
+      receiptRatio(exploratoryRepositoryContextActionRatio),
+    whole_task_wall_ratio: receiptRatio(wholeTaskWallRatio),
+    context_metric: "input_tokens",
+    input_context_ratio: receiptRatio(inputContextRatio),
+    adjudication_complete: packetCriticalComparison.complete,
+    packet_only_critical_claims: packetCriticalComparison.candidate_only.map((finding) => ({
+      task_id: finding.task_id,
+      repeat: finding.repeat,
+      packet_critical: finding.candidate_critical,
+      control_critical: finding.control_critical,
+      packet_only_finding_ids: finding.candidate_only_finding_ids,
+    })),
+  };
+}
+
+function marginalValue(rows, candidateArm, controlArm, adjudication) {
+  const pairs = pairedRows(rows, candidateArm, controlArm);
+  const timingCohortsComplete = pairs.length > 0 && pairs.every(timingPairIsEligible);
+  const taskIds = [...new Set(rows.map((row) => row.task_id))];
+  const candidateCounts = taskPassCounts(rows, candidateArm);
+  const controlCounts = taskPassCounts(rows, controlArm);
+  const passDifference = mean(taskIds.map((taskId) =>
+    ((candidateCounts.get(taskId)?.passes ?? 0) - (controlCounts.get(taskId)?.passes ?? 0)) / 3
+  ));
+  const explorationRatio = aggregateRatio(
+    pairs,
+    (row) => row.transcript_analysis
+      ?.exploratory_repository_context_actions_after_first_codestory,
+  );
+  const wallRatio = aggregateRatio(pairs, (row) => row.installed_agent_timing?.whole_task_wall_ms);
+  const contextRatio = aggregateRatio(pairs, (row) => row.usage?.input_tokens);
+  const ratios = [explorationRatio, wallRatio, contextRatio];
+  const completeEfficiency = ratios.every((value) => value != null);
+  const boundedCost = timingCohortsComplete && completeEfficiency && ratios.every((value) => value <= 1.05);
+  const materialEfficiencyGain = completeEfficiency && ratios.some((value) => value <= 0.95);
+  const improvesPass = passDifference != null && passDifference > 0 && boundedCost;
+  const holdsPassAndImprovesEfficiency = passDifference === 0 && boundedCost && materialEfficiencyGain;
+  const criticalComparison = candidateOnlyCriticalForPairs(
+    pairs,
+    normalizeAdjudication(adjudication),
+  );
+  return {
+    candidate_arm: candidateArm,
+    control_arm: controlArm,
+    positive: criticalComparison.complete &&
+      criticalComparison.candidate_only.length === 0 &&
+      (improvesPass || holdsPassAndImprovesEfficiency),
+    adjudication_complete: criticalComparison.complete,
+    candidate_only_critical_claims: criticalComparison.candidate_only,
+    timing_cohorts_complete: timingCohortsComplete,
+    mean_task_pass_difference: passDifference,
+    exploratory_repository_context_action_ratio: receiptRatio(explorationRatio),
+    whole_task_wall_ratio: receiptRatio(wallRatio),
+    input_context_ratio: receiptRatio(contextRatio),
+  };
+}
+
+export {
+  BUILDER_ABLATION_ARMS,
+  BUILDER_ABLATION_CONTRACT,
+  BUILDER_ABLATION_TASK_IDS,
+  EXACT_IDENTITY_SOURCE_OPERATIONS,
+  EXPLICIT_RELATION_OPERATIONS,
+  builderOperationViolations,
+  builderPacketRetrievalPolicy,
+  codeStoryInvocationsFromCommand,
+  codeStoryOperationFromCommand,
+  codeStoryOperationFromMcpTool,
+  evidenceCompilerBuilderAcceptance,
+  isBuilderAblationArm,
+  isBuilderCodeStoryArm,
+  isBuilderPacketArm,
+  marginalValue,
+  planBuilderAblationRuns,
+};

--- a/scripts/tests/codestory-evidence-compiler-ablation.test.mjs
+++ b/scripts/tests/codestory-evidence-compiler-ablation.test.mjs
@@ -1,0 +1,1050 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  agentRunnerEnv,
+  analyzeTranscript,
+  builderContinuationContract,
+  composeBuilderAblationPrompt,
+  opaqueBuilderAgentHome,
+  opaqueBuilderContinuationProofPath,
+  packetCommandArgs,
+  parseArgs,
+  planAgentRuns,
+} from "../codestory-agent-ab-benchmark.mjs";
+import {
+  BUILDER_ABLATION_ARMS,
+  BUILDER_ABLATION_TASK_IDS,
+  builderOperationViolations,
+  codeStoryInvocationsFromCommand,
+  codeStoryOperationFromCommand,
+  evidenceCompilerBuilderAcceptance,
+  marginalValue,
+} from "../lib/evidence-compiler-ablation.mjs";
+import {
+  evaluate,
+  packetNextAction,
+} from "../codestory-evidence-compiler-ablation-evaluate.mjs";
+import {
+  JUDGMENTS_CONTRACT,
+  finalizeAdjudication,
+  prepareBlindedCases,
+} from "../codestory-evidence-compiler-ablation-adjudication.mjs";
+
+const cliPath = process.execPath;
+const exactOptions = { expectedProject: "/tmp/repo" };
+const exactSearchCommand = "$CODESTORY_CLI search --project /tmp/repo --profile agent --run-id shared-agent --query Alpha --repo-text off";
+
+function commandEvent(id, phase, command, output = "", exitCode = 0) {
+  return {
+    type: `item.${phase}`,
+    item: {
+      id,
+      type: "command_execution",
+      command,
+      aggregated_output: output,
+      exit_code: exitCode,
+      status: exitCode === 0 ? "completed" : "failed",
+    },
+  };
+}
+
+test("builder ablation CLI freezes fresh five-arm shape", () => {
+  const opts = parseArgs(["--builder-ablation", "--codestory-cli", cliPath]);
+  assert.deepEqual(opts.arms, BUILDER_ABLATION_ARMS);
+  assert.deepEqual(opts.taskIds, BUILDER_ABLATION_TASK_IDS);
+  assert.equal(opts.repeats, 3);
+  assert.equal(opts.prepareCodestoryCache, true);
+  assert.equal(opts.publishable, false);
+  assert.throws(
+    () => parseArgs([
+      "--builder-ablation",
+      "--codestory-cli",
+      cliPath,
+      "--reuse-baseline-from",
+      "/tmp/old",
+    ]),
+    /builder-ablation mode forbids option/i,
+  );
+  assert.throws(
+    () => parseArgs([
+      "--builder-ablation",
+      "--codestory-cli",
+      cliPath,
+      "--diagnostic-extra-probes-from-manifest",
+    ]),
+    /builder-ablation mode forbids option/i,
+  );
+});
+
+test("builder run plan uses a balanced per-repeat rotation", () => {
+  const tasks = BUILDER_ABLATION_TASK_IDS.map((id, index) => ({
+    id,
+    repo: `repo-${index}`,
+  }));
+  const planned = planAgentRuns({ builderAblation: true, repeats: 3 }, tasks);
+  assert.equal(planned.length, tasks.length * 3 * BUILDER_ABLATION_ARMS.length);
+  for (let index = 0; index < tasks.length * 3; index += 1) {
+    const window = planned.slice(index * 5, index * 5 + 5);
+    assert.equal(new Set(window.map((row) => row.arm)).size, 5);
+    assert.equal(new Set(window.map((row) => row.task.id)).size, 1);
+    assert.equal(new Set(window.map((row) => row.repeat)).size, 1);
+  }
+  const firstPositions = Object.fromEntries(BUILDER_ABLATION_ARMS.map((arm) => [arm, 0]));
+  for (let index = 0; index < tasks.length * 3; index += 1) {
+    firstPositions[planned[index * 5].arm] += 1;
+  }
+  assert.ok(Math.max(...Object.values(firstPositions)) - Math.min(...Object.values(firstPositions)) <= 1);
+});
+
+test("hidden scorer fields cannot change builder prompt, packet args, environment, or run order", () => {
+  const repo = { path: "/tmp/repo", prompt: "fallback" };
+  const base = {
+    id: "visible-id-a",
+    repo: "repo-a",
+    prompt: "Explain Alpha and cite its source.",
+    task_class: "architecture_explanation",
+    expected_files: ["src/answer.rs"],
+    expected_symbols: ["Alpha"],
+    expected_claims: ["Alpha calls Beta"],
+  };
+  const hostile = {
+    ...base,
+    id: "renamed-hidden-id",
+    task_class: "bug_localization",
+    expected_files: ["totally/different.py"],
+    expected_symbols: ["RenamedSecret"],
+    expected_claims: ["A different answer shape"],
+  };
+  const prelude = {
+    public: {
+      command: "$CODESTORY_CLI packet --task-id visible-id-a --arm packet_semantic_on --repeat 03",
+    },
+    packet: {
+      schema_version: 3,
+      kind: "complete",
+      status: "continuation_available",
+      identity: { packet_id: "packet-1" },
+      publication: {
+        core: { generation_id: "core-1" },
+        retrieval: { retrieval_generation: "retrieval-1" },
+      },
+      evidence: [],
+      gaps: [{ identity: { gap_id: "gap-1" } }],
+      continuation: {
+        continuation_id: "packet-1",
+        remaining_rounds: 1,
+        gap_ids: [{ gap_id: "gap-1" }],
+      },
+    },
+  };
+  const continuation = builderContinuationContract(
+    repo,
+    base,
+    { builderAblation: true, diagnosticExtraProbesFromManifest: false },
+    prelude.packet,
+    "packet_semantic_on",
+    "/tmp/opaque-4fa40dce.json",
+  );
+  assert.ok(continuation);
+  const otherPacketTreatmentContinuation = builderContinuationContract(
+    repo,
+    base,
+    { builderAblation: true, diagnosticExtraProbesFromManifest: false },
+    prelude.packet,
+    "packet_semantic_off",
+    "/tmp/opaque-4fa40dce.json",
+  );
+  assert.equal(continuation.command, otherPacketTreatmentContinuation.command);
+  assert.equal(continuation.command.includes("--benchmark-disable-dense-semantic"), true);
+  assert.equal(
+    composeBuilderAblationPrompt("repo-a", repo, "packet_semantic_on", base, {
+      codestoryPrelude: prelude,
+      builderContinuationContract: continuation,
+    }),
+    composeBuilderAblationPrompt("repo-a", repo, "packet_semantic_on", hostile, {
+      codestoryPrelude: prelude,
+      builderContinuationContract: continuation,
+    }),
+  );
+  const prompt = composeBuilderAblationPrompt(
+    "repo-a",
+    repo,
+    "packet_semantic_on",
+    base,
+    { codestoryPrelude: prelude, builderContinuationContract: continuation },
+  );
+  assert.equal(prompt.includes(base.id), false);
+  assert.equal(prompt.includes(base.task_class), false);
+  assert.equal(prompt.includes("packet_semantic_on"), false);
+  assert.equal(prompt.includes("--repeat 03"), false);
+  assert.equal(prompt.includes("visible-id-a"), false);
+  assert.equal(prompt.includes("opaque-4fa40dce.json"), true);
+  assert.equal(prompt.includes("Project path: /tmp/repo"), true);
+  assert.deepEqual(
+    packetCommandArgs(repo, base, { builderAblation: true }, "packet_semantic_off"),
+    packetCommandArgs(repo, hostile, { builderAblation: true }, "packet_semantic_off"),
+  );
+  assert.deepEqual(
+    agentRunnerEnv({ PATH: "/bin" }, "/tmp/host", true),
+    agentRunnerEnv({ PATH: "/bin" }, "/tmp/host", true),
+  );
+  const project = (task) => planAgentRuns(
+    { builderAblation: true, repeats: 3 },
+    [task],
+  ).map((row) => [row.repo, row.arm, row.repeat]);
+  assert.deepEqual(project(base), project(hostile));
+});
+
+test("semantic-off packet command uses the hidden stage switch without manifest probes", () => {
+  const args = packetCommandArgs(
+    { path: "/tmp/repo", prompt: "fallback" },
+    { prompt: "Explain Alpha", expected_files: ["src/answer.rs"] },
+    { builderAblation: true, diagnosticExtraProbesFromManifest: false },
+    "packet_semantic_off",
+  );
+  assert.ok(args.includes("--benchmark-disable-dense-semantic"));
+  assert.equal(args.includes("--extra-probe"), false);
+});
+
+test("continuation proof paths are opaque and cannot encode experimental identities", () => {
+  const proofPath = opaqueBuilderContinuationProofPath(
+    "/tmp/codestory-agent-builder-ablation-private",
+    () => Buffer.alloc(24, 0xab),
+  );
+  assert.equal(
+    proofPath,
+    "/tmp/codestory-agent-builder-ablation-private/continuation-proofs/abababababababababababababababababababababababab.json",
+  );
+  for (const hidden of [
+    "python-requests-session-flow",
+    "packet_semantic_off",
+    "repeat-03",
+  ]) {
+    assert.equal(proofPath.includes(hidden), false);
+  }
+});
+
+test("builder agent homes have one opaque treatment-blind path shape", () => {
+  const home = opaqueBuilderAgentHome(
+    "/tmp/codestory-agent-builder-ablation-private",
+    () => Buffer.alloc(24, 0xcd),
+  );
+  assert.equal(
+    home,
+    "/tmp/codestory-agent-builder-ablation-private/agent-sessions/cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd/host",
+  );
+  for (const arm of BUILDER_ABLATION_ARMS) assert.equal(home.includes(arm), false);
+});
+
+test("operation parser and policy fail closed on arm leakage", () => {
+  const continuationContract = {
+    parent_packet_id: "parent-1",
+    allowed_option_ids: ["gap-1", "gap-2"],
+    core_generation_id: "core-1",
+    retrieval_generation: "retrieval-1",
+    project: "/tmp/repo",
+    question: "Explain Alpha",
+    question_sha256: createHash("sha256").update("Explain Alpha").digest("hex"),
+    proof_path: "/tmp/opaque-proof.json",
+  };
+  assert.equal(
+    codeStoryOperationFromCommand('"$CODESTORY_CLI" callers --project . --query Alpha'),
+    "callers",
+  );
+  assert.deepEqual(
+    builderOperationViolations("exact_identity_source", [{
+      operation: "search",
+      transport: "cli",
+      successful: true,
+      raw: { command: exactSearchCommand },
+    }], exactOptions),
+    [],
+  );
+  assert.deepEqual(
+    builderOperationViolations("exact_plus_relations", [{
+      operation: "callers",
+      transport: "cli",
+      source: "agent_cli",
+      successful: true,
+      raw: { command: "$CODESTORY_CLI callers --project /tmp/repo --query Alpha --depth 1" },
+    }], exactOptions),
+    [],
+  );
+  assert.match(
+    builderOperationViolations("exact_identity_source", [{
+      operation: "callers",
+      transport: "cli",
+      successful: true,
+      raw: { command: "$CODESTORY_CLI callers --query Alpha" },
+    }], exactOptions)[0],
+    /forbidden/,
+  );
+  assert.match(
+    builderOperationViolations("exact_identity_source", [{
+      operation: "search",
+      transport: "cli",
+      successful: true,
+      raw: { command: "codestory-cli search --query Alpha --repo-text off" },
+    }], exactOptions)[0],
+    /checksum-bound/,
+  );
+  assert.match(
+    builderOperationViolations("exact_identity_source", [{
+      operation: "search",
+      transport: "cli",
+      successful: true,
+      raw: {
+        command: "CODESTORY_CACHE_ROOT=/tmp/other $CODESTORY_CLI search --query Alpha --repo-text off",
+      },
+    }], exactOptions).join("\n"),
+    /benchmark state/,
+  );
+  assert.match(
+    builderOperationViolations("exact_identity_source", [{
+      operation: "search",
+      transport: "cli",
+      successful: true,
+      raw: {
+        command: "$CODESTORY_CLI search --query Alpha --repo-text off; cat src/lib.rs",
+      },
+    }], exactOptions).join("\n"),
+    /uncomposed/,
+  );
+  assert.match(
+    builderOperationViolations("packet_semantic_off", [
+      { operation: "packet", transport: "cli", source: "harness_packet_prelude", successful: true, raw: {} },
+      {
+        operation: "packet",
+        transport: "cli",
+        source: "agent_cli",
+        successful: true,
+        raw: { command: "$CODESTORY_CLI packet --parent-packet-id p --option-id o --core-generation-id c --retrieval-generation r" },
+      },
+    ], { continuationContract })[0],
+    /dense policy/,
+  );
+  const validContinuation = `$CODESTORY_CLI packet --project /tmp/repo --profile agent --run-id shared-agent --question 'Explain Alpha' --budget standard --format json --benchmark-disable-dense-semantic --parent-packet-id parent-1 --option-id gap-2 --core-generation-id core-1 --retrieval-generation retrieval-1 --benchmark-retrieval-proof-out /tmp/opaque-proof.json`;
+  assert.deepEqual(
+    builderOperationViolations("packet_semantic_off", [
+      { operation: "packet", transport: "cli", source: "harness_packet_prelude", successful: true, raw: {} },
+      {
+        operation: "packet",
+        transport: "cli",
+        source: "agent_cli",
+        successful: true,
+        raw: { command: validContinuation },
+      },
+    ], { continuationContract }),
+    [],
+  );
+  const inventedContinuation = validContinuation
+    .replace("parent-1", "fake-parent")
+    .replace("gap-2", "self-authored-option");
+  assert.match(
+    builderOperationViolations("packet_semantic_off", [
+      { operation: "packet", transport: "cli", source: "harness_packet_prelude", successful: true, raw: {} },
+      {
+        operation: "packet",
+        transport: "cli",
+        source: "agent_cli",
+        successful: false,
+        raw: { command: inventedContinuation },
+      },
+    ], { continuationContract }).join("\n"),
+    /continuation/i,
+  );
+  assert.deepEqual(
+    codeStoryInvocationsFromCommand(
+      '"${CODESTORY_CLI}" search --query Alpha --repo-text off; codestory-cli packet --question Alpha',
+    ),
+    [
+      { operation: "search", checksum_bound: true },
+      { operation: "packet", checksum_bound: false },
+    ],
+  );
+  const compound = analyzeTranscript([
+    commandEvent(
+      "compound",
+      "completed",
+      '"${CODESTORY_CLI}" search --query Alpha --repo-text off; "$CODESTORY_CLI" packet --question Alpha',
+      "{}",
+    ),
+  ]);
+  assert.deepEqual(
+    compound.codestory_operations.map((entry) => entry.operation),
+    ["search", "packet"],
+  );
+  assert.match(
+    builderOperationViolations("exact_identity_source", compound.codestory_operations, exactOptions).join("\n"),
+    /packet/,
+  );
+  assert.equal(
+    codeStoryInvocationsFromCommand("echo $CODESTORY_CLI")[0].operation,
+    null,
+  );
+  for (const wrapped of [
+    `sh -c '\"$CODESTORY_CLI\" search --query Alpha --repo-text off; cat src/lib.rs'`,
+    `eval '$CODESTORY_CLI search --query Alpha --repo-text off'`,
+    `env FOO=bar $CODESTORY_CLI search --query Alpha --repo-text off`,
+    `$CODESTORY_CLI search --query \"$(cat src/lib.rs)\" --repo-text off`,
+    `$CODESTORY_CLI search --query \"\u0060cat src/lib.rs\u0060\" --repo-text off`,
+    `sh -c \"$(printenv CODESTORY_CLI) search --query Alpha --repo-text off\"`,
+  ]) {
+    const wrapperAnalysis = analyzeTranscript([
+      commandEvent("wrapped", "completed", wrapped, "source text"),
+    ]);
+    assert.notEqual(
+      builderOperationViolations(
+        "exact_identity_source",
+        wrapperAnalysis.codestory_operations,
+        exactOptions,
+      ).length,
+      0,
+      wrapped,
+    );
+  }
+  assert.match(
+    builderOperationViolations("exact_identity_source", [{
+      operation: "search",
+      transport: "mcp",
+      source: "agent_mcp",
+      successful: true,
+      raw: {},
+    }], exactOptions).join("\n"),
+    /checksum-bound CodeStory CLI/,
+  );
+
+  const escaped = builderOperationViolations("exact_identity_source", [{
+    operation: "search",
+    transport: "cli",
+    source: "agent_cli",
+    successful: true,
+    raw: {
+      command: "$CODESTORY_CLI search --project /tmp/foreign --cache-dir /tmp/foreign-cache --query Alpha --repo-text off --refresh full --profile local --run-id other --output-file /tmp/leak.json",
+    },
+  }], exactOptions).join("\n");
+  assert.match(escaped, /--cache-dir/);
+  assert.match(escaped, /--refresh/);
+  assert.match(escaped, /--output-file/);
+  assert.match(escaped, /pinned repository/);
+  assert.match(escaped, /prepared agent profile/);
+});
+
+test("transcript records observed repository context after CodeStory", () => {
+  const events = [
+    commandEvent("cs", "started", "$CODESTORY_CLI search --query Alpha --repo-text off"),
+    commandEvent("cs", "completed", "$CODESTORY_CLI search --query Alpha --repo-text off", "result"),
+    commandEvent("rg", "started", "rg -n Alpha src"),
+    commandEvent("rg", "completed", "rg -n Alpha src", "src/lib.rs:1: Alpha\n"),
+    commandEvent("read", "started", "head -20 src/lib.rs"),
+    commandEvent("read", "completed", "head -20 src/lib.rs", "fn Alpha() {}\n"),
+    commandEvent("node-read", "started", "node -e \"require('fs').readFileSync('src/lib.rs','utf8')\""),
+    commandEvent("node-read", "completed", "node -e \"require('fs').readFileSync('src/lib.rs','utf8')\"", "fn Beta() {}\n"),
+    commandEvent("git-read", "started", "/usr/bin/git -C . show HEAD:src/lib.rs"),
+    commandEvent("git-read", "completed", "/usr/bin/git -C . show HEAD:src/lib.rs", "fn Gamma() {}\n"),
+    commandEvent("opaque-read", "started", "custom-reader src/lib.rs"),
+    commandEvent("opaque-read", "completed", "custom-reader src/lib.rs", "fn Delta() {}\n"),
+  ];
+  const analysis = analyzeTranscript(events, "/tmp/repo", {
+    arm: "exact_identity_source",
+    task: { prompt: "Explain Alpha" },
+  });
+  assert.deepEqual(analysis.codestory_operations.map((row) => row.operation), ["search"]);
+  assert.equal(analysis.codestory_was_first_context_command, true);
+  assert.equal(analysis.ordinary_source_actions_after_first_codestory, 5);
+  assert.equal(analysis.exploratory_source_reads_after_first_codestory, 5);
+  assert.equal(analysis.exploratory_repository_context_actions_after_first_codestory, 5);
+  assert.equal(
+    analysis.ordinary_source_output_bytes_after_first_codestory,
+    Buffer.byteLength("src/lib.rs:1: Alpha\nfn Alpha() {}\nfn Beta() {}\nfn Gamma() {}\nfn Delta() {}\n", "utf8"),
+  );
+  const sourceBeforeCodeStory = analyzeTranscript([
+    commandEvent("head", "started", "head -20 src/lib.rs"),
+    commandEvent("head", "completed", "head -20 src/lib.rs", "fn Alpha() {}\n"),
+    commandEvent("cs", "started", exactSearchCommand),
+    commandEvent("cs", "completed", exactSearchCommand, "result"),
+  ], "/tmp/repo");
+  assert.equal(sourceBeforeCodeStory.codestory_was_first_context_command, false);
+  const remote = analyzeTranscript([
+    commandEvent("local", "completed", "rg -n 'git fetch' src", "src/lib.rs:1: git fetch"),
+    commandEvent("remote", "completed", "git fetch origin main", ""),
+  ]);
+  assert.deepEqual(remote.remote_context_commands, ["git fetch origin main"]);
+});
+
+test("observed output closes failed, extensionless, and globbed reader accounting gaps", () => {
+  const failedBeforeCodeStory = analyzeTranscript([
+    commandEvent("failed-head", "started", "head -20 src/lib.rs; false"),
+    commandEvent(
+      "failed-head",
+      "completed",
+      "head -20 src/lib.rs; false",
+      "fn Alpha() {}\n",
+      1,
+    ),
+    commandEvent("cs", "started", exactSearchCommand),
+    commandEvent("cs", "completed", exactSearchCommand, "result"),
+  ], "/tmp/repo", { arm: "exact_identity_source" });
+  assert.equal(failedBeforeCodeStory.codestory_was_first_context_command, false);
+  assert.equal(
+    failedBeforeCodeStory.first_observed_repository_context_action.id,
+    "failed-head",
+  );
+
+  const extensionlessBeforeCodeStory = analyzeTranscript([
+    commandEvent("makefile", "started", "custom-reader Makefile"),
+    commandEvent("makefile", "completed", "custom-reader Makefile", "all: build\n"),
+    commandEvent("cs", "started", exactSearchCommand),
+    commandEvent("cs", "completed", exactSearchCommand, "result"),
+  ], "/tmp/repo", { arm: "exact_identity_source" });
+  assert.equal(extensionlessBeforeCodeStory.codestory_was_first_context_command, false);
+
+  const afterCodeStory = analyzeTranscript([
+    commandEvent("cs", "started", exactSearchCommand),
+    commandEvent("cs", "completed", exactSearchCommand, "result"),
+    commandEvent("glob", "started", "custom-reader src/lib.*"),
+    commandEvent("glob", "completed", "custom-reader src/lib.*", "fn Beta() {}\n"),
+    commandEvent("failed", "started", "custom-reader Makefile"),
+    commandEvent("failed", "completed", "custom-reader Makefile", "all: build\n", 1),
+    commandEvent("empty-search", "started", "rg DoesNotExist ."),
+    commandEvent("empty-search", "completed", "rg DoesNotExist .", "", 1),
+    commandEvent("empty-unknown", "started", "custom-reader missing"),
+    commandEvent("empty-unknown", "completed", "custom-reader missing", "", 1),
+  ], "/tmp/repo", { arm: "exact_identity_source" });
+  assert.equal(afterCodeStory.exploratory_repository_context_actions_after_first_codestory, 3);
+  assert.equal(
+    afterCodeStory.observed_repository_context_output_bytes_after_first_codestory,
+    Buffer.byteLength("fn Beta() {}\nall: build\n", "utf8"),
+  );
+});
+
+test("parallel exploration is sliced after the matched CodeStory action", () => {
+  const parallelCommand = analyzeTranscript([
+    commandEvent("cs", "started", exactSearchCommand),
+    commandEvent("reader", "started", "custom-reader Makefile"),
+    commandEvent("reader", "completed", "custom-reader Makefile", "all: build\n"),
+    commandEvent("cs", "completed", exactSearchCommand, "result"),
+  ], "/tmp/repo", { arm: "exact_identity_source" });
+  assert.equal(parallelCommand.codestory_was_first_repository_context_action, true);
+  assert.equal(
+    parallelCommand.exploratory_repository_context_actions_after_first_codestory,
+    1,
+  );
+
+  const parallelTool = analyzeTranscript([
+    commandEvent("cs", "started", exactSearchCommand),
+    {
+      type: "item.started",
+      item: {
+        id: "reader-tool",
+        type: "function_call",
+        name: "read_repository_file",
+      },
+    },
+    commandEvent("cs", "completed", exactSearchCommand, "result"),
+  ], "/tmp/repo", { arm: "exact_identity_source" });
+  assert.equal(parallelTool.codestory_was_first_repository_context_action, true);
+  assert.equal(
+    parallelTool.exploratory_repository_context_actions_after_first_codestory,
+    1,
+  );
+});
+
+function passingRows() {
+  return BUILDER_ABLATION_TASK_IDS.flatMap((taskId) =>
+    BUILDER_ABLATION_ARMS.flatMap((arm) => [1, 2, 3].map((repeat) => ({
+      task_id: taskId,
+      arm,
+      repeat,
+      status: "pass",
+      quality: { pass: true },
+      usage: { input_tokens: arm === "packet_semantic_off" ? 100 : 100 },
+      installed_agent_timing: {
+        timing_cohort_id: createHash("sha256").update(`${taskId}-${repeat}`).digest("hex"),
+        whole_task_wall_ms: 100,
+      },
+      installed_agent_timing_eligible: true,
+      transcript_analysis: {
+        codestory_was_first_repository_context_action: arm !== "native_tools",
+        exploratory_repository_context_actions_after_first_codestory:
+          arm === "packet_semantic_off" ? 4 : 5,
+        ordinary_source_output_bytes_after_first_codestory:
+          arm === "packet_semantic_off" ? 8 : 10,
+      },
+      builder_ablation: {
+        operation_violations: [],
+        continuation_offer: null,
+        first_codestory_required: arm !== "native_tools",
+        first_codestory_pass: true,
+      },
+      task_manifest_snapshot: { prompt: `Question for ${taskId}` },
+      repo_provenance: { git_dirty: false, git_head: "d".repeat(40) },
+      codestory_prelude_cli_sha256: arm === "native_tools" ? null : "a".repeat(64),
+      codestory_cache_provenance: arm === "native_tools"
+        ? null
+        : {
+            storage_path: `/cache/${taskId}/codestory.db`,
+            retrieval_status: {
+              sidecar_generation: `retrieval-${taskId}`,
+              semantic_generation: `semantic-${taskId}`,
+            },
+          },
+      codestory_harness_prelude: arm.startsWith("packet_")
+        ? {
+            packet_retrieval_proof: {
+              contract: "codestory.packet-builder-ablation-receipt/v1",
+              requested_dense_semantic: arm === "packet_semantic_on",
+              request: {
+                question_sha256: createHash("sha256")
+                  .update(`Question for ${taskId}`)
+                  .digest("hex"),
+                parent_packet_id: null,
+                option_ids: [],
+                core_generation_id: null,
+                retrieval_generation: null,
+              },
+              retrieval_proof: {
+                contract: "codestory.packet-dense-candidate-ablation-proof/v1",
+                requested_policy: arm === "packet_semantic_on"
+                  ? "repository_graph_lexical_dense_candidate_stage_enabled_v1"
+                  : "repository_graph_lexical_dense_candidate_stage_disabled_v1",
+                descriptor_query_count: 1,
+                descriptor_cache_hit_count: 0,
+                descriptor_stage_invocations: arm === "packet_semantic_on"
+                  ? { stage1b_semantic: 1 }
+                  : { stage1_lexical: 1 },
+                descriptor_stage_candidates: {},
+                dense_semantic_stage_invocations: arm === "packet_semantic_on" ? 1 : 0,
+              },
+              core_generation_id: `core-${taskId}`,
+              core_run_id: `run-${taskId}`,
+              retrieval_generation: `retrieval-${taskId}`,
+              semantic_generation: `semantic-${taskId}`,
+            },
+          }
+        : null,
+    })))
+  );
+}
+
+function zeroAdjudication(rows) {
+  return {
+    contract: "codestory.evidence-compiler-builder-adjudication/v1",
+    blinded: true,
+    independent_reviewer: "independent-test-reviewer",
+    source_cases_sha256: "b".repeat(64),
+    source_judgments_sha256: "c".repeat(64),
+    rows: rows
+      .filter((row) => row.arm !== "native_tools")
+      .map((row) => ({
+        task_id: row.task_id,
+        arm: row.arm,
+        repeat: row.repeat,
+        critical_factual_errors: 0,
+        critical_factual_finding_ids: [],
+        unsupported_relation_claims: 0,
+        unsupported_relation_finding_ids: [],
+      })),
+  };
+}
+
+test("frozen packet acceptance passes only with complete independent adjudication", () => {
+  const rows = passingRows();
+  const accepted = evidenceCompilerBuilderAcceptance(rows, zeroAdjudication(rows));
+  assert.equal(accepted.pass, true, accepted.reasons.join("; "));
+  assert.equal(accepted.exploratory_repository_context_action_ratio, 0.8);
+  const incomplete = evidenceCompilerBuilderAcceptance(rows, null);
+  assert.equal(incomplete.pass, false);
+  assert.match(incomplete.reasons.join("\n"), /adjudication/i);
+
+  const missingObservedBoundary = passingRows();
+  missingObservedBoundary.find((row) => row.arm === "exact_identity_source")
+    .transcript_analysis.codestory_was_first_repository_context_action = false;
+  const missingObservedReceipt = evidenceCompilerBuilderAcceptance(
+    missingObservedBoundary,
+    zeroAdjudication(missingObservedBoundary),
+  );
+  assert.equal(missingObservedReceipt.pass, false);
+  assert.match(missingObservedReceipt.reasons.join("\n"), /observed repository-context accounting/);
+
+  for (const row of rows) {
+    row.transcript_analysis.exploratory_repository_context_actions_after_first_codestory = 0;
+  }
+  const noDemonstratedReduction = evidenceCompilerBuilderAcceptance(rows, zeroAdjudication(rows));
+  assert.equal(noDemonstratedReduction.pass, false);
+  assert.equal(noDemonstratedReduction.exploratory_repository_context_action_ratio, 1);
+
+  const byteOnlyRows = passingRows();
+  for (const row of byteOnlyRows) {
+    row.transcript_analysis.ordinary_source_output_bytes_after_first_codestory =
+      row.arm === "packet_semantic_off" ? 100_000 : 1;
+  }
+  assert.equal(
+    evidenceCompilerBuilderAcceptance(byteOnlyRows, zeroAdjudication(byteOnlyRows)).pass,
+    true,
+    "source output size is diagnostic and cannot replace the frozen read-count gate",
+  );
+  const moreShortReads = passingRows();
+  for (const row of moreShortReads) {
+    if (row.arm === "packet_semantic_off") {
+      row.transcript_analysis.exploratory_repository_context_actions_after_first_codestory = 5;
+      row.transcript_analysis.ordinary_source_output_bytes_after_first_codestory = 1;
+    } else if (row.arm === "exact_plus_relations") {
+      row.transcript_analysis.exploratory_repository_context_actions_after_first_codestory = 4;
+      row.transcript_analysis.ordinary_source_output_bytes_after_first_codestory = 100_000;
+    }
+  }
+  const readCountWins = evidenceCompilerBuilderAcceptance(
+    moreShortReads,
+    zeroAdjudication(moreShortReads),
+  );
+  assert.equal(readCountWins.pass, false);
+  assert.equal(readCountWins.exploratory_repository_context_action_ratio, 1.25);
+});
+
+test("packet continuations require a same-publication dense-stage execution proof", () => {
+  const rows = passingRows();
+  const row = rows.find((entry) => entry.arm === "packet_semantic_off");
+  const questionSha256 = createHash("sha256")
+    .update(row.task_manifest_snapshot.prompt)
+    .digest("hex");
+  row.builder_ablation.continuation_offer = {
+    parent_packet_id: "packet-1",
+    allowed_option_ids: ["gap-1"],
+    core_generation_id: `core-${row.task_id}`,
+    retrieval_generation: `retrieval-${row.task_id}`,
+    question_sha256: questionSha256,
+  };
+  row.transcript_analysis.codestory_operations = [
+    { operation: "packet", source: "harness_packet_prelude", successful: true },
+    { operation: "packet", source: "agent_cli", successful: true },
+  ];
+  row.builder_ablation.continuation_retrieval_proof = structuredClone(
+    row.codestory_harness_prelude.packet_retrieval_proof,
+  );
+  row.builder_ablation.continuation_retrieval_proof.request = {
+    question_sha256: questionSha256,
+    parent_packet_id: "packet-1",
+    option_ids: ["gap-1"],
+    core_generation_id: `core-${row.task_id}`,
+    retrieval_generation: `retrieval-${row.task_id}`,
+  };
+  assert.equal(
+    evidenceCompilerBuilderAcceptance(rows, zeroAdjudication(rows)).pass,
+    true,
+  );
+  row.builder_ablation.continuation_retrieval_proof.request.parent_packet_id = "invented-parent";
+  const invented = evidenceCompilerBuilderAcceptance(rows, zeroAdjudication(rows));
+  assert.equal(invented.pass, false);
+  assert.match(invented.reasons.join("\n"), /continuation execution proof/);
+  row.builder_ablation.continuation_retrieval_proof.request.parent_packet_id = "packet-1";
+  row.builder_ablation.continuation_retrieval_proof.retrieval_generation = "different";
+  const changed = evidenceCompilerBuilderAcceptance(rows, zeroAdjudication(rows));
+  assert.equal(changed.pass, false);
+  assert.match(changed.reasons.join("\n"), /continuation execution proof/);
+});
+
+test("packet timing fails closed on cohort drift and serializes zero-denominator ratios", () => {
+  const cohortRows = passingRows();
+  const packet = cohortRows.find((entry) => entry.arm === "packet_semantic_off");
+  packet.installed_agent_timing.timing_cohort_id = "f".repeat(64);
+  const drifted = evidenceCompilerBuilderAcceptance(cohortRows, zeroAdjudication(cohortRows));
+  assert.equal(drifted.pass, false);
+  assert.match(drifted.reasons.join("\n"), /cohort identities/);
+
+  const infiniteRows = passingRows();
+  for (const row of infiniteRows) {
+    if (row.arm === "exact_plus_relations") {
+      row.transcript_analysis.exploratory_repository_context_actions_after_first_codestory = 0;
+    }
+    if (row.arm === "packet_semantic_off") {
+      row.transcript_analysis.exploratory_repository_context_actions_after_first_codestory = 1;
+    }
+  }
+  const infinite = evidenceCompilerBuilderAcceptance(
+    infiniteRows,
+    zeroAdjudication(infiniteRows),
+  );
+  assert.equal(infinite.pass, false);
+  assert.equal(infinite.exploratory_repository_context_action_ratio, "infinite");
+});
+
+test("builder Codex sessions use isolated ephemeral homes without MCP config", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "codestory-builder-isolation-"));
+  const sourceHome = path.join(root, "source-home");
+  const stateRoot = path.join(root, "state");
+  const outDir = path.join(root, "out");
+  await mkdir(sourceHome, { recursive: true });
+  await mkdir(stateRoot, { recursive: true });
+  await mkdir(outDir, { recursive: true });
+  await writeFile(path.join(sourceHome, "auth.json"), "{}\n");
+  const harnessUrl = new URL("../codestory-agent-ab-benchmark.mjs", import.meta.url).href;
+  const script = `
+    const benchmark = await import(${JSON.stringify(harnessUrl)});
+    const result = await benchmark.prepareAgentCodexIsolation(${JSON.stringify(outDir)}, {
+      builderAblation: true,
+      builderAblationStateRoot: ${JSON.stringify(stateRoot)},
+      model: "gpt-5.6-sol",
+    });
+    process.stdout.write(JSON.stringify(result));
+  `;
+  try {
+    const { spawnSync } = await import("node:child_process");
+    const child = spawnSync(process.execPath, ["--input-type=module", "-e", script], {
+      cwd: root,
+      env: { ...process.env, CODEX_HOME: sourceHome },
+      encoding: "utf8",
+    });
+    assert.equal(child.status, 0, child.stderr);
+    const isolation = JSON.parse(child.stdout);
+    assert.equal(isolation.receipt.contract, "codestory.agent-benchmark-codex-isolation/v4");
+    assert.equal(isolation.receipt.host_config_files, "none");
+    assert.deepEqual(Object.keys(isolation.homes), BUILDER_ABLATION_ARMS);
+    for (const [arm, home] of Object.entries(isolation.homes)) {
+      assert.equal(existsSync(path.join(home, "auth.json")), true);
+      assert.equal(existsSync(path.join(home, "config.toml")), false);
+      assert.equal(home.includes(arm), false);
+      assert.match(
+        path.relative(stateRoot, home).replaceAll(path.sep, "/"),
+        /^agent-sessions\/[0-9a-f]{48}\/host$/u,
+      );
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("packet-only critical findings are compared by identity rather than count", () => {
+  const rows = passingRows();
+  const adjudication = zeroAdjudication(rows);
+  const packet = adjudication.rows.find((row) => row.arm === "packet_semantic_off");
+  const control = adjudication.rows.find((row) =>
+    row.arm === "exact_plus_relations" &&
+    row.task_id === packet.task_id &&
+    row.repeat === packet.repeat
+  );
+  packet.critical_factual_errors = 1;
+  packet.critical_factual_finding_ids = ["packet-only-wrong-edge"];
+  control.critical_factual_errors = 1;
+  control.critical_factual_finding_ids = ["different-control-error"];
+  const receipt = evidenceCompilerBuilderAcceptance(rows, adjudication);
+  assert.equal(receipt.pass, false);
+  assert.deepEqual(
+    receipt.packet_only_critical_claims[0].packet_only_finding_ids,
+    ["factual:packet-only-wrong-edge"],
+  );
+});
+
+test("evaluator binds independent adjudication to the exact run ledger", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "codestory-builder-ablation-"));
+  try {
+    const rows = passingRows();
+    const runBytes = Buffer.from(`${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+    const adjudication = {
+      ...zeroAdjudication(rows),
+      source_runs_sha256: createHash("sha256").update(runBytes).digest("hex"),
+    };
+    await writeFile(path.join(root, "runs.jsonl"), runBytes);
+    const adjudicationPath = path.join(root, "adjudication.json");
+    await writeFile(adjudicationPath, `${JSON.stringify(adjudication)}\n`);
+
+    const receipt = await evaluate({
+      runDir: root,
+      adjudication: adjudicationPath,
+      attempt: "initial",
+    });
+    assert.equal(receipt.packet_acceptance.pass, true);
+    assert.equal(receipt.packet_decision, "advance");
+    assert.deepEqual(receipt.default_layer_decisions, {
+      graph_relations: "disable_default",
+      dense_semantic_candidates: "disable_default",
+    });
+    assert.equal(
+      JSON.parse(await readFile(path.join(root, "builder-ablation.json"), "utf8"))
+        .source_runs_sha256,
+      adjudication.source_runs_sha256,
+    );
+
+    await writeFile(adjudicationPath, `${JSON.stringify({
+      ...adjudication,
+      source_runs_sha256: "0".repeat(64),
+    })}\n`);
+    await assert.rejects(
+      () => evaluate({ runDir: root, adjudication: adjudicationPath, attempt: "initial" }),
+      /does not match runs\.jsonl/,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("blinded adjudication withholds arm identity and rejoins exact rows", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "codestory-builder-blind-"));
+  try {
+    const runDir = path.join(root, "run");
+    const blindDir = path.join(root, "blind");
+    await mkdir(runDir, { recursive: true });
+    const rows = passingRows();
+    for (const row of rows) {
+      const stdoutPath = path.join(
+        runDir,
+        `${row.task_id}-${row.arm}-${row.repeat}.stdout.jsonl`,
+      );
+      await writeFile(stdoutPath, `${JSON.stringify({
+        type: "item.completed",
+        item: { type: "agent_message", text: `Answer for ${row.task_id} repeat ${row.repeat}` },
+      })}\n`);
+      row.stdout_path = stdoutPath;
+      row.repo = `repo-${row.task_id}`;
+      row.repo_path = root;
+      row.repo_provenance = { git_head: "a".repeat(40) };
+      row.task_manifest_snapshot = { prompt: `Question for ${row.task_id}` };
+    }
+    await writeFile(
+      path.join(runDir, "runs.jsonl"),
+      `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`,
+    );
+    const prepared = await prepareBlindedCases({ runDir, outputDir: blindDir });
+    const cases = JSON.parse(await readFile(prepared.casesPath, "utf8"));
+    const serializedCases = JSON.stringify(cases);
+    assert.equal(cases.cases.length, 96);
+    assert.equal(serializedCases.includes("packet_semantic_off"), false);
+    assert.equal(serializedCases.includes("exact_plus_relations"), false);
+    const judgmentsPath = path.join(blindDir, "judgments.json");
+    await writeFile(judgmentsPath, `${JSON.stringify({
+      contract: JUDGMENTS_CONTRACT,
+      source_cases_sha256: prepared.casesSha256,
+      independent_reviewer: "independent-test-reviewer",
+      rows: cases.cases.map((entry) => ({
+        case_id: entry.case_id,
+        critical_factual_errors: 0,
+        critical_factual_finding_ids: [],
+        unsupported_relation_claims: 0,
+        unsupported_relation_finding_ids: [],
+        notes: "fixture",
+      })),
+    })}\n`);
+    const outputPath = path.join(blindDir, "adjudication.json");
+    const adjudication = await finalizeAdjudication({
+      runDir,
+      casesPath: prepared.casesPath,
+      mapPath: prepared.mapPath,
+      judgmentsPath,
+      outputPath,
+    });
+    assert.equal(adjudication.blinded, true);
+    assert.equal(adjudication.rows.length, 96);
+    assert.deepEqual(new Set(adjudication.rows.map((row) => row.arm)), new Set([
+      "exact_identity_source",
+      "exact_plus_relations",
+      "packet_semantic_off",
+      "packet_semantic_on",
+    ]));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("marginal value rejects neutral and cost-regressing layers", () => {
+  const rows = passingRows();
+  const adjudication = zeroAdjudication(rows);
+  const semantic = marginalValue(
+    rows,
+    "packet_semantic_on",
+    "packet_semantic_off",
+    adjudication,
+  );
+  assert.equal(semantic.positive, false);
+  const graph = marginalValue(
+    rows,
+    "exact_plus_relations",
+    "exact_identity_source",
+    adjudication,
+  );
+  assert.equal(graph.positive, false);
+});
+
+test("marginal decisions fail closed on candidate-only critical claims", () => {
+  const rows = passingRows();
+  for (const row of rows.filter((entry) => entry.arm === "exact_plus_relations")) {
+    row.quality.pass = true;
+    row.transcript_analysis.exploratory_repository_context_actions_after_first_codestory = 4;
+  }
+  const adjudication = zeroAdjudication(rows);
+  const candidate = adjudication.rows.find((row) => row.arm === "exact_plus_relations");
+  candidate.unsupported_relation_claims = 1;
+  candidate.unsupported_relation_finding_ids = ["candidate-only-edge"];
+  const graph = marginalValue(
+    rows,
+    "exact_plus_relations",
+    "exact_identity_source",
+    adjudication,
+  );
+  assert.equal(graph.positive, false);
+  assert.equal(graph.candidate_only_critical_claims.length, 1);
+});
+
+test("machine stop rule distinguishes first revision from terminal failure", () => {
+  assert.equal(packetNextAction(true, "initial", null), "advance");
+  assert.equal(packetNextAction(false, "initial", null), "failed_needs_causal_classification");
+  assert.equal(packetNextAction(false, "initial", "new"), "revise_once");
+  assert.equal(packetNextAction(false, "initial", "equivalent"), "stop");
+  assert.equal(packetNextAction(false, "general_revision", "new"), "stop");
+  assert.throws(
+    () => packetNextAction(true, "initial", "new"),
+    /passing packet gate/,
+  );
+});
+
+test("evaluator writes the bounded revision or stop decision for a failed packet gate", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "codestory-builder-stop-rule-"));
+  try {
+    const rows = passingRows();
+    for (const row of rows.filter((entry) => entry.arm === "packet_semantic_off")) {
+      row.quality.pass = false;
+    }
+    const runBytes = Buffer.from(`${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+    const adjudication = {
+      ...zeroAdjudication(rows),
+      source_runs_sha256: createHash("sha256").update(runBytes).digest("hex"),
+    };
+    await writeFile(path.join(root, "runs.jsonl"), runBytes);
+    const adjudicationPath = path.join(root, "adjudication.json");
+    await writeFile(adjudicationPath, `${JSON.stringify(adjudication)}\n`);
+
+    const unclassified = await evaluate({
+      runDir: root,
+      adjudication: adjudicationPath,
+      attempt: "initial",
+    });
+    assert.equal(unclassified.packet_decision, "failed_needs_causal_classification");
+    const revision = await evaluate({
+      runDir: root,
+      adjudication: adjudicationPath,
+      attempt: "initial",
+      causalClassification: "new",
+    });
+    assert.equal(revision.packet_decision, "revise_once");
+    const equivalent = await evaluate({
+      runDir: root,
+      adjudication: adjudicationPath,
+      attempt: "initial",
+      causalClassification: "equivalent",
+    });
+    assert.equal(equivalent.packet_decision, "stop");
+    const exhausted = await evaluate({
+      runDir: root,
+      adjudication: adjudicationPath,
+      attempt: "general_revision",
+    });
+    assert.equal(exhausted.packet_decision, "stop");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Context

PR #2107 landed the repository-derived packet compiler, but the packet remains a product hypothesis. This slice adds the frozen builder-visible experiment that must compare it with native tools and CodeStory's exact primitives before any 0.18 usefulness claim.

The historical language-expansion tasks are contaminated development inputs. They cannot authorize a release.

## What changed

- Adds five fixed arms: native tools, exact identity/source, exact plus relations, packet without dense candidates, and packet with dense candidates.
- Adds a benchmark-only dense-stage switch. Product builds neither expose nor accept it.
- Records actual descriptor-stage execution and binds optional continuations to the exact offered parent, option set, request, and publication.
- Holds typed continuations dense-disabled in both packet treatments, so only the withheld initial packet call differs between the semantic arms.
- Runs fresh rows in balanced order with opaque treatment-blind ephemeral Codex homes and one checksum-bound CLI.
- Allows adaptive local source inspection while rejecting wrappers, compound commands, MCP, cross-arm CodeStory operations, remote context, reuse, task hints, and hidden answer-shape input.
- Allowlists exact-tool arguments, binds the pinned project and prepared search namespace, and rejects cache, refresh, foreign-project, and output-path overrides.
- Keeps task, arm, repeat, and measurement artifact identities out of the model prompt.
- Partitions one observed local repository-context action sequence at the matched first successful CodeStory action. Unknown readers count when they expose output, failing exits cannot erase shown context, and parallel exploration cannot fall between first-action and post-CodeStory accounting.
- Blinds and independently adjudicates all 96 CodeStory-arm answers for critical factual and unsupported-relation claims.
- Emits the packet `advance` / `revise_once` / `stop` decision and enforced keep-or-disable decisions for graph and dense-semantic defaults.

## Review focus

- Can any agent command escape the direct checksum-bound CLI, prepared state, or pinned repository, or combine CodeStory with source inspection?
- Can task IDs, arm names, repeats, scorer fields, treatment labels, or artifact paths reach the model?
- Can a continuation use a parent or option not offered by the initial packet, fail, or change request/publication without invalidating the row?
- Can repository context exposed by an unfamiliar, extensionless, globbed, failing, or parallel command/tool evade either side of the observed-action partition?
- Can missing, reused, dirty, incompletely adjudicated, or candidate-only critical evidence pass a decision?
- Does semantic-off execute the normal descriptor pipeline with only Stage1b removed?

## Focused verification

- JavaScript analyzer and ablation contracts: 210 passed.
- CLI packet feature lane: 59 passed.
- Retrieval benchmark tests: 2 passed.
- Runtime benchmark proof test: 1 passed.
- Value-score tests: 16 passed.
- Plugin static tests: 140 passed, 1 Windows-only skip.
- Packet generalization boundary, workflow policy, documentation links, formatting, and diff checks: passed.

## Non-claims

- The 120-row builder ablation has not run.
- This does not establish packet usefulness, release accuracy, SLO compliance, installed-product acceptance, or 0.18 readiness.
- No version, calibration constant, package, workflow, or release surface changed.

Closes #2108
Refs #2098
