### PR TITLE
reuse coherent packet retrieval results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Explicit `search --repo-text off` now reads the complete core symbol index
+  without waiting for embeddings. Packet assembly reuses the retrieval result
+  that established admission instead of rerunning it under a shorter deadline.
 - Packet requests no longer accept `task_class`. Ordinary wording reaches
   generic retrieval; the public packet reports `answer_sufficiency: not_asserted`.
 - The serialized public packet is capped at 16 KiB. When exact hydration cannot

--- a/crates/codestory-cli/src/app.rs
+++ b/crates/codestory-cli/src/app.rs
@@ -97,6 +97,7 @@ use index_command::validate_index_watch_output_file;
 #[cfg(test)]
 use lifecycle::{
     embedding_client_transport_mode, map_embedding_preflight_error, open_agent_surface,
+    open_search_surface,
 };
 pub(crate) use readiness_commands::{
     attach_complete_publication, local_refresh_output_from_summary,

--- a/crates/codestory-cli/src/app/agent_context/packet.rs
+++ b/crates/codestory-cli/src/app/agent_context/packet.rs
@@ -239,6 +239,7 @@ fn evidence_status_label(status: &EvidenceAvailabilityV3Dto) -> &'static str {
 fn retrieval_state_label(state: &RetrievalStateV3Dto) -> &'static str {
     match state {
         RetrievalStateV3Dto::Full => "full",
+        RetrievalStateV3Dto::Symbolic => "symbolic",
         RetrievalStateV3Dto::Degraded => "degraded",
         RetrievalStateV3Dto::Unavailable => "unavailable",
     }

--- a/crates/codestory-cli/src/app/lifecycle.rs
+++ b/crates/codestory-cli/src/app/lifecycle.rs
@@ -7,7 +7,7 @@ use crate::runtime;
 use crate::runtime::{RuntimeContext, ensure_index_ready, map_api_error};
 use anyhow::Context;
 use anyhow::Result;
-use codestory_contracts::api::ProjectSummary;
+use codestory_contracts::api::{ProjectSummary, SearchRepoTextMode};
 use std::fmt::Write as _;
 
 pub(super) fn embedding_client_transport_mode(
@@ -97,6 +97,27 @@ pub(super) fn open_agent_surface(
     codestory_runtime::ensure_product_embedding_backend_for_runtime(&runtime.sidecar)
         .map_err(map_embedding_preflight_error)
         .with_context(|| format!("initialize retrieval for {surface}"))?;
+    Ok(OpenedAgentSurface {
+        runtime,
+        before,
+        opened,
+    })
+}
+
+pub(super) fn open_search_surface(
+    project: &ProjectArgs,
+    profile: Option<args::CliSidecarProfile>,
+    run_id: Option<&str>,
+    refresh: args::RefreshMode,
+    repo_text: SearchRepoTextMode,
+) -> Result<OpenedAgentSurface> {
+    if repo_text != SearchRepoTextMode::Off {
+        return open_agent_surface(project, profile, run_id, refresh, "search");
+    }
+
+    let runtime = RuntimeContext::new(project)?;
+    let (before, opened) = runtime.ensure_open_with_before(refresh)?;
+    ensure_index_ready(&opened, "search")?;
     Ok(OpenedAgentSurface {
         runtime,
         before,

--- a/crates/codestory-cli/src/app/search_command.rs
+++ b/crates/codestory-cli/src/app/search_command.rs
@@ -1,5 +1,5 @@
 use super::artifacts::{ensure_dot_only_for_trail, preflight_output_file};
-use super::lifecycle::{OpenedAgentSurface, open_agent_surface};
+use super::lifecycle::{OpenedAgentSurface, open_search_surface};
 use super::to_api_repo_text_mode;
 use crate::args::SearchCommand;
 use crate::output::{RenderedPublicOutput, emit_public_operation};
@@ -10,27 +10,31 @@ use codestory_contracts::api::SearchRequest;
 pub(super) fn run_search(cmd: SearchCommand) -> Result<()> {
     ensure_dot_only_for_trail(cmd.format, "search")?;
     preflight_output_file(cmd.output_file.as_deref())?;
-    let OpenedAgentSurface { runtime, .. } = open_agent_surface(
+    let repo_text = to_api_repo_text_mode(cmd.repo_text);
+    let OpenedAgentSurface { runtime, .. } = open_search_surface(
         &cmd.project,
         cmd.profile,
         cmd.run_id.as_deref(),
         cmd.refresh,
-        "search",
+        repo_text,
     )?;
-    let operation = runtime.run_public_operation("search", || {
-        let search_results = runtime
-            .browser
-            .search_results(search_request_from_command(&cmd))
+    let operation = runtime.run_public_operation(
+        codestory_runtime::search_operation_name(repo_text),
+        || {
+            let search_results = runtime
+                .browser
+                .search_results(search_request_from_command(&cmd))
+                .map_err(map_api_error)?;
+            let projection = codestory_runtime::project_search_v3(
+                &runtime.public_operation,
+                "codestory-cli",
+                &search_results,
+            )
             .map_err(map_api_error)?;
-        let projection = codestory_runtime::project_search_v3(
-            &runtime.public_operation,
-            "codestory-cli",
-            &search_results,
-        )
-        .map_err(map_api_error)?;
-        let markdown = render_search_projection_markdown(&projection);
-        RenderedPublicOutput::structured(&projection, markdown)
-    })?;
+            let markdown = render_search_projection_markdown(&projection);
+            RenderedPublicOutput::structured(&projection, markdown)
+        },
+    )?;
     emit_public_operation(cmd.format, operation, cmd.output_file.as_deref())
 }
 

--- a/crates/codestory-cli/src/app/tests/lifecycle/agent_surface.rs
+++ b/crates/codestory-cli/src/app/tests/lifecycle/agent_surface.rs
@@ -1,5 +1,5 @@
 use super::transport::EnvVarSnapshot;
-use crate::app::open_agent_surface;
+use crate::app::{open_agent_surface, open_search_surface};
 use crate::args;
 use crate::args::ProjectArgs;
 use crate::runtime;
@@ -228,6 +228,48 @@ fn agent_surface_embedding_preflight_preserves_cli_error_text() {
             "initialize retrieval for packet: embedding backend unavailable by test marker in {}",
             embedding_cache_root.display()
         )
+    );
+    fs::remove_file(marker).expect("remove embedding unavailable marker");
+}
+
+#[test]
+fn exact_search_opens_the_complete_core_without_embedding_preflight() {
+    let _env_lock = crate::config::config_env_test_lock();
+    let _env_snapshot = EnvVarSnapshot::clear(&[
+        "CODESTORY_RETRIEVAL_PROFILE",
+        "CODESTORY_RETRIEVAL_RUN_ID",
+        "CI",
+        "GITHUB_ACTIONS",
+    ]);
+    let (_temp, project_args, _storage_path, _current_schema) = agent_surface_refresh_fixture();
+    let runtime = RuntimeContext::new_inspect_only(&project_args).expect("create runtime");
+    let embedding_cache_root = runtime.sidecar.as_raw_config_for_test().cache_root.clone();
+    fs::create_dir_all(&embedding_cache_root).expect("create embedding cache root");
+    let marker = embedding_cache_root.join(codestory_retrieval::TEST_EMBEDDING_UNAVAILABLE_MARKER);
+    fs::write(&marker, b"unavailable").expect("write embedding unavailable marker");
+
+    open_search_surface(
+        &project_args,
+        None,
+        None,
+        args::RefreshMode::None,
+        codestory_contracts::api::SearchRepoTextMode::Off,
+    )
+    .expect("exact search must not initialize embeddings");
+
+    let error = match open_search_surface(
+        &project_args,
+        None,
+        None,
+        args::RefreshMode::None,
+        codestory_contracts::api::SearchRepoTextMode::Auto,
+    ) {
+        Ok(_) => panic!("ordinary search still requires embeddings"),
+        Err(error) => error,
+    };
+    assert!(
+        format!("{error:#}").contains("embedding backend unavailable by test marker"),
+        "{error:#}"
     );
     fs::remove_file(marker).expect("remove embedding unavailable marker");
 }

--- a/crates/codestory-cli/src/http_transport.rs
+++ b/crates/codestory-cli/src/http_transport.rs
@@ -141,25 +141,28 @@ pub(crate) fn handle_http_request(
                 .and_then(|value| value.parse::<u32>().ok())
                 .unwrap_or(10)
                 .clamp(1, 100);
-            let operation = match runtime.run_public_operation("search", || {
-                let results = runtime
-                    .browser
-                    .search_results(SearchRequest {
-                        query: query.clone(),
-                        repo_text,
-                        limit_per_source,
-                        expand_search_plan: false,
-                        hybrid_weights: None,
-                        hybrid_limits: None,
-                    })
-                    .map_err(map_api_error)?;
-                codestory_runtime::project_search_v3(
-                    &runtime.public_operation,
-                    "codestory-http",
-                    &results,
-                )
-                .map_err(map_api_error)
-            }) {
+            let operation = match runtime.run_public_operation(
+                codestory_runtime::search_operation_name(repo_text),
+                || {
+                    let results = runtime
+                        .browser
+                        .search_results(SearchRequest {
+                            query: query.clone(),
+                            repo_text,
+                            limit_per_source,
+                            expand_search_plan: false,
+                            hybrid_weights: None,
+                            hybrid_limits: None,
+                        })
+                        .map_err(map_api_error)?;
+                    codestory_runtime::project_search_v3(
+                        &runtime.public_operation,
+                        "codestory-http",
+                        &results,
+                    )
+                    .map_err(map_api_error)
+                },
+            ) {
                 Ok(operation) => operation,
                 Err(error) => {
                     return write_http_typed_error(&mut stream, 400, "search_unavailable", &error);

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -1722,7 +1722,7 @@ fn handle_stdio_request(
             let diagnostics_registry = Arc::clone(&session.diagnostics_v3);
             let (runtime, state) = session.active_project_mut();
             let public_operation = stdio_public_operation_name(name, &request);
-            let observes_complete_core = stdio_tool_observes_complete_core(name);
+            let observes_complete_core = stdio_tool_observes_complete_core(name, &request);
             if stdio_tool_reads_publication(name) {
                 if let Some(mismatch) = stdio_workspace_mismatch(runtime) {
                     let error = serde_json::json!({
@@ -2303,14 +2303,7 @@ fn handle_stdio_search_v3(
         .and_then(serde_json::Value::as_str)
         .unwrap_or_default()
         .to_owned();
-    let repo_text = match request
-        .pointer("/params/arguments/repo_text")
-        .and_then(serde_json::Value::as_str)
-    {
-        Some("on") => SearchRepoTextMode::On,
-        Some("off") => SearchRepoTextMode::Off,
-        _ => SearchRepoTextMode::Auto,
-    };
+    let repo_text = stdio_search_repo_text_mode(request);
     let limit_per_source = request
         .pointer("/params/arguments/limit")
         .and_then(serde_json::Value::as_u64)
@@ -2768,12 +2761,27 @@ fn stdio_tool_reads_publication(name: &str) -> bool {
     name != "status"
 }
 
-fn stdio_tool_observes_complete_core(name: &str) -> bool {
-    name == "affected" || crate::prove_call_path::is_proof_tool_name(name)
+fn stdio_search_repo_text_mode(request: &serde_json::Value) -> SearchRepoTextMode {
+    match request
+        .pointer("/params/arguments/repo_text")
+        .and_then(serde_json::Value::as_str)
+    {
+        Some("on") => SearchRepoTextMode::On,
+        Some("off") => SearchRepoTextMode::Off,
+        _ => SearchRepoTextMode::Auto,
+    }
+}
+
+fn stdio_tool_observes_complete_core(name: &str, request: &serde_json::Value) -> bool {
+    name == "affected"
+        || crate::prove_call_path::is_proof_tool_name(name)
+        || (name == "search" && stdio_search_repo_text_mode(request) == SearchRepoTextMode::Off)
 }
 
 fn stdio_public_operation_name<'a>(name: &'a str, request: &serde_json::Value) -> &'a str {
-    if matches!(
+    if name == "search" {
+        codestory_runtime::search_operation_name(stdio_search_repo_text_mode(request))
+    } else if matches!(
         name,
         "symbol"
             | "trail"
@@ -4790,14 +4798,7 @@ fn handle_stdio_search(
     request: &serde_json::Value,
     query: String,
 ) -> serde_json::Value {
-    let repo_text = match request
-        .pointer("/params/arguments/repo_text")
-        .and_then(|value| value.as_str())
-    {
-        Some("on") => SearchRepoTextMode::On,
-        Some("off") => SearchRepoTextMode::Off,
-        _ => SearchRepoTextMode::Auto,
-    };
+    let repo_text = stdio_search_repo_text_mode(request);
     let limit_per_source = request
         .pointer("/params/arguments/limit")
         .and_then(|value| value.as_u64())
@@ -7734,6 +7735,24 @@ mod tests {
             &Arc::new(AtomicBool::new(false)),
         )
         .expect("diagnostic resource response")
+    }
+
+    #[test]
+    fn only_explicit_repo_text_off_search_uses_core_only_stdio_activation() {
+        let exact = json!({
+            "params": {"arguments": {"query": "RenamedAnchor", "repo_text": "off"}}
+        });
+        let ordinary = json!({
+            "params": {"arguments": {"query": "RenamedAnchor", "repo_text": "auto"}}
+        });
+        assert!(stdio_tool_observes_complete_core("search", &exact));
+        assert!(!stdio_tool_observes_complete_core("search", &ordinary));
+        assert!(!stdio_tool_observes_complete_core("search", &json!({})));
+        assert_eq!(
+            stdio_public_operation_name("search", &exact),
+            "exact_search"
+        );
+        assert_eq!(stdio_public_operation_name("search", &ordinary), "search");
     }
 
     #[test]

--- a/crates/codestory-cli/src/stdio_v3/catalog.rs
+++ b/crates/codestory-cli/src/stdio_v3/catalog.rs
@@ -276,7 +276,7 @@ fn retrieval_state_schema_v3() -> Value {
     closed_object_schema_v3(vec![
         (
             "state",
-            enum_schema_v3(&["full", "degraded", "unavailable"]),
+            enum_schema_v3(&["full", "symbolic", "degraded", "unavailable"]),
         ),
         ("generation_id", nullable_schema_v3(string_schema_v3())),
     ])

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -3679,7 +3679,7 @@ fn every_production_gap_annotation_producer_is_pinned_to_the_gap_kind() {
     );
 }
 
-/// Repo-text search must not be disabled by a constant on any search path.
+/// Broad search must not disable requested repository text with a constant.
 ///
 /// The sidecar path -- the one the MCP tool surface and the packet both use -- once built
 /// its results with `let repo_text_hits = Vec::new();` and `repo_text_enabled: false`,
@@ -3689,18 +3689,27 @@ fn every_production_gap_annotation_producer_is_pinned_to_the_gap_kind() {
 /// across a 54-row benchmark, agents asked for repo text on 582 of 582 searches and every
 /// one of the 569 that completed reported a zero count.
 ///
-/// A literal `false` here is indistinguishable from "this path does not support repo text",
-/// which is why the regression was invisible. The flag has to follow the requested mode.
+/// The explicit complete-core exact lane intentionally reports repository text
+/// disabled. The sidecar path must still derive the flag from the requested
+/// mode rather than silently turning an `auto` or `on` request into exact-only
+/// search.
 #[test]
 fn search_paths_do_not_hardcode_repo_text_disabled() {
     let source = read("crates/codestory-runtime/src/search_plan.rs");
+    let sidecar_and_following = source
+        .split_once("fn search_results_sidecar_primary")
+        .expect("sidecar search function")
+        .1;
+    let sidecar = sidecar_and_following
+        .split_once("\n    fn ")
+        .map_or(sidecar_and_following, |(body, _)| body);
     assert!(
-        !source.contains("repo_text_enabled: false"),
-        "search_plan.rs disables repo text with a constant; it must follow the requested \
-         SearchRepoTextMode so a caller that asks for literal matches receives them"
+        !sidecar.contains("repo_text_enabled: false"),
+        "the broad sidecar search disables repo text with a constant; it must follow the \
+         requested SearchRepoTextMode so a caller that asks for literal matches receives them"
     );
     assert!(
-        source.contains("let repo_text_enabled = repo_text_mode != SearchRepoTextMode::Off;"),
+        sidecar.contains("let repo_text_enabled = repo_text_mode != SearchRepoTextMode::Off;"),
         "the sidecar search path must derive repo_text_enabled from the requested mode"
     );
 }

--- a/crates/codestory-cli/tests/cli_golden_path.rs
+++ b/crates/codestory-cli/tests/cli_golden_path.rs
@@ -1392,7 +1392,7 @@ fn app_controller_opens_project() {
         None,
     );
     search_dir_snapshot.assert_unchanged("ground symbol");
-    assert_product_search_fails_closed_without_full_sidecars(
+    assert_exact_search_uses_core_without_full_sidecars(
         workspace.path(),
         cache_dir.path(),
         "AppController",
@@ -1424,7 +1424,7 @@ fn app_controller_opens_project() {
     assert_files_and_affected_read_existing_cache(workspace.path(), cache_dir.path());
     search_dir_snapshot.assert_unchanged("files and affected");
 
-    assert_query_search_fails_closed_without_full_sidecars(workspace.path(), cache_dir.path());
+    assert_query_search_uses_core_without_full_sidecars(workspace.path(), cache_dir.path());
     search_dir_snapshot.assert_unchanged("query search");
     assert_packet_builds_broad_task_contract(workspace.path(), cache_dir.path());
     search_dir_snapshot.assert_unchanged("packet");
@@ -1642,7 +1642,7 @@ fn ground_symbol_node_id_from_existing_cache(
     string_field(hit, &["id"]).to_string()
 }
 
-fn assert_product_search_fails_closed_without_full_sidecars(
+fn assert_exact_search_uses_core_without_full_sidecars(
     workspace: &Path,
     cache_dir: &Path,
     query: &str,
@@ -1665,10 +1665,38 @@ fn assert_product_search_fails_closed_without_full_sidecars(
         ],
     );
     assert!(
-        !output.status.success(),
-        "product search should fail closed without full retrieval"
+        output.status.success(),
+        "exact search should use the complete core without retrieval sidecars: {}",
+        String::from_utf8_lossy(&output.stderr)
     );
-    assert_retrieval_failure_output(output);
+    let search: Value = serde_json::from_slice(&output.stdout)
+        .unwrap_or_else(|error| panic!("parse exact-search output: {error}; output={output:#?}"));
+    assert_eq!(search["schema_version"], 3, "{search:#}");
+    assert_eq!(search["kind"], "complete", "{search:#}");
+    assert_eq!(search["status"], "available", "{search:#}");
+    assert_eq!(search["retrieval"]["state"], "symbolic", "{search:#}");
+    assert!(
+        search["retrieval"]["generation_id"].is_null()
+            && search["publication"]["retrieval"].is_null(),
+        "exact search must not imply a sidecar publication: {search:#}"
+    );
+    assert!(
+        search["gaps"].as_array().is_some_and(Vec::is_empty),
+        "an intentionally symbolic search must not report retrieval unavailable: {search:#}"
+    );
+    assert!(
+        search["evidence"].as_array().is_some_and(|rows| {
+            rows.iter().any(|row| {
+                row["path"]
+                    .as_str()
+                    .is_some_and(|path| !path.starts_with('/'))
+                    && row["excerpt"]
+                        .as_str()
+                        .is_some_and(|excerpt| excerpt.contains(query))
+            })
+        }),
+        "exact search must return project-relative source evidence for {query}: {search:#}"
+    );
 }
 
 fn assert_product_search_fails_closed_on_stale_core(
@@ -1704,7 +1732,7 @@ fn assert_product_search_fails_closed_on_stale_core(
         "{failure:#}"
     );
     assert_eq!(
-        failure["error"]["message"], "search requires a fresh complete core publication",
+        failure["error"]["message"], "exact_search requires a fresh complete core publication",
         "{failure:#}"
     );
 }
@@ -2480,7 +2508,7 @@ fn run_git(workspace: &Path, args: &[&str]) {
     );
 }
 
-fn assert_query_search_fails_closed_without_full_sidecars(workspace: &Path, cache_dir: &Path) {
+fn assert_query_search_uses_core_without_full_sidecars(workspace: &Path, cache_dir: &Path) {
     let output = run_cli(
         workspace,
         cache_dir,
@@ -2494,10 +2522,22 @@ fn assert_query_search_fails_closed_without_full_sidecars(workspace: &Path, cach
         ],
     );
     assert!(
-        !output.status.success(),
-        "query search DSL should fail closed without full sidecars"
+        output.status.success(),
+        "query search DSL should use the complete core without sidecars: {}",
+        String::from_utf8_lossy(&output.stderr)
     );
-    assert_retrieval_failure_output(output);
+    let query: Value = serde_json::from_slice(&output.stdout)
+        .unwrap_or_else(|error| panic!("parse query-search output: {error}; output={output:#?}"));
+    assert!(
+        query["items"].as_array().is_some_and(|items| {
+            items.iter().any(|item| {
+                item["display_name"] == "AppController"
+                    && item["source"] == "search"
+                    && item["file_path"] == "src/lib.rs"
+            })
+        }),
+        "query search DSL should return the exact core symbol: {query:#}"
+    );
 }
 
 fn assert_context_id_fails_closed_without_full_sidecars(
@@ -2703,7 +2743,7 @@ fn bookmarks_degrade_gracefully_after_reindex_removes_target() {
         &["index", "--refresh", "full", "--format", "json"],
     );
 
-    assert_product_search_fails_closed_without_full_sidecars(
+    assert_exact_search_uses_core_without_full_sidecars(
         workspace.path(),
         cache_dir.path(),
         "normalize_project",
@@ -2890,7 +2930,7 @@ fn context_json_reports_deep_trace_by_default() {
         "index should discover investigation fixture symbols"
     );
 
-    assert_product_search_fails_closed_without_full_sidecars(
+    assert_exact_search_uses_core_without_full_sidecars(
         workspace.path(),
         cache_dir.path(),
         "parse_investigation_event",

--- a/crates/codestory-cli/tests/http_transport_contracts.rs
+++ b/crates/codestory-cli/tests/http_transport_contracts.rs
@@ -755,34 +755,30 @@ fn http_smoke_keeps_existing_routes_and_default_semantics_against_indexed_repo()
     let (_server, addr) = spawn_http_server(&fixture);
 
     let search = http_get(&addr, "/search?q=AppController&repo_text=off")
-        .expect("search fail-closed response");
+        .expect("exact core search response");
+    assert_eq!(search.status, 200, "{}", search.body);
+    assert_eq!(search.body["schema_version"], 3, "{}", search.body);
     assert_eq!(
-        search.status, 400,
-        "HTTP /search is product search and should fail closed without full sidecars: {}",
-        search.body
-    );
-    assert_eq!(
-        search.body.pointer("/error/code").and_then(Value::as_str),
-        Some("retrieval_unavailable"),
-        "HTTP /search must preserve the runtime's machine classification: {}",
-        search.body
-    );
-    assert_eq!(
-        search
-            .body
-            .pointer("/error/details/failed_layer")
-            .and_then(Value::as_str),
-        Some("retrieval_engine"),
-        "HTTP /search must preserve the typed repair details: {}",
+        search.body["retrieval"]["state"], "symbolic",
+        "explicit repo_text=off must use the core without implying sidecar readiness: {}",
         search.body
     );
     assert!(
-        search
-            .body
-            .pointer("/error/message")
-            .and_then(Value::as_str)
-            .is_some_and(|message| message.contains("retrieval")),
-        "HTTP /search should explain the sidecar-primary boundary: {}",
+        search.body["publication"]["retrieval"].is_null()
+            && search.body["retrieval"]["generation_id"].is_null(),
+        "exact HTTP search must not name a retrieval publication: {}",
+        search.body
+    );
+    assert!(
+        search.body["evidence"]
+            .as_array()
+            .is_some_and(|rows| rows.iter().any(|row| {
+                row["path"] == "src/lib.rs"
+                    && row["excerpt"]
+                        .as_str()
+                        .is_some_and(|excerpt| excerpt.contains("AppController"))
+            })),
+        "exact HTTP search must return project-relative source evidence: {}",
         search.body
     );
 

--- a/crates/codestory-cli/tests/search_json_output.rs
+++ b/crates/codestory-cli/tests/search_json_output.rs
@@ -342,6 +342,67 @@ fn search_json_fails_closed_without_full_sidecars() {
 }
 
 #[test]
+fn exact_search_json_uses_the_core_without_claiming_full_retrieval() {
+    let workspace = tempdir().expect("workspace dir");
+    write_retrieval_fixture(workspace.path());
+
+    let index = run_cli(
+        workspace.path(),
+        &["index", "--refresh", "full", "--format", "json"],
+    );
+    assert!(
+        index.status.success(),
+        "index command failed: {}",
+        String::from_utf8_lossy(&index.stderr)
+    );
+
+    let search = run_cli(
+        workspace.path(),
+        &[
+            "search",
+            "--query",
+            "exact_symbol_anchor",
+            "--repo-text",
+            "off",
+            "--refresh",
+            "none",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        search.status.success(),
+        "exact search command failed: {}",
+        String::from_utf8_lossy(&search.stderr)
+    );
+
+    let json: Value = serde_json::from_slice(&search.stdout).expect("parse exact search json");
+    assert_eq!(json["schema_version"], 3, "{json:#}");
+    assert_eq!(json["kind"], "complete", "{json:#}");
+    assert_eq!(json["status"], "available", "{json:#}");
+    assert_eq!(json["retrieval"]["state"], "symbolic", "{json:#}");
+    assert!(
+        json["retrieval"]["generation_id"].is_null() && json["publication"]["retrieval"].is_null(),
+        "exact search must not imply a sidecar publication: {json:#}"
+    );
+    assert!(
+        json["gaps"].as_array().is_some_and(Vec::is_empty),
+        "an intentionally symbolic search must not report retrieval unavailable: {json:#}"
+    );
+    assert!(
+        json["evidence"].as_array().is_some_and(|rows| {
+            rows.iter().any(|row| {
+                row["path"] == "src/lib.rs"
+                    && row["excerpt"]
+                        .as_str()
+                        .is_some_and(|excerpt| excerpt.contains("exact_symbol_anchor"))
+            })
+        }),
+        "exact search must return its source-backed symbol evidence: {json:#}"
+    );
+}
+
+#[test]
 fn search_json_rejects_removed_hybrid_tuning_flags_as_unknown_args() {
     let workspace = tempdir().expect("workspace dir");
 

--- a/crates/codestory-contracts/src/packet_projection_v3.rs
+++ b/crates/codestory-contracts/src/packet_projection_v3.rs
@@ -209,6 +209,7 @@ pub enum EvidenceAvailabilityV3Dto {
 #[serde(rename_all = "snake_case")]
 pub enum RetrievalStateV3Dto {
     Full,
+    Symbolic,
     Degraded,
     Unavailable,
 }
@@ -798,6 +799,7 @@ mod tests {
             ],
             "retrieval_variants": [
                 RetrievalStateV3Dto::Full,
+                RetrievalStateV3Dto::Symbolic,
                 RetrievalStateV3Dto::Degraded,
                 RetrievalStateV3Dto::Unavailable,
             ],

--- a/crates/codestory-runtime/src/agent/packet_candidate.rs
+++ b/crates/codestory-runtime/src/agent/packet_candidate.rs
@@ -13,11 +13,12 @@ use codestory_contracts::compilation::{
     PacketCandidateDescriptorV1,
 };
 use codestory_contracts::graph::NodeId as CoreNodeId;
+use codestory_retrieval::{QueryResult, RetrievalPublicationIdentity};
 use sha2::{Digest, Sha256};
-#[cfg(feature = "benchmark-support")]
+#[cfg(any(test, feature = "benchmark-support"))]
 use std::cell::Cell;
 use std::cell::RefCell;
-#[cfg(feature = "benchmark-support")]
+#[cfg(any(test, feature = "benchmark-support"))]
 use std::collections::BTreeMap;
 use std::collections::{HashMap, HashSet};
 use std::ops::Deref;
@@ -51,16 +52,24 @@ pub(crate) struct PacketProofSession {
     receipts: RefCell<Vec<PacketAdmissionReceiptV1>>,
     gaps: RefCell<Vec<PacketAdmissionGapV1>>,
     retrieval_admission_sealed: RefCell<bool>,
-    #[cfg(feature = "benchmark-support")]
+    descriptor_results: RefCell<Vec<RetainedPacketDescriptorResult>>,
     include_dense_semantic: bool,
-    #[cfg(feature = "benchmark-support")]
+    #[cfg(any(test, feature = "benchmark-support"))]
     descriptor_query_count: Cell<u32>,
-    #[cfg(feature = "benchmark-support")]
+    #[cfg(any(test, feature = "benchmark-support"))]
     descriptor_cache_hit_count: Cell<u32>,
-    #[cfg(feature = "benchmark-support")]
+    #[cfg(any(test, feature = "benchmark-support"))]
     descriptor_stage_invocations: RefCell<BTreeMap<String, u32>>,
-    #[cfg(feature = "benchmark-support")]
+    #[cfg(any(test, feature = "benchmark-support"))]
     descriptor_stage_candidates: RefCell<BTreeMap<String, u64>>,
+}
+
+#[derive(Debug, Clone)]
+struct RetainedPacketDescriptorResult {
+    query: String,
+    include_dense_semantic: bool,
+    publication: RetrievalPublicationIdentity,
+    result: QueryResult,
 }
 
 impl Default for PacketProofSession {
@@ -69,7 +78,7 @@ impl Default for PacketProofSession {
     }
 }
 
-#[cfg(feature = "benchmark-support")]
+#[cfg(any(test, feature = "benchmark-support"))]
 #[derive(Debug, Clone, serde::Serialize)]
 pub(crate) struct BenchmarkPacketRetrievalProof {
     pub contract: &'static str,
@@ -98,15 +107,15 @@ impl PacketProofSession {
             receipts: RefCell::new(Vec::new()),
             gaps: RefCell::new(Vec::new()),
             retrieval_admission_sealed: RefCell::new(false),
-            #[cfg(feature = "benchmark-support")]
+            descriptor_results: RefCell::new(Vec::new()),
             include_dense_semantic: true,
-            #[cfg(feature = "benchmark-support")]
+            #[cfg(any(test, feature = "benchmark-support"))]
             descriptor_query_count: Cell::new(0),
-            #[cfg(feature = "benchmark-support")]
+            #[cfg(any(test, feature = "benchmark-support"))]
             descriptor_cache_hit_count: Cell::new(0),
-            #[cfg(feature = "benchmark-support")]
+            #[cfg(any(test, feature = "benchmark-support"))]
             descriptor_stage_invocations: RefCell::new(BTreeMap::new()),
-            #[cfg(feature = "benchmark-support")]
+            #[cfg(any(test, feature = "benchmark-support"))]
             descriptor_stage_candidates: RefCell::new(BTreeMap::new()),
         }
     }
@@ -119,12 +128,11 @@ impl PacketProofSession {
         }
     }
 
-    #[cfg(feature = "benchmark-support")]
     pub(crate) fn includes_dense_semantic(&self) -> bool {
         self.include_dense_semantic
     }
 
-    #[cfg(feature = "benchmark-support")]
+    #[cfg(any(test, feature = "benchmark-support"))]
     pub(crate) fn record_descriptor_trace(&self, trace: &codestory_retrieval::QueryTrace) {
         self.descriptor_query_count
             .set(self.descriptor_query_count.get().saturating_add(1));
@@ -146,7 +154,7 @@ impl PacketProofSession {
         }
     }
 
-    #[cfg(feature = "benchmark-support")]
+    #[cfg(any(test, feature = "benchmark-support"))]
     pub(crate) fn benchmark_retrieval_proof(&self) -> BenchmarkPacketRetrievalProof {
         let descriptor_stage_invocations = self.descriptor_stage_invocations.borrow().clone();
         BenchmarkPacketRetrievalProof {
@@ -165,6 +173,55 @@ impl PacketProofSession {
             descriptor_stage_invocations,
             descriptor_stage_candidates: self.descriptor_stage_candidates.borrow().clone(),
         }
+    }
+
+    /// Retain the exact descriptor result that authorized packet admission.
+    ///
+    /// The key includes the query, retrieval policy, and full immutable
+    /// publication. A later hydration stage may reuse only an identical key;
+    /// it cannot silently rerun under a shorter budget or cross a packet,
+    /// policy, or publication boundary.
+    pub(crate) fn retain_descriptor_result(
+        &self,
+        result: &QueryResult,
+        include_dense_semantic: bool,
+        publication: &RetrievalPublicationIdentity,
+    ) -> Result<(), &'static str> {
+        if result.publication_identity.as_ref() != Some(publication) {
+            return Err("descriptor result publication does not match the packet pin");
+        }
+        let mut retained = self.descriptor_results.borrow_mut();
+        if retained.iter().any(|entry| {
+            entry.query == result.query
+                && entry.include_dense_semantic == include_dense_semantic
+                && entry.publication == *publication
+        }) {
+            return Err("descriptor result was retained twice for one packet query");
+        }
+        retained.push(RetainedPacketDescriptorResult {
+            query: result.query.clone(),
+            include_dense_semantic,
+            publication: publication.clone(),
+            result: result.clone(),
+        });
+        Ok(())
+    }
+
+    pub(crate) fn descriptor_result(
+        &self,
+        query: &str,
+        include_dense_semantic: bool,
+        publication: &RetrievalPublicationIdentity,
+    ) -> Option<QueryResult> {
+        self.descriptor_results
+            .borrow()
+            .iter()
+            .find(|entry| {
+                entry.query == query
+                    && entry.include_dense_semantic == include_dense_semantic
+                    && entry.publication == *publication
+            })
+            .map(|entry| entry.result.clone())
     }
 
     pub(crate) fn remaining_hydration_slots(&self) -> usize {

--- a/crates/codestory-runtime/src/agent/packet_execution_record_v3.rs
+++ b/crates/codestory-runtime/src/agent/packet_execution_record_v3.rs
@@ -597,7 +597,8 @@ fn validate_retrieval_state(
         {
             Ok(())
         }
-        (RetrievalStateV3Dto::Degraded, None, None)
+        (RetrievalStateV3Dto::Symbolic, None, None)
+        | (RetrievalStateV3Dto::Degraded, None, None)
         | (RetrievalStateV3Dto::Unavailable, None, None) => Ok(()),
         (RetrievalStateV3Dto::Degraded, Some(publication), Some(generation))
             if generation.as_str() == publication.retrieval_generation.as_str() =>

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -901,8 +901,9 @@ pub(crate) fn run_sidecar_query(
 
 /// Run every generic packet query through the descriptor-only sidecar path,
 /// rank the combined identities once, and seal packet admission before any
-/// candidate source or graph hydration begins. The later query calls reuse the
-/// sidecar cache and may hydrate only identities admitted here.
+/// candidate source or graph hydration begins. The packet session retains
+/// these exact query results under its retrieval policy and publication pin;
+/// later resolution reuses them and may hydrate only identities admitted here.
 pub(crate) fn preadmit_packet_descriptor_queries(
     controller: &AppController,
     queries: &[String],
@@ -958,7 +959,6 @@ pub(crate) fn preadmit_packet_descriptor_queries(
                 budget_ms: Some(per_query_budget),
             })
             .collect::<Vec<_>>();
-        #[cfg(feature = "benchmark-support")]
         let include_dense_semantic = session.includes_dense_semantic();
         let query_results = with_detached_sidecar_query_cache(controller, |cache| {
             #[cfg(feature = "benchmark-support")]
@@ -978,7 +978,7 @@ pub(crate) fn preadmit_packet_descriptor_queries(
             )
         })
         .map_err(map_pinned_query_error)?;
-        #[cfg(feature = "benchmark-support")]
+        #[cfg(any(test, feature = "benchmark-support"))]
         for result in &query_results {
             session.record_descriptor_trace(&result.trace);
         }
@@ -1004,6 +1004,19 @@ pub(crate) fn preadmit_packet_descriptor_queries(
                 ));
             }
             pinned.ensure_query_identity(result, "admitting packet descriptors")?;
+        }
+        for result in &query_results {
+            session
+                .retain_descriptor_result(
+                    result,
+                    include_dense_semantic,
+                    pinned.session.publication_identity(),
+                )
+                .map_err(|reason| {
+                    ApiError::internal(format!(
+                        "packet descriptor retention violated its coherent session: {reason}"
+                    ))
+                })?;
         }
         admit_packet_candidate_descriptors(
             &session,
@@ -1075,11 +1088,26 @@ pub(crate) fn run_and_resolve_sidecar_query(
     latency_budget_ms: Option<u32>,
 ) -> Result<(QueryResult, SidecarCandidateResolutionOutcome), ApiError> {
     with_pinned_retrieval_read(controller, |pinned| {
-        let query_result = with_detached_sidecar_query_cache(controller, |cache| {
-            if let Some(_session) = crate::agent::packet_candidate::active_packet_proof_session() {
-                #[cfg(feature = "benchmark-support")]
-                if !_session.includes_dense_semantic() {
-                    return pinned
+        let packet_session = crate::agent::packet_candidate::active_packet_proof_session();
+        let include_dense_semantic = packet_session
+            .as_ref()
+            .is_none_or(|session| session.includes_dense_semantic());
+        let retained = packet_session.as_ref().and_then(|session| {
+            session.descriptor_result(
+                query,
+                include_dense_semantic,
+                pinned.session.publication_identity(),
+            )
+        });
+        let _executed_query = retained.is_none();
+        let query_result = if let Some(result) = retained {
+            result
+        } else {
+            with_detached_sidecar_query_cache(controller, |cache| {
+                if packet_session.is_some() {
+                    #[cfg(feature = "benchmark-support")]
+                    if !include_dense_semantic {
+                        return pinned
                         .session
                         .execute_packet_descriptors_without_dense_semantic_for_benchmark_with_cache(
                             query,
@@ -1087,25 +1115,26 @@ pub(crate) fn run_and_resolve_sidecar_query(
                             crate::services::active_public_operation_cancellation(),
                             cache,
                         );
+                    }
+                    pinned.session.execute_packet_descriptors_with_cache(
+                        query,
+                        Some(sidecar_budget_ms(latency_budget_ms)),
+                        crate::services::active_public_operation_cancellation(),
+                        cache,
+                    )
+                } else {
+                    pinned.session.execute_with_cache(
+                        query,
+                        Some(sidecar_budget_ms(latency_budget_ms)),
+                        crate::services::active_public_operation_cancellation(),
+                        cache,
+                    )
                 }
-                pinned.session.execute_packet_descriptors_with_cache(
-                    query,
-                    Some(sidecar_budget_ms(latency_budget_ms)),
-                    crate::services::active_public_operation_cancellation(),
-                    cache,
-                )
-            } else {
-                pinned.session.execute_with_cache(
-                    query,
-                    Some(sidecar_budget_ms(latency_budget_ms)),
-                    crate::services::active_public_operation_cancellation(),
-                    cache,
-                )
-            }
-        })
-        .map_err(map_pinned_query_error)?;
-        #[cfg(feature = "benchmark-support")]
-        if let Some(session) = crate::agent::packet_candidate::active_packet_proof_session() {
+            })
+            .map_err(map_pinned_query_error)?
+        };
+        #[cfg(any(test, feature = "benchmark-support"))]
+        if _executed_query && let Some(session) = packet_session {
             session.record_descriptor_trace(&query_result.trace);
         }
         pinned.ensure_query_identity(&query_result, "resolving sidecar candidates")?;
@@ -1374,39 +1403,85 @@ fn search_sidecar_packet_batch_inner(
         .collect::<Vec<_>>();
     with_pinned_retrieval_read(controller, |pinned| {
         let batch_started_at = Instant::now();
-        let batch_items = batch_queries
+        let packet_session = active_packet_proof_session();
+        let include_dense_semantic = packet_session
+            .as_ref()
+            .is_none_or(|session| session.includes_dense_semantic());
+        let mut query_results = vec![None; batch_queries.len()];
+        let mut missing_indices = Vec::new();
+        for (index, (query, _)) in batch_queries.iter().enumerate() {
+            let retained = packet_session.as_ref().and_then(|session| {
+                session.descriptor_result(
+                    query,
+                    include_dense_semantic,
+                    pinned.session.publication_identity(),
+                )
+            });
+            if let Some(result) = retained {
+                query_results[index] = Some(result);
+            } else {
+                missing_indices.push(index);
+            }
+        }
+        let missing_items = missing_indices
             .iter()
-            .map(|(query, budget_ms)| QueryBatchItem {
-                query,
-                budget_ms: Some(*budget_ms),
+            .map(|index| QueryBatchItem {
+                query: batch_queries[*index].0.as_str(),
+                budget_ms: Some(batch_queries[*index].1),
             })
             .collect::<Vec<_>>();
-        let query_results = with_detached_sidecar_query_cache(controller, |cache| {
+        let executed_results = if missing_items.is_empty() {
+            Vec::new()
+        } else {
+            with_detached_sidecar_query_cache(controller, |cache| {
             #[cfg(feature = "benchmark-support")]
-            if active_packet_proof_session()
-                .is_some_and(|session| !session.includes_dense_semantic())
-            {
+                if packet_session.is_some() && !include_dense_semantic {
                 return pinned
                     .session
                     .execute_packet_descriptor_batch_without_dense_semantic_for_benchmark_with_cache(
-                        &batch_items,
+                            &missing_items,
                         crate::services::active_public_operation_cancellation(),
                         cache,
                     );
-            }
-            pinned.session.execute_packet_descriptor_batch_with_cache(
-                &batch_items,
-                crate::services::active_public_operation_cancellation(),
-                cache,
-            )
-        })
-        .map_err(map_pinned_query_error)?;
-        #[cfg(feature = "benchmark-support")]
-        if let Some(session) = active_packet_proof_session() {
-            for result in &query_results {
+                }
+                pinned.session.execute_packet_descriptor_batch_with_cache(
+                    &missing_items,
+                    crate::services::active_public_operation_cancellation(),
+                    cache,
+                )
+            })
+            .map_err(map_pinned_query_error)?
+        };
+        if executed_results.len() != missing_indices.len() {
+            return Err(sidecar_retrieval_unavailable_error(
+                controller,
+                format!(
+                    "packet descriptor batch returned {} results for {} missing queries",
+                    executed_results.len(),
+                    missing_indices.len()
+                ),
+            ));
+        }
+        #[cfg(any(test, feature = "benchmark-support"))]
+        if let Some(session) = packet_session.as_ref() {
+            for result in &executed_results {
                 session.record_descriptor_trace(&result.trace);
             }
         }
+        for (index, result) in missing_indices.into_iter().zip(executed_results) {
+            query_results[index] = Some(result);
+        }
+        let query_results = query_results
+            .into_iter()
+            .enumerate()
+            .map(|(index, result)| {
+                result.ok_or_else(|| {
+                    ApiError::internal(format!(
+                        "packet descriptor result {index} was neither retained nor executed"
+                    ))
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
         for result in &query_results {
             pinned.ensure_query_identity(result, "resolving sidecar packet batch")?;
         }
@@ -4055,6 +4130,112 @@ mod tests {
             PacketAdmissionDecision::CountBudgetExceeded,
             "the sealed session must not admit a late lower-scoring query candidate"
         );
+    }
+
+    #[test]
+    fn preadmitted_descriptor_result_is_reused_by_initial_resolution() {
+        use crate::agent::packet_candidate::{PacketProofSession, install_packet_proof_session};
+
+        let fixture = pinned_operation_fixture();
+        let pinned = Rc::new(
+            PinnedRetrievalRead::begin_packet_descriptor(&fixture.controller)
+                .expect("begin packet descriptor pin"),
+        );
+        let session = Rc::new(PacketProofSession::new());
+        let query = "renamed lattice transition";
+
+        with_active_pinned_retrieval_read(&fixture.controller, Rc::clone(&pinned), || {
+            let _guard = install_packet_proof_session(Rc::clone(&session));
+            preadmit_packet_descriptor_queries(&fixture.controller, &[query.to_string()], None)
+                .expect("preadmit renamed descriptor query");
+            assert_eq!(
+                session.benchmark_retrieval_proof().descriptor_query_count,
+                1,
+                "preadmission executes the descriptor query once"
+            );
+
+            let (result, _) = run_and_resolve_sidecar_query(&fixture.controller, query, 4, None)
+                .expect("resolve the preadmitted descriptor result");
+            assert_eq!(result.query, query);
+            assert_eq!(
+                session.benchmark_retrieval_proof().descriptor_query_count,
+                1,
+                "initial resolution must reuse the preadmitted result instead of executing retrieval again"
+            );
+
+            let publication = pinned.session.publication_identity().clone();
+            let mut different_publication = publication.clone();
+            different_publication
+                .sidecar_generation
+                .push_str("-different");
+            assert!(
+                session
+                    .descriptor_result("another query", true, &publication)
+                    .is_none()
+            );
+            assert!(
+                session
+                    .descriptor_result(query, false, &publication)
+                    .is_none()
+            );
+            assert!(
+                session
+                    .descriptor_result(query, true, &different_publication)
+                    .is_none()
+            );
+            assert!(
+                PacketProofSession::new()
+                    .descriptor_result(query, true, &publication)
+                    .is_none(),
+                "a retained descriptor result is scoped to one packet session"
+            );
+
+            let mut mismatched_result = result;
+            mismatched_result.publication_identity = Some(different_publication);
+            assert!(
+                PacketProofSession::new()
+                    .retain_descriptor_result(&mismatched_result, true, &publication)
+                    .is_err(),
+                "the retained result must authenticate the packet's exact publication"
+            );
+        });
+    }
+
+    #[test]
+    fn preadmitted_descriptor_result_is_reused_by_planned_query_batch() {
+        use crate::agent::packet_candidate::{PacketProofSession, install_packet_proof_session};
+
+        let fixture = pinned_operation_fixture();
+        let pinned = Rc::new(
+            PinnedRetrievalRead::begin_packet_descriptor(&fixture.controller)
+                .expect("begin packet descriptor pin"),
+        );
+        let session = Rc::new(PacketProofSession::new());
+        let query = "renamed lattice continuation";
+
+        with_active_pinned_retrieval_read(&fixture.controller, Rc::clone(&pinned), || {
+            let _guard = install_packet_proof_session(Rc::clone(&session));
+            preadmit_packet_descriptor_queries(&fixture.controller, &[query.to_string()], None)
+                .expect("preadmit planned descriptor query");
+            assert_eq!(
+                session.benchmark_retrieval_proof().descriptor_query_count,
+                1
+            );
+
+            let outcome = search_sidecar_packet_batch_inner(
+                &fixture.controller,
+                &[(query.to_string(), 4)],
+                None,
+            )
+            .expect("resolve the preadmitted planned query");
+            assert_eq!(outcome.results.len(), 1);
+            assert_eq!(outcome.results[0].0, query);
+            assert_eq!(
+                session.benchmark_retrieval_proof().descriptor_query_count,
+                1,
+                "planned query resolution must reuse the preadmitted result"
+            );
+        });
     }
 
     #[test]

--- a/crates/codestory-runtime/src/browser.rs
+++ b/crates/codestory-runtime/src/browser.rs
@@ -193,11 +193,15 @@ impl ReadOnlyBrowserService {
     }
 
     pub fn search(&self, req: SearchRequest) -> Result<Vec<SearchHit>, ApiError> {
-        self.run_public("search", || self.controller.search(req.clone()))
+        self.run_public(crate::search_operation_name(req.repo_text), || {
+            self.controller.search(req.clone())
+        })
     }
 
     pub fn search_results(&self, req: SearchRequest) -> Result<SearchResultsDto, ApiError> {
-        self.run_public("search", || self.controller.search_results(req.clone()))
+        self.run_public(crate::search_operation_name(req.repo_text), || {
+            self.controller.search_results(req.clone())
+        })
     }
 
     pub fn resolve_indexed_symbol_candidates(

--- a/crates/codestory-runtime/src/controller_symbols.rs
+++ b/crates/codestory-runtime/src/controller_symbols.rs
@@ -276,8 +276,9 @@ impl AppController {
     ///
     /// This intentionally bypasses mandatory sidecar product search so symbol,
     /// snippet, trail, and graph-query target resolution can work from an
-    /// already-open indexed store. Product search and packet evidence must use
-    /// the sidecar-primary search paths instead.
+    /// already-open indexed store. Explicit `search --repo-text off` composes
+    /// this resolver as its complete-core lane. Ordinary search and packet
+    /// evidence still use the sidecar-primary paths.
     pub fn resolve_indexed_symbol_candidates(
         &self,
         query: &str,

--- a/crates/codestory-runtime/src/evidence_projection_v3.rs
+++ b/crates/codestory-runtime/src/evidence_projection_v3.rs
@@ -477,13 +477,20 @@ pub fn project_search_v3(
     results: &SearchResultsDto,
 ) -> Result<SearchProjectionV3Dto, codestory_contracts::api::ApiError> {
     let request_id = format!("search-{}", digest_hex(results.query.as_bytes()));
-    let (identity, publication, retrieval) = projection_envelope(
+    let (identity, publication, mut retrieval) = projection_envelope(
         service,
         caller_id,
         &results.query,
         &request_id,
         results.retrieval_publication.as_ref(),
     )?;
+    let symbolic = results.retrieval.mode == codestory_contracts::api::RetrievalModeDto::Symbolic;
+    if symbolic {
+        retrieval = RetrievalStateDescriptorV3Dto {
+            state: RetrievalStateV3Dto::Symbolic,
+            generation_id: None,
+        };
+    }
     let evidence = results
         .hits
         .iter()
@@ -499,7 +506,7 @@ pub fn project_search_v3(
             Some("Additional search rows were omitted from the bounded public projection."),
         )?);
     }
-    if results.retrieval_publication.is_none() {
+    if results.retrieval_publication.is_none() && !symbolic {
         gaps.push(gap_row(
             "search-retrieval-unavailable",
             GapKindV3Dto::RetrievalUnavailable,

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -433,7 +433,7 @@ pub use services::{
     ActivationRun, ActivationService, ActivationSnapshot, ActivationStage, ActivationState,
     ActivePublicOperationPublication, AgentService, BookmarkService, GroundingService,
     IndexService, ProjectService, PublicOperation, PublicOperationService, SearchService,
-    TrailService, embedding_api_error, set_activation_fail_stop_hook,
+    TrailService, embedding_api_error, search_operation_name, set_activation_fail_stop_hook,
 };
 pub use symbol_workflow::{
     SymbolWorkflowCaps, SymbolWorkflowMode, SymbolWorkflowNode, SymbolWorkflowOutcome,

--- a/crates/codestory-runtime/src/search_evidence.rs
+++ b/crates/codestory-runtime/src/search_evidence.rs
@@ -129,10 +129,11 @@ pub(super) fn attach_pinned_exact_search_source(
         let Some(hit_path) = hit.file_path.clone() else {
             continue;
         };
-        let absolute = resolve_path(Some(project_root), Path::new(&hit_path));
-        let Some(relative) = codestory_workspace::workspace_relative_path(project_root, &absolute)
+        let Ok(codestory_workspace::ProjectRelativePathResolution::Existing { relative, .. }) =
+            codestory_workspace::resolve_project_relative_path(project_root, Path::new(&hit_path))
         else {
             hit.file_path = None;
+            hit.source_excerpt = None;
             continue;
         };
         hit.file_path = Some(relative.to_string_lossy().replace('\\', "/"));
@@ -163,7 +164,11 @@ fn verified_file(
 ) -> Option<VerifiedSourceFile> {
     let expected_hash = storage.get_file_content_hash(file.id).ok().flatten()?;
     let path = resolve_path(project_root, &file.path);
-    let bytes = std::fs::read(&path).ok()?;
+    let read_path = match project_root {
+        Some(root) => contained_existing_read_path(root, &path).ok()?,
+        None => path.clone(),
+    };
+    let bytes = std::fs::read(read_path).ok()?;
     if format!("{:x}", Sha256::digest(&bytes)) != expected_hash {
         return None;
     }
@@ -171,6 +176,26 @@ fn verified_file(
         path,
         content: String::from_utf8(bytes).ok()?,
     })
+}
+
+fn contained_existing_read_path(project_root: &Path, path: &Path) -> std::io::Result<PathBuf> {
+    let resolution = codestory_workspace::resolve_project_relative_path(project_root, path)?;
+    let codestory_workspace::ProjectRelativePathResolution::Existing { absolute, .. } = resolution
+    else {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "indexed source path is not an existing file inside the project",
+        ));
+    };
+    let resolved_root = project_root.canonicalize()?;
+    let resolved_file = absolute.canonicalize()?;
+    if codestory_workspace::workspace_relative_path(&resolved_root, &resolved_file).is_none() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "indexed source path resolves outside the project",
+        ));
+    }
+    Ok(resolved_file)
 }
 
 fn resolve_path(project_root: Option<&Path>, path: &Path) -> PathBuf {
@@ -477,6 +502,37 @@ mod tests {
         assert!(
             changed.source_excerpt.is_none(),
             "changed source bytes must not be attached to the pinned result"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn exact_search_drops_an_indexed_symlink_that_resolves_outside_the_project() {
+        use std::os::unix::fs::symlink;
+
+        let project = tempfile::tempdir().expect("project");
+        let outside = tempfile::tempdir().expect("outside");
+        let source = b"pub fn external_anchor() {}\n";
+        let outside_source = outside.path().join("external.rs");
+        std::fs::write(&outside_source, source).expect("outside source");
+        std::fs::create_dir_all(project.path().join("src")).expect("source directory");
+        let linked_source = project.path().join("src/external.rs");
+        symlink(&outside_source, &linked_source).expect("outside-project source symlink");
+
+        let storage = Store::new_in_memory().expect("storage");
+        insert_file(&storage, 1, Path::new("src/external.rs"), source);
+        let mut hit = SearchHit {
+            display_name: "external_anchor".to_string(),
+            file_path: Some(linked_source.to_string_lossy().into_owned()),
+            line: Some(1),
+            ..project_hit()
+        };
+
+        attach_pinned_exact_search_source(&storage, project.path(), std::slice::from_mut(&mut hit));
+
+        assert!(
+            hit.file_path.is_none() && hit.source_excerpt.is_none(),
+            "an in-project spelling must not expose source that resolves outside the project"
         );
     }
 

--- a/crates/codestory-runtime/src/search_evidence.rs
+++ b/crates/codestory-runtime/src/search_evidence.rs
@@ -14,6 +14,7 @@ struct VerifiedFileIndex<'a> {
     project_root: Option<&'a Path>,
     files: Vec<FileInfo>,
     directories: HashMap<PathBuf, Vec<VerifiedSourceFile>>,
+    exact_files: HashMap<PathBuf, Option<VerifiedSourceFile>>,
 }
 
 impl<'a> VerifiedFileIndex<'a> {
@@ -23,6 +24,7 @@ impl<'a> VerifiedFileIndex<'a> {
             project_root,
             files: storage.get_files().ok()?,
             directories: HashMap::new(),
+            exact_files: HashMap::new(),
         })
     }
 
@@ -42,6 +44,22 @@ impl<'a> VerifiedFileIndex<'a> {
                     &directory,
                 )
             })
+    }
+
+    fn verified_hit(&mut self, hit_path: &str) -> Option<&VerifiedSourceFile> {
+        let absolute = self.hit_path(hit_path);
+        if !self.exact_files.contains_key(&absolute) {
+            let verified = self
+                .files
+                .iter()
+                .find(|file| {
+                    let indexed = resolve_path(self.project_root, &file.path);
+                    codestory_workspace::same_workspace_path(&indexed, &absolute)
+                })
+                .and_then(|file| verified_file(self.storage, self.project_root, file));
+            self.exact_files.insert(absolute.clone(), verified);
+        }
+        self.exact_files.get(&absolute).and_then(Option::as_ref)
     }
 }
 
@@ -93,6 +111,49 @@ pub(super) fn attach_pinned_search_evidence(
             ));
         dedupe_targets(&mut hit.verification_targets);
     }
+}
+
+/// Attach a small source window to exact core-symbol results and expose the
+/// path relative to the selected project. The content hash check binds the
+/// bytes to the pinned core generation; source drift therefore cannot be
+/// mistaken for evidence from that publication.
+pub(super) fn attach_pinned_exact_search_source(
+    storage: &Store,
+    project_root: &Path,
+    hits: &mut [SearchHit],
+) {
+    let Some(mut files) = VerifiedFileIndex::load(storage, Some(project_root)) else {
+        return;
+    };
+    for hit in hits {
+        let Some(hit_path) = hit.file_path.clone() else {
+            continue;
+        };
+        let absolute = resolve_path(Some(project_root), Path::new(&hit_path));
+        let Some(relative) = codestory_workspace::workspace_relative_path(project_root, &absolute)
+        else {
+            hit.file_path = None;
+            continue;
+        };
+        hit.file_path = Some(relative.to_string_lossy().replace('\\', "/"));
+        let Some(source) = files.verified_hit(&hit_path) else {
+            continue;
+        };
+        hit.source_excerpt = hit
+            .line
+            .and_then(|line| bounded_source_window_at_line(&source.content, line));
+    }
+}
+
+fn bounded_source_window_at_line(content: &str, line: u32) -> Option<String> {
+    let line = usize::try_from(line).ok()?.checked_sub(1)?;
+    let lines = content.lines().collect::<Vec<_>>();
+    if line >= lines.len() {
+        return None;
+    }
+    let start = line.saturating_sub(2);
+    let end = (line + 3).min(lines.len());
+    Some(lines[start..end].join("\n"))
 }
 
 fn verified_file(
@@ -213,7 +274,10 @@ fn is_cxx_implementation_path(path: &Path) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{FileInfo, Path, PathBuf, SearchHit, Sha256, Store, attach_pinned_search_evidence};
+    use super::{
+        FileInfo, Path, PathBuf, SearchHit, Sha256, Store, attach_pinned_exact_search_source,
+        attach_pinned_search_evidence,
+    };
     use codestory_contracts::api::{NodeId, NodeKind, SearchHitOrigin};
     use codestory_store::FileRole;
     use sha2::Digest;
@@ -359,6 +423,60 @@ mod tests {
         assert!(
             hit.verification_targets.is_empty(),
             "independent byte fragments must not infer an interface relationship"
+        );
+    }
+
+    #[test]
+    fn exact_search_source_is_hash_bound_and_project_relative() {
+        let project = tempfile::tempdir().expect("project");
+        let relative = PathBuf::from("src/lib.rs");
+        let source = b"fn before() {}\npub fn exact_anchor() {}\nfn after() {}\n";
+        std::fs::create_dir_all(project.path().join("src")).expect("source directory");
+        std::fs::write(project.path().join(&relative), source).expect("source");
+        let storage = Store::new_in_memory().expect("storage");
+        insert_file(&storage, 1, &relative, source);
+        let mut hit = SearchHit {
+            display_name: "exact_anchor".to_string(),
+            file_path: Some(
+                project
+                    .path()
+                    .join(&relative)
+                    .to_string_lossy()
+                    .into_owned(),
+            ),
+            line: Some(2),
+            ..project_hit()
+        };
+
+        attach_pinned_exact_search_source(&storage, project.path(), std::slice::from_mut(&mut hit));
+
+        assert_eq!(hit.file_path.as_deref(), Some("src/lib.rs"));
+        assert_eq!(
+            hit.source_excerpt.as_deref(),
+            Some("fn before() {}\npub fn exact_anchor() {}\nfn after() {}")
+        );
+
+        std::fs::write(project.path().join(&relative), "fn changed() {}\n").expect("mutate source");
+        let mut changed = SearchHit {
+            display_name: "exact_anchor".to_string(),
+            file_path: Some(
+                project
+                    .path()
+                    .join(&relative)
+                    .to_string_lossy()
+                    .into_owned(),
+            ),
+            line: Some(2),
+            ..project_hit()
+        };
+        attach_pinned_exact_search_source(
+            &storage,
+            project.path(),
+            std::slice::from_mut(&mut changed),
+        );
+        assert!(
+            changed.source_excerpt.is_none(),
+            "changed source bytes must not be attached to the pinned result"
         );
     }
 

--- a/crates/codestory-runtime/src/search_plan.rs
+++ b/crates/codestory-runtime/src/search_plan.rs
@@ -6,9 +6,9 @@ use super::{
     SearchPlanBridgeStatusDto, SearchPlanCandidateWindowDto, SearchPlanChannelDto, SearchPlanDto,
     SearchPlanNextActionDto, SearchPlanPromotionStatusDto, SearchPlanRejectedHitDto,
     SearchPlanSubqueryDto, SearchPlanTermsDto, SearchQueryAssessmentDto, SearchRepoTextMode,
-    SearchRequest, SearchResultsDto, Storage, TrailConfigDto, agent, clamp_usize_to_u32,
-    compare_search_hits_with_project_root, leading_symbol_segment, looks_like_repo_text_query,
-    normalize_symbol_query, retrieval_file_role_from_path,
+    SearchRequest, SearchResultsDto, SemanticModeDto, Storage, TrailConfigDto, agent,
+    clamp_usize_to_u32, compare_search_hits_with_project_root, leading_symbol_segment,
+    looks_like_repo_text_query, normalize_symbol_query, retrieval_file_role_from_path,
     retrieval_state_from_storage_for_runtime, should_expand_symbol_query, terminal_symbol_segment,
 };
 use crate::root_rank::{
@@ -33,6 +33,7 @@ use crate::search_terms::{
 };
 use crate::symbol_query::{OrientationEvidence, OrientationHitEvidence, is_non_primary_source_hit};
 use codestory_contracts::api::{GroundingOrientationDto, GroundingOrientationUncertaintyDto};
+use codestory_contracts::api::{RetrievalFallbackReasonDto, RetrievalModeDto};
 use codestory_contracts::graph::STRUCTURAL_COLLECTION_CANONICAL_ID_PREFIXES;
 use codestory_store::FileRole;
 use std::cmp::Reverse;
@@ -1785,8 +1786,85 @@ impl AppController {
     /// The returned retrieval state distinguishes full sidecar evidence from degraded or
     /// diagnostic-only paths. Callers should not collapse those states into a generic success.
     pub fn search_results(&self, req: SearchRequest) -> Result<SearchResultsDto, ApiError> {
+        if req.repo_text == SearchRepoTextMode::Off {
+            return self.search_results_core_exact(req);
+        }
         agent::retrieval_primary::with_stable_retrieval_publication(self, "search output", || {
             self.search_results_once(req.clone())
+        })
+    }
+
+    /// Search only the complete core symbol projection.
+    ///
+    /// `repo_text=off` is an explicit request for this narrow lane. It does not
+    /// open a retrieval publication, initialize embeddings, run semantic or
+    /// repository-text retrieval, or imply that those richer lanes are ready.
+    fn search_results_core_exact(&self, req: SearchRequest) -> Result<SearchResultsDto, ApiError> {
+        self.ensure_consistent_read_state("Exact search")?;
+        let original_query = req.query.clone();
+        let intent_query = parse_search_intent_query(&original_query);
+        let query = intent_query.effective_query.clone();
+        let limit_per_source = req.limit_per_source.clamp(1, 50) as usize;
+        let mut hits = self.resolve_indexed_symbol_candidates(&query, limit_per_source)?;
+        apply_search_intent_filters(&mut hits, &intent_query.filters);
+        dedupe_inexact_search_hits_by_display_key(&query, &mut hits);
+        hits.truncate(limit_per_source);
+        annotate_search_hit_match_quality(&query, &mut hits);
+
+        let project_root = self.require_project_root()?;
+        let storage = self.open_storage_read_only()?;
+        crate::search_evidence::attach_pinned_exact_search_source(
+            &storage,
+            project_root.as_path(),
+            &mut hits,
+        );
+        crate::search_evidence::attach_pinned_search_evidence(
+            &storage,
+            Some(project_root.as_path()),
+            &mut hits,
+        );
+        let freshness = self.index_freshness().ok();
+        let query_assessment = search_query_assessment(
+            &query,
+            &hits,
+            &[],
+            SearchRepoTextMode::Off,
+            false,
+            None,
+            None,
+        );
+        let retrieval = RetrievalStateDto {
+            mode: RetrievalModeDto::Symbolic,
+            hybrid_configured: false,
+            semantic_ready: false,
+            semantic_mode: SemanticModeDto::DisabledByConfig,
+            semantic_doc_count: 0,
+            embedding_model: None,
+            current_embedding: None,
+            stored_embedding: None,
+            fallback_reason: Some(RetrievalFallbackReasonDto::DisabledByConfig),
+            fallback_message: Some(
+                "Search used the complete core symbol index; semantic and repository-text retrieval were not requested."
+                    .to_string(),
+            ),
+        };
+
+        Ok(SearchResultsDto {
+            query: original_query,
+            retrieval_publication: None,
+            retrieval,
+            retrieval_shadow: None,
+            freshness,
+            limit_per_source: limit_per_source as u32,
+            repo_text_mode: SearchRepoTextMode::Off,
+            repo_text_enabled: false,
+            query_assessment: Some(query_assessment),
+            search_plan: None,
+            repo_text_stats: None,
+            suggestions: Vec::new(),
+            indexed_symbol_hits: hits.clone(),
+            repo_text_hits: Vec::new(),
+            hits,
         })
     }
 

--- a/crates/codestory-runtime/src/services.rs
+++ b/crates/codestory-runtime/src/services.rs
@@ -7,9 +7,10 @@ use codestory_contracts::api::{
     IndexFreshnessNotCheckedCauseDto, IndexFreshnessStatusDto, IndexMode, IndexPublicationDto,
     IndexedFilesDto, IndexedFilesRequest, IndexingPhaseTimings, ListChildrenSymbolsRequest,
     ListRootSymbolsRequest, NodeDetailsDto, NodeDetailsRequest, NodeId, OpenProjectRequest,
-    ProjectSummary, RetrievalStateDto, SearchHit, SearchRequest, SearchResultsDto,
-    SnippetContextDto, SourceOccurrenceDto, StartIndexingRequest, SummaryGenerationDto,
-    SymbolContextDto, SymbolSummaryDto, TrailConfigDto, TrailContextDto, UpdateBookmarkRequest,
+    ProjectSummary, RetrievalStateDto, SearchHit, SearchRepoTextMode, SearchRequest,
+    SearchResultsDto, SnippetContextDto, SourceOccurrenceDto, StartIndexingRequest,
+    SummaryGenerationDto, SymbolContextDto, SymbolSummaryDto, TrailConfigDto, TrailContextDto,
+    UpdateBookmarkRequest,
 };
 
 use crate::AppController;
@@ -1802,6 +1803,18 @@ impl ActivationService {
     }
 }
 
+/// Public-operation identity for search's two deliberately different lanes.
+///
+/// Explicit `repo_text=off` is the complete-core exact-symbol surface. Every
+/// other search mode keeps the full retrieval publication contract.
+pub fn search_operation_name(repo_text: SearchRepoTextMode) -> &'static str {
+    if repo_text == SearchRepoTextMode::Off {
+        "exact_search"
+    } else {
+        "search"
+    }
+}
+
 fn operation_requires_retrieval(operation: &str) -> bool {
     matches!(
         operation,
@@ -3141,6 +3154,16 @@ mod freshness_gate_tests {
         for operation in ["packet", "search", "context", "drill"] {
             assert!(operation_requires_retrieval(operation));
         }
+        assert_eq!(
+            search_operation_name(SearchRepoTextMode::Off),
+            "exact_search"
+        );
+        assert!(!operation_requires_retrieval(search_operation_name(
+            SearchRepoTextMode::Off
+        )));
+        assert!(operation_requires_retrieval(search_operation_name(
+            SearchRepoTextMode::Auto
+        )));
     }
 
     fn freshness(

--- a/crates/codestory-runtime/src/tests/search_scoring.rs
+++ b/crates/codestory-runtime/src/tests/search_scoring.rs
@@ -866,8 +866,8 @@ fn search_requires_full_sidecars_for_exact_type_queries() {
         );
     }
 
-    let error = controller
-        .search(SearchRequest {
+    let exact = controller
+        .search_results(SearchRequest {
             query: "AppController".to_string(),
             repo_text: SearchRepoTextMode::Off,
             limit_per_source: 10,
@@ -875,7 +875,22 @@ fn search_requires_full_sidecars_for_exact_type_queries() {
             hybrid_weights: None,
             hybrid_limits: None,
         })
-        .expect_err("search should require full sidecars");
+        .expect("repo-text off should use the complete core without retrieval sidecars");
+    assert_eq!(exact.retrieval.mode, RetrievalModeDto::Symbolic);
+    assert!(exact.retrieval_publication.is_none());
+    assert!(!exact.indexed_symbol_hits.is_empty());
+    assert!(exact.repo_text_hits.is_empty());
+
+    let error = controller
+        .search(SearchRequest {
+            query: "AppController".to_string(),
+            repo_text: SearchRepoTextMode::Auto,
+            limit_per_source: 10,
+            expand_search_plan: false,
+            hybrid_weights: None,
+            hybrid_limits: None,
+        })
+        .expect_err("ordinary search should still require full sidecars");
     assert_mandatory_retrieval_unavailable(&error);
 }
 
@@ -946,7 +961,7 @@ fn search_prefers_full_sidecars_for_tictactoe_queries() {
         let error = controller
             .search(SearchRequest {
                 query: query.to_string(),
-                repo_text: SearchRepoTextMode::Off,
+                repo_text: SearchRepoTextMode::Auto,
                 limit_per_source: 10,
                 expand_search_plan: false,
                 hybrid_weights: None,
@@ -974,7 +989,7 @@ fn repo_explanation_search_requires_full_sidecar_retrieval() {
     let generic_error = controller
         .search_results(SearchRequest {
             query: "Explain how this repo fits together".to_string(),
-            repo_text: SearchRepoTextMode::Off,
+            repo_text: SearchRepoTextMode::Auto,
             limit_per_source: 10,
             expand_search_plan: false,
             hybrid_weights: None,
@@ -986,7 +1001,7 @@ fn repo_explanation_search_requires_full_sidecar_retrieval() {
     let symbol_error = controller
         .search_results(SearchRequest {
             query: "Explain how check_winner fits in this repo".to_string(),
-            repo_text: SearchRepoTextMode::Off,
+            repo_text: SearchRepoTextMode::Auto,
             limit_per_source: 10,
             expand_search_plan: true,
             hybrid_weights: None,
@@ -1039,7 +1054,7 @@ fn search_rejects_natural_language_queries_without_full_sidecars() {
     let error_without_plan = controller
         .search_results(SearchRequest {
             query: broad_query.to_string(),
-            repo_text: SearchRepoTextMode::Off,
+            repo_text: SearchRepoTextMode::Auto,
             limit_per_source: 20,
             expand_search_plan: false,
             hybrid_weights: None,
@@ -1051,7 +1066,7 @@ fn search_rejects_natural_language_queries_without_full_sidecars() {
     let error_with_plan = controller
         .search_results(SearchRequest {
             query: broad_query.to_string(),
-            repo_text: SearchRepoTextMode::Off,
+            repo_text: SearchRepoTextMode::Auto,
             limit_per_source: 20,
             expand_search_plan: true,
             hybrid_weights: None,
@@ -2404,7 +2419,7 @@ fn search_rejects_reads_while_indexing_is_active() {
     let error = controller
         .search_results(SearchRequest {
             query: "check_winner".to_string(),
-            repo_text: SearchRepoTextMode::Off,
+            repo_text: SearchRepoTextMode::Auto,
             limit_per_source: 10,
             expand_search_plan: false,
             hybrid_weights: None,
@@ -2432,7 +2447,7 @@ fn search_after_summary_open_stays_sidecar_primary_without_runtime_refresh() {
     let error = controller
         .search(SearchRequest {
             query: "check_winner".to_string(),
-            repo_text: SearchRepoTextMode::Off,
+            repo_text: SearchRepoTextMode::Auto,
             limit_per_source: 10,
             expand_search_plan: false,
             hybrid_weights: None,

--- a/docs/architecture/runtime-execution-path.md
+++ b/docs/architecture/runtime-execution-path.md
@@ -38,15 +38,18 @@ refresh a project, initialize the engine, or mutate status state.
 | Class | Examples | May activate work | Required state |
 | --- | --- | --- | --- |
 | Observational | `status`, `doctor`, retrieval-engine diagnostics | No | readable current state |
-| Local graph | `ground`, `files`, `symbol`, `callers`, `trail`, `snippet` | bounded local refresh | current core publication for the requested surface |
-| Broad retrieval | `packet`, `search`, broad query-based `context` | local refresh, engine init, retrieval finalization | coherent retrieval publication and live policy-compliant engine |
+| Local graph | `ground`, `files`, `symbol`, `callers`, `trail`, `snippet`, explicit `search --repo-text off` | bounded local refresh | current core publication for the requested surface |
+| Broad retrieval | `packet`, ordinary `search`, broad query-based `context` | local refresh, engine init, retrieval finalization | coherent retrieval publication and live policy-compliant engine |
 | Exact target | definition/reference/node and focused context calls | only what the selected operation needs | resolved target plus its declared readiness |
 
 `ground` is the normal first call. It can return a useful local repository map
 after the bounded graph refresh while managed broad-retrieval preparation
-continues. A later `packet` or `search` call either completes that preparation,
-returns `preparing` for a bounded retry, or reports an environment gap. There is
-no user-facing sidecar setup or repair decision.
+continues. A later `packet` or ordinary `search` call either completes that
+preparation, returns `preparing` for a bounded retry, or reports an environment
+gap. Explicit `search --repo-text off` instead searches the complete core symbol
+projection and truthfully reports symbolic retrieval without initializing or
+claiming semantic readiness. There is no user-facing sidecar setup or repair
+decision.
 
 ## Core indexing
 
@@ -111,7 +114,10 @@ Runtime reads graph rows, occurrences, trails, search documents, or grounding
 snapshots from `codestory-store` and assembles contract DTOs. `explore` and
 `serve` reuse those services; adapters do not open SQLite or invent product
 fallbacks. When broad retrieval is unavailable, local graph tools can remain
-usable, but their output must not be presented as a full packet/search result.
+usable. Explicit `search --repo-text off` is one such complete-core operation:
+it returns exact indexed-symbol matches with source evidence, no retrieval
+publication, and a symbolic retrieval state. Its output is never presented as
+full broad or semantic search.
 
 Packet callers may supply tagged probes for an exact project-relative path,
 stable symbol ID, file-scoped symbol, free query, or continuation. CLI and

--- a/docs/users/configuration-reference.md
+++ b/docs/users/configuration-reference.md
@@ -137,8 +137,8 @@ Only the test suites set these. They drive failure shapes that must never occur 
 
 | Variable | Type | Owner | Meaning |
 | --- | --- | --- | --- |
-| `CODESTORY_TEST_EMBED_ALLOW_CPU` | boolean | `crates/codestory-retrieval/src/config.rs` | Test-support builds only: exercises CPU-shaped embedding failures. |
 | `CODESTORY_TEST_CORE_PUBLICATION_ABORT_POINT` | text | `crates/codestory-store/src/core_generation.rs` | Named crash-injection point during immutable core publication (tests only). |
 | `CODESTORY_TEST_CORE_PUBLICATION_ABORT_SENTINEL` | path | `crates/codestory-store/src/core_generation.rs` | Sentinel path written before aborting an immutable core publication (tests only). |
+| `CODESTORY_TEST_EMBED_ALLOW_CPU` | boolean | `crates/codestory-retrieval/src/config.rs` | Test-support builds only: exercises CPU-shaped embedding failures. |
 | `CODESTORY_TEST_PROMOTION_ABORT_SENTINEL` | path | `crates/codestory-store/src/storage_impl/mod.rs` | Sentinel path that aborts a promotion mid-flight to prove crash recovery. |
 

--- a/plugins/codestory/generated-mcp-catalog.json
+++ b/plugins/codestory/generated-mcp-catalog.json
@@ -12,8 +12,8 @@
     "discoveryContracts": {
       "2024-11-05": "390ee890235e847b1bb8a7fd65a31907744f6e8c0c91f53cb09f2c7bf38674ec",
       "2025-03-26": "2b9db80728bcab16706c27431199efc18cb265fe2e4faa140c91ec7089d9da59",
-      "2025-06-18": "23a5bcdeac9dbdd0335d2d286908e17356b99a59577063d2395a60bb36df5f1a",
-      "2025-11-25": "9347140dca5574571ffd434d09b944349fa71b704fbcd757b98de41b7e8aa2bc"
+      "2025-06-18": "4174c543d4e96f8f460c46403c3aad6c771c281098effde2812a3d3e8ba05712",
+      "2025-11-25": "c71f1497d39fa4dabed10834bfddd51fddb1e4874abb926d1e89818beeaa2f78"
     }
   },
   "revisionProfiles": {
@@ -3250,7 +3250,7 @@
       ]
     },
     "2025-06-18": {
-      "discoveryContractSha256": "23a5bcdeac9dbdd0335d2d286908e17356b99a59577063d2395a60bb36df5f1a",
+      "discoveryContractSha256": "4174c543d4e96f8f460c46403c3aad6c771c281098effde2812a3d3e8ba05712",
       "tools": [
         {
           "_meta": {
@@ -4135,6 +4135,7 @@
                               "state": {
                                 "enum": [
                                   "full",
+                                  "symbolic",
                                   "degraded",
                                   "unavailable"
                                 ],
@@ -4418,6 +4419,7 @@
                               "state": {
                                 "enum": [
                                   "full",
+                                  "symbolic",
                                   "degraded",
                                   "unavailable"
                                 ],
@@ -4945,6 +4947,7 @@
                           "state": {
                             "enum": [
                               "full",
+                              "symbolic",
                               "degraded",
                               "unavailable"
                             ],
@@ -13633,7 +13636,7 @@
       ]
     },
     "2025-11-25": {
-      "discoveryContractSha256": "9347140dca5574571ffd434d09b944349fa71b704fbcd757b98de41b7e8aa2bc",
+      "discoveryContractSha256": "c71f1497d39fa4dabed10834bfddd51fddb1e4874abb926d1e89818beeaa2f78",
       "tools": [
         {
           "_meta": {
@@ -14518,6 +14521,7 @@
                               "state": {
                                 "enum": [
                                   "full",
+                                  "symbolic",
                                   "degraded",
                                   "unavailable"
                                 ],
@@ -14801,6 +14805,7 @@
                               "state": {
                                 "enum": [
                                   "full",
+                                  "symbolic",
                                   "degraded",
                                   "unavailable"
                                 ],
@@ -15328,6 +15333,7 @@
                           "state": {
                             "enum": [
                               "full",
+                              "symbolic",
                               "degraded",
                               "unavailable"
                             ],
@@ -24900,6 +24906,7 @@
                           "state": {
                             "enum": [
                               "full",
+                              "symbolic",
                               "degraded",
                               "unavailable"
                             ],
@@ -25183,6 +25190,7 @@
                           "state": {
                             "enum": [
                               "full",
+                              "symbolic",
                               "degraded",
                               "unavailable"
                             ],
@@ -25710,6 +25718,7 @@
                       "state": {
                         "enum": [
                           "full",
+                          "symbolic",
                           "degraded",
                           "unavailable"
                         ],

--- a/scripts/codestory-agent-ab-benchmark.mjs
+++ b/scripts/codestory-agent-ab-benchmark.mjs
@@ -38,6 +38,7 @@ import {
   codeStoryInvocationsFromCommand,
   codeStoryOperationFromCommand,
   codeStoryOperationFromMcpTool,
+  directBenchmarkCliInvocation,
   isBuilderAblationArm,
   isBuilderCodeStoryArm,
   isBuilderPacketArm,
@@ -2794,10 +2795,10 @@ function builderAblationArmInstruction(arm, continuationContract = null) {
     return "Do not use CodeStory. Investigate with ordinary local search and source reads.";
   }
   if (arm === "exact_identity_source") {
-    return "Your first repository-context action must be a successful CodeStory exact operation. With $CODESTORY_CLI, use only search with --repo-text off, files, symbol, or snippet. Every CodeStory command must include the exact --project path shown above; search must also include --profile agent --run-id shared-agent. Do not pass cache, refresh, or output-file overrides. After the first CodeStory output, investigate adaptively with ordinary local search and source reads. Any other CodeStory operation invalidates the row.";
+    return "Your first repository-context action must be a successful CodeStory exact operation. With $CODESTORY_CLI, use only `search --query <identifier-or-terms> --repo-text off`, files, symbol, or snippet. Every CodeStory command must include the exact --project path shown above; search must also include --profile agent --run-id shared-agent. Do not pass cache, refresh, or output-file overrides. After the first CodeStory output, investigate adaptively with ordinary local search and source reads. Any other CodeStory operation invalidates the row.";
   }
   if (arm === "exact_plus_relations") {
-    return "Your first repository-context action must be a successful CodeStory exact operation. With $CODESTORY_CLI, use search with --repo-text off, files, symbol, snippet, context, trail, callers, callees, or trace. Every CodeStory command must include the exact --project path shown above; search must also include --profile agent --run-id shared-agent. Do not pass cache, refresh, or output-file overrides. After the first CodeStory output, investigate adaptively with ordinary local search and source reads. Any other CodeStory operation invalidates the row.";
+    return "Your first repository-context action must be a successful CodeStory exact operation. With $CODESTORY_CLI, use `search --query <identifier-or-terms> --repo-text off`, files, symbol, snippet, context, trail, callers, callees, or trace. Every CodeStory command must include the exact --project path shown above; search must also include --profile agent --run-id shared-agent. Do not pass cache, refresh, or output-file overrides. After the first CodeStory output, investigate adaptively with ordinary local search and source reads. Any other CodeStory operation invalidates the row.";
   }
   const continuation = continuationContract
     ? ` The packet offers one optional continuation. If you use it, run this exact command as a separate repository-context action and do not run another CodeStory command:
@@ -3351,6 +3352,7 @@ function isCommandEvent(event) {
 
 function commandCategory(command) {
   const text = String(command ?? "");
+  if (directBenchmarkCliInvocation(text)) return "codestory_cli";
   const shellText = text.replace(/\\"/g, '"');
   const codestoryCommands = "\\b[a-z][a-z0-9-]*\\b";
   const knownCodestoryCommands =
@@ -4048,10 +4050,18 @@ function analyzeTranscript(events, projectRoot = null, context = {}) {
       command.category === "codestory_cli" &&
       command.exit_code === 0 &&
       (command.harness_semantics?.operation === "packet" ||
-        isCodestoryPacketCommand(command.command)),
+        isCodestoryPacketCommand(command.command) ||
+        (command.codestory_operation === "packet" &&
+          directBenchmarkCliInvocation(command.command)?.args.some(
+            (argument) => argument === "--question" || argument.startsWith("--question="),
+          ))),
   );
   const codestoryIndexCommands = commands.filter(
-    (command) => command.category === "codestory_cli" && isCodestoryIndexCommand(command.command),
+    (command) =>
+      command.category === "codestory_cli" &&
+      (isCodestoryIndexCommand(command.command) ||
+        (command.codestory_operation === "index" &&
+          directBenchmarkCliInvocation(command.command) != null)),
   );
   const firstSuccessfulContextCommand = commands.find(isSuccessfulContextCommand);
   const observedContextActions = observedRepositoryContextActions(commands, events);

--- a/scripts/lib/evidence-compiler-ablation.mjs
+++ b/scripts/lib/evidence-compiler-ablation.mjs
@@ -185,7 +185,7 @@ function shellWords(command) {
   return words;
 }
 
-function directBenchmarkCliInvocation(command) {
+function directPinnedBenchmarkCliInvocation(command) {
   const text = String(command ?? "");
   const executable = String.raw`(?:"\$(?:CODESTORY_CLI|\{CODESTORY_CLI\})"|\$(?:CODESTORY_CLI|\{CODESTORY_CLI\}))`;
   if (!new RegExp(`^\\s*${executable}(?=\\s)`, "u").test(text)) return null;
@@ -197,6 +197,20 @@ function directBenchmarkCliInvocation(command) {
     operation: normalizeCodeStoryOperation(words[1]),
     args: words.slice(2),
   };
+}
+
+function directBenchmarkCliInvocation(command) {
+  const direct = directPinnedBenchmarkCliInvocation(command);
+  if (direct) return direct;
+
+  const outer = shellWords(command);
+  if (
+    !outer || outer.length !== 3 || outer[0] !== "/bin/zsh" ||
+    !["-lc", "-c"].includes(outer[1])
+  ) {
+    return null;
+  }
+  return directPinnedBenchmarkCliInvocation(outer[2]);
 }
 
 function codeStoryInvocationsFromCommand(command) {
@@ -1030,6 +1044,7 @@ export {
   codeStoryInvocationsFromCommand,
   codeStoryOperationFromCommand,
   codeStoryOperationFromMcpTool,
+  directBenchmarkCliInvocation,
   evidenceCompilerBuilderAcceptance,
   isBuilderAblationArm,
   isBuilderCodeStoryArm,

--- a/scripts/lib/evidence-compiler-ablation.mjs
+++ b/scripts/lib/evidence-compiler-ablation.mjs
@@ -189,10 +189,12 @@ function hasDynamicShellExpansion(command) {
   const text = String(command ?? "");
   let quote = null;
   let escaped = false;
+  let wordStarted = false;
   for (let index = 0; index < text.length; index += 1) {
     const character = text[index];
     if (escaped) {
       escaped = false;
+      wordStarted = true;
       continue;
     }
     if (character === "\\" && quote !== "'") {
@@ -201,6 +203,7 @@ function hasDynamicShellExpansion(command) {
     }
     if (quote === "'") {
       if (character === "'") quote = null;
+      wordStarted = true;
       continue;
     }
     if (quote === '"') {
@@ -209,20 +212,29 @@ function hasDynamicShellExpansion(command) {
       } else if (character === "$" || character === "`") {
         return true;
       }
+      wordStarted = true;
       continue;
     }
     if (character === "'" || character === '"') {
       quote = character;
+      wordStarted = true;
+      continue;
+    }
+    if (/\s/u.test(character)) {
+      wordStarted = false;
       continue;
     }
     if (
       character === "$" || character === "`" || character === "*" ||
       character === "?" || character === "[" || character === "]" ||
       character === "{" || character === "}" || character === "(" ||
-      character === ")"
+      character === ")" || character === "~" || character === "^" ||
+      character === "#" || character === "!" ||
+      (character === "=" && !wordStarted)
     ) {
       return true;
     }
+    wordStarted = true;
   }
   return escaped || quote != null;
 }

--- a/scripts/lib/evidence-compiler-ablation.mjs
+++ b/scripts/lib/evidence-compiler-ablation.mjs
@@ -185,10 +185,54 @@ function shellWords(command) {
   return words;
 }
 
+function hasDynamicShellExpansion(command) {
+  const text = String(command ?? "");
+  let quote = null;
+  let escaped = false;
+  for (let index = 0; index < text.length; index += 1) {
+    const character = text[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === "\\" && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if (quote === "'") {
+      if (character === "'") quote = null;
+      continue;
+    }
+    if (quote === '"') {
+      if (character === '"') {
+        quote = null;
+      } else if (character === "$" || character === "`") {
+        return true;
+      }
+      continue;
+    }
+    if (character === "'" || character === '"') {
+      quote = character;
+      continue;
+    }
+    if (
+      character === "$" || character === "`" || character === "*" ||
+      character === "?" || character === "[" || character === "]" ||
+      character === "{" || character === "}" || character === "(" ||
+      character === ")"
+    ) {
+      return true;
+    }
+  }
+  return escaped || quote != null;
+}
+
 function directPinnedBenchmarkCliInvocation(command) {
   const text = String(command ?? "");
   const executable = String.raw`(?:"\$(?:CODESTORY_CLI|\{CODESTORY_CLI\})"|\$(?:CODESTORY_CLI|\{CODESTORY_CLI\}))`;
-  if (!new RegExp(`^\\s*${executable}(?=\\s)`, "u").test(text)) return null;
+  const executableMatch = text.match(new RegExp(`^\\s*${executable}(?=\\s)`, "u"));
+  if (!executableMatch) return null;
+  if (hasDynamicShellExpansion(text.slice(executableMatch[0].length))) return null;
   const words = shellWords(text);
   if (!words || words.length < 2) return null;
   if (!["$CODESTORY_CLI", "${CODESTORY_CLI}"].includes(words[0])) return null;

--- a/scripts/lib/evidence-compiler-ablation.mjs
+++ b/scripts/lib/evidence-compiler-ablation.mjs
@@ -132,14 +132,13 @@ function hasUnquotedShellComposition(command) {
   return escaped || quote != null;
 }
 
-function shellWords(command) {
-  if (hasUnquotedShellComposition(command)) return null;
+function literalShellWords(command) {
   const text = String(command ?? "");
+  if (/[\0\r\n]/u.test(text)) return null;
   const words = [];
   let word = "";
   let wordStarted = false;
   let quote = null;
-  let escaped = false;
   const finishWord = () => {
     if (!wordStarted) return;
     words.push(word);
@@ -148,20 +147,17 @@ function shellWords(command) {
   };
   for (let index = 0; index < text.length; index += 1) {
     const character = text[index];
-    if (escaped) {
-      word += character;
-      wordStarted = true;
-      escaped = false;
-      continue;
-    }
-    if (character === "\\" && quote !== "'") {
-      escaped = true;
+    if (quote === "'") {
+      if (character === "'") quote = null;
+      else word += character;
       wordStarted = true;
       continue;
     }
-    if (quote) {
-      if (character === quote) {
+    if (quote === '"') {
+      if (character === '"') {
         quote = null;
+      } else if (character === "\\" || character === "$" || character === "`") {
+        return null;
       } else {
         word += character;
       }
@@ -177,66 +173,21 @@ function shellWords(command) {
       finishWord();
       continue;
     }
+    if (character === "\\") {
+      if (text[index + 1] !== "'") return null;
+      word += "'";
+      wordStarted = true;
+      index += 1;
+      continue;
+    }
+    if (!/[A-Za-z0-9_./:@%+,=-]/u.test(character)) return null;
+    if (character === "=" && !wordStarted) return null;
     word += character;
     wordStarted = true;
   }
-  if (escaped || quote) return null;
+  if (quote) return null;
   finishWord();
   return words;
-}
-
-function hasDynamicShellExpansion(command) {
-  const text = String(command ?? "");
-  let quote = null;
-  let escaped = false;
-  let wordStarted = false;
-  for (let index = 0; index < text.length; index += 1) {
-    const character = text[index];
-    if (escaped) {
-      escaped = false;
-      wordStarted = true;
-      continue;
-    }
-    if (character === "\\" && quote !== "'") {
-      escaped = true;
-      continue;
-    }
-    if (quote === "'") {
-      if (character === "'") quote = null;
-      wordStarted = true;
-      continue;
-    }
-    if (quote === '"') {
-      if (character === '"') {
-        quote = null;
-      } else if (character === "$" || character === "`") {
-        return true;
-      }
-      wordStarted = true;
-      continue;
-    }
-    if (character === "'" || character === '"') {
-      quote = character;
-      wordStarted = true;
-      continue;
-    }
-    if (/\s/u.test(character)) {
-      wordStarted = false;
-      continue;
-    }
-    if (
-      character === "$" || character === "`" || character === "*" ||
-      character === "?" || character === "[" || character === "]" ||
-      character === "{" || character === "}" || character === "(" ||
-      character === ")" || character === "~" || character === "^" ||
-      character === "#" || character === "!" ||
-      (character === "=" && !wordStarted)
-    ) {
-      return true;
-    }
-    wordStarted = true;
-  }
-  return escaped || quote != null;
 }
 
 function directPinnedBenchmarkCliInvocation(command) {
@@ -244,14 +195,12 @@ function directPinnedBenchmarkCliInvocation(command) {
   const executable = String.raw`(?:"\$(?:CODESTORY_CLI|\{CODESTORY_CLI\})"|\$(?:CODESTORY_CLI|\{CODESTORY_CLI\}))`;
   const executableMatch = text.match(new RegExp(`^\\s*${executable}(?=\\s)`, "u"));
   if (!executableMatch) return null;
-  if (hasDynamicShellExpansion(text.slice(executableMatch[0].length))) return null;
-  const words = shellWords(text);
-  if (!words || words.length < 2) return null;
-  if (!["$CODESTORY_CLI", "${CODESTORY_CLI}"].includes(words[0])) return null;
-  if (!/^[a-z][a-z0-9-]*$/iu.test(words[1])) return null;
+  const words = literalShellWords(text.slice(executableMatch[0].length));
+  if (!words || words.length < 1) return null;
+  if (!/^[a-z][a-z0-9-]*$/iu.test(words[0])) return null;
   return {
-    operation: normalizeCodeStoryOperation(words[1]),
-    args: words.slice(2),
+    operation: normalizeCodeStoryOperation(words[0]),
+    args: words.slice(1),
   };
 }
 
@@ -259,7 +208,7 @@ function directBenchmarkCliInvocation(command) {
   const direct = directPinnedBenchmarkCliInvocation(command);
   if (direct) return direct;
 
-  const outer = shellWords(command);
+  const outer = literalShellWords(command);
   if (
     !outer || outer.length !== 3 || outer[0] !== "/bin/zsh" ||
     !["-lc", "-c"].includes(outer[1])

--- a/scripts/tests/codestory-evidence-compiler-ablation.test.mjs
+++ b/scripts/tests/codestory-evidence-compiler-ablation.test.mjs
@@ -292,6 +292,19 @@ test("operation parser and policy fail closed on arm leakage", () => {
     ),
     [],
   );
+  const literalDollar = "$CODESTORY_CLI search --project /tmp/repo --profile agent --run-id shared-agent --query '$fixture' --repo-text off";
+  const literalDollarAnalysis = analyzeTranscript([
+    commandEvent("literal-dollar", "completed", literalDollar, "{}"),
+  ], "/tmp/repo");
+  assert.deepEqual(
+    builderOperationViolations(
+      "exact_identity_source",
+      literalDollarAnalysis.codestory_operations,
+      exactOptions,
+    ),
+    [],
+    "single-quoted literal query text must remain valid",
+  );
   assert.deepEqual(
     builderOperationViolations("exact_plus_relations", [{
       operation: "callers",
@@ -418,6 +431,10 @@ test("operation parser and policy fail closed on arm leakage", () => {
     `sh -c '\"$CODESTORY_CLI\" search --query Alpha --repo-text off; cat src/lib.rs'`,
     `eval '$CODESTORY_CLI search --query Alpha --repo-text off'`,
     `env FOO=bar $CODESTORY_CLI search --query Alpha --repo-text off`,
+    `$CODESTORY_CLI search --project /tmp/repo --profile agent --run-id shared-agent --query \${(z):-"anchor --cache-dir /tmp"} --repo-text off`,
+    `/bin/zsh -lc '$CODESTORY_CLI search --project /tmp/repo --profile agent --run-id shared-agent --query \${(z):-"anchor --cache-dir /tmp"} --repo-text off'`,
+    `$CODESTORY_CLI search --project /tmp/repo --profile agent --run-id shared-agent --query * --repo-text off`,
+    `$CODESTORY_CLI search --project /tmp/repo --profile agent --run-id shared-agent --query {anchor,--cache-dir,/tmp} --repo-text off`,
     `$CODESTORY_CLI search --query \"$(cat src/lib.rs)\" --repo-text off`,
     `$CODESTORY_CLI search --query \"\u0060cat src/lib.rs\u0060\" --repo-text off`,
     `sh -c \"$(printenv CODESTORY_CLI) search --query Alpha --repo-text off\"`,

--- a/scripts/tests/codestory-evidence-compiler-ablation.test.mjs
+++ b/scripts/tests/codestory-evidence-compiler-ablation.test.mjs
@@ -292,7 +292,7 @@ test("operation parser and policy fail closed on arm leakage", () => {
     ),
     [],
   );
-  const literalDollar = "$CODESTORY_CLI search --project /tmp/repo --profile agent --run-id shared-agent --query '$fixture' --repo-text off";
+  const literalDollar = "$CODESTORY_CLI search --project /tmp/repo --profile agent --run-id shared-agent --query '$fixture ~ =ls * {anchor}' --repo-text off";
   const literalDollarAnalysis = analyzeTranscript([
     commandEvent("literal-dollar", "completed", literalDollar, "{}"),
   ], "/tmp/repo");
@@ -435,6 +435,10 @@ test("operation parser and policy fail closed on arm leakage", () => {
     `/bin/zsh -lc '$CODESTORY_CLI search --project /tmp/repo --profile agent --run-id shared-agent --query \${(z):-"anchor --cache-dir /tmp"} --repo-text off'`,
     `$CODESTORY_CLI search --project /tmp/repo --profile agent --run-id shared-agent --query * --repo-text off`,
     `$CODESTORY_CLI search --project /tmp/repo --profile agent --run-id shared-agent --query {anchor,--cache-dir,/tmp} --repo-text off`,
+    `$CODESTORY_CLI search --project /tmp/repo --profile agent --run-id shared-agent --query ~ --repo-text off`,
+    `/bin/zsh -lc '$CODESTORY_CLI search --project /tmp/repo --profile agent --run-id shared-agent --query ~ --repo-text off'`,
+    `$CODESTORY_CLI search --project /tmp/repo --profile agent --run-id shared-agent --query =ls --repo-text off`,
+    `/bin/zsh -lc '$CODESTORY_CLI search --project /tmp/repo --profile agent --run-id shared-agent --query =ls --repo-text off'`,
     `$CODESTORY_CLI search --query \"$(cat src/lib.rs)\" --repo-text off`,
     `$CODESTORY_CLI search --query \"\u0060cat src/lib.rs\u0060\" --repo-text off`,
     `sh -c \"$(printenv CODESTORY_CLI) search --query Alpha --repo-text off\"`,

--- a/scripts/tests/codestory-evidence-compiler-ablation.test.mjs
+++ b/scripts/tests/codestory-evidence-compiler-ablation.test.mjs
@@ -427,6 +427,14 @@ test("operation parser and policy fail closed on arm leakage", () => {
     codeStoryInvocationsFromCommand("echo $CODESTORY_CLI")[0].operation,
     null,
   );
+  const directLineContinuation = [
+    "$CODESTORY_CLI search --project /tmp/repo --profile agent --run-id shared-agent --query Alpha\\",
+    "Beta --repo-text off",
+  ].join("\n");
+  const wrappedLineContinuation = [
+    "/bin/zsh -lc '$CODESTORY_CLI search --project /tmp/repo --profile agent --run-id shared-agent --query Alpha\\",
+    "Beta --repo-text off'",
+  ].join("\n");
   for (const wrapped of [
     `sh -c '\"$CODESTORY_CLI\" search --query Alpha --repo-text off; cat src/lib.rs'`,
     `eval '$CODESTORY_CLI search --query Alpha --repo-text off'`,
@@ -439,6 +447,9 @@ test("operation parser and policy fail closed on arm leakage", () => {
     `/bin/zsh -lc '$CODESTORY_CLI search --project /tmp/repo --profile agent --run-id shared-agent --query ~ --repo-text off'`,
     `$CODESTORY_CLI search --project /tmp/repo --profile agent --run-id shared-agent --query =ls --repo-text off`,
     `/bin/zsh -lc '$CODESTORY_CLI search --project /tmp/repo --profile agent --run-id shared-agent --query =ls --repo-text off'`,
+    `$CODESTORY_CLI search --project /tmp/repo --profile agent --run-id shared-agent --query Alpha\\ Beta --repo-text off`,
+    directLineContinuation,
+    wrappedLineContinuation,
     `$CODESTORY_CLI search --query \"$(cat src/lib.rs)\" --repo-text off`,
     `$CODESTORY_CLI search --query \"\u0060cat src/lib.rs\u0060\" --repo-text off`,
     `sh -c \"$(printenv CODESTORY_CLI) search --query Alpha --repo-text off\"`,

--- a/scripts/tests/codestory-evidence-compiler-ablation.test.mjs
+++ b/scripts/tests/codestory-evidence-compiler-ablation.test.mjs
@@ -212,6 +212,18 @@ test("semantic-off packet command uses the hidden stage switch without manifest 
   assert.equal(args.includes("--extra-probe"), false);
 });
 
+test("exact-arm prompt shows the generic query flag without task-shaped vocabulary", () => {
+  const prompt = composeBuilderAblationPrompt(
+    "repo-a",
+    { path: "/tmp/repo", prompt: "fallback" },
+    "exact_identity_source",
+    { prompt: "Describe a renamed subsystem" },
+  );
+  assert.match(prompt, /search --query <identifier-or-terms> --repo-text off/);
+  assert.equal(prompt.includes("HTTP client"), false);
+  assert.equal(prompt.includes("request finalizer"), false);
+});
+
 test("continuation proof paths are opaque and cannot encode experimental identities", () => {
   const proofPath = opaqueBuilderContinuationProofPath(
     "/tmp/codestory-agent-builder-ablation-private",
@@ -264,6 +276,20 @@ test("operation parser and policy fail closed on arm leakage", () => {
       successful: true,
       raw: { command: exactSearchCommand },
     }], exactOptions),
+    [],
+  );
+  const wrappedExactSearch = `/bin/zsh -lc '$CODESTORY_CLI search --project /tmp/repo --profile agent --run-id shared-agent --query "Alpha Beta" --repo-text off'`;
+  const wrappedAnalysis = analyzeTranscript([
+    commandEvent("wrapped-exact", "completed", wrappedExactSearch, "{}"),
+  ], "/tmp/repo");
+  assert.equal(wrappedAnalysis.first_successful_codestory_command?.command, wrappedExactSearch);
+  assert.equal(wrappedAnalysis.codestory_was_first_repository_context_action, true);
+  assert.deepEqual(
+    builderOperationViolations(
+      "exact_identity_source",
+      wrappedAnalysis.codestory_operations,
+      exactOptions,
+    ),
     [],
   );
   assert.deepEqual(
@@ -395,6 +421,10 @@ test("operation parser and policy fail closed on arm leakage", () => {
     `$CODESTORY_CLI search --query \"$(cat src/lib.rs)\" --repo-text off`,
     `$CODESTORY_CLI search --query \"\u0060cat src/lib.rs\u0060\" --repo-text off`,
     `sh -c \"$(printenv CODESTORY_CLI) search --query Alpha --repo-text off\"`,
+    `/bin/zsh -lc '$CODESTORY_CLI search --project /tmp/repo --profile agent --run-id shared-agent --query Alpha --repo-text off; cat src/lib.rs'`,
+    `/bin/zsh -lc 'CODESTORY_CACHE_ROOT=/tmp/other $CODESTORY_CLI search --project /tmp/repo --profile agent --run-id shared-agent --query Alpha --repo-text off'`,
+    `/bin/zsh -lc 'codestory-cli search --project /tmp/repo --profile agent --run-id shared-agent --query Alpha --repo-text off'`,
+    `/bin/zsh -lc '/bin/zsh -lc \"$CODESTORY_CLI search --project /tmp/repo --profile agent --run-id shared-agent --query Alpha --repo-text off\"'`,
   ]) {
     const wrapperAnalysis = analyzeTranscript([
       commandEvent("wrapped", "completed", wrapped, "source text"),


### PR DESCRIPTION
## Context

The first builder-visible evidence-compiler ablation produced an invalid comparison and a packet failure with one common cause: packet pre-admission ran a repository-scale descriptor query successfully, discarded that result, and repeated it under the shorter hydration deadline. At the same time, the supposed exact control still required full retrieval, while the analyzer rejected Codex's ordinary one-command zsh wrapper.

This is the single general compiler revision allowed by #2098. It contains no repository, language, task, symbol, or answer-family policy.

Closes #2114
Refs #2098

## What changed

- Retain each authenticated descriptor result inside its packet session, keyed by exact query, dense policy, and immutable retrieval publication.
- Reuse that result during initial and planned packet resolution; execute only genuinely new continuation queries.
- Make explicit `search --repo-text off` a complete-core symbol lane that does not initialize embeddings or claim a retrieval-sidecar publication.
- Bind exact-search excerpts to indexed content hashes, canonical project containment, and project-relative paths; outside-resolving symlinks fail closed.
- Route CLI, stdio, HTTP, browser, and graph-query search through the same explicit core-only operation contract.
- Accept only a direct checksum-bound CLI invocation or one ordinary `/bin/zsh -lc`/`-c` wrapper around it in builder accounting; a literal-token grammar rejects every shell-transformed argument form.
- Show the required `search --query <identifier-or-terms> --repo-text off` syntax in both primitive-arm prompts.

## Review focus

1. A retained result cannot cross packet session, query, dense policy, or full publication identity.
2. The seventeenth/unadmitted identity still cannot trigger source or graph hydration.
3. Only explicit `repo_text=off` bypasses retrieval activation; `auto` and `on` remain unchanged.
4. Exact-search source bytes are hash-bound to the pinned core and never expose an absolute or out-of-project path.
5. Wrapper recognition cannot admit command composition, substitutions, environment overrides, nested shells, or another executable.

## Verification

Exact source head: `929701c53bad1b4355fc252ddca577d8a60acdfb`

Focused checks passed:

- `codestory-runtime --lib`: 836 passed, 4 ignored
- `codestory-cli --lib`: 459 passed, 1 ignored
- `codestory-contracts`: unit, generated-config drift, and public API checks passed
- CLI golden path: 18 passed
- stdio protocol contracts: 66 passed
- architecture contracts: 56 passed
- HTTP transport contracts: 6 passed
- search JSON output: 5 passed, 8 ignored
- runtime search tests: 106 passed, 3 ignored
- packet descriptor reuse under `benchmark-support`: 2 passed
- packet budget and capping: passed
- AB analyzer: 189 passed
- evidence-compiler analyzer: 22 passed, including direct and wrapped shell-expansion and physical-line-continuation mutations
- exact-search source-integrity tests: 5 passed, including an outside-resolving symlink
- generalization boundary, hostile boundary, routing conformance, plugin-static, generated MCP catalog, formatting, diff hygiene, and documentation links: passed

Independent review found an outside-resolving source symlink and a family of zsh argument transformations. Source reads now require canonical project containment, and the command recognizer was redesigned around a literal-token grammar rather than another expansion denylist. A fresh verifier will review this exact head before the PR leaves draft.

## Non-claims

- This PR does not establish packet usefulness or pass the builder ablation.
- It does not bump, calibrate, qualify, or release 0.18.
- It does not change ordinary semantic search or add planner policy.
- The ablation is rerun from zero only after this support slice merges.
