### PR TITLE
[codex] retain verified malformed source without projection authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Malformed text configuration files no longer block the entire repository
+  index. Their source remains visible with an explicit coverage gap; stale
+  symbols and structural claims from an earlier valid version are removed.
+
 - Exact `search --repo-text off --refresh none` works from the existing core
   publication even when retrieval catalogs are unwritable. A project without
   a published core returns `project_unavailable` without creating a cache.

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -1422,6 +1422,14 @@ impl<'a> ProjectionWriter<'a> {
     }
 
     fn accept_storage(&mut self, mut local_storage: IntermediateStorage) -> Result<()> {
+        // A verified malformed snapshot replaces the old projection with source
+        // identity only. An operational failure cannot authorize that removal.
+        let verified_malformed = !local_storage.file_content_hashes.is_empty()
+            && !local_storage.errors.is_empty()
+            && local_storage
+                .errors
+                .iter()
+                .all(|error| error.coverage_reason == Some(FileCoverageReason::Malformed));
         let mut source_identity_only = false;
         if let Some((file_id, file_complete, file_path)) = local_storage
             .files
@@ -1440,12 +1448,12 @@ impl<'a> ProjectionWriter<'a> {
                 .storage
                 .get_callable_projection_states_for_file(file_id)
                 .map_err(|e| anyhow!("Storage state lookup error: {:?}", e))?;
-            let replace_file_owned_projection =
-                !local_storage.structural_text_projections.is_empty()
-                    || local_storage
-                        .files
-                        .first()
-                        .is_some_and(|file| file.language == "openapi");
+            let replace_file_owned_projection = verified_malformed
+                || !local_storage.structural_text_projections.is_empty()
+                || local_storage
+                    .files
+                    .first()
+                    .is_some_and(|file| file.language == "openapi");
             let update_mode = if replace_file_owned_projection {
                 ProjectionUpdateMode::FullReplace
             } else {
@@ -1480,7 +1488,7 @@ impl<'a> ProjectionWriter<'a> {
                 local_storage.impl_anchor_node_ids.clear();
                 self.stats.source_identity_only_files =
                     self.stats.source_identity_only_files.saturating_add(1);
-            } else if !file_complete {
+            } else if !file_complete && !verified_malformed {
                 // An unreadable, drifting, oversized, or parser-partial source is retry
                 // evidence, not proof that its previous symbols disappeared. Preserve the
                 // last verified projection and update only the file/error rows below.
@@ -4006,24 +4014,46 @@ impl WorkspaceIndexer {
                         FileCoverageReason::Oversized
                     }
                 };
-                return PreparedIndexJobResult {
-                    local_storage: incomplete_file_storage(
+                let mut local_storage = incomplete_file_storage(
+                    &prepared_input.full_path,
+                    Some(&prepared_input.source),
+                    language,
+                    codestory_contracts::graph::ErrorInfo {
+                        message: format!(
+                            "Failed to index structural file {:?}: {}",
+                            prepared_input.full_path, error
+                        ),
+                        file_id: None,
+                        line: None,
+                        column: None,
+                        is_fatal: false,
+                        index_step: codestory_contracts::graph::IndexStep::Indexing,
+                        coverage_reason: Some(reason),
+                    },
+                );
+                if reason == FileCoverageReason::Malformed {
+                    match verify_source_snapshot(
                         &prepared_input.full_path,
-                        Some(&prepared_input.source),
-                        language,
-                        codestory_contracts::graph::ErrorInfo {
-                            message: format!(
-                                "Failed to index structural file {:?}: {}",
-                                prepared_input.full_path, error
-                            ),
-                            file_id: None,
-                            line: None,
-                            column: None,
-                            is_fatal: false,
-                            index_step: codestory_contracts::graph::IndexStep::Indexing,
-                            coverage_reason: Some(reason),
-                        },
-                    ),
+                        &prepared_input.content_hash,
+                    ) {
+                        Ok(modification_time) => {
+                            let file = &mut local_storage.files[0];
+                            file.modification_time = modification_time;
+                            local_storage.file_content_hashes.push(
+                                codestory_store::FileContentHash {
+                                    file_id: file.id,
+                                    content_hash: prepared_input.content_hash.clone(),
+                                },
+                            );
+                        }
+                        Err(error) => {
+                            local_storage =
+                                changed_source_storage(&prepared_input.full_path, language, error);
+                        }
+                    }
+                }
+                return PreparedIndexJobResult {
+                    local_storage,
                     cache_write: None,
                     policy_exclusion: None,
                 };

--- a/crates/codestory-runtime/src/index_commit.rs
+++ b/crates/codestory-runtime/src/index_commit.rs
@@ -303,6 +303,7 @@ impl PreparedCoreCommit {
         #[cfg(test)]
         publication_test_checkpoint(PublicationTestBoundary::DatabaseReplacement, cancel_token)?;
         ensure_indexing_active(cancel_token)?;
+        crate::index_coverage::revalidate_malformed_sources(self.staged_mut().store_mut())?;
         let staged_path = self.staged_mut().path().to_path_buf();
         let staged = self
             .staged

--- a/crates/codestory-runtime/src/index_coverage.rs
+++ b/crates/codestory-runtime/src/index_coverage.rs
@@ -54,10 +54,17 @@ fn file_coverage_reason(
     if file.complete {
         return None;
     }
-    if let Some(reason) = errors_by_file
-        .get(&file.id)
-        .and_then(|reasons| reasons.first())
-    {
+    if let Some(reason) = errors_by_file.get(&file.id).and_then(|reasons| {
+        reasons
+            .iter()
+            .find(|reason| {
+                !matches!(
+                    reason,
+                    FileCoverageReason::Malformed | FileCoverageReason::ParserPartial
+                )
+            })
+            .or_else(|| reasons.first())
+    }) {
         return Some(*reason);
     }
     if !file.complete && file.indexed && has_verified_content {
@@ -74,6 +81,44 @@ pub(crate) fn file_coverage_retryable(reason: FileCoverageReason) -> bool {
             | FileCoverageReason::DiscoveryIncomplete
             | FileCoverageReason::CollectorFailure
     )
+}
+
+pub(crate) fn coverage_gap_blocks_publication(gap: &FileCoverageDiagnosticDto) -> bool {
+    match gap.reason {
+        FileCoverageReason::ParserPartial => !gap.verified_source,
+        FileCoverageReason::Malformed => !gap.verified_source || gap.projection_available,
+        _ => true,
+    }
+}
+
+/// Malformed files have no projection to validate. Recheck their authenticated
+/// source identity at the final commit fence, including same-mtime replacement.
+pub(crate) fn revalidate_malformed_sources(storage: &Store) -> Result<(), ApiError> {
+    let malformed = storage
+        .get_errors(None)
+        .map_err(|error| ApiError::internal(format!("Failed to read coverage errors: {error}")))?
+        .into_iter()
+        .filter(|error| error.coverage_reason == Some(FileCoverageReason::Malformed))
+        .filter_map(|error| error.file_id.map(|id| id.0))
+        .collect::<HashSet<_>>();
+    if malformed.is_empty() {
+        return Ok(());
+    }
+    let files = storage.files().inventory().map_err(|error| {
+        ApiError::internal(format!("Failed to read source identities: {error}"))
+    })?;
+    codestory_workspace::reverify_source_freshness_from_content();
+    for file in files.iter().filter(|file| malformed.contains(&file.id)) {
+        if file.content_hash.is_none()
+            || codestory_workspace::stored_file_requires_reindex(&file.path, file)
+        {
+            return Err(ApiError::new(
+                "source_changed",
+                "Malformed source could not be reverified at publication; the candidate was discarded.",
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn file_coverage_detail(reason: FileCoverageReason) -> &'static str {
@@ -499,7 +544,9 @@ impl IndexedFilesAggregation {
                         reason,
                         retryable: file_coverage_retryable(reason),
                         verified_source,
-                        projection_available: file.indexed && verified_source,
+                        projection_available: file.indexed
+                            && verified_source
+                            && reason != FileCoverageReason::Malformed,
                     })
             })
             .collect();

--- a/crates/codestory-runtime/src/index_full.rs
+++ b/crates/codestory-runtime/src/index_full.rs
@@ -26,7 +26,6 @@ use crate::{
 };
 use codestory_contracts::api::{ApiError, AppEventPayload};
 use codestory_contracts::events::EventBus;
-use codestory_contracts::graph::FileCoverageReason;
 use codestory_indexer::{
     ArtifactCachePolicies, ArtifactCachePolicy, CancellationToken, IncrementalIndexingStats,
     WorkspaceIndexer as V2WorkspaceIndexer,
@@ -176,7 +175,7 @@ fn validate_full_refresh_coverage(
 ) -> Result<(), ApiError> {
     let blocking_gaps = stored_file_coverage_diagnostics(root, staged.store_mut())?
         .into_iter()
-        .filter(|entry| entry.reason != FileCoverageReason::ParserPartial)
+        .filter(crate::index_coverage::coverage_gap_blocks_publication)
         .collect::<Vec<_>>();
     if blocking_gaps.is_empty() {
         return Ok(());

--- a/crates/codestory-runtime/src/index_incremental.rs
+++ b/crates/codestory-runtime/src/index_incremental.rs
@@ -382,7 +382,7 @@ fn evaluate_incremental_plan_probe(
     };
     if stored_coverage
         .iter()
-        .any(|entry| entry.reason != FileCoverageReason::ParserPartial)
+        .any(crate::index_coverage::coverage_gap_blocks_publication)
     {
         return IncrementalPlanProbeOutcomeDto::StoredCoverageGap;
     }
@@ -747,7 +747,7 @@ fn validate_incremental_refresh_coverage(
 ) -> Result<(), ApiError> {
     let blocking_gaps = stored_file_coverage_diagnostics(root, staged.store_mut())?
         .into_iter()
-        .filter(|entry| entry.reason != FileCoverageReason::ParserPartial)
+        .filter(crate::index_coverage::coverage_gap_blocks_publication)
         .collect::<Vec<_>>();
     if blocking_gaps.is_empty() {
         return Ok(());

--- a/crates/codestory-runtime/src/source_coverage.rs
+++ b/crates/codestory-runtime/src/source_coverage.rs
@@ -88,11 +88,17 @@ pub(crate) fn observe_source_coverage(
         }
     };
 
-    // `ParserPartial` is the one coverage reason that survives publication —
-    // both refresh gates refuse to commit on any other — so it is exactly the
-    // defect a served packet can rest on, and reporting such a file `Indexed`
-    // would contradict this contract's own definition of the word.
-    let diagnostics = stored_file_coverage_diagnostics(&project_root, &storage).unwrap_or_default();
+    // Parser-partial and verified malformed sources survive publication with
+    // explicit gaps. Neither may be presented as complete indexed coverage.
+    let diagnostics = match stored_file_coverage_diagnostics(&project_root, &storage) {
+        Ok(diagnostics) => diagnostics,
+        Err(_) => {
+            return not_established(
+                &deduped,
+                SourceCoverageNotEstablishedCauseDto::LookupUnavailable,
+            );
+        }
+    };
     let incomplete: Vec<(PathBuf, codestory_contracts::graph::FileCoverageReason)> = diagnostics
         .iter()
         .map(|diagnostic| (project_root.join(&diagnostic.path), diagnostic.reason))

--- a/crates/codestory-runtime/src/tests.rs
+++ b/crates/codestory-runtime/src/tests.rs
@@ -8041,21 +8041,20 @@ fn structural_full_generations_reuse_unchanged_cache_and_preserve_previous_on_in
         "{\"missing_value\":",
     )
     .expect("write malformed JSON");
-    let error = controller
+    controller
         .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
-        .expect_err("malformed structural input must fail closed");
-    assert_eq!(error.code, "source_malformed");
-    assert!(error.details.as_ref().is_some_and(|details| {
-        details
-            .coverage_gaps
+        .expect("verified malformed source publishes without a projection");
+    let structural_before_failure = structural_live_identity(&storage_path);
+    let storage = Store::open_read_only(&storage_path).unwrap();
+    assert!(
+        crate::stored_file_coverage_diagnostics(workspace.path(), &storage)
+            .unwrap()
             .iter()
-            .any(|gap| gap.reason == FileCoverageReason::Malformed)
-    }));
-    assert_eq!(
-        structural_live_identity(&storage_path),
-        structural_before_failure,
-        "malformed input changed the prior structural manifest or cache identity"
+            .any(|gap| gap.reason == FileCoverageReason::Malformed
+                && gap.verified_source
+                && !gap.projection_available)
     );
+    drop(storage);
     assert_no_staged_publication_artifacts(&storage_path);
 
     fs::remove_file(workspace.path().join("malformed.json"))
@@ -8085,7 +8084,7 @@ fn structural_full_generations_reuse_unchanged_cache_and_preserve_previous_on_in
 }
 
 #[test]
-fn full_refresh_excludes_controlled_negative_fixture_but_rejects_production_malformed_source() {
+fn full_refresh_retains_malformed_source_separately_from_controlled_exclusions() {
     let workspace = tempdir().expect("workspace dir");
     let fixture = workspace
         .path()
@@ -8114,16 +8113,19 @@ fn full_refresh_excludes_controlled_negative_fixture_but_rejects_production_malf
         "{\"missing_value\":",
     )
     .expect("write malformed production source");
-    let error = controller
+    controller
         .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
-        .expect_err("malformed production source must still fail closed");
-    assert_eq!(error.code, "source_malformed");
-    assert!(error.details.as_ref().is_some_and(|details| {
-        details
-            .coverage_gaps
+        .expect("verified malformed production source remains in the inventory");
+    let storage = Store::open_read_only(&storage_path).unwrap();
+    assert!(
+        crate::stored_file_coverage_diagnostics(workspace.path(), &storage)
+            .unwrap()
             .iter()
-            .any(|gap| gap.reason == FileCoverageReason::Malformed)
-    }));
+            .any(|gap| gap.path == "production-malformed.json"
+                && gap.reason == FileCoverageReason::Malformed
+                && gap.verified_source
+                && !gap.projection_available)
+    );
 }
 
 #[test]
@@ -8532,15 +8534,19 @@ fn explicit_incremental_rejects_incompatible_structural_publication_before_sourc
     assert!(!controller.state.lock().is_indexing);
     assert_no_staged_publication_artifacts(&storage_path);
 
-    let full_error = controller
+    controller
         .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
-        .expect_err("explicit full refresh must reach malformed source verification");
-    assert_eq!(full_error.code, "source_malformed");
+        .expect("explicit full refresh repairs the manifest and retains malformed source");
+    let storage = Store::open_read_only(&storage_path).unwrap();
+    let publication = storage.get_complete_index_publication().unwrap().unwrap();
+    storage
+        .validate_structural_text_unit_publication(&publication)
+        .unwrap();
     assert!(
-        full_error
-            .message
-            .contains("Effective refresh mode `full` could not verify"),
-        "unexpected full-refresh error: {full_error:?}"
+        crate::stored_file_coverage_diagnostics(workspace.path(), &storage)
+            .unwrap()
+            .iter()
+            .any(|gap| gap.reason == FileCoverageReason::Malformed && gap.verified_source)
     );
 }
 

--- a/crates/codestory-runtime/src/tests/activation_coverage_tests.rs
+++ b/crates/codestory-runtime/src/tests/activation_coverage_tests.rs
@@ -16,6 +16,217 @@ use std::fs;
 use tempfile::tempdir;
 
 #[test]
+fn malformed_source_publication_preserves_bytes_without_projection_authority() {
+    let _env = hybrid_test_env();
+    for (name, malformed, valid) in [
+        (
+            "settings.yml",
+            "options: [\n",
+            "options:\n  enabled: true\n",
+        ),
+        ("settings.json", "{\"options\":", "{\"options\": true}\n"),
+        ("settings.toml", "options = [\n", "options = true\n"),
+    ] {
+        let workspace = tempdir().unwrap();
+        let cache = tempdir().unwrap();
+        let source_path = workspace.path().join(name);
+        let storage_path = cache.path().join("codestory.db");
+        fs::write(workspace.path().join("lib.rs"), "pub fn retained() {}\n").unwrap();
+        let controller = AppController::new_with_config(test_sidecar_runtime_from_env());
+        controller
+            .open_project_summary_with_storage_path(
+                workspace.path().to_path_buf(),
+                storage_path.clone(),
+            )
+            .unwrap();
+
+        // Cold, repair, and regression to malformed all use the same source policy.
+        for (index, source) in [malformed, valid, malformed].into_iter().enumerate() {
+            fs::write(&source_path, source).unwrap();
+            let mode = if index == 0 {
+                IndexMode::Full
+            } else {
+                IndexMode::Incremental
+            };
+            controller
+                .run_indexing_blocking_without_runtime_refresh(mode)
+                .expect("verified malformed source must not prevent publication");
+            let storage = Store::open_read_only(&storage_path).unwrap();
+            assert_eq!(fs::read_to_string(&source_path).unwrap(), source);
+            assert!(
+                storage
+                    .get_nodes()
+                    .unwrap()
+                    .iter()
+                    .any(|node| node.serialized_name == "retained")
+            );
+            let publication = storage.get_complete_index_publication().unwrap().unwrap();
+            let file = storage.get_file_by_path(&source_path).unwrap().unwrap();
+            let inventory = storage.files().inventory().unwrap();
+            let observed = inventory.iter().find(|entry| entry.id == file.id).unwrap();
+            use sha2::{Digest, Sha256};
+            assert_eq!(
+                observed.content_hash.as_deref(),
+                Some(format!("{:x}", Sha256::digest(source.as_bytes())).as_str()),
+                "source digest must survive {name}"
+            );
+            assert!(
+                !observed.retry_required,
+                "unchanged source must not be rescheduled"
+            );
+            let gaps = crate::stored_file_coverage_diagnostics(workspace.path(), &storage).unwrap();
+            if source == malformed {
+                assert!(!file.complete);
+                assert!(gaps.iter().any(|gap| gap.path == name
+                    && gap.reason == FileCoverageReason::Malformed
+                    && gap.verified_source
+                    && !gap.projection_available
+                    && !gap.retryable));
+                let connection = storage.get_connection();
+                let nodes: i64 = connection
+                    .query_row(
+                        "SELECT COUNT(*) FROM node WHERE file_node_id = ?1 AND id != ?1",
+                        [file.id],
+                        |row| row.get(0),
+                    )
+                    .unwrap();
+                assert_eq!(nodes, 0, "malformed source retained graph nodes");
+                for table in ["symbol_search_doc", "dense_anchor_input"] {
+                    let count: i64 = connection
+                        .query_row(
+                            &format!("SELECT COUNT(*) FROM {table} WHERE file_node_id = ?1"),
+                            [file.id],
+                            |row| row.get(0),
+                        )
+                        .unwrap();
+                    assert_eq!(count, 0, "malformed source retained {table}");
+                }
+                assert!(
+                    !storage
+                        .get_structural_text_projection_file_ids()
+                        .unwrap()
+                        .contains(&file.id)
+                );
+                assert_eq!(storage.proof_resolution_fact_count().unwrap(), 0);
+            } else {
+                assert!(file.complete);
+                assert!(gaps.iter().all(|gap| gap.path != name));
+                assert!(
+                    storage
+                        .get_structural_text_projection_file_ids()
+                        .unwrap()
+                        .contains(&file.id)
+                );
+            }
+            drop(storage);
+            let public_files = controller
+                .indexed_files(IndexedFilesRequest {
+                    path_contains: Some(name.into()),
+                    language: None,
+                    role: None,
+                    limit: Some(10),
+                })
+                .unwrap();
+            if source == malformed {
+                assert!(public_files.coverage_gaps.iter().any(|gap| gap.path == name
+                    && gap.reason == FileCoverageReason::Malformed
+                    && gap.verified_source
+                    && !gap.projection_available));
+            }
+            controller
+                .run_indexing_blocking_without_runtime_refresh(IndexMode::Incremental)
+                .expect("unchanged source refresh");
+            assert_eq!(
+                Store::database_index_publication(&storage_path).unwrap(),
+                Some(publication),
+                "unchanged source must preserve its publication"
+            );
+        }
+    }
+}
+
+#[test]
+fn malformed_source_publication_rejects_drift_and_preserves_previous_on_faults() {
+    let _env = hybrid_test_env();
+    for mode in [IndexMode::Full, IndexMode::Incremental] {
+        for scenario in [
+            "drift",
+            "unreadable",
+            "cancel",
+            "publish_failure",
+            "search_cancel",
+            "marker_failure",
+        ] {
+            if scenario == "marker_failure" && mode == IndexMode::Full {
+                continue;
+            }
+            let workspace = tempdir().unwrap();
+            let cache = tempdir().unwrap();
+            let source = workspace.path().join("settings.yml");
+            let storage_path = cache.path().join("codestory.db");
+            fs::write(&source, "options: true\n").unwrap();
+            let controller = AppController::new_with_config(test_sidecar_runtime_from_env());
+            controller
+                .open_project_summary_with_storage_path(
+                    workspace.path().to_path_buf(),
+                    storage_path.clone(),
+                )
+                .unwrap();
+            controller
+                .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+                .unwrap();
+            let previous = Store::database_index_publication(&storage_path).unwrap();
+            let previous_structure = super::structural_live_identity(&storage_path);
+            fs::write(&source, "options: [\n").unwrap();
+            let token = CancellationToken::new();
+            if matches!(scenario, "drift" | "unreadable") {
+                crate::arm_source_policy_before_revalidate_hook(move || {
+                    if scenario == "drift" {
+                        fs::write(&source, "options: {\n").unwrap();
+                    } else {
+                        fs::remove_file(&source).unwrap();
+                        fs::create_dir(&source).unwrap();
+                    }
+                });
+            } else {
+                arm_publication_test_fault(
+                    match scenario {
+                        "search_cancel" => PublicationTestBoundary::SearchBuild,
+                        "marker_failure" => PublicationTestBoundary::MarkerCompletion,
+                        _ => PublicationTestBoundary::DatabaseReplacement,
+                    },
+                    if matches!(scenario, "cancel" | "search_cancel") {
+                        PublicationTestAction::Cancel
+                    } else {
+                        PublicationTestAction::Fail
+                    },
+                );
+            }
+            let error = controller
+                .run_indexing_blocking_without_runtime_refresh_with_cancel(mode, &token)
+                .expect_err("unverified or cancelled source must not publish");
+            assert_eq!(
+                error.code,
+                match scenario {
+                    "cancel" | "search_cancel" => "cancelled",
+                    "publish_failure" | "marker_failure" => "internal",
+                    _ => "source_changed",
+                }
+            );
+            assert_eq!(
+                Store::database_index_publication(&storage_path).unwrap(),
+                previous
+            );
+            assert_eq!(
+                super::structural_live_identity(&storage_path),
+                previous_structure
+            );
+            super::assert_no_staged_publication_artifacts(&storage_path);
+        }
+    }
+}
+
+#[test]
 fn full_refresh_publishes_verified_generic_tagged_template_parser_partial() {
     let _env = hybrid_test_env();
     let workspace = tempdir().expect("workspace");

--- a/crates/codestory-store/src/file_store.rs
+++ b/crates/codestory-store/src/file_store.rs
@@ -44,6 +44,15 @@ impl<'a> FileStore<'a> {
             .storage
             .get_errors(None)?
             .into_iter()
+            .filter(|error| {
+                // Stable format rejection is coverage, not transient failure.
+                // Missing verification or any other error still requires retry.
+                !(error.coverage_reason
+                    == Some(codestory_contracts::graph::FileCoverageReason::Malformed)
+                    && error
+                        .file_id
+                        .is_some_and(|id| content_hashes.contains_key(&id.0)))
+            })
             .filter_map(|error| error.file_id.map(|id| id.0))
             .collect::<HashSet<_>>();
         self.storage
@@ -69,6 +78,51 @@ mod tests {
     use super::*;
     use crate::FileRole;
     use codestory_contracts::graph::{ErrorInfo, FileCoverageReason, IndexStep, NodeId};
+
+    #[test]
+    fn inventory_only_skips_retry_for_verified_format_rejection() {
+        for (reason, verified, retry) in [
+            (FileCoverageReason::Malformed, true, false),
+            (FileCoverageReason::Malformed, false, true),
+            (FileCoverageReason::CollectorFailure, true, true),
+            (FileCoverageReason::SourceChanged, true, true),
+            (FileCoverageReason::Unreadable, false, true),
+        ] {
+            let storage = Store::new_in_memory().unwrap();
+            let file = FileInfo {
+                id: 1,
+                path: PathBuf::from("settings.yml"),
+                language: "yaml".into(),
+                modification_time: 1,
+                indexed: true,
+                complete: false,
+                line_count: 1,
+                file_role: FileRole::Source,
+            };
+            storage.insert_file(&file).unwrap();
+            if verified {
+                storage
+                    .update_file_metadata(&file, Some(&"a".repeat(64)))
+                    .unwrap();
+            }
+            storage
+                .insert_error(&ErrorInfo {
+                    message: "coverage".into(),
+                    file_id: Some(NodeId(1)),
+                    line: None,
+                    column: None,
+                    is_fatal: false,
+                    index_step: IndexStep::Indexing,
+                    coverage_reason: Some(reason),
+                })
+                .unwrap();
+            assert_eq!(
+                storage.files().inventory().unwrap()[0].retry_required,
+                retry,
+                "{reason:?}"
+            );
+        }
+    }
 
     #[test]
     fn inventory_retries_file_errors_but_not_parser_partial_coverage() {

--- a/docs/architecture/subsystems/runtime.md
+++ b/docs/architecture/subsystems/runtime.md
@@ -37,6 +37,14 @@ adapter syntax, SQLite mechanics, parsers, or model execution.
 
 ## Publication contract
 
+A complete core publication may retain verified malformed UTF-8 source with a
+`malformed` coverage gap. It retains the file identity and content digest, not
+structural units, symbol documents, or proof facts. Both full and incremental
+refresh reverify those bytes before publication. A transition from valid to
+malformed removes the old projection; unchanged malformed source does not
+trigger a retry. Unreadable source, incomplete discovery, source drift, and
+collector failures still prevent publication.
+
 Runtime publishes the core index through store, then asks retrieval to finalize
 immutable lexical/vector/SCIP state when a broad operation needs it. On reads it
 requires query hits and candidate resolution to share one


### PR DESCRIPTION
## Result

Verified malformed UTF-8 source can publish with an explicit coverage gap and no structural, semantic, or proof projection. This separate repair unblocks preparation for #2119; it is not evidence that the packet compiler works.

Closes #2121. Refs #2116, #2119.

## Context and change

The frozen witness experiment stopped before any candidate output because one malformed YAML file prevented cold core publication. An independent generic reproduction confirmed the same failure. The user authorized a separate publication-policy repair rather than changing or excluding evaluation source.

The indexer now revalidates and retains malformed-source hashes. Full and incremental gates share the same narrow allowance: verified malformed source without a projection. Incremental valid-to-malformed transitions remove inherited evidence; unchanged malformed files do not request retry. The commit fence rechecks those source identities. Unreadability, source drift, incomplete discovery, and collector failures remain blocking. Public file diagnostics retain the gap and false projection availability.

## Verification

- New cold/repair/regression matrix over YAML, JSON, and TOML; authentic hashes, no stale graph/symbol/dense/proof rows, stable no-op publication, and public diagnostics.
- Drift, unreadability, cancellation, search-build, marker-completion, and publication-failure boundaries preserve the previous generation and leave no staged debris.
- Runtime activation/coverage: 7 passed; structural: 24 passed; malformed filter: 5 passed.
- Store inventory: 2 passed.
- Complete indexer fidelity: 8 passed; complete language coverage: 13 passed.
- Formatting, diff whitespace, and documentation links passed.

The original generic failure and independently specified mutation matrix are preserved externally at `/Users/albert/.codex/evidence/codestory-2121-prechange/`. Independent exact-head acceptance is pending; this PR stays draft until it and required CI pass.

## Risk and non-claims

This changes what constitutes a publishable core: complete source accounting no longer implies successful structural parsing of every file. Malformed source remains incomplete coverage. The correction does not relax proof rules, retrieval readiness, discovery completeness, or content freshness.

No corpus edits, packet ranking, public schema changes, model sessions, version bump, calibration, or release qualification. Old stop receipts are unchanged.
