### PR TITLE
[codex] preserve failed builder-ablation rows

### DIFF
--- a/scripts/codestory-agent-ab-benchmark.mjs
+++ b/scripts/codestory-agent-ab-benchmark.mjs
@@ -5849,7 +5849,7 @@ function resultPacketObligationAccounting(result) {
 }
 
 function resultRequiresPacketObligationAccounting(result) {
-  if (!isCodeStoryArm(result?.arm) && result?.mode == null) {
+  if (!isPacketArm(result?.arm) && result?.mode == null) {
     return false;
   }
   const prelude = result?.codestory_harness_prelude;
@@ -8794,6 +8794,9 @@ async function reanalysisPacketProjection(result, runDir, task) {
     return null;
   }
   const packet = JSON.parse(await readFile(resolved, "utf8"));
+  if (packetCommandFailureEnvelope(packet)) {
+    return null;
+  }
   const manifestQuality = task ? packetManifestQualitySummary(packet, task) : null;
   const evidenceGapAccounting = packetV3EvidenceGapAccounting(packet);
   const sufficiency = packetSufficiencyTelemetry(packet, manifestQuality);

--- a/scripts/codestory-evidence-compiler-ablation-adjudication.mjs
+++ b/scripts/codestory-evidence-compiler-ablation-adjudication.mjs
@@ -81,7 +81,14 @@ async function answerFromRow(runDir, row) {
   if (size > MAX_TRANSCRIPT_BYTES) {
     throw new Error(`runner transcript exceeds ${MAX_TRANSCRIPT_BYTES} bytes: ${transcriptPath}`);
   }
-  return extractFinalAnswer(parseJsonl(await readFile(transcriptPath, "utf8"), "runner transcript"));
+  const transcript = await readFile(transcriptPath, "utf8");
+  if (row.status === "fail" && transcript.length === 0) {
+    return { answer: "", answerStatus: "not_produced" };
+  }
+  return {
+    answer: extractFinalAnswer(parseJsonl(transcript, "runner transcript")),
+    answerStatus: "produced",
+  };
 }
 
 function opaqueCaseId(used) {
@@ -111,7 +118,7 @@ async function prepareBlindedCases({ runDir, outputDir }) {
   const cases = [];
   const entries = [];
   for (const row of rows) {
-    const answer = await answerFromRow(runDir, row);
+    const { answer, answerStatus } = await answerFromRow(runDir, row);
     const caseId = opaqueCaseId(usedIds);
     const answerSha256 = sha256(Buffer.from(answer, "utf8"));
     cases.push({
@@ -120,6 +127,7 @@ async function prepareBlindedCases({ runDir, outputDir }) {
       repository_path: row.repo_path,
       repository_commit: row.repo_provenance?.git_head ?? null,
       question: row.task_manifest_snapshot?.prompt ?? null,
+      answer_status: answerStatus,
       answer,
       answer_sha256: answerSha256,
     });
@@ -139,6 +147,7 @@ async function prepareBlindedCases({ runDir, outputDir }) {
     instructions: {
       critical_factual_error: "Count each unique materially wrong statement about the requested code behavior that could change the answer's conclusion.",
       unsupported_relation_claim: "Count each unique material call, import, implementation, data-flow, or control-flow claim that is not established by the answer's cited source or the pinned repository source.",
+      no_answer: "A case with answer_status=not_produced contains no answer claims. Record zero counts and note that no answer was produced.",
       output: "Return the judgments contract with every case_id exactly once. Include nonnegative integer counts plus unique critical_factual_finding_ids and unsupported_relation_finding_ids arrays of the same lengths. Reuse one stable finding id when two answers make the same error. Add concise source-backed notes. Do not identify or infer experimental arms.",
     },
     cases,
@@ -235,6 +244,12 @@ async function finalizeAdjudication({ runDir, casesPath, mapPath, judgmentsPath,
       judgment.unsupported_relation_claims,
       `${caseId} unsupported_relation_claims`,
     );
+    if (
+      answer?.answer_status === "not_produced" &&
+      (criticalFactualErrors !== 0 || unsupportedRelationClaims !== 0)
+    ) {
+      throw new Error(`${caseId} not_produced answer cannot contain adjudicated claims`);
+    }
     return {
       task_id: mapped.task_id,
       arm: mapped.arm,

--- a/scripts/tests/codestory-agent-ab-analyzer.test.mjs
+++ b/scripts/tests/codestory-agent-ab-analyzer.test.mjs
@@ -2737,6 +2737,26 @@ test("saved packet reanalysis rebuilds revision-native accounting and derived ac
     assert.equal(v3WithoutTask.packet_evidence_gap_accounting.gap_count, 1);
     assert.equal(v3WithoutTask.packet_manifest_quality, null);
 
+    const failurePath = path.join(root, "packet-failure.json");
+    await writeFile(failurePath, JSON.stringify({
+      schema_version: 1,
+      error: {
+        code: "retrieval_unavailable",
+        message: "retrieval rejected query: stage_deadline",
+      },
+    }));
+    assert.equal(
+      await reanalysisPacketProjection({
+        status: "fail",
+        codestory_harness_prelude: {
+          stdout_path: failurePath,
+          packet_schema_version: null,
+        },
+      }, root, task),
+      null,
+      "a typed command failure is not a packet and cannot mint packet accounting",
+    );
+
     const refreshed = reanalysisExactCandidateAcceptance({
       exact_candidate_acceptance: { stale: true },
       exact_candidate_lifecycle: exactLifecycle(),
@@ -2788,6 +2808,19 @@ test("packet obligation accounting rejects unreconciled summaries", () => {
     ], "benchmark summary"),
     null,
   );
+  for (const arm of ["exact_identity_source", "exact_plus_relations"]) {
+    assert.equal(
+      summarizePacketObligationAccounting([{
+        repo: "fixture",
+        task_id: "builder-control",
+        arm,
+        repeat: 1,
+        status: "pass",
+      }], "benchmark summary"),
+      null,
+      `${arm} is a CodeStory control arm, not a packet arm`,
+    );
+  }
   for (const missing of [
     { repo: "fixture", task_id: "measured", arm: "with_codestory", repeat: 1, status: "pass" },
     { repo: "fixture", task_id: "runtime", mode: "cold_cli_packet", repeat: 1, status: "pass" },

--- a/scripts/tests/codestory-evidence-compiler-ablation.test.mjs
+++ b/scripts/tests/codestory-evidence-compiler-ablation.test.mjs
@@ -906,6 +906,14 @@ test("blinded adjudication withholds arm identity and rejoins exact rows", async
       row.repo_provenance = { git_head: "a".repeat(40) };
       row.task_manifest_snapshot = { prompt: `Question for ${row.task_id}` };
     }
+    const failedPacket = rows.find((row) =>
+      row.task_id === BUILDER_ABLATION_TASK_IDS[0] &&
+      row.arm === "packet_semantic_off" &&
+      row.repeat === 1
+    );
+    failedPacket.status = "fail";
+    failedPacket.error = "retrieval_unavailable: stage_deadline";
+    await writeFile(failedPacket.stdout_path, "");
     await writeFile(
       path.join(runDir, "runs.jsonl"),
       `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`,
@@ -916,8 +924,17 @@ test("blinded adjudication withholds arm identity and rejoins exact rows", async
     assert.equal(cases.cases.length, 96);
     assert.equal(serializedCases.includes("packet_semantic_off"), false);
     assert.equal(serializedCases.includes("exact_plus_relations"), false);
+    const failedCase = cases.cases.find((entry) => entry.answer_status === "not_produced");
+    assert.ok(failedCase);
+    assert.equal(failedCase.answer, "");
+    assert.equal(
+      failedCase.answer_sha256,
+      createHash("sha256").update("").digest("hex"),
+    );
+    assert.equal(cases.cases.filter((entry) => entry.answer_status === "not_produced").length, 1);
+    assert.equal(cases.cases.filter((entry) => entry.answer_status === "produced").length, 95);
     const judgmentsPath = path.join(blindDir, "judgments.json");
-    await writeFile(judgmentsPath, `${JSON.stringify({
+    const judgments = {
       contract: JUDGMENTS_CONTRACT,
       source_cases_sha256: prepared.casesSha256,
       independent_reviewer: "independent-test-reviewer",
@@ -929,8 +946,25 @@ test("blinded adjudication withholds arm identity and rejoins exact rows", async
         unsupported_relation_finding_ids: [],
         notes: "fixture",
       })),
-    })}\n`);
+    };
+    const fabricatedClaim = judgments.rows.find((entry) => entry.case_id === failedCase.case_id);
+    fabricatedClaim.critical_factual_errors = 1;
+    fabricatedClaim.critical_factual_finding_ids = ["fabricated-no-answer-claim"];
+    await writeFile(judgmentsPath, `${JSON.stringify(judgments)}\n`);
     const outputPath = path.join(blindDir, "adjudication.json");
+    await assert.rejects(
+      () => finalizeAdjudication({
+        runDir,
+        casesPath: prepared.casesPath,
+        mapPath: prepared.mapPath,
+        judgmentsPath,
+        outputPath,
+      }),
+      /not_produced answer cannot contain adjudicated claims/,
+    );
+    fabricatedClaim.critical_factual_errors = 0;
+    fabricatedClaim.critical_factual_finding_ids = [];
+    await writeFile(judgmentsPath, `${JSON.stringify(judgments)}\n`);
     const adjudication = await finalizeAdjudication({
       runDir,
       casesPath: prepared.casesPath,
@@ -946,6 +980,31 @@ test("blinded adjudication withholds arm identity and rejoins exact rows", async
       "packet_semantic_off",
       "packet_semantic_on",
     ]));
+
+    for (const [status, label] of [
+      ["pass", "passing"],
+      [undefined, "missing-status"],
+      [null, "null-status"],
+      ["cancelled", "cancelled"],
+      ["unknown", "unknown"],
+    ]) {
+      if (status === undefined) {
+        delete failedPacket.status;
+      } else {
+        failedPacket.status = status;
+      }
+      await writeFile(
+        path.join(runDir, "runs.jsonl"),
+        `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`,
+      );
+      await assert.rejects(
+        () => prepareBlindedCases({
+          runDir,
+          outputDir: path.join(root, `${label}-row-without-answer`),
+        }),
+        /runner transcript contains no final agent answer/,
+      );
+    }
   } finally {
     await rm(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Context

The complete builder-visible ablation wrote all 120 immutable rows at source head `208e1295137bc8b1e66abdd37e959e7740cc544d`, then postprocessing failed for two coupled reasons: exact-navigation controls were incorrectly required to carry packet-obligation accounting, and blinded adjudication assumed even a failed packet prelude had produced an agent answer.

## What changed

- Packet-obligation accounting is required only for packet arms and packet-runtime modes.
- Reanalysis recognizes a typed command-failure envelope as a failure, not as a packet.
- Failed rows with an empty runner transcript become blinded `answer_status: not_produced` cases with an empty-answer digest.
- Successful rows still fail closed without a final answer.
- Finalization rejects any adjudicated claim attached to a `not_produced` case.

No product path, recorded benchmark row, scorer, threshold, task, prompt, or run ordering changed.

## Verification

- `node --test scripts/tests/codestory-agent-ab-analyzer.test.mjs`: 189 passed.
- `node --test scripts/tests/codestory-evidence-compiler-ablation.test.mjs`: 21 passed.
- Existing 120-row ledger reanalysis: 120 rows completed.
- Blinded bundle: 96 cases, 84 produced answers, 12 typed no-answer cases, no arm identity.
- `git diff --check`: passed.

## Review focus

Confirm this patch cannot turn a failed product row into a passing row, cannot invent an answer, and does not weaken accounting for any emitted packet.

Closes #2112
Refs #2098
