### PR TITLE
Preserve packet request identity across budget trimming

### DIFF
--- a/crates/codestory-runtime/src/agent/packet_budget.rs
+++ b/crates/codestory-runtime/src/agent/packet_budget.rs
@@ -1054,11 +1054,15 @@ pub(crate) fn packet_budget_usage(answer: &AgentAnswerDto) -> PacketBudgetUsageD
 
 #[cfg(test)]
 pub(super) mod tests {
+    use std::fs;
+    use std::sync::{Arc, atomic::AtomicBool};
+
     use codestory_contracts::api::{
-        AgentAnswerDto, AgentPacketDto, AgentResponseBlockDto, AgentResponseSectionDto,
-        AgentRetrievalPolicyModeDto, AgentRetrievalPresetDto, AgentRetrievalTraceDto,
-        PacketBudgetDto, PacketBudgetLimitsDto, PacketBudgetModeDto, PacketBudgetUsageDto,
-        PacketDispositionDto, PacketPlanDto, PacketRetrievalTraceSummaryDto,
+        AgentAnswerDto, AgentPacketDto, AgentPacketRequestDto, AgentResponseBlockDto,
+        AgentResponseSectionDto, AgentRetrievalPolicyModeDto, AgentRetrievalPresetDto,
+        AgentRetrievalTraceDto, IndexMode, PacketBudgetDto, PacketBudgetLimitsDto,
+        PacketBudgetModeDto, PacketBudgetUsageDto, PacketDispositionDto, PacketPlanDto,
+        PacketRetrievalTraceSummaryDto,
     };
 
     pub(in crate::agent) fn test_packet(question: &str, max_output_bytes: u32) -> AgentPacketDto {
@@ -1153,5 +1157,70 @@ pub(super) mod tests {
             value.get("answer_sufficiency"),
             Some(&serde_json::json!("not_asserted"))
         );
+    }
+
+    #[test]
+    fn hard_budget_minimizer_cannot_destroy_the_v3_request_identity() {
+        let project = tempfile::tempdir().expect("project");
+        fs::write(project.path().join("lib.rs"), "pub fn retained() {}\n").expect("source");
+        let controller = crate::AppController::new();
+        controller
+            .open_project_summary_with_storage_path(
+                project.path().to_path_buf(),
+                project.path().join("codestory.db"),
+            )
+            .expect("open project");
+        controller
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+            .expect("index project");
+        let service = crate::services::PublicOperationService::new(controller);
+        let request = AgentPacketRequestDto {
+            question: "Locate retained".to_owned(),
+            budget: PacketBudgetModeDto::Standard,
+            probes: Vec::new(),
+            latency_budget_ms: None,
+            parent_packet_id: None,
+            option_ids: Vec::new(),
+            core_generation_id: None,
+            retrieval_generation: None,
+        };
+        let mut packet = test_packet(&request.question, 16 * 1024);
+
+        assert!(super::minimize_packet_for_hard_budget(&mut packet));
+        assert!(packet.answer.retrieval_trace.request_id.is_empty());
+        assert!(!packet.packet_id.is_empty());
+
+        let product = service
+            .run_observational_with_cancel("packet", Arc::new(AtomicBool::new(false)), || {
+                crate::evidence_projection_v3::project_packet_v3(
+                    &service,
+                    "test",
+                    &request,
+                    &packet,
+                    |candidate| {
+                        serde_json::to_vec(candidate)
+                            .map(|bytes| bytes.len())
+                            .map_err(|_| ())
+                    },
+                )
+            })
+            .expect("hard-budget packet should retain an authoritative request identity")
+            .value;
+        let serialized = serde_json::to_vec(&product.projection).expect("serialize projection");
+        assert!(
+            serialized.len()
+                <= crate::agent::packet_projection_v3::PACKET_PUBLIC_RESULT_MAX_BYTES_V3
+        );
+        let identity = match product.projection {
+            codestory_contracts::packet_projection_v3::PacketProjectionV3Dto::Complete {
+                identity,
+                ..
+            }
+            | codestory_contracts::packet_projection_v3::PacketProjectionV3Dto::BudgetExceeded {
+                identity,
+                ..
+            } => identity,
+        };
+        assert_eq!(identity.request_id.as_str(), "packet-budget-test");
     }
 }

--- a/crates/codestory-runtime/src/evidence_projection_v3.rs
+++ b/crates/codestory-runtime/src/evidence_projection_v3.rs
@@ -119,7 +119,10 @@ pub fn project_packet_v3(
     let retrieval = retrieval_state(packet.answer.retrieval_trace.retrieval_publication.as_ref());
     let input = FinalizedPacketExecutionInputV3::new(
         identity(caller_id, "caller_id")?,
-        identity(&packet.answer.retrieval_trace.request_id, "request_id")?,
+        // `packet_id` is the immutable execution request identity on the
+        // internal packet. The trace copy is optional diagnostics and the hard
+        // public-budget path may remove it before this projection is built.
+        identity(&packet.packet_id, "request_id")?,
         PacketRequestFingerprintV3::from_current_request(request),
         evidence,
         gaps,


### PR DESCRIPTION
## Context

The builder-visible evidence-compiler ablation stopped after five rows at merged head `114542cb1074dd2da1dbcea434884b479ec7138b`. Both packet cells failed before agent execution because hard public-budget trimming removed a duplicate trace request ID and the v3 projection later treated that optional diagnostic copy as authoritative.

Closes #2110. Refs #2098.

## What changed

- Build the authoritative v3 request identity from the internal packet execution ID, which is mandatory and survives all budget paths.
- Leave the duplicate retrieval-trace ID optional so the 16 KiB minimizer can still remove diagnostics.
- Add a cross-boundary regression test that executes the hard minimizer, proves the trace copy is gone, projects through a pinned core publication, verifies the request identity, and remeasures the result under 16 KiB.

## How to review

Trace `agent_packet_with_session` from its request-ID mint through `AgentPacketDto.packet_id`, the hard minimizer, and `project_packet_v3`. Confirm that continuation parent IDs and the separately minted public v3 packet ID remain distinct.

## Verification

- Reproducer before fix: failed with `The finalized v3 request_id was empty.`
- Focused regression: 1 passed.
- `cargo test --locked -p codestory-runtime --lib`: 833 passed, 4 ignored.
- `cargo test --locked -p codestory-cli --features benchmark-support --lib packet`: 59 passed.
- `cargo fmt --all -- --check`
- `git diff --check`

The invalid five-row builder receipt remains preserved separately and will not be reused. The full 120-row builder run restarts from zero only after this repair is independently accepted and merged.
