### PR TITLE
[codex] make exact controls observational and reject invalid experiments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Exact `search --repo-text off --refresh none` works from the existing core
+  publication even when retrieval catalogs are unwritable. A project without
+  a published core returns `project_unavailable` without creating a cache.
 - Explicit `search --repo-text off` now reads the complete core symbol index
   without waiting for embeddings. Packet assembly reuses the retrieval result
   that established admission instead of rerunning it under a shorter deadline.

--- a/crates/codestory-cli/src/app/lifecycle.rs
+++ b/crates/codestory-cli/src/app/lifecycle.rs
@@ -116,6 +116,15 @@ pub(super) fn open_search_surface(
     }
 
     let runtime = RuntimeContext::new(project)?;
+    if refresh == args::RefreshMode::None {
+        let opened = runtime.open_core_read_only()?;
+        ensure_index_ready(&opened, "search")?;
+        return Ok(OpenedAgentSurface {
+            before: Some(opened.summary.clone()),
+            runtime,
+            opened,
+        });
+    }
     let (before, opened) = runtime.ensure_open_with_before(refresh)?;
     ensure_index_ready(&opened, "search")?;
     Ok(OpenedAgentSurface {

--- a/crates/codestory-cli/src/runtime.rs
+++ b/crates/codestory-cli/src/runtime.rs
@@ -472,6 +472,24 @@ impl RuntimeContext {
             .map_err(|error| map_api_error_for_project(error, &self.project_root))
     }
 
+    /// Attach the existing immutable core for an exact read without creating
+    /// cache state or consulting retrieval-owned catalogs.
+    pub(crate) fn open_core_read_only(&self) -> Result<OpenedProject> {
+        let summary = self
+            .project
+            .open_core_read_only_with_storage_path(
+                self.project_root.clone(),
+                self.storage_path.clone(),
+            )
+            .map_err(|error| map_api_error_for_project(error, &self.project_root))?;
+        Ok(OpenedProject {
+            summary,
+            refresh_mode: None,
+            refresh_reason: None,
+            phase_timings: None,
+        })
+    }
+
     pub(crate) fn inspect_project_summary(&self) -> Result<Option<ProjectSummary>> {
         self.project
             .inspect_project_summary_with_storage_path(

--- a/crates/codestory-cli/tests/cli_golden_path.rs
+++ b/crates/codestory-cli/tests/cli_golden_path.rs
@@ -1,11 +1,15 @@
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 use tempfile::tempdir;
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 
 fn write_tiny_rust_workspace(root: &Path) {
     fs::write(
@@ -676,6 +680,59 @@ fn search_dir_for_storage(storage_path: &Path) -> PathBuf {
         return generations.pop().expect("published search generation");
     }
     parent.join(format!("{stem}.search"))
+}
+
+fn search_catalog_lock_for_storage(storage_path: &Path) -> PathBuf {
+    let parent = storage_path.parent().expect("storage parent");
+    let stem = storage_path
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .expect("storage file stem");
+    parent.join(format!("{stem}.search-generations.lock"))
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct CacheFileSnapshot {
+    relative_path: PathBuf,
+    byte_len: u64,
+    sha256: String,
+    modified: SystemTime,
+}
+
+fn cache_file_snapshots(root: &Path) -> Vec<CacheFileSnapshot> {
+    fn visit(root: &Path, current: &Path, snapshots: &mut Vec<CacheFileSnapshot>) {
+        let mut entries = fs::read_dir(current)
+            .expect("read cache directory")
+            .map(|entry| entry.expect("read cache entry"))
+            .collect::<Vec<_>>();
+        entries.sort_by_key(|entry| entry.file_name());
+        for entry in entries {
+            let path = entry.path();
+            let metadata = entry.metadata().expect("read cache entry metadata");
+            if metadata.is_dir() {
+                visit(root, &path, snapshots);
+            } else if metadata.is_file() {
+                snapshots.push(CacheFileSnapshot {
+                    relative_path: path
+                        .strip_prefix(root)
+                        .expect("cache entry below root")
+                        .to_path_buf(),
+                    byte_len: metadata.len(),
+                    sha256: format!(
+                        "{:x}",
+                        Sha256::digest(fs::read(&path).expect("read cache file"))
+                    ),
+                    modified: metadata.modified().expect("read cache file mtime"),
+                });
+            }
+        }
+    }
+
+    let mut snapshots = Vec::new();
+    if root.is_dir() {
+        visit(root, root, &mut snapshots);
+    }
+    snapshots
 }
 
 fn find_index_freshness(value: &Value) -> Option<&Value> {
@@ -1696,6 +1753,118 @@ fn assert_exact_search_uses_core_without_full_sidecars(
             })
         }),
         "exact search must return project-relative source evidence for {query}: {search:#}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn exact_search_reads_the_immutable_core_when_the_search_catalog_is_unwritable() {
+    let workspace = tempdir().expect("workspace dir");
+    let cache_dir = tempdir().expect("cache dir");
+    write_tiny_rust_workspace(workspace.path());
+    let index = run_cli_json(
+        workspace.path(),
+        cache_dir.path(),
+        &["index", "--refresh", "full", "--format", "json"],
+    );
+    let storage_path = PathBuf::from(string_field(&index, &["storage_path"]));
+    let catalog_lock = search_catalog_lock_for_storage(&storage_path);
+    assert!(
+        catalog_lock.is_file(),
+        "index should publish a catalog lock"
+    );
+    fs::set_permissions(&catalog_lock, fs::Permissions::from_mode(0o400))
+        .expect("make search catalog lock read-only");
+    let before = cache_file_snapshots(cache_dir.path());
+
+    let output = run_cli(
+        workspace.path(),
+        cache_dir.path(),
+        &[
+            "search",
+            "--query",
+            "AppController",
+            "--repo-text",
+            "off",
+            "--limit",
+            "5",
+            "--refresh",
+            "none",
+            "--format",
+            "json",
+        ],
+    );
+
+    fs::set_permissions(&catalog_lock, fs::Permissions::from_mode(0o600))
+        .expect("restore search catalog lock permissions");
+    assert!(
+        output.status.success(),
+        "core-only exact search must not open the search-generation catalog: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let search: Value = serde_json::from_slice(&output.stdout).expect("parse exact search JSON");
+    assert!(
+        search["evidence"]
+            .as_array()
+            .is_some_and(|rows| rows.iter().any(|row| {
+                row["excerpt"]
+                    .as_str()
+                    .is_some_and(|excerpt| excerpt.contains("AppController"))
+            })),
+        "core-only exact search should return source evidence: {search:#}"
+    );
+    assert_eq!(
+        cache_file_snapshots(cache_dir.path()),
+        before,
+        "core-only exact search must not mutate cache bytes or mtimes"
+    );
+}
+
+#[test]
+fn cold_exact_search_returns_project_unavailable_without_creating_cache_files() {
+    let workspace = tempdir().expect("workspace dir");
+    let cache_dir = tempdir().expect("cache dir");
+    write_tiny_rust_workspace(workspace.path());
+    let before = cache_file_snapshots(cache_dir.path());
+
+    let output = run_cli(
+        workspace.path(),
+        cache_dir.path(),
+        &[
+            "search",
+            "--query",
+            "AppController",
+            "--repo-text",
+            "off",
+            "--limit",
+            "5",
+            "--refresh",
+            "none",
+            "--format",
+            "json",
+        ],
+    );
+
+    assert!(
+        !output.status.success(),
+        "cold exact search must fail closed"
+    );
+    let failure: Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "parse cold exact-search failure: {error}; stdout={} stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    assert_eq!(
+        failure["error"]["code"], "project_unavailable",
+        "{failure:#}"
+    );
+    assert_eq!(
+        cache_file_snapshots(cache_dir.path()),
+        before,
+        "cold exact search must not create cache files"
     );
 }
 

--- a/crates/codestory-runtime/src/controller_core.rs
+++ b/crates/codestory-runtime/src/controller_core.rs
@@ -262,12 +262,12 @@ impl AppController {
                 "Failed to finish public operation snapshot: {error}"
             ))
         })?;
-        let revalidate_path =
-            codestory_store::resolve_core_database_path(&storage_path).unwrap_or(storage_path);
-        let live =
-            Store::database_complete_index_publication(&revalidate_path).map_err(|error| {
-                ApiError::internal(format!("Failed to revalidate public operation: {error}"))
-            })?;
+        // Revalidate through the logical path. Passing the resolved generation
+        // path loses its immutable-publication context and lets SQLite create
+        // WAL/SHM sidecars beside a sealed generation merely to observe it.
+        let live = Store::database_complete_index_publication(&storage_path).map_err(|error| {
+            ApiError::internal(format!("Failed to revalidate public operation: {error}"))
+        })?;
         if live.as_ref() != Some(&publication) {
             return Err(ApiError::new(
                 "publication_changed",

--- a/crates/codestory-runtime/src/controller_indexing.rs
+++ b/crates/codestory-runtime/src/controller_indexing.rs
@@ -44,7 +44,9 @@ use codestory_contracts::api::{
     StartIndexingRequest, StorageStatsDto, SummaryGenerationDto,
 };
 use codestory_indexer::CancellationToken;
-use codestory_store::{CURRENT_SCHEMA_VERSION, IndexPublicationRecord, Store, SymbolSummaryRecord};
+use codestory_store::{
+    CURRENT_SCHEMA_VERSION, CoreReadSession, IndexPublicationRecord, Store, SymbolSummaryRecord,
+};
 use codestory_workspace::{RefreshInputs, WorkspaceManifest};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -57,7 +59,7 @@ pub(crate) struct ActivationIndexingEvidence {
 }
 
 impl AppController {
-    pub(crate) fn project_summary_from_storage(
+    fn core_project_summary_from_storage(
         &self,
         root: &Path,
         storage_path: &Path,
@@ -98,14 +100,88 @@ impl AppController {
             root: root.to_string_lossy().to_string(),
             stats: dto_stats,
             members,
-            retrieval: Some(retrieval_state_from_storage_for_runtime(
-                storage,
-                root,
-                &self.runtime_config,
-            )?),
+            retrieval: None,
             freshness: Some(freshness),
             publication,
         })
+    }
+
+    pub(crate) fn project_summary_from_storage(
+        &self,
+        root: &Path,
+        storage_path: &Path,
+        storage: &Storage,
+    ) -> Result<ProjectSummary, ApiError> {
+        let mut summary = self.core_project_summary_from_storage(root, storage_path, storage)?;
+        summary.retrieval = Some(retrieval_state_from_storage_for_runtime(
+            storage,
+            root,
+            &self.runtime_config,
+        )?);
+        Ok(summary)
+    }
+
+    /// Attach an existing immutable core without touching retrieval-owned
+    /// state or creating a cache path.
+    pub fn open_core_read_only_with_storage_path(
+        &self,
+        root: PathBuf,
+        storage_path: PathBuf,
+    ) -> Result<ProjectSummary, ApiError> {
+        if !root.exists() {
+            return Err(ApiError::not_found(format!(
+                "Project path does not exist: {}",
+                root.display()
+            )));
+        }
+        if !root.is_dir() {
+            return Err(ApiError::invalid_argument(format!(
+                "Project path is not a directory: {}",
+                root.display()
+            )));
+        }
+        let session = CoreReadSession::pin(&storage_path).map_err(|error| {
+            ApiError::new(
+                "project_unavailable",
+                format!("no complete core publication is available: {error}"),
+            )
+        })?;
+        let summary =
+            self.core_project_summary_from_storage(&root, &storage_path, session.storage())?;
+        if summary.publication.is_none() {
+            return Err(ApiError::new(
+                "project_unavailable",
+                "no complete core publication is available",
+            ));
+        }
+
+        let changed = {
+            let mut state = self.state.lock();
+            let changed =
+                state.project_root.as_ref().is_none_or(|current| {
+                    !codestory_workspace::same_workspace_path(current, &root)
+                }) || state.storage_path.as_ref().is_none_or(|current| {
+                    !codestory_workspace::same_workspace_path(current, &storage_path)
+                }) || state.observed_core_publication.as_ref() != summary.publication.as_ref();
+            state.project_root = Some(root);
+            state.storage_path = Some(storage_path);
+            state.observed_core_publication = summary.publication.clone();
+            if changed {
+                state.node_names.clear();
+                clear_search_engine(&mut state);
+            }
+            changed
+        };
+        if changed {
+            self.sidecar_query_cache.lock().clear();
+            #[cfg(any(
+                test,
+                feature = "test-support",
+                feature = "proof-qualification-support"
+            ))]
+            self.clear_proof_publication_validation_cache();
+        }
+        Ok(summary)
     }
 
     pub fn complete_index_publication_at(

--- a/crates/codestory-runtime/src/controller_symbols.rs
+++ b/crates/codestory-runtime/src/controller_symbols.rs
@@ -3,6 +3,7 @@ use crate::route_coverage::{
     RouteHandlerCandidate, compare_route_handler_candidates,
     route_endpoint_metadata_from_canonical, route_endpoint_metadata_from_openapi_label,
 };
+use crate::search::engine::search_core_symbol_names_with_scores;
 #[cfg(test)]
 use crate::search_scoring::HybridSearchInstrumentation;
 use crate::support::node_display_name;
@@ -299,6 +300,54 @@ impl AppController {
         let mut hits = matches
             .into_iter()
             .map(|(id, score)| Self::build_search_hit(&storage, &node_names, id, score))
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .flatten()
+            .map(|mut hit| {
+                decorate_lexical_search_hit_evidence(&mut hit);
+                hit
+            })
+            .collect::<Vec<_>>();
+        let project_root = self.require_project_root().ok();
+        hits.sort_by(|left, right| {
+            compare_search_hits_with_project_root(project_root.as_deref(), query, left, right, None)
+        });
+        hits.truncate(max_results.clamp(1, 50));
+        Ok(hits)
+    }
+
+    /// Resolve symbols from the immutable core projection only.
+    ///
+    /// This deliberately avoids `ensure_search_state`: that path attaches the
+    /// persisted search generation and therefore acquires its catalog lock.
+    /// An explicit `repo_text=off` query owns no retrieval or search-generation
+    /// dependency, so it streams canonical identities from the already-pinned
+    /// core and applies the same in-memory fuzzy matcher directly.
+    pub(crate) fn resolve_core_symbol_candidates(
+        &self,
+        query: &str,
+        max_results: usize,
+    ) -> Result<Vec<SearchHit>, ApiError> {
+        let storage = self.open_storage_read_only()?;
+        let mut symbols = Vec::new();
+        let (node_names, _) = crate::load_canonical_search_symbols(
+            &storage,
+            crate::semantic_projection::SEARCH_SYMBOL_STREAM_BATCH_SIZE,
+            None,
+            |batch| {
+                symbols.extend(
+                    batch
+                        .into_iter()
+                        .map(|entry| (entry.node_id, entry.display_name)),
+                );
+                Ok(())
+            },
+        )?;
+        let matches = search_core_symbol_names_with_scores(&symbols, query);
+        let names = node_names_for_ids(&node_names, matches.iter().map(|(id, _)| *id));
+        let mut hits = matches
+            .into_iter()
+            .map(|(id, score)| Self::build_search_hit(&storage, &names, id, score))
             .collect::<Result<Vec<_>, _>>()?
             .into_iter()
             .flatten()

--- a/crates/codestory-runtime/src/index_freshness.rs
+++ b/crates/codestory-runtime/src/index_freshness.rs
@@ -1054,7 +1054,10 @@ pub(super) fn open_existing_storage_for_read(path: &Path) -> Result<Storage, Api
             ));
         }
     };
-    let schema = Storage::database_schema_version(&resolved).map_err(|error| {
+    // Inspect through the logical path so immutable-generation context is
+    // preserved. Opening the resolved generation as a legacy database lets
+    // SQLite materialize WAL/SHM files beside a sealed read target.
+    let schema = Storage::database_schema_version(path).map_err(|error| {
         ApiError::internal(format!("Failed to inspect storage schema: {error}"))
     })?;
     if schema != CURRENT_SCHEMA_VERSION {

--- a/crates/codestory-runtime/src/search/engine.rs
+++ b/crates/codestory-runtime/src/search/engine.rs
@@ -1090,6 +1090,23 @@ pub(crate) fn search_symbols_with_scores(
         .collect()
 }
 
+/// Rank canonical core symbols without opening a persisted search generation.
+///
+/// Exact core search uses this adapter after streaming the immutable core's
+/// identity projection. Keeping UTF-32 conversion here preserves the same
+/// matcher and ordering as the resident search engine without acquiring or
+/// creating any search-generation artifact.
+pub(crate) fn search_core_symbol_names_with_scores(
+    symbols: &[(NodeId, String)],
+    query: &str,
+) -> Vec<(NodeId, f32)> {
+    let symbols = symbols
+        .iter()
+        .map(|(id, name)| (Utf32String::from(name.as_str()), *id))
+        .collect::<Vec<_>>();
+    search_symbols_with_scores(&symbols, query)
+}
+
 fn symbol_candidate_rank(query: &str, name: &Utf32String, score: u32) -> SymbolCandidateRank {
     let query = query.trim().to_ascii_lowercase();
     let display = name.to_string();

--- a/crates/codestory-runtime/src/search_plan.rs
+++ b/crates/codestory-runtime/src/search_plan.rs
@@ -1805,7 +1805,7 @@ impl AppController {
         let intent_query = parse_search_intent_query(&original_query);
         let query = intent_query.effective_query.clone();
         let limit_per_source = req.limit_per_source.clamp(1, 50) as usize;
-        let mut hits = self.resolve_indexed_symbol_candidates(&query, limit_per_source)?;
+        let mut hits = self.resolve_core_symbol_candidates(&query, limit_per_source)?;
         apply_search_intent_filters(&mut hits, &intent_query.filters);
         dedupe_inexact_search_hits_by_display_key(&query, &mut hits);
         hits.truncate(limit_per_source);

--- a/crates/codestory-runtime/src/services.rs
+++ b/crates/codestory-runtime/src/services.rs
@@ -2664,6 +2664,17 @@ impl ProjectService {
             .open_project_summary_with_storage_path(root, storage_path)
     }
 
+    /// Attach one existing immutable core without opening retrieval catalogs
+    /// or creating cache state.
+    pub fn open_core_read_only_with_storage_path(
+        &self,
+        root: std::path::PathBuf,
+        storage_path: std::path::PathBuf,
+    ) -> Result<ProjectSummary, ApiError> {
+        self.controller
+            .open_core_read_only_with_storage_path(root, storage_path)
+    }
+
     /// Observe an existing project store without creating directories,
     /// initializing a database, migrating schema, or binding controller state.
     pub fn inspect_project_summary_with_storage_path(

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -60,6 +60,29 @@ cargo test --locked -p codestory-agent
 
 ## Draft source checks
 
+Experiment-validity changes use the core-only exact-search cases in
+`cli_golden_path`, plus these harness contracts:
+
+```sh
+node --test scripts/tests/codestory-control-row-audit.test.mjs
+node --test scripts/tests/builder-operation-canary.test.mjs
+node --test scripts/tests/codestory-evidence-compiler-ablation.test.mjs
+node --test scripts/tests/codestory-agent-ab-analyzer.test.mjs
+```
+
+The builder runs deterministic operation canaries through the pinned Codex
+macOS sandbox before launching any model sessions. Missing operation telemetry,
+failed commands, or invalid output shapes invalidate the experiment; quality
+aggregation cannot convert them into a packet `stop` or `advance`. Canaries
+retain commands, exit statuses, durations, and output digests. They do not count
+as installed-product acceptance.
+
+For a historical control audit, run
+`node scripts/codestory-control-row-audit.mjs --run-dir <preserved-receipt> --out-dir <new-external-directory>`.
+It authenticates the run ledger against the original receipt and reads only
+preserved transcript copies. The checksummed erratum withdraws affected
+comparisons without replacing the original receipt or its decision.
+
 Run the relevant focused commands while implementing. A typical Rust lane is:
 
 ```sh

--- a/scripts/codestory-agent-ab-benchmark.mjs
+++ b/scripts/codestory-agent-ab-benchmark.mjs
@@ -44,6 +44,7 @@ import {
   isBuilderPacketArm,
   planBuilderAblationRuns,
 } from "./lib/evidence-compiler-ablation.mjs";
+import { canaryBlockers, runBuilderOperationCanary, sandboxCommand } from "./lib/builder-operation-canary.mjs";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const benchmarkHarnessPath = fileURLToPath(import.meta.url);
@@ -2795,10 +2796,10 @@ function builderAblationArmInstruction(arm, continuationContract = null) {
     return "Do not use CodeStory. Investigate with ordinary local search and source reads.";
   }
   if (arm === "exact_identity_source") {
-    return "Your first repository-context action must be a successful CodeStory exact operation. With $CODESTORY_CLI, use only `search --query <identifier-or-terms> --repo-text off`, files, symbol, or snippet. Every CodeStory command must include the exact --project path shown above; search must also include --profile agent --run-id shared-agent. Do not pass cache, refresh, or output-file overrides. After the first CodeStory output, investigate adaptively with ordinary local search and source reads. Any other CodeStory operation invalidates the row.";
+    return "Your first repository-context action must be a successful CodeStory search. With $CODESTORY_CLI, use only `search --query <identifier-or-terms> --repo-text off --refresh none`, files, symbol, or snippet. Every CodeStory command must include the exact --project path shown above; search must also include --profile agent --run-id shared-agent. Do not pass cache, mutating refresh, or output-file overrides. After the first CodeStory output, investigate adaptively with ordinary local search and source reads. Any other CodeStory operation invalidates the row.";
   }
   if (arm === "exact_plus_relations") {
-    return "Your first repository-context action must be a successful CodeStory exact operation. With $CODESTORY_CLI, use `search --query <identifier-or-terms> --repo-text off`, files, symbol, snippet, context, trail, callers, callees, or trace. Every CodeStory command must include the exact --project path shown above; search must also include --profile agent --run-id shared-agent. Do not pass cache, refresh, or output-file overrides. After the first CodeStory output, investigate adaptively with ordinary local search and source reads. Any other CodeStory operation invalidates the row.";
+    return "Your first repository-context action must be a successful CodeStory search. With $CODESTORY_CLI, use `search --query <identifier-or-terms> --repo-text off --refresh none`, files, symbol, snippet, context, trail, callers, callees, or trace. Include at least one successful explicit relation operation. Every CodeStory command must include the exact --project path shown above; search must also include --profile agent --run-id shared-agent. Do not pass cache, mutating refresh, or output-file overrides. After the first CodeStory output, investigate adaptively with ordinary local search and source reads. Any other CodeStory operation invalidates the row.";
   }
   const continuation = continuationContract
     ? ` The packet offers one optional continuation. If you use it, run this exact command as a separate repository-context action and do not run another CodeStory command:
@@ -6532,7 +6533,10 @@ async function runCodeStoryPacketPrelude(opts, run, repoConfig, outDir, runId, c
   const stdoutPath = path.join(outDir, `${runId}.codestory-packet.stdout.json`);
   const stderrPath = path.join(outDir, `${runId}.codestory-packet.stderr.txt`);
   const started = performance.now();
-  let result = await runProcess(codestoryCli, args, {
+  const invocation = opts.builderAblation
+    ? sandboxCommand(opts.sandbox, repoConfig.path, codestoryCli, args)
+    : { command: codestoryCli, args };
+  let result = await runProcess(invocation.command, invocation.args, {
     cwd: repoConfig.path,
     env,
     signal: opts.signal,
@@ -14513,6 +14517,7 @@ async function runBuilderAblationPipeline({
   recordPreparation,
   recordPreparationState,
   recordFirstFailure,
+  runOperationCanary,
 }) {
   const cachePreparation = [];
   opts.cachePreparationByRepo ??= new Map();
@@ -14569,6 +14574,22 @@ async function runBuilderAblationPipeline({
     };
   }
 
+  let operationCanary;
+  try {
+    operationCanary = await runOperationCanary({ opts, outDir });
+    const blockers = canaryBlockers(operationCanary);
+    if (blockers.length) throw new Error(blockers.join("; "));
+    opts.operationCanary = operationCanary;
+  } catch (error) {
+    const failure = pipelineStageFailure("operation_canary", null, error);
+    await recordFirstFailure(failure);
+    return {
+      results: [], firstFailure: failure, comparativeFailure: null,
+      comparativePublishable: false, cachePreparation, agentCodexIsolation,
+      operationCanary, experiment_status: "invalid", packet_decision: "not_evaluated", aborted: true,
+    };
+  }
+
   const outcome = await runPlannedAgentRuns(
     { ...opts, jobs: 1 },
     plannedRuns,
@@ -14588,8 +14609,42 @@ async function runBuilderAblationPipeline({
     comparativePublishable: outcome.firstFailure == null,
     cachePreparation,
     agentCodexIsolation,
+    operationCanary,
     aborted: false,
   };
+}
+
+async function runTimedAgentOperationCanary({ opts, outDir }) {
+  if (opts.runner !== "codex") throw new Error("operation canary requires the pinned Codex runner");
+  const cli = resolveCodeStoryCli(opts);
+  const question = "What does seed call?";
+  const proofPath = (arm, continuation = false) => path.join(outDir, `canary-${arm}-${continuation ? "continuation" : "packet"}-proof.json`);
+  return await runBuilderOperationCanary({
+    root: opts.builderAblationStateRoot, outDir, cli, sandbox: opts.sandbox,
+    envForArm: (arm) => {
+      const env = agentRunnerEnv(selectedBenchmarkChildEnv(opts), opts.agentCodexHomes?.[arm], isCodeStoryArm(arm));
+      if (isCodeStoryArm(arm)) env.CODESTORY_CLI = cli;
+      return env;
+    },
+    runProcess,
+    scopeArgs: benchmarkAgentScopeArgs,
+    retrievalArgs: retrievalIndexCommandArgs,
+    packetArgs: (project, arm) => [
+      ...packetCommandArgs({ path: project }, { prompt: question }, opts, arm),
+      "--benchmark-retrieval-proof-out", proofPath(arm),
+    ],
+    continuationArgs: (project, arm, packet) => {
+      const args = drillPacketCommandArgs({ path: project }, { prompt: question }, opts, packet, arm);
+      return args ? [...args, "--benchmark-retrieval-proof-out", proofPath(arm, true)] : null;
+    },
+    validatePacket: async (packet, arm, previous) => {
+      const proof = JSON.parse(await readFile(proofPath(arm, Boolean(previous)), "utf8"));
+      return builderPacketRetrievalProofErrors(proof, previous ? "packet_semantic_off" : arm).length === 0 &&
+        packetV3ContractBlockers(packet).length === 0 &&
+        packet.evidence?.some((row) => row.path === "src/lib.rs" && row.start_line > 0 && row.summary?.includes("leaf")) &&
+        (!previous || JSON.stringify(packet.publication) === JSON.stringify(previous.publication));
+    },
+  });
 }
 
 async function runAgentBenchmarkPipeline({
@@ -14607,6 +14662,7 @@ async function runAgentBenchmarkPipeline({
   recordPreparationState = async () => {},
   recordFirstFailure = async () => {},
   recordComparativeFailure = async () => {},
+  runOperationCanary = runTimedAgentOperationCanary,
 }) {
   if (opts.builderAblation) {
     return await runBuilderAblationPipeline({
@@ -14622,6 +14678,7 @@ async function runAgentBenchmarkPipeline({
       recordPreparation,
       recordPreparationState,
       recordFirstFailure,
+      runOperationCanary,
     });
   }
   if (opts.exactCandidate) {
@@ -15226,6 +15283,8 @@ async function main() {
           packet_semantic_off_scope:
             "dense_candidate_stage_only_model_residency_and_full_publication_health_retained",
           critical_claim_adjudication: "required_external_blinded_receipt",
+          operation_canary: pipeline.operationCanary ?? null,
+          experiment_status: pipeline.experiment_status ?? (firstFailure ? "invalid" : "pending_evaluation"),
         }
       : null,
     runner: opts.runner,

--- a/scripts/codestory-agent-ab-benchmark.mjs
+++ b/scripts/codestory-agent-ab-benchmark.mjs
@@ -44,7 +44,7 @@ import {
   isBuilderPacketArm,
   planBuilderAblationRuns,
 } from "./lib/evidence-compiler-ablation.mjs";
-import { canaryBlockers, runBuilderOperationCanary, sandboxCommand } from "./lib/builder-operation-canary.mjs";
+import { canaryBlockers, canaryExecutionContext, digestObject, environmentIdentity, runBuilderOperationCanary, sandboxCommand } from "./lib/builder-operation-canary.mjs";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const benchmarkHarnessPath = fileURLToPath(import.meta.url);
@@ -5226,6 +5226,7 @@ function builderContinuationOfferReceipt(contract) {
     core_generation_id: contract.core_generation_id,
     retrieval_generation: contract.retrieval_generation,
     question_sha256: contract.question_sha256,
+    proof_path: contract.proof_path,
   };
 }
 
@@ -6767,6 +6768,10 @@ async function runOne(opts, run, outDir) {
   if (opts.builderAblation && isCodeStoryArm(run.arm)) {
     env.CODESTORY_CLI = codestoryPreludeCli;
   }
+  if (opts.builderAblation && (JSON.stringify(environmentIdentity(env)) !== JSON.stringify(opts.operationCanaryContext?.arms?.[run.arm]) ||
+      (isCodeStoryArm(run.arm) && codestoryPreludeCliSha256 !== opts.operationCanaryContext?.cli_sha256))) {
+    throw new Error("timed-agent environment or CLI changed after its operation canary");
+  }
   const interactionStarted = performance.now();
   const baselinePrelude =
     run.arm === "without_codestory"
@@ -7031,6 +7036,7 @@ async function runOne(opts, run, outDir) {
     builder_ablation: opts.builderAblation
       ? {
           contract: "codestory.evidence-compiler-builder-row/v1",
+          execution_context_sha256: digestObject(opts.operationCanaryContext),
           development_only: true,
           release_authority: false,
           fresh: true,
@@ -14518,6 +14524,7 @@ async function runBuilderAblationPipeline({
   recordPreparationState,
   recordFirstFailure,
   runOperationCanary,
+  prepareOperationCanaryContext,
 }) {
   const cachePreparation = [];
   opts.cachePreparationByRepo ??= new Map();
@@ -14575,18 +14582,21 @@ async function runBuilderAblationPipeline({
   }
 
   let operationCanary;
+  let operationCanaryContext;
   try {
-    operationCanary = await runOperationCanary({ opts, outDir });
-    const blockers = canaryBlockers(operationCanary);
+    operationCanaryContext = await prepareOperationCanaryContext(opts);
+    operationCanary = await runOperationCanary({ opts, outDir, expectedContext: operationCanaryContext });
+    const blockers = canaryBlockers(operationCanary, operationCanaryContext);
     if (blockers.length) throw new Error(blockers.join("; "));
     opts.operationCanary = operationCanary;
+    opts.operationCanaryContext = operationCanaryContext;
   } catch (error) {
     const failure = pipelineStageFailure("operation_canary", null, error);
     await recordFirstFailure(failure);
     return {
       results: [], firstFailure: failure, comparativeFailure: null,
       comparativePublishable: false, cachePreparation, agentCodexIsolation,
-      operationCanary, experiment_status: "invalid", packet_decision: "not_evaluated", aborted: true,
+      operationCanary, operationCanaryContext, experiment_status: "invalid", packet_decision: "not_evaluated", aborted: true,
     };
   }
 
@@ -14610,22 +14620,33 @@ async function runBuilderAblationPipeline({
     cachePreparation,
     agentCodexIsolation,
     operationCanary,
+    operationCanaryContext,
     aborted: false,
   };
 }
 
-async function runTimedAgentOperationCanary({ opts, outDir }) {
+function builderCanaryEnvironment(opts, arm) {
+  const env = agentRunnerEnv(selectedBenchmarkChildEnv(opts, arm), opts.agentCodexHomes?.[arm], isCodeStoryArm(arm));
+  if (isCodeStoryArm(arm)) env.CODESTORY_CLI = path.resolve(resolveCodeStoryCli(opts));
+  return env;
+}
+
+async function prepareTimedAgentCanaryContext(opts) {
+  const cli = path.resolve(resolveCodeStoryCli(opts));
+  return canaryExecutionContext({
+    cli, cliSha256: sha256Bytes(await readFile(cli)), sandbox: opts.sandbox,
+    timeoutMs: opts.timeoutMs, envForArm: (arm) => builderCanaryEnvironment(opts, arm),
+  });
+}
+
+async function runTimedAgentOperationCanary({ opts, outDir, expectedContext }) {
   if (opts.runner !== "codex") throw new Error("operation canary requires the pinned Codex runner");
   const cli = resolveCodeStoryCli(opts);
   const question = "What does seed call?";
   const proofPath = (arm, continuation = false) => path.join(outDir, `canary-${arm}-${continuation ? "continuation" : "packet"}-proof.json`);
   return await runBuilderOperationCanary({
-    root: opts.builderAblationStateRoot, outDir, cli, sandbox: opts.sandbox,
-    envForArm: (arm) => {
-      const env = agentRunnerEnv(selectedBenchmarkChildEnv(opts), opts.agentCodexHomes?.[arm], isCodeStoryArm(arm));
-      if (isCodeStoryArm(arm)) env.CODESTORY_CLI = cli;
-      return env;
-    },
+    root: opts.builderAblationStateRoot, outDir, cli, sandbox: opts.sandbox, expectedContext,
+    envForArm: (arm) => builderCanaryEnvironment(opts, arm),
     runProcess,
     scopeArgs: benchmarkAgentScopeArgs,
     retrievalArgs: retrievalIndexCommandArgs,
@@ -14663,6 +14684,7 @@ async function runAgentBenchmarkPipeline({
   recordFirstFailure = async () => {},
   recordComparativeFailure = async () => {},
   runOperationCanary = runTimedAgentOperationCanary,
+  prepareOperationCanaryContext = prepareTimedAgentCanaryContext,
 }) {
   if (opts.builderAblation) {
     return await runBuilderAblationPipeline({
@@ -14679,6 +14701,7 @@ async function runAgentBenchmarkPipeline({
       recordPreparationState,
       recordFirstFailure,
       runOperationCanary,
+      prepareOperationCanaryContext,
     });
   }
   if (opts.exactCandidate) {
@@ -15284,6 +15307,7 @@ async function main() {
             "dense_candidate_stage_only_model_residency_and_full_publication_health_retained",
           critical_claim_adjudication: "required_external_blinded_receipt",
           operation_canary: pipeline.operationCanary ?? null,
+          operation_canary_context: pipeline.operationCanaryContext ?? null,
           experiment_status: pipeline.experiment_status ?? (firstFailure ? "invalid" : "pending_evaluation"),
         }
       : null,

--- a/scripts/codestory-control-row-audit.mjs
+++ b/scripts/codestory-control-row-audit.mjs
@@ -1,0 +1,553 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseArgs as parseNodeArgs } from "node:util";
+
+import {
+  codeStoryInvocationsFromCommand,
+  directBenchmarkCliInvocation,
+} from "./lib/evidence-compiler-ablation.mjs";
+
+const CONTROL_ROW_AUDIT_CONTRACT = "codestory.control-row-audit/v1";
+const CONTROL_ERRATUM_CONTRACT = "codestory.control-row-erratum/v1";
+const CONTROL_ARMS = Object.freeze([
+  "exact_identity_source",
+  "exact_plus_relations",
+]);
+const RELATION_OPERATIONS = new Set([
+  "references",
+  "trail",
+  "callers",
+  "callees",
+  "trace",
+  "neighbors",
+  "shortest_path",
+  "query_subgraph",
+]);
+const SOURCE_BEARING_OPERATIONS = new Set([
+  "search",
+  "symbol",
+  "symbols",
+  "get_node",
+  "definition",
+  "snippet",
+  "context",
+  ...RELATION_OPERATIONS,
+]);
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function parseArgs(argv) {
+  const { values } = parseNodeArgs({
+    args: argv,
+    allowPositionals: false,
+    strict: true,
+    options: {
+      "run-dir": { type: "string" },
+      "out-dir": { type: "string" },
+    },
+  });
+  if (!values["run-dir"] || !values["out-dir"]) {
+    throw new Error(
+      "usage: codestory-control-row-audit.mjs --run-dir <immutable-receipt-dir> --out-dir <new-dir>",
+    );
+  }
+  return {
+    runDir: path.resolve(values["run-dir"]),
+    outDir: path.resolve(values["out-dir"]),
+  };
+}
+
+function parseJsonlWithRawLines(bytes, label) {
+  return bytes.toString("utf8").split(/\r?\n/u).flatMap((line, index) => {
+    if (!line) return [];
+    try {
+      return [{ value: JSON.parse(line), raw: line, line: index + 1 }];
+    } catch (error) {
+      throw new Error(`${label} line ${index + 1} is invalid JSON: ${error.message}`);
+    }
+  });
+}
+
+function artifactPath(runDir, storedPath) {
+  if (typeof storedPath !== "string" || !storedPath) return null;
+  const preserved = path.join(runDir, path.basename(storedPath));
+  return existsSync(preserved) ? preserved : null;
+}
+
+async function readArtifact(runDir, storedPath, label) {
+  const resolved = artifactPath(runDir, storedPath);
+  if (!resolved) {
+    throw new Error(`${label} artifact is missing: ${storedPath ?? "unrecorded"}`);
+  }
+  const bytes = await readFile(resolved);
+  return {
+    bytes,
+    preserved_name: path.basename(resolved),
+    sha256: sha256(bytes),
+  };
+}
+
+function commandEvents(events) {
+  return events.flatMap((event, eventIndex) => {
+    const item = event?.item;
+    if (event?.type !== "item.completed" || item?.type !== "command_execution") {
+      return [];
+    }
+    return [{
+      id: item.id ?? null,
+      event_index: eventIndex,
+      command: String(item.command ?? ""),
+      output: String(item.aggregated_output ?? ""),
+      exit_code: Number.isInteger(item.exit_code) ? item.exit_code : null,
+      status: item.status ?? null,
+    }];
+  });
+}
+
+function parseStructuredError(output) {
+  const text = String(output ?? "").trim();
+  if (!text) return null;
+  try {
+    const parsed = JSON.parse(text);
+    if (parsed?.error && typeof parsed.error === "object") {
+      return {
+        code: typeof parsed.error.code === "string" ? parsed.error.code : "unknown",
+        message: typeof parsed.error.message === "string" ? parsed.error.message : null,
+      };
+    }
+  } catch {
+    // Human CLI errors are parsed below.
+  }
+  const match = text.match(/^Error:\s*([a-z][a-z0-9_-]*):\s*([^\n]*)/iu);
+  return match ? {
+    status: "unavailable",
+    observed_text_error: { code: match[1], message: match[2] },
+    output_sha256: sha256(Buffer.from(text, "utf8")),
+  } : null;
+}
+
+function commandReceipt(command) {
+  const invocations = codeStoryInvocationsFromCommand(command.command);
+  if (!invocations.length) return null;
+  const direct = directBenchmarkCliInvocation(command.command);
+  const structuredError = command.exit_code === 0
+    ? null
+    : parseStructuredError(command.output);
+  return {
+    event_index: command.event_index,
+    command: command.command,
+    operation: direct?.operation ?? invocations[0]?.operation ?? null,
+    arguments: direct?.args ?? null,
+    checksum_bound: invocations.every((entry) => entry.checksum_bound === true),
+    exit_status: command.exit_code,
+    status: command.status,
+    output_bytes: Buffer.byteLength(command.output, "utf8"),
+    output_sha256: sha256(Buffer.from(command.output, "utf8")),
+    error: command.exit_code === 0
+      ? null
+      : structuredError ?? {
+          status: "unavailable",
+          output_sha256: sha256(Buffer.from(command.output, "utf8")),
+        },
+  };
+}
+
+function sourceReadIndex(row, commands) {
+  const reads = row.transcript_analysis?.direct_source_reads;
+  if (!Array.isArray(reads) || row.transcript_analysis?.direct_source_reads_total !== reads.length) {
+    throw new Error(`${row.benchmark_run_id}: source-read telemetry is missing or inconsistent`);
+  }
+  const commandIds = new Set(commands.map((command) => command.id));
+  const byCommand = new Map();
+  for (const read of reads) {
+    const id = read?.command_id;
+    if (typeof id !== "string" || !commandIds.has(id)) {
+      throw new Error(`${row.benchmark_run_id}: source-read telemetry cannot join command ${id}`);
+    }
+    const current = byCommand.get(id) ?? [];
+    current.push(read);
+    byCommand.set(id, current);
+  }
+  return byCommand;
+}
+
+function sourceExposure(command, sourceReads, codeStoryReceipt) {
+  const nativeReads = sourceReads.get(command.id) ?? [];
+  const codeStorySource = codeStoryReceipt?.exit_status === 0 &&
+    SOURCE_BEARING_OPERATIONS.has(codeStoryReceipt.operation);
+  return {
+    read_count: nativeReads.length,
+    bytes: nativeReads.length || codeStorySource
+      ? Buffer.byteLength(command.output, "utf8")
+      : 0,
+  };
+}
+
+function requiredOperationValidity(arm, commands) {
+  const first = commands[0] ?? null;
+  const firstSearchValid = first?.operation === "search" && first?.exit_status === 0;
+  const relationValid = arm !== "exact_plus_relations" ||
+    commands.some((entry) => entry.exit_status === 0 && RELATION_OPERATIONS.has(entry.operation));
+  const reasons = [];
+  if (!firstSearchValid) reasons.push("first required exact search did not succeed");
+  if (!relationValid) reasons.push("no required explicit relation operation succeeded");
+  return {
+    valid: reasons.length === 0,
+    reasons,
+  };
+}
+
+function telemetryValidity(row) {
+  const violations = row.builder_ablation?.operation_violations;
+  const reasons = [];
+  if (!Array.isArray(violations)) {
+    reasons.push("operation telemetry is missing");
+  } else {
+    reasons.push(...violations);
+  }
+  if (row.builder_ablation?.first_codestory_required !== true) {
+    reasons.push("first-CodeStory requirement was not recorded");
+  }
+  if (row.builder_ablation?.first_codestory_pass !== true) {
+    reasons.push("first-CodeStory requirement did not pass");
+  }
+  if (row.transcript_analysis?.codestory_was_first_repository_context_action !== true) {
+    reasons.push("CodeStory was not the first valid repository-context action");
+  }
+  return {
+    valid: reasons.length === 0,
+    reasons: [...new Set(reasons)],
+  };
+}
+
+async function auditControlRow({
+  row,
+  rawRow,
+  runDir,
+  sourceCommit,
+  sourceTree,
+  sourceRunsSha256,
+}) {
+  const stdout = await readArtifact(runDir, row.stdout_path, `${row.benchmark_run_id} stdout`);
+  const stderr = await readArtifact(runDir, row.stderr_path, `${row.benchmark_run_id} stderr`);
+  const transcript = parseJsonlWithRawLines(stdout.bytes, stdout.preserved_name)
+    .map((entry) => entry.value);
+  const commands = commandEvents(transcript);
+  const sourceReads = sourceReadIndex(row, commands);
+  const codeStoryByEvent = new Map();
+  for (const command of commands) {
+    const receipt = commandReceipt(command);
+    if (receipt) codeStoryByEvent.set(command.event_index, receipt);
+  }
+  const codeStoryCommands = [...codeStoryByEvent.values()];
+  const firstFailure = codeStoryCommands.find((entry) => entry.exit_status !== 0) ?? null;
+  const failureIndex = firstFailure?.event_index ?? Number.POSITIVE_INFINITY;
+  const beforeFailure = commands.filter((entry) => entry.event_index < failureIndex);
+  const sourceBeforeFailure = beforeFailure.reduce((total, command) => {
+    const exposure = sourceExposure(command, sourceReads, codeStoryByEvent.get(command.event_index));
+    return {
+      read_count: total.read_count + exposure.read_count,
+      bytes: total.bytes + exposure.bytes,
+    };
+  }, { read_count: 0, bytes: 0 });
+  const fallbackCommands = commands.filter((entry) => entry.event_index > failureIndex);
+  const fallbackActions = fallbackCommands.map((command) => {
+    const codeStory = codeStoryByEvent.get(command.event_index) ?? null;
+    const reads = sourceReads.get(command.id) ?? [];
+    return {
+      event_index: command.event_index,
+      kind: codeStory ? "codestory" : "native",
+      operation: codeStory?.operation ?? null,
+      command: command.command,
+      exit_status: command.exit_code,
+      output_bytes: Buffer.byteLength(command.output, "utf8"),
+      source_read_count: reads.length,
+      source_paths: reads.map((read) => read.path),
+    };
+  });
+  const nativeFallbackWithSource = fallbackActions.filter(
+    (action) => action.kind === "native" && action.source_read_count > 0,
+  );
+  const requiredOperation = requiredOperationValidity(row.arm, codeStoryCommands);
+  const telemetry = telemetryValidity(row);
+  return {
+    contract: CONTROL_ROW_AUDIT_CONTRACT,
+    task: row.task_id,
+    arm: row.arm,
+    repeat: row.repeat,
+    source_commit: sourceCommit,
+    source_tree: sourceTree,
+    row_identity: row.benchmark_run_id,
+    input_binding: {
+      source_runs_sha256: sourceRunsSha256,
+      runs_jsonl_line: rawRow.line,
+      row_sha256: sha256(Buffer.from(rawRow.raw, "utf8")),
+      stdout: {
+        preserved_name: stdout.preserved_name,
+        sha256: stdout.sha256,
+      },
+      stderr: {
+        preserved_name: stderr.preserved_name,
+        sha256: stderr.sha256,
+      },
+    },
+    attempted_codestory_commands: codeStoryCommands,
+    first_failed_codestory_command: firstFailure,
+    source_exposed_before_failure: sourceBeforeFailure,
+    source_byte_measurement: "whole command output containing source; includes formatting; combined reads counted once",
+    subsequent_actions: fallbackActions,
+    native_fallback: {
+      source_read_count: nativeFallbackWithSource.reduce(
+        (sum, action) => sum + action.source_read_count,
+        0,
+      ),
+      source_bytes: nativeFallbackWithSource.reduce(
+        (sum, action) => sum + action.output_bytes,
+        0,
+      ),
+    },
+    required_operation: requiredOperation,
+    telemetry,
+    intervention_valid: requiredOperation.valid && telemetry.valid,
+  };
+}
+
+function auditJsonl(audits) {
+  return `${audits.map((audit) => JSON.stringify(audit)).join("\n")}\n`;
+}
+
+function completeTaskComparison(audits, task, candidateArm, controlArm) {
+  const auditedArms = [candidateArm, controlArm].filter((arm) => CONTROL_ARMS.includes(arm));
+  const expected = auditedArms.flatMap((arm) =>
+    [1, 2, 3].map((repeat) => `${task}\t${arm}\t${repeat}`)
+  );
+  const byKey = new Map(audits.map((row) => [
+    `${row.task}\t${row.arm}\t${row.repeat}`,
+    row,
+  ]));
+  return expected.every((key) => byKey.get(key)?.intervention_valid === true);
+}
+
+function originalMetricSnapshot(builderReceipt, comparison) {
+  if (
+    comparison.candidate_arm === "packet_semantic_off" &&
+    comparison.control_arm === "exact_plus_relations"
+  ) {
+    const source = builderReceipt.packet_acceptance ?? {};
+    return {
+      task_quality_deltas: source.task_quality_deltas ?? null,
+      mean_task_pass_difference: source.mean_task_pass_difference ?? null,
+      exploratory_repository_context_action_ratio:
+        source.exploratory_repository_context_action_ratio ?? null,
+      whole_task_wall_ratio: source.whole_task_wall_ratio ?? null,
+      input_context_ratio: source.input_context_ratio ?? null,
+      packet_only_critical_claims: source.packet_only_critical_claims ?? null,
+    };
+  }
+  const source = builderReceipt.marginal_value?.graph_relations ?? {};
+  return {
+    mean_task_pass_difference: source.mean_task_pass_difference ?? null,
+    exploratory_repository_context_action_ratio:
+      source.exploratory_repository_context_action_ratio ?? null,
+    whole_task_wall_ratio: source.whole_task_wall_ratio ?? null,
+    input_context_ratio: source.input_context_ratio ?? null,
+    candidate_only_critical_claims: source.candidate_only_critical_claims ?? null,
+  };
+}
+
+function buildErratum(audits, builderReceipt, sourceRunsSha256) {
+  const serializedAudit = auditJsonl(audits);
+  const auditSha256 = sha256(Buffer.from(serializedAudit, "utf8"));
+  const tasks = [...new Set(audits.map((row) => row.task))].sort();
+  const comparisons = [
+    { candidate_arm: "packet_semantic_off", control_arm: "exact_plus_relations" },
+    { candidate_arm: "exact_plus_relations", control_arm: "exact_identity_source" },
+  ].map((comparison) => {
+    const taskValidity = tasks.map((task) => ({
+      task,
+      valid: completeTaskComparison(
+        audits,
+        task,
+        comparison.candidate_arm,
+        comparison.control_arm,
+      ),
+    }));
+    return {
+      ...comparison,
+      task_comparisons: taskValidity,
+      aggregate_valid: taskValidity.every((entry) => entry.valid),
+      original_metrics: originalMetricSnapshot(builderReceipt, comparison),
+    };
+  });
+  const invalidComparisons = comparisons.filter((comparison) => !comparison.aggregate_valid);
+  const graphComparison = comparisons.find(
+    (comparison) => comparison.candidate_arm === "exact_plus_relations",
+  );
+  return {
+    contract: CONTROL_ERRATUM_CONTRACT,
+    source_receipt: {
+      source_commit: builderReceipt.source_commit ?? null,
+      source_tree: builderReceipt.source_tree ?? null,
+      runs_sha256: sourceRunsSha256,
+      original_packet_decision: builderReceipt.packet_decision ?? null,
+      original_packet_decision_status: "preserved",
+    },
+    control_row_audit: {
+      contract: CONTROL_ROW_AUDIT_CONTRACT,
+      sha256: auditSha256,
+      rows: audits.length,
+      valid_rows: audits.filter((row) => row.intervention_valid).length,
+      invalid_rows: audits.filter((row) => !row.intervention_valid).map((row) => row.row_identity),
+    },
+    invalidated_comparisons: invalidComparisons,
+    invalidated_layer_decisions: graphComparison?.aggregate_valid === false
+      ? [{
+          layer: "graph_relations",
+          original_decision: builderReceipt.default_layer_decisions?.graph_relations ?? null,
+          reason: "the exact-plus-relations intervention lacked complete valid control rows",
+        }]
+      : [],
+    retained_authority: {
+      absolute_row_outputs: "descriptive_only",
+      packet_decision: "preserved_for_the_evaluated_architecture",
+      dense_semantic_comparison: "not_invalidated_by_this_control_audit",
+      new_architecture_revision_token: "not_created_by_this_erratum",
+    },
+  };
+}
+
+function erratumMarkdown(erratum) {
+  const invalidRows = erratum.control_row_audit.invalid_rows.length;
+  const comparisons = erratum.invalidated_comparisons.map((comparison) =>
+    `- \`${comparison.candidate_arm}\` versus \`${comparison.control_arm}\`: ` +
+    `${comparison.task_comparisons.filter((entry) => !entry.valid).length} task comparisons and ` +
+    "the corresponding aggregate metrics are withdrawn.",
+  ).join("\n");
+  return `# Evidence compiler control erratum
+
+The original \`${erratum.source_receipt.original_packet_decision}\` decision remains attached to the evaluated architecture and receipt. This erratum does not grant it another revision.
+
+The row audit found ${invalidRows} invalid control rows. Their answer text, timings, token counts, and fallback reads remain descriptions of those sessions, but they cannot estimate the named CodeStory interventions.
+
+## Withdrawn comparisons
+
+${comparisons || "- None."}
+
+The dense semantic packet comparison is not invalidated by this control defect. Any separately recorded packet telemetry or continuation violation also remains in force.
+
+Audit SHA-256: \`${erratum.control_row_audit.sha256}\`
+Source runs SHA-256: \`${erratum.source_receipt.runs_sha256}\`
+`;
+}
+
+async function buildControlAudit({ runDir, requireFrozenShape = true }) {
+  const runsPath = path.join(runDir, "runs.jsonl");
+  const builderPath = path.join(runDir, "builder-ablation.json");
+  if (!existsSync(runsPath) || !existsSync(builderPath)) {
+    throw new Error("run directory must contain runs.jsonl and builder-ablation.json");
+  }
+  const runsBytes = await readFile(runsPath);
+  const rawRows = parseJsonlWithRawLines(runsBytes, "runs.jsonl");
+  const builderReceipt = JSON.parse(await readFile(builderPath, "utf8"));
+  const sourceRunsSha256 = sha256(runsBytes);
+  if (builderReceipt.source_runs_sha256 !== sourceRunsSha256) {
+    throw new Error("runs.jsonl SHA256 does not match the preserved builder receipt");
+  }
+  const controlRows = rawRows.filter((entry) => CONTROL_ARMS.includes(entry.value?.arm));
+  if (requireFrozenShape) {
+    const tasks = new Set(controlRows.map((entry) => entry.value?.task_id));
+    const keys = new Set(controlRows.map((entry) =>
+      `${entry.value?.task_id}\t${entry.value?.arm}\t${entry.value?.repeat}`
+    ));
+    const complete = [...tasks].every((task) => CONTROL_ARMS.every((arm) =>
+      [1, 2, 3].every((repeat) => keys.has(`${task}\t${arm}\t${repeat}`))
+    ));
+    if (controlRows.length !== 48 || tasks.size !== 8 || keys.size !== 48 || !complete) {
+      throw new Error(
+        `expected 48 unique control rows across 8 tasks; received ${controlRows.length} rows, ${tasks.size} tasks, and ${keys.size} keys`,
+      );
+    }
+  }
+  const audits = [];
+  for (const rawRow of controlRows) {
+    audits.push(await auditControlRow({
+      row: rawRow.value,
+      rawRow,
+      runDir,
+      sourceCommit: builderReceipt.source_commit ?? null,
+      sourceTree: builderReceipt.source_tree ?? null,
+      sourceRunsSha256,
+    }));
+  }
+  audits.sort((left, right) =>
+    left.task.localeCompare(right.task) ||
+    left.arm.localeCompare(right.arm) ||
+    left.repeat - right.repeat
+  );
+  const erratum = buildErratum(audits, builderReceipt, sourceRunsSha256);
+  erratum.source_receipt.builder_receipt_sha256 = sha256(await readFile(builderPath));
+  return { audits, erratum, sourceRunsSha256 };
+}
+
+async function writeControlAudit({ runDir, outDir }) {
+  if (existsSync(outDir)) {
+    throw new Error(`refusing to replace existing audit directory: ${outDir}`);
+  }
+  const result = await buildControlAudit({ runDir, requireFrozenShape: true });
+  await mkdir(outDir, { recursive: false });
+  const auditText = auditJsonl(result.audits);
+  const erratumJson = `${JSON.stringify(result.erratum, null, 2)}\n`;
+  const erratumMd = erratumMarkdown(result.erratum);
+  const artifacts = {
+    "control-row-audit.jsonl": auditText,
+    "control-row-erratum.json": erratumJson,
+    "control-row-erratum.md": erratumMd,
+  };
+  for (const [name, value] of Object.entries(artifacts)) {
+    await writeFile(path.join(outDir, name), value, "utf8");
+  }
+  const checksums = Object.fromEntries(Object.entries(artifacts).map(([name, value]) => [
+    name,
+    sha256(Buffer.from(value, "utf8")),
+  ]));
+  await writeFile(
+    path.join(outDir, "SHA256SUMS.json"),
+    `${JSON.stringify({
+      contract: "codestory.control-row-audit-checksums/v1",
+      source_runs_sha256: result.sourceRunsSha256,
+      artifacts: checksums,
+    }, null, 2)}\n`,
+    "utf8",
+  );
+  return { ...result, checksums };
+}
+
+export {
+  CONTROL_ERRATUM_CONTRACT,
+  CONTROL_ROW_AUDIT_CONTRACT,
+  auditControlRow,
+  auditJsonl,
+  buildControlAudit,
+  buildErratum,
+  erratumMarkdown,
+  parseArgs,
+  writeControlAudit,
+};
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  writeControlAudit(parseArgs(process.argv.slice(2))).then((result) => {
+    console.log(
+      `audited ${result.audits.length} rows; ` +
+      `${result.erratum.control_row_audit.invalid_rows.length} invalid`,
+    );
+  }).catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}

--- a/scripts/codestory-control-row-audit.mjs
+++ b/scripts/codestory-control-row-audit.mjs
@@ -158,16 +158,22 @@ function commandReceipt(command) {
   };
 }
 
-function sourceReadIndex(row, commands) {
+function sourceReadIndex(row, commands, events) {
   const reads = row.transcript_analysis?.direct_source_reads;
   if (!Array.isArray(reads) || row.transcript_analysis?.direct_source_reads_total !== reads.length) {
     throw new Error(`${row.benchmark_run_id}: source-read telemetry is missing or inconsistent`);
   }
-  const commandIds = new Set(commands.map((command) => command.id));
   const byCommand = new Map();
   for (const read of reads) {
     const id = read?.command_id;
-    if (typeof id !== "string" || !commandIds.has(id)) {
+    const matches = commands.filter((command) => command.id === id);
+    const event = events[read.event_index];
+    const starts = events.filter((entry) => entry.type === "item.started" && entry.item?.id === id);
+    if (typeof id !== "string" || matches.length !== 1 ||
+        starts.length > 1 || !["item.started", "item.completed"].includes(event?.type) ||
+        event.item?.type !== "command_execution" || event.item.id !== id ||
+        event.item.command !== matches[0].command || read.event_index > matches[0].event_index ||
+        typeof read.path !== "string" || !read.path.trim()) {
       throw new Error(`${row.benchmark_run_id}: source-read telemetry cannot join command ${id}`);
     }
     const current = byCommand.get(id) ?? [];
@@ -197,6 +203,15 @@ function requiredOperationValidity(arm, commands) {
   const reasons = [];
   if (!firstSearchValid) reasons.push("first required exact search did not succeed");
   if (!relationValid) reasons.push("no required explicit relation operation succeeded");
+  for (const command of commands) {
+    if (command.exit_status !== 0) reasons.push(`CodeStory ${command.operation} did not succeed`);
+    if (!command.checksum_bound || !Array.isArray(command.arguments)) {
+      reasons.push(`CodeStory ${command.operation} lacks a direct checksum-bound command`);
+    }
+    const allowed = new Set(["search", "files", "symbol", "symbols", "get_node", "definition", "snippet",
+      ...(arm === "exact_plus_relations" ? ["context", ...RELATION_OPERATIONS] : [])]);
+    if (!allowed.has(command.operation)) reasons.push(`CodeStory ${command.operation} is forbidden in ${arm}`);
+  }
   return {
     valid: reasons.length === 0,
     reasons,
@@ -239,7 +254,7 @@ async function auditControlRow({
   const transcript = parseJsonlWithRawLines(stdout.bytes, stdout.preserved_name)
     .map((entry) => entry.value);
   const commands = commandEvents(transcript);
-  const sourceReads = sourceReadIndex(row, commands);
+  const sourceReads = sourceReadIndex(row, commands, transcript);
   const codeStoryByEvent = new Map();
   for (const command of commands) {
     const receipt = commandReceipt(command);

--- a/scripts/codestory-evidence-compiler-ablation-evaluate.mjs
+++ b/scripts/codestory-evidence-compiler-ablation-evaluate.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
-import { readFile, writeFile } from "node:fs/promises";
+import { open, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseArgs as parseNodeArgs } from "node:util";
@@ -13,7 +13,7 @@ import {
   evidenceCompilerExperimentValidity,
   marginalValue,
 } from "./lib/evidence-compiler-ablation.mjs";
-import { canaryBlockers } from "./lib/builder-operation-canary.mjs";
+import { canaryBlockers, digestObject } from "./lib/builder-operation-canary.mjs";
 
 function parseArgs(argv) {
   const { values } = parseNodeArgs({
@@ -129,8 +129,13 @@ async function evaluate(opts) {
   const validity = evidenceCompilerExperimentValidity(rows);
   validity.reasons.push(...canaryBlockers(
     summary?.builder_ablation?.operation_canary,
-    rows.find((row) => row.codestory_prelude_cli_sha256)?.codestory_prelude_cli_sha256,
+    summary?.builder_ablation?.operation_canary_context,
   ));
+  const context = summary?.builder_ablation?.operation_canary_context;
+  if (rows.some((row) => row.builder_ablation?.execution_context_sha256 !== digestObject(context) ||
+      (row.arm !== "native_tools" && row.codestory_prelude_cli_sha256 !== context?.cli_sha256))) {
+    validity.reasons.push("model rows do not bind the canary's exact execution context and CLI");
+  }
   validity.valid = validity.reasons.length === 0;
   const packetAcceptance = validity.valid ? evidenceCompilerBuilderAcceptance(rows, adjudication) : null;
   const graphRelations = validity.valid ? marginalValue(
@@ -178,15 +183,22 @@ async function evaluate(opts) {
         : "disable_default",
     },
   };
+  // Exclusive reservation serializes the JSON/Markdown pair. Keep the marker
+  // after failure as well: recovery must never replace a possibly published decision.
+  const reservation = await open(path.join(opts.runDir, ".builder-ablation-reservation"), "wx").catch((error) => {
+    if (error.code === "EEXIST") throw new Error("refusing to replace a reserved builder receipt");
+    throw error;
+  });
+  await reservation.close();
   await writeFile(
     path.join(opts.runDir, "builder-ablation.json"),
     `${JSON.stringify(receipt, null, 2)}\n`,
-    "utf8",
+    { encoding: "utf8", flag: "wx" },
   );
   await writeFile(
     path.join(opts.runDir, "builder-ablation.md"),
     markdownReceipt(receipt),
-    "utf8",
+    { encoding: "utf8", flag: "wx" },
   );
   console.log(`wrote ${path.join(opts.runDir, "builder-ablation.json")}`);
   return receipt;

--- a/scripts/codestory-evidence-compiler-ablation-evaluate.mjs
+++ b/scripts/codestory-evidence-compiler-ablation-evaluate.mjs
@@ -10,8 +10,10 @@ import {
   BUILDER_ABLATION_ARMS,
   BUILDER_ABLATION_TASK_IDS,
   evidenceCompilerBuilderAcceptance,
+  evidenceCompilerExperimentValidity,
   marginalValue,
 } from "./lib/evidence-compiler-ablation.mjs";
+import { canaryBlockers } from "./lib/builder-operation-canary.mjs";
 
 function parseArgs(argv) {
   const { values } = parseNodeArgs({
@@ -66,6 +68,9 @@ function formatRatio(value) {
 }
 
 function markdownReceipt(receipt) {
+  if (receipt.experiment_status === "invalid") {
+    return `# Evidence compiler experiment invalid\n\nPacket decision: **not_evaluated**\n\n${receipt.experiment_validity.reasons.map((reason) => `- ${reason}`).join("\n")}\n\nNo quality aggregate or layer decision was computed. Earlier receipts and their stop decisions are unchanged.\n`;
+  }
   const acceptance = receipt.packet_acceptance;
   const graph = receipt.default_layer_decisions.graph_relations;
   const semantic = receipt.default_layer_decisions.dense_semantic_candidates;
@@ -114,28 +119,37 @@ async function evaluate(opts) {
   if (adjudication.source_runs_sha256 !== runsSha256) {
     throw new Error("adjudication source_runs_sha256 does not match runs.jsonl");
   }
-  const packetAcceptance = evidenceCompilerBuilderAcceptance(rows, adjudication);
-  const graphRelations = marginalValue(
-    rows,
-    "exact_plus_relations",
-    "exact_identity_source",
-    adjudication,
-  );
-  const denseSemanticCandidates = marginalValue(
-    rows,
-    "packet_semantic_on",
-    "packet_semantic_off",
-    adjudication,
-  );
-  const packetDecision = packetNextAction(
-    packetAcceptance.pass,
-    attempt,
-    causalClassification,
-  );
+  if (existsSync(path.join(opts.runDir, "builder-ablation.json"))) {
+    throw new Error("refusing to replace an existing builder receipt; preserve its decision");
+  }
   const summaryPath = path.join(opts.runDir, "summary.json");
   const summary = existsSync(summaryPath)
     ? JSON.parse(await readFile(summaryPath, "utf8"))
     : null;
+  const validity = evidenceCompilerExperimentValidity(rows);
+  validity.reasons.push(...canaryBlockers(
+    summary?.builder_ablation?.operation_canary,
+    rows.find((row) => row.codestory_prelude_cli_sha256)?.codestory_prelude_cli_sha256,
+  ));
+  validity.valid = validity.reasons.length === 0;
+  const packetAcceptance = validity.valid ? evidenceCompilerBuilderAcceptance(rows, adjudication) : null;
+  const graphRelations = validity.valid ? marginalValue(
+    rows,
+    "exact_plus_relations",
+    "exact_identity_source",
+    adjudication,
+  ) : null;
+  const denseSemanticCandidates = validity.valid ? marginalValue(
+    rows,
+    "packet_semantic_on",
+    "packet_semantic_off",
+    adjudication,
+  ) : null;
+  const packetDecision = validity.valid ? packetNextAction(
+    packetAcceptance.pass,
+    attempt,
+    causalClassification,
+  ) : "not_evaluated";
   const receipt = {
     generated_at: new Date().toISOString(),
     evidence_status: "builder_visible_development_only",
@@ -144,6 +158,8 @@ async function evaluate(opts) {
     experiment_attempt: attempt,
     causal_classification: causalClassification,
     packet_decision: packetDecision,
+    experiment_status: validity.valid ? "valid" : "invalid",
+    experiment_validity: validity,
     source_runs_sha256: runsSha256,
     adjudication_sha256: sha256(await readFile(opts.adjudication)),
     source_commit: summary?.source_commit ?? summary?.shard?.attestation?.source_commit ?? null,
@@ -156,8 +172,8 @@ async function evaluate(opts) {
       dense_semantic_candidates: denseSemanticCandidates,
     },
     default_layer_decisions: {
-      graph_relations: graphRelations.positive ? "keep_default" : "disable_default",
-      dense_semantic_candidates: denseSemanticCandidates.positive
+      graph_relations: !validity.valid ? "not_evaluated" : graphRelations.positive ? "keep_default" : "disable_default",
+      dense_semantic_candidates: !validity.valid ? "not_evaluated" : denseSemanticCandidates.positive
         ? "keep_default"
         : "disable_default",
     },

--- a/scripts/lib/builder-operation-canary.mjs
+++ b/scripts/lib/builder-operation-canary.mjs
@@ -7,6 +7,8 @@ import { BUILDER_ABLATION_ARMS } from "./evidence-compiler-ablation.mjs";
 const CONTRACT = "codestory.builder-operation-canary/v1";
 const SOURCE = "pub fn seed() -> usize { leaf() }\npub fn leaf() -> usize { 7 }\n";
 const sha256 = (value) => createHash("sha256").update(value).digest("hex");
+const digestObject = (value) => sha256(JSON.stringify(value ?? null));
+const isDigest = (value) => /^[a-f0-9]{64}$/u.test(value ?? "");
 const REQUIRED = Object.freeze({
   native_tools: ["native_search", "native_source"],
   exact_identity_source: ["search", "snippet"],
@@ -27,17 +29,50 @@ function sandboxCommand(sandbox, project, command, args) {
   };
 }
 
-function canaryBlockers(receipt, cliSha256 = null) {
+function environmentIdentity(env) {
+  return {
+    codex_home: env.CODEX_HOME ?? null,
+    environment_sha256: digestObject(Object.entries(env).sort(([left], [right]) => left.localeCompare(right))),
+    cache_configuration_sha256: digestObject(Object.entries(env).filter(([key]) => /CODESTORY|HOME|XDG/u.test(key)).sort(([left], [right]) => left.localeCompare(right))),
+  };
+}
+
+function canaryExecutionContext({ cli, cliSha256, sandbox, envForArm, timeoutMs }) {
+  return {
+    contract: "codestory.builder-execution-context/v1",
+    cli_path: path.resolve(cli), cli_sha256: cliSha256,
+    sandbox, permission_profile: ":workspace", runner: "codex", platform: "darwin",
+    process: { shell: false, stdin: "ignore", timeout_ms: timeoutMs },
+    arms: Object.fromEntries(BUILDER_ABLATION_ARMS.map((arm) => [arm, environmentIdentity(envForArm(arm))])),
+  };
+}
+
+function canaryBlockers(receipt, expectedContext) {
   const reasons = [];
+  const operations = Array.isArray(receipt?.operations) ? receipt.operations : [];
   if (receipt?.contract !== CONTRACT || receipt?.status !== "pass") {
     reasons.push("operation canary did not pass");
   }
-  if (cliSha256 && receipt?.cli_sha256 !== cliSha256) {
-    reasons.push("operation canary binary differs from the model-row binary");
+  if (expectedContext?.contract !== "codestory.builder-execution-context/v1" ||
+      expectedContext?.sandbox !== "workspace-write" || expectedContext?.permission_profile !== ":workspace" ||
+      expectedContext?.platform !== "darwin" || expectedContext?.runner !== "codex" ||
+      !path.isAbsolute(expectedContext?.cli_path ?? "") || !isDigest(expectedContext?.cli_sha256) ||
+      expectedContext?.process?.shell !== false || expectedContext?.process?.stdin !== "ignore" ||
+      !(expectedContext?.process?.timeout_ms > 0) ||
+      BUILDER_ABLATION_ARMS.some((arm) => !path.isAbsolute(expectedContext?.arms?.[arm]?.codex_home ?? "") ||
+        !isDigest(expectedContext?.arms?.[arm]?.environment_sha256) || !isDigest(expectedContext?.arms?.[arm]?.cache_configuration_sha256))) {
+    reasons.push("expected timed-agent execution context is missing or invalid");
+  }
+  if (receipt?.context_sha256 !== digestObject(expectedContext) ||
+      receipt?.cli_sha256 !== expectedContext?.cli_sha256 || receipt?.sandbox !== expectedContext?.sandbox) {
+    reasons.push("operation canary differs from the timed-agent execution context");
+  }
+  if (!path.isAbsolute(receipt?.project ?? "")) {
+    reasons.push("operation canary project is missing");
   }
   for (const arm of BUILDER_ABLATION_ARMS) {
     for (const operation of REQUIRED[arm]) {
-      const rows = receipt?.operations?.filter((row) => row.arm === arm && row.operation === operation) ?? [];
+      const rows = operations.filter((row) => row?.arm === arm && row?.operation === operation);
       if (rows.length !== 1 || rows[0].exit_code !== 0 || rows[0].shape_valid !== true ||
           !/^[a-f0-9]{64}$/u.test(rows[0].stdout_sha256 ?? "") ||
           !/^[a-f0-9]{64}$/u.test(rows[0].stderr_sha256 ?? "") ||
@@ -46,14 +81,37 @@ function canaryBlockers(receipt, cliSha256 = null) {
       }
     }
   }
-  for (const row of receipt?.operations ?? []) {
+  for (const row of operations) {
+    if (!row || typeof row.operation !== "string") {
+      reasons.push("malformed operation canary telemetry");
+      continue;
+    }
     if (row.exit_code !== 0 || row.shape_valid !== true) reasons.push(`${row.arm}/${row.operation} failed`);
+    const prefix = ["sandbox", "--permission-profile", ":workspace", "--cd", receipt.project, "--"];
+    const args = Array.isArray(row.arguments) ? row.arguments : [];
+    const command = args?.[6];
+    const operationArgs = args?.slice(7) ?? [];
+    const expectedCommand = row.operation === "native_search" ? "rg" : row.operation === "native_source" ? "sed" : expectedContext?.cli_path;
+    const expectedOperation = row.operation === "continuation" ? "packet" : row.operation;
+    const projectFlag = operationArgs.indexOf("--project");
+    if (row.command !== "codex" || !Array.isArray(args) ||
+        prefix.some((value, index) => args[index] !== value) || command !== expectedCommand ||
+        (!row.operation.startsWith("native_") && (operationArgs[0] !== expectedOperation ||
+          projectFlag < 0 || operationArgs[projectFlag + 1] !== receipt.project)) ||
+        operationArgs.includes("--cache-dir") ||
+        JSON.stringify(row.environment) !== JSON.stringify(expectedContext?.arms?.[row.arm]) ||
+        JSON.stringify(row.process) !== JSON.stringify(expectedContext?.process) ||
+        row.codex_home !== expectedContext?.arms?.[row.arm]?.codex_home ||
+        !BUILDER_ABLATION_ARMS.includes(row.arm) ||
+        !(REQUIRED[row.arm]?.includes(row.operation) || (row.arm.startsWith("packet_") && row.operation === "continuation"))) {
+      reasons.push(`${row.arm}/${row.operation} has missing or mismatched command/environment/process binding`);
+    }
   }
   return reasons;
 }
 
 async function runBuilderOperationCanary({
-  root, outDir, cli, sandbox, envForArm, runProcess,
+  root, outDir, cli, sandbox, envForArm, runProcess, expectedContext,
   scopeArgs, retrievalArgs, packetArgs, continuationArgs, validatePacket,
 }) {
   await mkdir(root, { recursive: true });
@@ -68,6 +126,7 @@ async function runBuilderOperationCanary({
     source_sha256: sha256(SOURCE),
     cli_sha256: sha256(await readFile(cli)),
     sandbox,
+    context_sha256: digestObject(expectedContext),
     operations: [],
   };
   const persist = async () => {
@@ -94,9 +153,12 @@ async function runBuilderOperationCanary({
       const wrapped = sandboxCommand(sandbox, project, command, args);
       const env = envForArm(arm);
       if (!env.CODEX_HOME) throw new Error(`${arm} lacks the isolated timed-agent home`);
+      if (JSON.stringify(environmentIdentity(env)) !== JSON.stringify(expectedContext?.arms?.[arm])) {
+        throw new Error(`${arm} environment changed after context freeze`);
+      }
       const started = performance.now();
       const result = await runProcess(wrapped.command, wrapped.args, {
-        cwd: project, env, timeoutMs: 60_000,
+        cwd: project, env, timeoutMs: expectedContext.process.timeout_ms,
       });
       let shapeValid = false;
       let output = null;
@@ -109,6 +171,7 @@ async function runBuilderOperationCanary({
       receipt.operations.push({
         arm, operation, command: wrapped.command, arguments: wrapped.args,
         sandboxed: true, codex_home: env.CODEX_HOME,
+        environment: environmentIdentity(env), process: expectedContext.process,
         exit_code: result.exitCode, wall_ms: performance.now() - started,
         stdout_sha256: sha256(result.stdout), stderr_sha256: sha256(result.stderr),
         shape_valid: shapeValid,
@@ -148,4 +211,4 @@ async function runBuilderOperationCanary({
   return await persist();
 }
 
-export { CONTRACT, REQUIRED, canaryBlockers, runBuilderOperationCanary, sandboxCommand };
+export { CONTRACT, REQUIRED, canaryBlockers, canaryExecutionContext, digestObject, environmentIdentity, runBuilderOperationCanary, sandboxCommand };

--- a/scripts/lib/builder-operation-canary.mjs
+++ b/scripts/lib/builder-operation-canary.mjs
@@ -1,0 +1,151 @@
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { BUILDER_ABLATION_ARMS } from "./evidence-compiler-ablation.mjs";
+
+const CONTRACT = "codestory.builder-operation-canary/v1";
+const SOURCE = "pub fn seed() -> usize { leaf() }\npub fn leaf() -> usize { 7 }\n";
+const sha256 = (value) => createHash("sha256").update(value).digest("hex");
+const REQUIRED = Object.freeze({
+  native_tools: ["native_search", "native_source"],
+  exact_identity_source: ["search", "snippet"],
+  exact_plus_relations: ["search", "snippet", "callees"],
+  packet_semantic_off: ["packet"],
+  packet_semantic_on: ["packet"],
+});
+
+// Use Codex's own OS sandbox, with the same built-in policy as the agent runner.
+// Unsupported hosts/policies fail closed; a direct CLI fallback is not equivalent.
+function sandboxCommand(sandbox, project, command, args) {
+  if (process.platform !== "darwin" || sandbox !== "workspace-write") {
+    throw new Error("operation canary currently requires the pinned macOS workspace-write cell");
+  }
+  return {
+    command: "codex",
+    args: ["sandbox", "--permission-profile", ":workspace", "--cd", project, "--", command, ...args],
+  };
+}
+
+function canaryBlockers(receipt, cliSha256 = null) {
+  const reasons = [];
+  if (receipt?.contract !== CONTRACT || receipt?.status !== "pass") {
+    reasons.push("operation canary did not pass");
+  }
+  if (cliSha256 && receipt?.cli_sha256 !== cliSha256) {
+    reasons.push("operation canary binary differs from the model-row binary");
+  }
+  for (const arm of BUILDER_ABLATION_ARMS) {
+    for (const operation of REQUIRED[arm]) {
+      const rows = receipt?.operations?.filter((row) => row.arm === arm && row.operation === operation) ?? [];
+      if (rows.length !== 1 || rows[0].exit_code !== 0 || rows[0].shape_valid !== true ||
+          !/^[a-f0-9]{64}$/u.test(rows[0].stdout_sha256 ?? "") ||
+          !/^[a-f0-9]{64}$/u.test(rows[0].stderr_sha256 ?? "") ||
+          !rows[0].sandboxed || !Number.isFinite(rows[0].wall_ms)) {
+        reasons.push(`${arm}/${operation} lacks successful sandboxed operation telemetry`);
+      }
+    }
+  }
+  for (const row of receipt?.operations ?? []) {
+    if (row.exit_code !== 0 || row.shape_valid !== true) reasons.push(`${row.arm}/${row.operation} failed`);
+  }
+  return reasons;
+}
+
+async function runBuilderOperationCanary({
+  root, outDir, cli, sandbox, envForArm, runProcess,
+  scopeArgs, retrievalArgs, packetArgs, continuationArgs, validatePacket,
+}) {
+  await mkdir(root, { recursive: true });
+  const project = await mkdtemp(path.join(root, "operation-canary-"));
+  await mkdir(path.join(project, "src"));
+  await writeFile(path.join(project, "Cargo.toml"), '[package]\nname = "canary"\nversion = "0.0.0"\nedition = "2021"\n');
+  await writeFile(path.join(project, "src", "lib.rs"), SOURCE);
+  const receipt = {
+    contract: CONTRACT,
+    status: "fail",
+    project,
+    source_sha256: sha256(SOURCE),
+    cli_sha256: sha256(await readFile(cli)),
+    sandbox,
+    operations: [],
+  };
+  const persist = async () => {
+    await writeFile(path.join(outDir, "operation-canary.json"), JSON.stringify(receipt, null, 2) + "\n");
+    return receipt;
+  };
+  try {
+    // Preparation is outside the agent sandbox, exactly as task preparation is.
+    receipt.preparation = [];
+    for (const args of [["index", "--project", project, "--format", "json"], retrievalArgs(project)]) {
+      const prepared = await runProcess(cli, args, {
+        cwd: project, env: envForArm("exact_identity_source"), timeoutMs: 120_000,
+      });
+      receipt.preparation.push({
+        arguments: args, exit_code: prepared.exitCode,
+        stdout_sha256: sha256(prepared.stdout), stderr_sha256: sha256(prepared.stderr),
+      });
+      await writeFile(path.join(outDir, `canary-preparation-${args[0]}.stdout`), prepared.stdout);
+      await writeFile(path.join(outDir, `canary-preparation-${args[0]}.stderr`), prepared.stderr);
+      if (prepared.exitCode !== 0) throw new Error("canary preparation failed");
+    }
+
+    async function execute(arm, operation, command, args, validate) {
+      const wrapped = sandboxCommand(sandbox, project, command, args);
+      const env = envForArm(arm);
+      if (!env.CODEX_HOME) throw new Error(`${arm} lacks the isolated timed-agent home`);
+      const started = performance.now();
+      const result = await runProcess(wrapped.command, wrapped.args, {
+        cwd: project, env, timeoutMs: 60_000,
+      });
+      let shapeValid = false;
+      let output = null;
+      if (result.exitCode === 0) {
+        try {
+          output = operation.startsWith("native_") ? result.stdout : JSON.parse(result.stdout);
+          shapeValid = await validate(output) === true;
+        } catch { /* Wrong JSON shape is an invalid intervention, never a quality failure. */ }
+      }
+      receipt.operations.push({
+        arm, operation, command: wrapped.command, arguments: wrapped.args,
+        sandboxed: true, codex_home: env.CODEX_HOME,
+        exit_code: result.exitCode, wall_ms: performance.now() - started,
+        stdout_sha256: sha256(result.stdout), stderr_sha256: sha256(result.stderr),
+        shape_valid: shapeValid,
+      });
+      await writeFile(path.join(outDir, `canary-${arm}-${operation}.stdout`), result.stdout);
+      await writeFile(path.join(outDir, `canary-${arm}-${operation}.stderr`), result.stderr);
+      if (result.exitCode !== 0 || !shapeValid) throw new Error(`${arm}/${operation} failed its operation canary`);
+      return output;
+    }
+    for (const arm of BUILDER_ABLATION_ARMS) {
+      if (arm === "native_tools") {
+        await execute(arm, "native_search", "rg", ["pub fn seed", "src/lib.rs"], (value) => value.includes("pub fn seed"));
+        await execute(arm, "native_source", "sed", ["-n", "1,2p", "src/lib.rs"], (value) => value === SOURCE);
+      } else if (arm.startsWith("exact_")) {
+        const common = ["--project", project, "--refresh", "none", "--format", "json"];
+        const search = await execute(arm, "search", cli,
+          ["search", ...common, ...scopeArgs(), "--query", "seed", "--repo-text", "off"],
+          (value) => value.indexed_symbol_hits?.some((hit) => hit.display_name === "seed" && typeof hit.node_id === "string"));
+        const id = search.indexed_symbol_hits.find((hit) => hit.display_name === "seed").node_id;
+        await execute(arm, "snippet", cli, ["snippet", ...common, "--id", id],
+          (value) => value.snippet?.snippet?.includes("leaf()") === true);
+        if (arm === "exact_plus_relations") {
+          await execute(arm, "callees", cli, ["callees", ...common, "--id", id, "--depth", "1"],
+            (value) => value.trail?.trail?.edges?.length > 0 || value.trail?.edges?.length > 0);
+        }
+      } else {
+        const args = packetArgs(project, arm);
+        const packet = await execute(arm, "packet", cli, args, (value) => validatePacket(value, arm));
+        const next = continuationArgs(project, arm, packet);
+        if (next) await execute(arm, "continuation", cli, next, (value) => validatePacket(value, arm, packet));
+      }
+    }
+    receipt.status = "pass";
+  } catch (error) {
+    receipt.error = error.message;
+  }
+  return await persist();
+}
+
+export { CONTRACT, REQUIRED, canaryBlockers, runBuilderOperationCanary, sandboxCommand };

--- a/scripts/lib/builder-operation-canary.mjs
+++ b/scripts/lib/builder-operation-canary.mjs
@@ -44,12 +44,19 @@ function canaryExecutionContext({ cli, cliSha256, sandbox, envForArm, timeoutMs 
     sandbox, permission_profile: ":workspace", runner: "codex", platform: "darwin",
     process: { shell: false, stdin: "ignore", timeout_ms: timeoutMs },
     arms: Object.fromEntries(BUILDER_ABLATION_ARMS.map((arm) => [arm, environmentIdentity(envForArm(arm))])),
+    canary_requests: [],
   };
+}
+
+function requestBinding(row) {
+  return Object.fromEntries(["arm", "operation", "command", "arguments", "cwd", "codex_home", "environment", "process"]
+    .map((key) => [key, row?.[key]]));
 }
 
 function canaryBlockers(receipt, expectedContext) {
   const reasons = [];
   const operations = Array.isArray(receipt?.operations) ? receipt.operations : [];
+  const requests = Array.isArray(expectedContext?.canary_requests) ? expectedContext.canary_requests : [];
   if (receipt?.contract !== CONTRACT || receipt?.status !== "pass") {
     reasons.push("operation canary did not pass");
   }
@@ -70,6 +77,9 @@ function canaryBlockers(receipt, expectedContext) {
   if (!path.isAbsolute(receipt?.project ?? "")) {
     reasons.push("operation canary project is missing");
   }
+  if (requests.length === 0 || requests.length !== operations.length) {
+    reasons.push("operation canary lacks its complete pre-dispatch request record");
+  }
   for (const arm of BUILDER_ABLATION_ARMS) {
     for (const operation of REQUIRED[arm]) {
       const rows = operations.filter((row) => row?.arm === arm && row?.operation === operation);
@@ -81,24 +91,17 @@ function canaryBlockers(receipt, expectedContext) {
       }
     }
   }
-  for (const row of operations) {
+  for (const [ordinal, row] of operations.entries()) {
     if (!row || typeof row.operation !== "string") {
       reasons.push("malformed operation canary telemetry");
       continue;
     }
     if (row.exit_code !== 0 || row.shape_valid !== true) reasons.push(`${row.arm}/${row.operation} failed`);
-    const prefix = ["sandbox", "--permission-profile", ":workspace", "--cd", receipt.project, "--"];
-    const args = Array.isArray(row.arguments) ? row.arguments : [];
-    const command = args?.[6];
-    const operationArgs = args?.slice(7) ?? [];
-    const expectedCommand = row.operation === "native_search" ? "rg" : row.operation === "native_source" ? "sed" : expectedContext?.cli_path;
-    const expectedOperation = row.operation === "continuation" ? "packet" : row.operation;
-    const projectFlag = operationArgs.indexOf("--project");
-    if (row.command !== "codex" || !Array.isArray(args) ||
-        prefix.some((value, index) => args[index] !== value) || command !== expectedCommand ||
-        (!row.operation.startsWith("native_") && (operationArgs[0] !== expectedOperation ||
-          projectFlag < 0 || operationArgs[projectFlag + 1] !== receipt.project)) ||
-        operationArgs.includes("--cache-dir") ||
+    // The operation owner records the complete request before execution. Do not
+    // reconstruct expected arguments from results or accept a subset of flags.
+    const request = requests[ordinal];
+    if (!request || JSON.stringify(requestBinding(row)) !== JSON.stringify(requestBinding(request)) ||
+        row.command !== "codex" || !Array.isArray(row.arguments) || row.cwd !== receipt.project ||
         JSON.stringify(row.environment) !== JSON.stringify(expectedContext?.arms?.[row.arm]) ||
         JSON.stringify(row.process) !== JSON.stringify(expectedContext?.process) ||
         row.codex_home !== expectedContext?.arms?.[row.arm]?.codex_home ||
@@ -126,14 +129,17 @@ async function runBuilderOperationCanary({
     source_sha256: sha256(SOURCE),
     cli_sha256: sha256(await readFile(cli)),
     sandbox,
-    context_sha256: digestObject(expectedContext),
     operations: [],
   };
   const persist = async () => {
+    receipt.context_sha256 = digestObject(expectedContext);
     await writeFile(path.join(outDir, "operation-canary.json"), JSON.stringify(receipt, null, 2) + "\n");
     return receipt;
   };
   try {
+    if (!Array.isArray(expectedContext?.canary_requests) || expectedContext.canary_requests.length !== 0) {
+      throw new Error("canary requires a fresh pre-dispatch request record");
+    }
     // Preparation is outside the agent sandbox, exactly as task preparation is.
     receipt.preparation = [];
     for (const args of [["index", "--project", project, "--format", "json"], retrievalArgs(project)]) {
@@ -156,9 +162,19 @@ async function runBuilderOperationCanary({
       if (JSON.stringify(environmentIdentity(env)) !== JSON.stringify(expectedContext?.arms?.[arm])) {
         throw new Error(`${arm} environment changed after context freeze`);
       }
+      const dispatch = {
+        arm, operation, command: wrapped.command, arguments: [...wrapped.args], cwd: project,
+        codex_home: env.CODEX_HOME, environment: environmentIdentity(env), process: { ...expectedContext.process },
+      };
+      const request = structuredClone(dispatch);
+      const ordinal = expectedContext.canary_requests.length;
+      // Persist separately, before invoking the process. Results cannot mint or
+      // overwrite the request against which dispatch and evaluation are checked.
+      await writeFile(path.join(outDir, `canary-request-${ordinal}.json`), JSON.stringify(request, null, 2) + "\n", { flag: "wx" });
+      expectedContext.canary_requests.push(request);
       const started = performance.now();
-      const result = await runProcess(wrapped.command, wrapped.args, {
-        cwd: project, env, timeoutMs: expectedContext.process.timeout_ms,
+      const result = await runProcess(dispatch.command, [...dispatch.arguments], {
+        cwd: dispatch.cwd, env: { ...env }, timeoutMs: dispatch.process.timeout_ms,
       });
       let shapeValid = false;
       let output = null;
@@ -169,9 +185,7 @@ async function runBuilderOperationCanary({
         } catch { /* Wrong JSON shape is an invalid intervention, never a quality failure. */ }
       }
       receipt.operations.push({
-        arm, operation, command: wrapped.command, arguments: wrapped.args,
-        sandboxed: true, codex_home: env.CODEX_HOME,
-        environment: environmentIdentity(env), process: expectedContext.process,
+        ...dispatch, sandboxed: true,
         exit_code: result.exitCode, wall_ms: performance.now() - started,
         stdout_sha256: sha256(result.stdout), stderr_sha256: sha256(result.stderr),
         shape_valid: shapeValid,

--- a/scripts/lib/evidence-compiler-ablation.mjs
+++ b/scripts/lib/evidence-compiler-ablation.mjs
@@ -262,7 +262,7 @@ const EXACT_OPERATION_ARGUMENTS = Object.freeze({
   search: {
     values: new Set([
       "--project", "--query", "--limit", "--repo-text", "--profile", "--run-id",
-      "--format",
+      "--format", "--refresh",
     ]),
     booleans: new Set(["--why", "--plan-details"]),
   },
@@ -343,6 +343,9 @@ function exactOperationArgumentViolations(operation, command, expectedProject) {
     }
     if (seen.get("--profile") !== "agent" || seen.get("--run-id") !== "shared-agent") {
       violations.push("CLI search must bind the prepared agent profile and run id");
+    }
+    if (seen.has("--refresh") && seen.get("--refresh") !== "none") {
+      violations.push("CLI exact search permits only observational --refresh none");
     }
   }
   return violations;
@@ -454,6 +457,9 @@ function builderOperationViolations(arm, operations, options = {}) {
     return ["CodeStory arm executed no successful CodeStory operation"];
   }
   for (const entry of attempted) {
+    if (entry.successful !== true) {
+      violations.push(`CodeStory operation ${entry.operation ?? "unknown"} did not succeed`);
+    }
     if (entry.source !== "harness_packet_prelude" && entry.transport !== "cli") {
       violations.push("builder ablation permits only the checksum-bound CodeStory CLI");
     }
@@ -771,7 +777,7 @@ function denseStageProofInvocations(receipt, arm) {
   return invocations;
 }
 
-function evidenceCompilerBuilderAcceptance(rows, adjudication, options = {}) {
+function evidenceCompilerExperimentValidity(rows, options = {}) {
   const reasons = [];
   const expectedTaskIds = options.taskIds ?? BUILDER_ABLATION_TASK_IDS;
   const expectedRepeats = options.repeats ?? 3;
@@ -794,6 +800,19 @@ function evidenceCompilerBuilderAcceptance(rows, adjudication, options = {}) {
     const violations = row.builder_ablation?.operation_violations;
     if (!Array.isArray(violations) || violations.length) {
       reasons.push(`row ${row.task_id}/${row.arm}/${row.repeat} has missing or forbidden operation telemetry`);
+    }
+    const operations = row.transcript_analysis?.codestory_operations;
+    if (!Array.isArray(operations) || operations.some((operation) => operation.successful !== true)) {
+      reasons.push(`row ${row.task_id}/${row.arm}/${row.repeat} has missing or failed required-operation telemetry`);
+    } else if (row.arm.startsWith("exact_")) {
+      if (operations[0]?.operation !== "search") {
+        reasons.push(`row ${row.task_id}/${row.arm}/${row.repeat} did not start with exact search`);
+      }
+      if (row.arm === "exact_plus_relations" && !operations.some((operation) =>
+        EXPLICIT_RELATION_OPERATIONS.has(operation.operation) && !EXACT_IDENTITY_SOURCE_OPERATIONS.has(operation.operation)
+      )) {
+        reasons.push(`row ${row.task_id}/${row.arm}/${row.repeat} executed no explicit relation operation`);
+      }
     }
     if (row.comparator_reuse_provenance || row.resume_provenance || row.reused_from) {
       reasons.push(`row ${row.task_id}/${row.arm}/${row.repeat} is not fresh`);
@@ -904,6 +923,20 @@ function evidenceCompilerBuilderAcceptance(rows, adjudication, options = {}) {
   if (denseSemanticOnInvocations < 1) {
     reasons.push("semantic-on packet rows contain no executed dense candidate stage");
   }
+
+  const pairs = pairedRows(rows, "packet_semantic_off", "exact_plus_relations");
+  if (pairs.length !== expectedTaskIds.length * expectedRepeats || pairs.some((pair) => !timingPairIsEligible(pair))) {
+    reasons.push("packet and primitive timing rows do not share complete eligible cohort identities");
+  }
+  return { valid: reasons.length === 0, reasons: [...new Set(reasons)], expected_rows: expectedRows };
+}
+
+function evidenceCompilerBuilderAcceptance(rows, adjudication, options = {}) {
+  const validity = evidenceCompilerExperimentValidity(rows, options);
+  const reasons = [...validity.reasons];
+  const expectedTaskIds = options.taskIds ?? BUILDER_ABLATION_TASK_IDS;
+  const expectedRepeats = options.repeats ?? 3;
+  const expectedRows = validity.expected_rows;
 
   const packetArm = "packet_semantic_off";
   const controlArm = "exact_plus_relations";
@@ -1051,6 +1084,7 @@ export {
   codeStoryOperationFromMcpTool,
   directBenchmarkCliInvocation,
   evidenceCompilerBuilderAcceptance,
+  evidenceCompilerExperimentValidity,
   isBuilderAblationArm,
   isBuilderCodeStoryArm,
   isBuilderPacketArm,

--- a/scripts/lib/evidence-compiler-ablation.mjs
+++ b/scripts/lib/evidence-compiler-ablation.mjs
@@ -814,6 +814,15 @@ function evidenceCompilerExperimentValidity(rows, options = {}) {
         reasons.push(`row ${row.task_id}/${row.arm}/${row.repeat} executed no explicit relation operation`);
       }
     }
+    if (Array.isArray(operations)) {
+      const offer = row.builder_ablation?.continuation_offer;
+      reasons.push(...builderOperationViolations(row.arm, operations, {
+        expectedProject: row.repo_path,
+        continuationContract: offer ? {
+          ...offer, project: row.repo_path, question: row.task_manifest_snapshot?.prompt,
+        } : null,
+      }).map((reason) => `row ${row.task_id}/${row.arm}/${row.repeat}: ${reason}`));
+    }
     if (row.comparator_reuse_provenance || row.resume_provenance || row.reused_from) {
       reasons.push(`row ${row.task_id}/${row.arm}/${row.repeat} is not fresh`);
     }

--- a/scripts/tests/builder-operation-canary.test.mjs
+++ b/scripts/tests/builder-operation-canary.test.mjs
@@ -1,17 +1,23 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { mkdtemp, readFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { canaryBlockers, runBuilderOperationCanary, sandboxCommand } from "../lib/builder-operation-canary.mjs";
+import { canaryBlockers, canaryExecutionContext, runBuilderOperationCanary, sandboxCommand } from "../lib/builder-operation-canary.mjs";
+import { contextMutations, passingCanaryFixture } from "./helpers/builder-canary-fixture.mjs";
 
 test("operation canary executes required surfaces in the timed-agent sandbox and fails closed", { skip: process.platform !== "darwin" }, async () => {
   for (const fault of [null, "exit", "shape", "missing_exit"]) {
     const root = await mkdtemp(path.join(os.tmpdir(), "codestory-canary-test-"));
     const calls = [];
+    const envForArm = (arm) => ({ CODEX_HOME: `/isolated/${arm}`, CODESTORY_CACHE_ROOT: "/prepared/cache" });
+    const expectedContext = canaryExecutionContext({
+      cli: process.execPath, cliSha256: createHash("sha256").update(await readFile(process.execPath)).digest("hex"),
+      sandbox: "workspace-write", envForArm, timeoutMs: 60_000,
+    });
     const receipt = await runBuilderOperationCanary({
-      root, outDir: root, cli: process.execPath, sandbox: "workspace-write",
-      envForArm: (arm) => ({ CODEX_HOME: `/isolated/${arm}`, CODESTORY_CACHE_ROOT: "/prepared/cache" }),
+      root, outDir: root, cli: process.execPath, sandbox: "workspace-write", expectedContext, envForArm,
       scopeArgs: () => ["--profile", "agent", "--run-id", "shared-agent"],
       retrievalArgs: (project) => ["retrieval", "index", "--project", project],
       packetArgs: (project) => ["packet", "--project", project],
@@ -39,13 +45,23 @@ test("operation canary executes required surfaces in the timed-agent sandbox and
       assert.ok(canaryBlockers(receipt).length > 0);
     } else {
       assert.equal(receipt.status, "pass", receipt.error);
-      assert.deepEqual(canaryBlockers(receipt, receipt.cli_sha256), []);
+      assert.deepEqual(canaryBlockers(receipt, expectedContext), []);
       assert.equal(receipt.operations.length, 9);
-      assert.ok(canaryBlockers(receipt, "0".repeat(64)).length > 0);
+      assert.ok(canaryBlockers(receipt, { ...expectedContext, cli_sha256: "0".repeat(64) }).length > 0);
       assert.ok(calls.filter((call) => call.command === "codex").every((call) => call.options.env.CODESTORY_CACHE_ROOT === "/prepared/cache"));
     }
     assert.deepEqual(JSON.parse(await readFile(path.join(root, "operation-canary.json"), "utf8")), receipt);
     assert.equal(calls.some((call) => call.args[0] === "exec"), false, "canary never starts a model");
+  }
+});
+
+test("canary rejects missing and contradictory execution context", () => {
+  const passing = passingCanaryFixture();
+  assert.deepEqual(canaryBlockers(passing.receipt, passing.context), []);
+  for (const mutate of contextMutations) {
+    const { receipt, context } = passingCanaryFixture();
+    mutate(receipt);
+    assert.ok(canaryBlockers(receipt, context).length > 0);
   }
 });
 

--- a/scripts/tests/builder-operation-canary.test.mjs
+++ b/scripts/tests/builder-operation-canary.test.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { canaryBlockers, runBuilderOperationCanary, sandboxCommand } from "../lib/builder-operation-canary.mjs";
+
+test("operation canary executes required surfaces in the timed-agent sandbox and fails closed", { skip: process.platform !== "darwin" }, async () => {
+  for (const fault of [null, "exit", "shape", "missing_exit"]) {
+    const root = await mkdtemp(path.join(os.tmpdir(), "codestory-canary-test-"));
+    const calls = [];
+    const receipt = await runBuilderOperationCanary({
+      root, outDir: root, cli: process.execPath, sandbox: "workspace-write",
+      envForArm: (arm) => ({ CODEX_HOME: `/isolated/${arm}`, CODESTORY_CACHE_ROOT: "/prepared/cache" }),
+      scopeArgs: () => ["--profile", "agent", "--run-id", "shared-agent"],
+      retrievalArgs: (project) => ["retrieval", "index", "--project", project],
+      packetArgs: (project) => ["packet", "--project", project],
+      continuationArgs: () => null,
+      validatePacket: (value) => value.schema_version === 3,
+      runProcess: async (command, args, options) => {
+        calls.push({ command, args, options });
+        if (command !== "codex") return { exitCode: 0, stdout: "{}", stderr: "" };
+        assert.deepEqual(args.slice(0, 3), ["sandbox", "--permission-profile", ":workspace"]);
+        const operation = args[7] === "--project" ? args[6] : args[7];
+        const source = "pub fn seed() -> usize { leaf() }\npub fn leaf() -> usize { 7 }\n";
+        let stdout;
+        if (args[6] === "rg" || args[6] === "sed") stdout = source;
+        else if (operation === "search") stdout = JSON.stringify({ indexed_symbol_hits: [{ display_name: "seed", node_id: "node-a" }] });
+        else if (operation === "snippet") stdout = JSON.stringify({ snippet: { snippet: source } });
+        else if (operation === "callees") stdout = JSON.stringify({ trail: { trail: { edges: [{}] } } });
+        else stdout = JSON.stringify({ schema_version: 3 });
+        if (fault === "shape") stdout = "{}";
+        return { exitCode: fault === "missing_exit" ? null : fault === "exit" ? 1 : 0, stdout, stderr: fault ? "fault" : "" };
+      },
+    });
+    if (fault) {
+      assert.equal(receipt.status, "fail");
+      assert.equal(receipt.operations.length, 1);
+      assert.ok(canaryBlockers(receipt).length > 0);
+    } else {
+      assert.equal(receipt.status, "pass", receipt.error);
+      assert.deepEqual(canaryBlockers(receipt, receipt.cli_sha256), []);
+      assert.equal(receipt.operations.length, 9);
+      assert.ok(canaryBlockers(receipt, "0".repeat(64)).length > 0);
+      assert.ok(calls.filter((call) => call.command === "codex").every((call) => call.options.env.CODESTORY_CACHE_ROOT === "/prepared/cache"));
+    }
+    assert.deepEqual(JSON.parse(await readFile(path.join(root, "operation-canary.json"), "utf8")), receipt);
+    assert.equal(calls.some((call) => call.args[0] === "exec"), false, "canary never starts a model");
+  }
+});
+
+test("unsupported canary policies never fall back to an unsandboxed command", () => {
+  assert.throws(() => sandboxCommand("danger-full-access", "/repo", "cli", []), /pinned macOS/);
+});

--- a/scripts/tests/builder-operation-canary.test.mjs
+++ b/scripts/tests/builder-operation-canary.test.mjs
@@ -26,6 +26,12 @@ test("operation canary executes required surfaces in the timed-agent sandbox and
       runProcess: async (command, args, options) => {
         calls.push({ command, args, options });
         if (command !== "codex") return { exitCode: 0, stdout: "{}", stderr: "" };
+        const requestOrdinal = expectedContext.canary_requests.length - 1;
+        const request = JSON.parse(await readFile(path.join(root, `canary-request-${requestOrdinal}.json`), "utf8"));
+        assert.deepEqual(request, expectedContext.canary_requests[requestOrdinal]);
+        assert.equal(request.command, command);
+        assert.deepEqual(request.arguments, args);
+        assert.equal(request.cwd, options.cwd);
         assert.deepEqual(args.slice(0, 3), ["sandbox", "--permission-profile", ":workspace"]);
         const operation = args[7] === "--project" ? args[6] : args[7];
         const source = "pub fn seed() -> usize { leaf() }\npub fn leaf() -> usize { 7 }\n";

--- a/scripts/tests/codestory-agent-ab-analyzer.test.mjs
+++ b/scripts/tests/codestory-agent-ab-analyzer.test.mjs
@@ -4,6 +4,7 @@ import { spawnSync } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { existsSync } from "node:fs";
 import assert from "node:assert/strict";
+import { contextMutations, passingCanaryFixture } from "./helpers/builder-canary-fixture.mjs";
 import { chmod, copyFile, mkdir, mkdtemp, readFile, readdir, realpath, rm, symlink, truncate, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -3605,6 +3606,7 @@ test("builder operation canary aborts all model launches on failure or missing t
     const outcome = await runAgentBenchmarkPipeline({
       ...fixture,
       prepareGroup: async (group) => [pipelinePreparation(group.repo)],
+      prepareOperationCanaryContext: async () => passingCanaryFixture().context,
       runOperationCanary: async () => canary,
       executeRun: async (_opts, run) => {
         launches.push(run);
@@ -3615,6 +3617,28 @@ test("builder operation canary aborts all model launches on failure or missing t
     assert.equal(outcome.experiment_status, "invalid");
     assert.equal(outcome.packet_decision, "not_evaluated");
     assert.equal(outcome.aborted, true);
+  }
+});
+
+test("builder operation canary binds permissions, commands and environment before dispatch", async () => {
+  for (const mutate of [null, ...contextMutations]) {
+    const fixture = pipelineFixture({ repos: ["canary"] });
+    fixture.opts.builderAblation = true;
+    const { context, receipt } = passingCanaryFixture();
+    if (mutate) mutate(receipt);
+    const launches = [];
+    const outcome = await runAgentBenchmarkPipeline({
+      ...fixture,
+      prepareGroup: async (group) => [pipelinePreparation(group.repo)],
+      prepareOperationCanaryContext: async () => context,
+      runOperationCanary: async () => receipt,
+      executeRun: async (_opts, run) => { launches.push(run); return pipelineResult(run); },
+    });
+    assert.equal(launches.length, mutate ? 0 : fixture.plannedRuns.length);
+    if (mutate) {
+      assert.equal(outcome.experiment_status, "invalid");
+      assert.equal(outcome.packet_decision, "not_evaluated");
+    }
   }
 });
 

--- a/scripts/tests/codestory-agent-ab-analyzer.test.mjs
+++ b/scripts/tests/codestory-agent-ab-analyzer.test.mjs
@@ -3597,6 +3597,27 @@ test("benchmark pipeline fences a failed canary and counts a passing canary once
   assert.equal(nonOwnerResult.results.some((row) => row.canary), false);
 });
 
+test("builder operation canary aborts all model launches on failure or missing telemetry", async () => {
+  for (const canary of [null, { status: "fail" }, { status: "pass", operations: [] }]) {
+    const fixture = pipelineFixture({ repos: ["canary"] });
+    fixture.opts.builderAblation = true;
+    const launches = [];
+    const outcome = await runAgentBenchmarkPipeline({
+      ...fixture,
+      prepareGroup: async (group) => [pipelinePreparation(group.repo)],
+      runOperationCanary: async () => canary,
+      executeRun: async (_opts, run) => {
+        launches.push(run);
+        return pipelineResult(run);
+      },
+    });
+    assert.deepEqual(launches, []);
+    assert.equal(outcome.experiment_status, "invalid");
+    assert.equal(outcome.packet_decision, "not_evaluated");
+    assert.equal(outcome.aborted, true);
+  }
+});
+
 test("benchmark pipeline rejects missing or wrong-repository canary preparation before agents", async () => {
   for (const prepared of [[], [pipelinePreparation("wrong-repo")]]) {
     const launched = [];

--- a/scripts/tests/codestory-control-row-audit.test.mjs
+++ b/scripts/tests/codestory-control-row-audit.test.mjs
@@ -1,0 +1,166 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  auditControlRow,
+  buildControlAudit,
+  buildErratum,
+} from "../codestory-control-row-audit.mjs";
+
+const hash = (value) => createHash("sha256").update(value).digest("hex");
+const receipt = {
+  source_commit: "a".repeat(40),
+  source_tree: "b".repeat(40),
+  packet_decision: "stop",
+  packet_acceptance: { mean_task_pass_difference: -0.2 },
+  marginal_value: { graph_relations: { mean_task_pass_difference: 0.1 } },
+  default_layer_decisions: { graph_relations: "disable_default" },
+};
+
+async function fixture() {
+  const runDir = await mkdtemp(path.join(os.tmpdir(), "codestory-control-audit-"));
+  const events = [
+    {
+      type: "item.completed",
+      item: {
+        id: "search",
+        type: "command_execution",
+        command: '$CODESTORY_CLI search --project /repo --query Alpha --repo-text off',
+        aggregated_output: "Error: internal: Operation not permitted\n",
+        exit_code: 1,
+        status: "failed",
+      },
+    },
+    {
+      type: "item.completed",
+      item: {
+        id: "read",
+        type: "command_execution",
+        command: "sed -n '1,2p' src/alpha.rs src/beta.rs",
+        aggregated_output: "fn alpha() { beta(); }\nfn beta() {}\n",
+        exit_code: 0,
+        status: "completed",
+      },
+    },
+  ];
+  const stdout = events.map((event) => JSON.stringify(event)).join("\n") + "\n";
+  await writeFile(path.join(runDir, "row.stdout.jsonl"), stdout);
+  await writeFile(path.join(runDir, "row.stderr.txt"), "");
+  const row = {
+    benchmark_run_id: "case-exact-1",
+    task_id: "case",
+    arm: "exact_identity_source",
+    repeat: 1,
+    stdout_path: "/old/location/row.stdout.jsonl",
+    stderr_path: "/old/location/row.stderr.txt",
+    builder_ablation: {
+      first_codestory_required: true,
+      first_codestory_pass: false,
+      operation_violations: ["first required operation failed"],
+    },
+    transcript_analysis: {
+      codestory_was_first_repository_context_action: false,
+      direct_source_reads_total: 2,
+      direct_source_reads: [
+        { command_id: "read", path: "src/alpha.rs", event_index: 1 },
+        { command_id: "read", path: "src/beta.rs", event_index: 1 },
+      ],
+    },
+  };
+  const raw = JSON.stringify(row);
+  const params = {
+    row,
+    rawRow: { raw, line: 1 },
+    runDir,
+    sourceCommit: receipt.source_commit,
+    sourceTree: receipt.source_tree,
+    sourceRunsSha256: hash(raw + "\n"),
+  };
+  return { runDir, events, stdout, row, params };
+}
+
+test("control audit binds commands and artifacts and counts composed source output once", async () => {
+  const setup = await fixture();
+  const audit = await auditControlRow(setup.params);
+  assert.equal(audit.intervention_valid, false);
+  assert.equal(audit.first_failed_codestory_command.exit_status, 1);
+  assert.deepEqual(audit.first_failed_codestory_command.arguments, [
+    "--project", "/repo", "--query", "Alpha", "--repo-text", "off",
+  ]);
+  assert.equal(audit.input_binding.stdout.sha256, hash(setup.stdout));
+  assert.equal(audit.input_binding.stderr.sha256, hash(""));
+  assert.equal(audit.input_binding.row_sha256, hash(setup.params.rawRow.raw));
+  assert.deepEqual(audit.source_exposed_before_failure, { read_count: 0, bytes: 0 });
+  assert.equal(audit.native_fallback.source_read_count, 2);
+  assert.equal(audit.native_fallback.source_bytes,
+    Buffer.byteLength(setup.events[1].item.aggregated_output));
+});
+
+test("audit uses the preserved artifact even when the former mutable path still exists", async () => {
+  const setup = await fixture();
+  const mutableDir = await mkdtemp(path.join(os.tmpdir(), "codestory-audit-mutable-"));
+  const formerPath = path.join(mutableDir, "row.stdout.jsonl");
+  await writeFile(formerPath, '{"type":"unrelated"}\n');
+  setup.params.row.stdout_path = formerPath;
+  const audit = await auditControlRow(setup.params);
+  assert.equal(audit.input_binding.stdout.sha256, hash(setup.stdout));
+  assert.equal(audit.first_failed_codestory_command.exit_status, 1);
+});
+
+test("missing or unjoinable source-read telemetry is never reported as zero measured reads", async () => {
+  for (const mutate of [
+    (row) => { delete row.transcript_analysis.direct_source_reads; },
+    (row) => { row.transcript_analysis.direct_source_reads[0].command_id = "absent"; },
+  ]) {
+    const setup = await fixture();
+    mutate(setup.row);
+    await assert.rejects(() => auditControlRow(setup.params), /source.read telemetry/i);
+  }
+});
+
+test("erratum withdraws the whole aggregate for one invalid repeat and preserves the old stop", () => {
+  const audits = ["one", "two"].flatMap((task) =>
+    ["exact_identity_source", "exact_plus_relations"].flatMap((arm) =>
+      [1, 2, 3].map((repeat) => ({
+        task, arm, repeat,
+        row_identity: `${task}/${arm}/${repeat}`,
+        intervention_valid: true,
+      }))
+    )
+  );
+  assert.equal(buildErratum(audits, receipt, "c".repeat(64)).invalidated_comparisons.length, 0);
+  audits.find((row) => row.task === "two" && row.arm === "exact_plus_relations").intervention_valid = false;
+  const erratum = buildErratum(audits, receipt, "c".repeat(64));
+  assert.equal(erratum.invalidated_comparisons.length, 2);
+  for (const comparison of erratum.invalidated_comparisons) {
+    assert.equal(comparison.aggregate_valid, false);
+    assert.deepEqual(comparison.task_comparisons, [
+      { task: "one", valid: true }, { task: "two", valid: false },
+    ]);
+  }
+  assert.equal(erratum.source_receipt.original_packet_decision, "stop");
+  assert.equal(erratum.source_receipt.original_packet_decision_status, "preserved");
+  const changed = structuredClone(audits);
+  changed[0].observed_bytes = 1;
+  const next = buildErratum(changed, receipt, "c".repeat(64));
+  assert.notEqual(next.control_row_audit.sha256, erratum.control_row_audit.sha256);
+  assert.notEqual(hash(JSON.stringify(next)), hash(JSON.stringify(erratum)));
+});
+
+test("audit rejects a receipt whose runs digest no longer matches", async () => {
+  const setup = await fixture();
+  await writeFile(path.join(setup.runDir, "runs.jsonl"), setup.params.rawRow.raw + "\n");
+  await writeFile(path.join(setup.runDir, "builder-ablation.json"), JSON.stringify({
+    ...receipt, source_runs_sha256: "0".repeat(64),
+  }));
+  await assert.rejects(
+    () => buildControlAudit({ runDir: setup.runDir, requireFrozenShape: false }),
+    /runs.*digest|runs.*sha256/i,
+  );
+  assert.equal(await readFile(path.join(setup.runDir, "runs.jsonl"), "utf8"),
+    setup.params.rawRow.raw + "\n");
+});

--- a/scripts/tests/codestory-control-row-audit.test.mjs
+++ b/scripts/tests/codestory-control-row-audit.test.mjs
@@ -115,11 +115,45 @@ test("missing or unjoinable source-read telemetry is never reported as zero meas
   for (const mutate of [
     (row) => { delete row.transcript_analysis.direct_source_reads; },
     (row) => { row.transcript_analysis.direct_source_reads[0].command_id = "absent"; },
+    (row) => { row.transcript_analysis.direct_source_reads[0].event_index = 0; },
+    (row) => { delete row.transcript_analysis.direct_source_reads[0].path; },
   ]) {
     const setup = await fixture();
     mutate(setup.row);
     await assert.rejects(() => auditControlRow(setup.params), /source.read telemetry/i);
   }
+});
+
+test("duplicate completed command identities cannot multiply measured exposure", async () => {
+  const setup = await fixture();
+  setup.events.push(setup.events[1]);
+  await writeFile(path.join(setup.runDir, "row.stdout.jsonl"), setup.events.map(JSON.stringify).join("\n") + "\n");
+  await assert.rejects(() => auditControlRow(setup.params), /source.read telemetry/);
+});
+
+test("source telemetry may bind the unique start event paired with its completion", async () => {
+  const setup = await fixture();
+  setup.events.splice(1, 0, { type: "item.started", item: { ...setup.events[1].item, exit_code: null } });
+  await writeFile(path.join(setup.runDir, "row.stdout.jsonl"), setup.events.map(JSON.stringify).join("\n") + "\n");
+  const audit = await auditControlRow(setup.params);
+  assert.equal(audit.native_fallback.source_read_count, 2);
+});
+
+test("a failed CodeStory operation remains invalid after successful native fallback", async () => {
+  const setup = await fixture();
+  setup.events[0].item.exit_code = 0;
+  setup.events[0].item.aggregated_output = "source";
+  setup.events.push({ type: "item.completed", item: {
+    id: "snippet", type: "command_execution", command: "$CODESTORY_CLI snippet --project /repo --id node",
+    exit_code: 1, aggregated_output: "failed",
+  } });
+  setup.row.builder_ablation.first_codestory_pass = true;
+  setup.row.builder_ablation.operation_violations = [];
+  setup.row.transcript_analysis.codestory_was_first_repository_context_action = true;
+  await writeFile(path.join(setup.runDir, "row.stdout.jsonl"), setup.events.map(JSON.stringify).join("\n") + "\n");
+  const audit = await auditControlRow(setup.params);
+  assert.equal(audit.intervention_valid, false);
+  assert.match(audit.required_operation.reasons.join(" "), /snippet did not succeed/);
 });
 
 test("erratum withdraws the whole aggregate for one invalid repeat and preserves the old stop", () => {

--- a/scripts/tests/codestory-evidence-compiler-ablation.test.mjs
+++ b/scripts/tests/codestory-evidence-compiler-ablation.test.mjs
@@ -30,7 +30,8 @@ import {
   evaluate,
   packetNextAction,
 } from "../codestory-evidence-compiler-ablation-evaluate.mjs";
-import { CONTRACT as CANARY_CONTRACT, REQUIRED as CANARY_REQUIRED } from "../lib/builder-operation-canary.mjs";
+import { digestObject } from "../lib/builder-operation-canary.mjs";
+import { contextMutations, passingCanaryFixture } from "./helpers/builder-canary-fixture.mjs";
 import {
   JUDGMENTS_CONTRACT,
   finalizeAdjudication,
@@ -625,6 +626,7 @@ function passingRows() {
       task_id: taskId,
       arm,
       repeat,
+      repo_path: "/tmp/repo",
       status: "pass",
       quality: { pass: true },
       usage: { input_tokens: arm === "packet_semantic_off" ? 100 : 100 },
@@ -636,7 +638,8 @@ function passingRows() {
       transcript_analysis: {
         codestory_operations: arm === "native_tools" ? [] : arm.startsWith("packet_")
           ? [{ operation: "packet", successful: true, source: "harness_packet_prelude" }]
-          : [{ operation: "search", successful: true }, ...(arm === "exact_plus_relations" ? [{ operation: "callees", successful: true }] : [])],
+          : [{ operation: "search", successful: true, transport: "cli", source: "agent_cli", raw: { command: exactSearchCommand } },
+            ...(arm === "exact_plus_relations" ? [{ operation: "callees", successful: true, transport: "cli", source: "agent_cli", raw: { command: "$CODESTORY_CLI callees --project /tmp/repo --id node" } }] : [])],
         codestory_was_first_repository_context_action: arm !== "native_tools",
         exploratory_repository_context_actions_after_first_codestory:
           arm === "packet_semantic_off" ? 4 : 5,
@@ -644,6 +647,7 @@ function passingRows() {
           arm === "packet_semantic_off" ? 8 : 10,
       },
       builder_ablation: {
+        execution_context_sha256: digestObject(passingCanaryFixture().context),
         operation_violations: [],
         continuation_offer: null,
         first_codestory_required: arm !== "native_tools",
@@ -721,14 +725,8 @@ function zeroAdjudication(rows) {
 }
 
 async function writePassingCanary(root) {
-  const operationCanary = {
-    contract: CANARY_CONTRACT, status: "pass", cli_sha256: "a".repeat(64),
-    operations: Object.entries(CANARY_REQUIRED).flatMap(([arm, operations]) => operations.map((operation) => ({
-      arm, operation, exit_code: 0, shape_valid: true, sandboxed: true,
-      wall_ms: 1, stdout_sha256: "b".repeat(64), stderr_sha256: "c".repeat(64),
-    }))),
-  };
-  await writeFile(path.join(root, "summary.json"), JSON.stringify({ builder_ablation: { operation_canary: operationCanary } }));
+  const { context, receipt } = passingCanaryFixture();
+  await writeFile(path.join(root, "summary.json"), JSON.stringify({ builder_ablation: { operation_canary: receipt, operation_canary_context: context } }));
 }
 
 test("frozen packet acceptance passes only with complete independent adjudication", () => {
@@ -797,10 +795,13 @@ test("packet continuations require a same-publication dense-stage execution proo
     core_generation_id: `core-${row.task_id}`,
     retrieval_generation: `retrieval-${row.task_id}`,
     question_sha256: questionSha256,
+    proof_path: "/private/proof.json",
   };
   row.transcript_analysis.codestory_operations = [
     { operation: "packet", source: "harness_packet_prelude", successful: true },
-    { operation: "packet", source: "agent_cli", successful: true },
+    { operation: "packet", source: "agent_cli", transport: "cli", successful: true, raw: {
+      command: `$CODESTORY_CLI packet --project /tmp/repo --profile agent --run-id shared-agent --question '${row.task_manifest_snapshot.prompt}' --budget standard --format json --parent-packet-id packet-1 --option-id gap-1 --core-generation-id core-${row.task_id} --retrieval-generation retrieval-${row.task_id} --benchmark-retrieval-proof-out /private/proof.json --benchmark-disable-dense-semantic`,
+    } },
   ];
   row.builder_ablation.continuation_retrieval_proof = structuredClone(
     row.codestory_harness_prelude.packet_retrieval_proof,
@@ -963,13 +964,18 @@ test("evaluator binds independent adjudication to the exact run ledger", async (
 });
 
 test("invalid interventions never produce a quality aggregate or consume a revision", async () => {
-  for (const fault of ["no_canary", "missing_telemetry", "failed_search", "no_relation"]) {
+  for (const fault of ["no_canary", "missing_telemetry", "failed_search", "no_relation", "empty_packet", "substituted_packet", "forbidden_native", "wrong_command"]) {
     const root = await mkdtemp(path.join(os.tmpdir(), "codestory-invalid-intervention-"));
     const rows = passingRows();
     const control = rows.find((row) => row.arm === "exact_plus_relations");
     if (fault === "missing_telemetry") delete control.transcript_analysis.codestory_operations;
     if (fault === "failed_search") control.transcript_analysis.codestory_operations[0].successful = false;
     if (fault === "no_relation") control.transcript_analysis.codestory_operations.pop();
+    const packet = rows.find((row) => row.arm === "packet_semantic_off");
+    if (fault === "empty_packet") packet.transcript_analysis.codestory_operations = [];
+    if (fault === "substituted_packet") packet.transcript_analysis.codestory_operations = [control.transcript_analysis.codestory_operations[0]];
+    if (fault === "forbidden_native") rows.find((row) => row.arm === "native_tools").transcript_analysis.codestory_operations.push(control.transcript_analysis.codestory_operations[0]);
+    if (fault === "wrong_command") control.transcript_analysis.codestory_operations[0].raw.command = "/bin/true";
     const runBytes = rows.map((row) => JSON.stringify(row)).join("\n") + "\n";
     await writeFile(path.join(root, "runs.jsonl"), runBytes);
     if (fault !== "no_canary") await writePassingCanary(root);
@@ -980,6 +986,35 @@ test("invalid interventions never produce a quality aggregate or consume a revis
     assert.equal(receipt.packet_decision, "not_evaluated");
     assert.equal(receipt.packet_acceptance, null);
     assert.deepEqual(receipt.marginal_value, { graph_relations: null, dense_semantic_candidates: null });
+  }
+});
+
+test("evaluator rejects context drift and publishes one concurrent decision without replacement", async () => {
+  for (const mutate of [null, ...contextMutations]) {
+    const root = await mkdtemp(path.join(os.tmpdir(), "codestory-context-receipt-"));
+    const rows = passingRows();
+    for (const row of rows.filter((row) => row.arm === "packet_semantic_off")) row.quality.pass = false;
+    const bytes = rows.map(JSON.stringify).join("\n") + "\n";
+    await writeFile(path.join(root, "runs.jsonl"), bytes);
+    const { context, receipt } = passingCanaryFixture();
+    if (mutate) mutate(receipt);
+    await writeFile(path.join(root, "summary.json"), JSON.stringify({ builder_ablation: { operation_canary: receipt, operation_canary_context: context } }));
+    const adjudication = path.join(root, "adjudication.json");
+    await writeFile(adjudication, JSON.stringify({ ...zeroAdjudication(rows), source_runs_sha256: createHash("sha256").update(bytes).digest("hex") }));
+    const opts = { runDir: root, adjudication, attempt: "initial", causalClassification: "new" };
+    if (mutate) {
+      const result = await evaluate(opts);
+      assert.equal(result.packet_decision, "not_evaluated");
+      assert.equal(result.packet_acceptance, null);
+    } else {
+      const results = await Promise.allSettled([evaluate(opts), evaluate({ ...opts, attempt: "general_revision", causalClassification: "equivalent" })]);
+      assert.equal(results.filter((result) => result.status === "fulfilled").length, 1);
+      assert.equal(results.filter((result) => result.status === "rejected").length, 1);
+      const winner = results.find((result) => result.status === "fulfilled").value;
+      const persisted = JSON.parse(await readFile(path.join(root, "builder-ablation.json"), "utf8"));
+      assert.deepEqual(persisted, winner);
+      assert.ok((await readFile(path.join(root, "builder-ablation.md"), "utf8")).includes(winner.packet_decision));
+    }
   }
 });
 

--- a/scripts/tests/codestory-evidence-compiler-ablation.test.mjs
+++ b/scripts/tests/codestory-evidence-compiler-ablation.test.mjs
@@ -30,6 +30,7 @@ import {
   evaluate,
   packetNextAction,
 } from "../codestory-evidence-compiler-ablation-evaluate.mjs";
+import { CONTRACT as CANARY_CONTRACT, REQUIRED as CANARY_REQUIRED } from "../lib/builder-operation-canary.mjs";
 import {
   JUDGMENTS_CONTRACT,
   finalizeAdjudication,
@@ -633,6 +634,9 @@ function passingRows() {
       },
       installed_agent_timing_eligible: true,
       transcript_analysis: {
+        codestory_operations: arm === "native_tools" ? [] : arm.startsWith("packet_")
+          ? [{ operation: "packet", successful: true, source: "harness_packet_prelude" }]
+          : [{ operation: "search", successful: true }, ...(arm === "exact_plus_relations" ? [{ operation: "callees", successful: true }] : [])],
         codestory_was_first_repository_context_action: arm !== "native_tools",
         exploratory_repository_context_actions_after_first_codestory:
           arm === "packet_semantic_off" ? 4 : 5,
@@ -714,6 +718,17 @@ function zeroAdjudication(rows) {
         unsupported_relation_finding_ids: [],
       })),
   };
+}
+
+async function writePassingCanary(root) {
+  const operationCanary = {
+    contract: CANARY_CONTRACT, status: "pass", cli_sha256: "a".repeat(64),
+    operations: Object.entries(CANARY_REQUIRED).flatMap(([arm, operations]) => operations.map((operation) => ({
+      arm, operation, exit_code: 0, shape_valid: true, sandboxed: true,
+      wall_ms: 1, stdout_sha256: "b".repeat(64), stderr_sha256: "c".repeat(64),
+    }))),
+  };
+  await writeFile(path.join(root, "summary.json"), JSON.stringify({ builder_ablation: { operation_canary: operationCanary } }));
 }
 
 test("frozen packet acceptance passes only with complete independent adjudication", () => {
@@ -913,6 +928,7 @@ test("evaluator binds independent adjudication to the exact run ledger", async (
       source_runs_sha256: createHash("sha256").update(runBytes).digest("hex"),
     };
     await writeFile(path.join(root, "runs.jsonl"), runBytes);
+    await writePassingCanary(root);
     const adjudicationPath = path.join(root, "adjudication.json");
     await writeFile(adjudicationPath, `${JSON.stringify(adjudication)}\n`);
 
@@ -943,6 +959,27 @@ test("evaluator binds independent adjudication to the exact run ledger", async (
     );
   } finally {
     await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("invalid interventions never produce a quality aggregate or consume a revision", async () => {
+  for (const fault of ["no_canary", "missing_telemetry", "failed_search", "no_relation"]) {
+    const root = await mkdtemp(path.join(os.tmpdir(), "codestory-invalid-intervention-"));
+    const rows = passingRows();
+    const control = rows.find((row) => row.arm === "exact_plus_relations");
+    if (fault === "missing_telemetry") delete control.transcript_analysis.codestory_operations;
+    if (fault === "failed_search") control.transcript_analysis.codestory_operations[0].successful = false;
+    if (fault === "no_relation") control.transcript_analysis.codestory_operations.pop();
+    const runBytes = rows.map((row) => JSON.stringify(row)).join("\n") + "\n";
+    await writeFile(path.join(root, "runs.jsonl"), runBytes);
+    if (fault !== "no_canary") await writePassingCanary(root);
+    const adjudicationPath = path.join(root, "adjudication.json");
+    await writeFile(adjudicationPath, JSON.stringify({ ...zeroAdjudication(rows), source_runs_sha256: createHash("sha256").update(runBytes).digest("hex") }));
+    const receipt = await evaluate({ runDir: root, adjudication: adjudicationPath, attempt: "general_revision", causalClassification: "equivalent" });
+    assert.equal(receipt.experiment_status, "invalid");
+    assert.equal(receipt.packet_decision, "not_evaluated");
+    assert.equal(receipt.packet_acceptance, null);
+    assert.deepEqual(receipt.marginal_value, { graph_relations: null, dense_semantic_candidates: null });
   }
 });
 
@@ -1135,36 +1172,22 @@ test("evaluator writes the bounded revision or stop decision for a failed packet
       ...zeroAdjudication(rows),
       source_runs_sha256: createHash("sha256").update(runBytes).digest("hex"),
     };
-    await writeFile(path.join(root, "runs.jsonl"), runBytes);
     const adjudicationPath = path.join(root, "adjudication.json");
     await writeFile(adjudicationPath, `${JSON.stringify(adjudication)}\n`);
-
-    const unclassified = await evaluate({
-      runDir: root,
-      adjudication: adjudicationPath,
-      attempt: "initial",
-    });
-    assert.equal(unclassified.packet_decision, "failed_needs_causal_classification");
-    const revision = await evaluate({
-      runDir: root,
-      adjudication: adjudicationPath,
-      attempt: "initial",
-      causalClassification: "new",
-    });
-    assert.equal(revision.packet_decision, "revise_once");
-    const equivalent = await evaluate({
-      runDir: root,
-      adjudication: adjudicationPath,
-      attempt: "initial",
-      causalClassification: "equivalent",
-    });
-    assert.equal(equivalent.packet_decision, "stop");
-    const exhausted = await evaluate({
-      runDir: root,
-      adjudication: adjudicationPath,
-      attempt: "general_revision",
-    });
-    assert.equal(exhausted.packet_decision, "stop");
+    for (const [attempt, causalClassification, expected] of [
+      ["initial", null, "failed_needs_causal_classification"],
+      ["initial", "new", "revise_once"],
+      ["initial", "equivalent", "stop"],
+      ["general_revision", null, "stop"],
+    ]) {
+      const runDir = await mkdtemp(path.join(root, "decision-"));
+      await writeFile(path.join(runDir, "runs.jsonl"), runBytes);
+      await writePassingCanary(runDir);
+      const opts = { runDir, adjudication: adjudicationPath, attempt, causalClassification };
+      const receipt = await evaluate(opts);
+      assert.equal(receipt.packet_decision, expected);
+      await assert.rejects(() => evaluate(opts), /refusing to replace/);
+    }
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/scripts/tests/helpers/builder-canary-fixture.mjs
+++ b/scripts/tests/helpers/builder-canary-fixture.mjs
@@ -6,17 +6,21 @@ export function passingCanaryFixture() {
     cli: process.execPath, cliSha256: "a".repeat(64), sandbox: "workspace-write", timeoutMs: 60_000,
     envForArm: (arm) => ({ CODEX_HOME: `/host/${arm}`, CODESTORY_CACHE_ROOT: "/cache/root" }),
   });
+  context.canary_requests = Object.entries(REQUIRED).flatMap(([arm, operations]) => operations.map((operation) => ({
+    arm, operation, command: "codex", cwd: project,
+    arguments: ["sandbox", "--permission-profile", ":workspace", "--cd", project, "--",
+      ...(operation === "native_search" ? ["rg", "seed", "src/lib.rs"] : operation === "native_source" ? ["sed", "-n", "1,2p", "src/lib.rs"] :
+        [context.cli_path, operation, "--project", project, "--refresh", "none", "--format", "json",
+          ...(operation === "search" ? ["--profile", "agent", "--run-id", "shared-agent", "--query", "seed", "--repo-text", "off"] : ["--id", "seed-id"])])],
+    codex_home: context.arms[arm].codex_home, environment: { ...context.arms[arm] }, process: { ...context.process },
+  })));
   const receipt = {
     contract: CONTRACT, status: "pass", project, cli_sha256: context.cli_sha256,
     sandbox: context.sandbox, context_sha256: digestObject(context),
-    operations: Object.entries(REQUIRED).flatMap(([arm, operations]) => operations.map((operation) => ({
-      arm, operation, exit_code: 0, shape_valid: true, sandboxed: true,
+    operations: context.canary_requests.map((request) => ({
+      ...structuredClone(request), exit_code: 0, shape_valid: true, sandboxed: true,
       wall_ms: 1, stdout_sha256: "b".repeat(64), stderr_sha256: "c".repeat(64),
-      command: "codex",
-      arguments: ["sandbox", "--permission-profile", ":workspace", "--cd", project, "--",
-        ...(operation === "native_search" ? ["rg", "seed", "src/lib.rs"] : operation === "native_source" ? ["sed", "-n", "1,2p", "src/lib.rs"] : [context.cli_path, operation, "--project", project])],
-      codex_home: context.arms[arm].codex_home, environment: { ...context.arms[arm] }, process: { ...context.process },
-    }))),
+    })),
   };
   return { context, receipt };
 }
@@ -28,4 +32,9 @@ export const contextMutations = [
   (receipt) => { receipt.operations[0].command = "/bin/true"; receipt.operations[0].arguments = []; },
   (receipt) => { receipt.operations[0].process = { timeout_ms: 1 }; },
   (receipt) => { receipt.operations[0].environment.cache_configuration_sha256 = "0".repeat(64); },
+  (receipt) => { receipt.operations.find((row) => row.operation === "search").arguments.push("--repo-text", "on", "--refresh", "full"); },
+  (receipt) => { receipt.operations.find((row) => row.operation === "search").arguments.push("--profile", "other", "--run-id", "other"); },
+  (receipt) => { receipt.operations.find((row) => row.operation === "search").arguments.push("--project", "/other/project"); },
+  (receipt) => { receipt.operations.find((row) => row.operation === "native_source").arguments.splice(-1, 1, "/unrelated/source"); },
+  (receipt) => { receipt.operations[0].cwd = "/other/project"; },
 ];

--- a/scripts/tests/helpers/builder-canary-fixture.mjs
+++ b/scripts/tests/helpers/builder-canary-fixture.mjs
@@ -1,0 +1,31 @@
+import { CONTRACT, REQUIRED, canaryExecutionContext, digestObject } from "../../lib/builder-operation-canary.mjs";
+
+export function passingCanaryFixture() {
+  const project = "/canary/project";
+  const context = canaryExecutionContext({
+    cli: process.execPath, cliSha256: "a".repeat(64), sandbox: "workspace-write", timeoutMs: 60_000,
+    envForArm: (arm) => ({ CODEX_HOME: `/host/${arm}`, CODESTORY_CACHE_ROOT: "/cache/root" }),
+  });
+  const receipt = {
+    contract: CONTRACT, status: "pass", project, cli_sha256: context.cli_sha256,
+    sandbox: context.sandbox, context_sha256: digestObject(context),
+    operations: Object.entries(REQUIRED).flatMap(([arm, operations]) => operations.map((operation) => ({
+      arm, operation, exit_code: 0, shape_valid: true, sandboxed: true,
+      wall_ms: 1, stdout_sha256: "b".repeat(64), stderr_sha256: "c".repeat(64),
+      command: "codex",
+      arguments: ["sandbox", "--permission-profile", ":workspace", "--cd", project, "--",
+        ...(operation === "native_search" ? ["rg", "seed", "src/lib.rs"] : operation === "native_source" ? ["sed", "-n", "1,2p", "src/lib.rs"] : [context.cli_path, operation, "--project", project])],
+      codex_home: context.arms[arm].codex_home, environment: { ...context.arms[arm] }, process: { ...context.process },
+    }))),
+  };
+  return { context, receipt };
+}
+
+export const contextMutations = [
+  (receipt) => { receipt.sandbox = "danger-full-access"; },
+  (receipt) => { delete receipt.operations[0].environment; },
+  (receipt) => { receipt.operations[0].codex_home = "/different/host"; },
+  (receipt) => { receipt.operations[0].command = "/bin/true"; receipt.operations[0].arguments = []; },
+  (receipt) => { receipt.operations[0].process = { timeout_ms: 1 }; },
+  (receipt) => { receipt.operations[0].environment.cache_configuration_sha256 = "0".repeat(64); },
+];


### PR DESCRIPTION
## Outcome

Phase 0 of #2116: exact controls become observational, historical comparisons receive a row-bound audit, and invalid experiments cannot produce packet-quality decisions. This draft does not restart the stopped compiler or establish 0.18 usefulness.

Closes #2117
Refs #2116

## Changes

- `search --repo-text off --refresh none` attaches the immutable core directly, without retrieval catalogs or a writer lock. Cold projects fail with `project_unavailable` without creating a cache.
- Preserve immutable context when inspecting the core schema and revalidating a read, preventing SQLite WAL/SHM creation beside sealed generations.
- Add a reproducible 48-row control audit. It authenticates the runs ledger, uses preserved transcripts, binds command outputs and fallback accounting, and emits a separately checksummed erratum. Original receipts are never overwritten.
- Run deterministic arm-operation canaries through the timed-agent Codex sandbox before model launch. Failed commands, wrong shapes, or missing telemetry block the launch barrier.
- Separate experiment validity from quality aggregation. Invalid experiments report `invalid` / `not_evaluated`; no layer selection or revision decision is computed.

## Review

Base: `d8e23f8183353189aeadfcdab6e79504841988ce`.
Review head: `d45cd00bacc1c4a84eb5acad5abd102d4a9cab57`.
Tree: `ccdc3c68ac95ea3f7c7c366d99ce216cc4c694b4`.
Worktree: `/Users/albert/.codex/worktrees/2117-experiment-validity/CodeStory`.

Review the runtime read boundary first, then audit input bindings and validity-before-aggregation. The consolidated review found four evidence-handling issues: incomplete operation validation, missing execution-context binding, ambiguous read joins, and concurrent receipt replacement. All four corrections are independently accepted. The last correction replaced partial flag checks with complete requests recorded separately before execution. Independent mutation runs at the exact head confirmed zero launches and no quality aggregate for changed arguments, source targets, working directory, or missing requests. Keep this PR draft until required CI passes.

## Verification

- CLI golden-path exact-search matrix: 2 passed, including unwritable catalogs and byte/mtime observation, plus cold no-mutation behavior.
- Audit, deterministic-canary, and ablation contracts: 35 passed.
- AB analyzer: 191 passed on the correction tree.
- Rust formatting, diff whitespace, and documentation links passed.
- Authenticated historical audit: 48 invalid control rows, zero source-output bytes before the first failed CodeStory call, 785 subsequent native source reads. The original `stop` remains in force. Output byte totals are whole source-command output, including formatting, not an assertion of exact raw source length.

Audit output: `/Users/albert/.codex/evidence/codestory-2117-control-audit-747dd96d`.
Original evidence: `/Users/albert/.codex/evidence/codestory-v018-evidence-compiler-stop-d8e23f8`.

| Audit artifact | SHA-256 |
| --- | --- |
| `control-row-audit.jsonl` | `68adfcf8813bfbf84bb8f6f3de030f67adc7ad8a660123f39d58cb322d14e13a` |
| `control-row-erratum.json` | `9f9d5169fd47a75f0eed02285e1a30a2867182497acb8df521d17cdbf1766877` |
| `control-row-erratum.md` | `1d104c90fdac6db74526200898a7c03f6766ebd2f466309d5cfe4493e9b5c8c7` |

## Non-claims and follow-up

No model sessions or broad qualification were run. The deterministic sandbox canary has contract-test coverage, not a claimed passing installed-product receipt. No addressed kernel, public schema migration, version bump, calibration, package, or release proof is included. The remaining three delivery slices and all evidence/product gates remain under #2116.

The canary intentionally refuses unsupported host/policy combinations and never falls back to an unsandboxed command. A failure in the exact installed setup remains a blocker, not permission to alter that setup.
