### PR TITLE
[codex] restore full-refresh graph resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Full indexing now runs call and import resolution after writing the source
+  graph, including when replaying cached parser output. Previously, full
+  refreshes could leave relationships unresolved until an incremental edit.
+
 - Pointer-returning C and C++ functions and variable-bound JavaScript,
   TypeScript, and TSX functions and generators retain their full definitions
   in the source index. Calls through a function expression's private name no

--- a/crates/codestory-cli/tests/codestory_repo_e2e_stats.rs
+++ b/crates/codestory-cli/tests/codestory_repo_e2e_stats.rs
@@ -1,3 +1,6 @@
+use codestory_contracts::packet_projection_v3::{
+    EvidenceAvailabilityV3Dto, RetrievalStateV3Dto, SearchProjectionV3Dto,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::env;
@@ -59,6 +62,7 @@ struct RepoE2eStats {
     retrieval_manifest: RetrievalManifestStats,
     ground_seconds: f64,
     search_seconds: f64,
+    full_search_seconds: f64,
     symbol_seconds: f64,
     trail_seconds: f64,
     snippet_seconds: f64,
@@ -128,13 +132,54 @@ struct GroundStats {
 #[derive(Debug, Serialize)]
 struct SearchStats {
     query: String,
-    retrieval_shadow_mode: String,
-    legacy_search_retrieval_mode: String,
-    semantic_doc_count: u64,
-    indexed_symbol_hits: usize,
-    repo_text_hits: usize,
+    retrieval_state: RetrievalStateV3Dto,
+    full_retrieval_state: RetrievalStateV3Dto,
+    evidence_rows: usize,
+    symbol_rows: usize,
     top_symbol_id: String,
     top_symbol_name: String,
+}
+
+fn stats_search_projection(value: &Value) -> Result<SearchProjectionV3Dto, String> {
+    let mut payload = value.clone();
+    payload
+        .as_object_mut()
+        .ok_or("search output is not an object")?
+        .remove("_meta");
+    let projection: SearchProjectionV3Dto = serde_json::from_value(payload)
+        .map_err(|error| format!("invalid v3 search projection: {error}"))?;
+    if projection.schema_version != 3 || projection.status != EvidenceAvailabilityV3Dto::Available {
+        return Err("search evidence is unavailable or has the wrong schema".into());
+    }
+    if projection.evidence.as_slice().iter().any(|row| {
+        row.symbol_id
+            .as_ref()
+            .is_some_and(|id| id.as_str().is_empty())
+    }) {
+        return Err("search supplied an empty symbol identity".into());
+    }
+    if !projection.evidence.as_slice().iter().any(|row| {
+        row.symbol_id
+            .as_ref()
+            .is_some_and(|id| !id.as_str().is_empty())
+    }) {
+        return Err("search supplied no resolvable symbol".into());
+    }
+    if projection.retrieval.state == RetrievalStateV3Dto::Full {
+        let publication = projection
+            .publication
+            .retrieval
+            .as_ref()
+            .ok_or("full search omitted its retrieval publication")?;
+        if projection.retrieval.generation_id.as_ref() != Some(&publication.retrieval_generation)
+            || publication.retrieval_generation.as_str().is_empty()
+            || publication.core_generation_id != projection.publication.core.generation_id
+            || publication.core_run_id != projection.publication.core.run_id
+        {
+            return Err("full search returned inconsistent publication identities".into());
+        }
+    }
+    Ok(projection)
 }
 
 #[derive(Debug, Serialize)]
@@ -538,6 +583,77 @@ fn release_readiness_proof_tier_requires_full_retrieval_evidence() {
     );
 }
 
+fn stats_search_fixture() -> Value {
+    serde_json::json!({
+        "kind":"complete", "schema_version":3, "status":"available",
+        "identity":{"packet_id":"search-1","request_id":"request-1","question_sha256":"a".repeat(64)},
+        "publication":{"core":{"project_id":"project-1","generation_id":"core-1","run_id":"run-1"},"retrieval":null},
+        "retrieval":{"state":"symbolic","generation_id":null},
+        "evidence":[{"identity":{"evidence_id":"row-1"},"path":"src/app.rs","symbol_id":"123",
+            "start_line":2,"end_line":2,"excerpt":"struct AppController;"}],
+        "gaps":[],"continuation":null,"diagnostics":{"availability":"unavailable"},
+        "_meta":{"operation":{"operation_id":"operation-1","attempt":1}}
+    })
+}
+
+#[test]
+fn repo_stats_consumes_public_v3_search_without_legacy_fields() {
+    let projection = stats_search_projection(&stats_search_fixture()).expect("v3 search");
+    assert_eq!(projection.retrieval.state, RetrievalStateV3Dto::Symbolic);
+    assert_eq!(
+        projection.evidence.as_slice()[0]
+            .symbol_id
+            .as_ref()
+            .unwrap()
+            .as_str(),
+        "123"
+    );
+}
+
+#[test]
+fn repo_stats_rejects_unavailable_unresolvable_and_wrong_schema_search() {
+    for (field, value) in [
+        ("status", serde_json::json!("unavailable")),
+        ("schema_version", serde_json::json!(4)),
+        ("evidence", serde_json::json!([])),
+    ] {
+        let mut fixture = stats_search_fixture();
+        fixture[field] = value;
+        assert!(stats_search_projection(&fixture).is_err());
+    }
+    let mut fixture = stats_search_fixture();
+    fixture["evidence"][0]["symbol_id"] = Value::Null;
+    assert!(stats_search_projection(&fixture).is_err());
+    fixture["evidence"][0]["symbol_id"] = serde_json::json!("");
+    assert!(stats_search_projection(&fixture).is_err());
+    fixture["evidence"]
+        .as_array_mut()
+        .unwrap()
+        .push(stats_search_fixture()["evidence"][0].clone());
+    assert!(stats_search_projection(&fixture).is_err());
+    let legacy = serde_json::json!({"indexed_symbol_hits":[{"node_id":"123"}]});
+    assert!(stats_search_projection(&legacy).is_err());
+}
+
+#[test]
+fn repo_stats_full_search_requires_one_coherent_publication() {
+    let mut fixture = stats_search_fixture();
+    fixture["retrieval"] = serde_json::json!({"state":"full","generation_id":"retrieval-1"});
+    assert!(stats_search_projection(&fixture).is_err());
+    fixture["publication"]["retrieval"] = serde_json::json!({
+        "core_generation_id":"core-1", "core_run_id":"run-1", "retrieval_generation":"retrieval-1",
+        "retrieval_input_sha256":"a".repeat(64), "semantic_generation":"semantic-1"
+    });
+    stats_search_projection(&fixture).expect("coherent full retrieval");
+    for field in ["core_generation_id", "core_run_id", "retrieval_generation"] {
+        let mut changed = fixture.clone();
+        changed["publication"]["retrieval"][field] = serde_json::json!("other");
+        assert!(stats_search_projection(&changed).is_err());
+    }
+    fixture["retrieval"]["generation_id"] = Value::Null;
+    assert!(stats_search_projection(&fixture).is_err());
+}
+
 #[test]
 fn release_readiness_proof_tier_does_not_claim_drill_or_promotion() {
     let proof_tier = release_readiness_proof_tier("full", "full");
@@ -545,6 +661,56 @@ fn release_readiness_proof_tier_does_not_claim_drill_or_promotion() {
     assert_eq!(proof_tier, PROOF_TIER_FULL_RETRIEVAL);
     assert_ne!(proof_tier, "real_repo_drill");
     assert_ne!(proof_tier, "promotion_grade");
+}
+
+#[test]
+#[ignore = "native public search canary; supply CODESTORY_RELEASE_EVIDENCE_CLI_BINARY"]
+fn repo_stats_public_search_canary() {
+    let project = tempfile::tempdir().expect("isolated canary project");
+    let cache = tempfile::tempdir().expect("isolated canary cache");
+    fs::write(
+        project.path().join("app.rs"),
+        "pub struct AppController;\nimpl AppController { pub fn start(&self) {} }\n",
+    )
+    .expect("write canary source");
+    let binary = release_cli_binary();
+    run_cli_json(
+        &binary,
+        project.path(),
+        cache.path(),
+        &[
+            "index".into(),
+            "--refresh".into(),
+            "full".into(),
+            "--format".into(),
+            "json".into(),
+        ],
+    );
+    let (_, output) = run_cli_json(
+        &binary,
+        project.path(),
+        cache.path(),
+        &[
+            "search".into(),
+            "--query".into(),
+            "AppController".into(),
+            "--repo-text".into(),
+            "off".into(),
+            "--refresh".into(),
+            "none".into(),
+            "--format".into(),
+            "json".into(),
+        ],
+    );
+    let projection = stats_search_projection(&output).expect("real public search projection");
+    assert_eq!(projection.retrieval.state, RetrievalStateV3Dto::Symbolic);
+    assert!(
+        projection
+            .evidence
+            .as_slice()
+            .iter()
+            .any(|row| row.path.as_str() == "app.rs")
+    );
 }
 
 #[test]
@@ -773,6 +939,14 @@ fn repo_root() -> PathBuf {
 }
 
 fn release_cli_binary() -> PathBuf {
+    if let Some(binary) = env::var_os("CODESTORY_RELEASE_EVIDENCE_CLI_BINARY") {
+        let binary = PathBuf::from(binary);
+        assert!(
+            binary.is_absolute() && binary.is_file(),
+            "supplied release binary must be an existing absolute file"
+        );
+        return binary;
+    }
     repo_root()
         .join("target")
         .join("release")
@@ -862,6 +1036,33 @@ fn run_cli_output_with_sidecar_cache_root(
         .output()
         .expect("run codestory-cli");
     let seconds = started.elapsed().as_secs_f64();
+    if let Some(directory) = env::var_os("CODESTORY_RELEASE_EVIDENCE_COMMAND_DIR") {
+        use std::io::Write as _;
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static ORDINAL: AtomicU64 = AtomicU64::new(0);
+        let directory = PathBuf::from(directory);
+        fs::create_dir_all(&directory).expect("create command evidence directory");
+        let file = directory.join(format!(
+            "{:04}.json",
+            ORDINAL.fetch_add(1, Ordering::Relaxed)
+        ));
+        let mut output_file = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(file)
+            .expect("create immutable command receipt");
+        let receipt = serde_json::json!({"binary": binary, "project": project_root, "cache": cache_dir,
+            "arguments": args, "wall_seconds": seconds, "exit_code": output.status.code(),
+            "stdout": String::from_utf8_lossy(&output.stdout), "stderr": String::from_utf8_lossy(&output.stderr)});
+        output_file
+            .write_all(
+                serde_json::to_string(&receipt)
+                    .expect("serialize command receipt")
+                    .as_bytes(),
+            )
+            .expect("write command receipt");
+        output_file.sync_all().expect("sync command receipt");
+    }
     assert!(
         output.status.success(),
         "command failed: {:?}\nstdout:\n{}\nstderr:\n{}",
@@ -1163,8 +1364,51 @@ fn codestory_repo_release_e2e_emits_stats() {
         ],
     );
 
-    let top_symbol_id = string_field(&search_json, &["indexed_symbol_hits", "0", "node_id"]);
-    let top_symbol_name = string_field(&search_json, &["indexed_symbol_hits", "0", "display_name"]);
+    let search = stats_search_projection(&search_json).expect("usable v3 exact search");
+    assert_eq!(
+        search.retrieval.state,
+        RetrievalStateV3Dto::Symbolic,
+        "repo-text off must remain core-only"
+    );
+    let top_symbol_id = search
+        .evidence
+        .as_slice()
+        .iter()
+        .find_map(|row| row.symbol_id.as_ref())
+        .expect("resolvable exact search row")
+        .as_str();
+    let (full_search_seconds, full_search_json) = run_cli_json(
+        &binary,
+        project_root.as_path(),
+        cache_dir.path(),
+        &[
+            "search".into(),
+            "--query".into(),
+            "AppController".into(),
+            "--repo-text".into(),
+            "auto".into(),
+            "--limit".into(),
+            "10".into(),
+            "--refresh".into(),
+            "none".into(),
+            "--profile".into(),
+            "agent".into(),
+            "--run-id".into(),
+            sidecar_run_id.into(),
+            "--format".into(),
+            "json".into(),
+        ],
+    );
+    let full_search = stats_search_projection(&full_search_json).expect("usable v3 full search");
+    assert_eq!(full_search.retrieval.state, RetrievalStateV3Dto::Full);
+    assert_eq!(
+        full_search.publication.core, search.publication.core,
+        "read-only searches changed core generation"
+    );
+    assert!(
+        full_search.retrieval.generation_id.is_some(),
+        "full search must identify its retrieval generation"
+    );
 
     let (symbol_seconds, symbol_json) = run_cli_json(
         &binary,
@@ -1282,8 +1526,7 @@ fn codestory_repo_release_e2e_emits_stats() {
         + repeat_semantic_reload_ms
         + repeat_semantic_prune_ms;
     let semantic_phase_seconds = semantic_phase_ms as f64 / 1000.0;
-    let search_retrieval_shadow_mode =
-        string_field(&search_json, &["retrieval_shadow", "retrieval_mode"]).to_string();
+    let full_search_retrieval_state = string_field(&full_search_json, &["retrieval", "state"]);
     let dense_reason_counts_json = string_field(
         &retrieval_status_json,
         &["manifest", "dense_reason_counts_json"],
@@ -1310,11 +1553,9 @@ fn codestory_repo_release_e2e_emits_stats() {
         dense_reason_count_total: dense_reason_count_total(&dense_reason_counts_json),
         dense_reason_counts_json,
     };
-    let proof_tier = release_readiness_proof_tier(
-        sidecar_retrieval_mode.as_str(),
-        search_retrieval_shadow_mode.as_str(),
-    )
-    .to_string();
+    let proof_tier =
+        release_readiness_proof_tier(sidecar_retrieval_mode.as_str(), full_search_retrieval_state)
+            .to_string();
     let stats_baseline = latest_phase_stats_baseline(project_root.as_path());
     let warnings = release_readiness_warnings(
         index_seconds,
@@ -1448,6 +1689,7 @@ fn codestory_repo_release_e2e_emits_stats() {
         retrieval_manifest,
         ground_seconds,
         search_seconds,
+        full_search_seconds,
         symbol_seconds,
         trail_seconds,
         snippet_seconds,
@@ -1471,15 +1713,19 @@ fn codestory_repo_release_e2e_emits_stats() {
             coverage_total_files: u64_field(&ground_json, &["coverage", "total_files"]),
         },
         search: SearchStats {
-            query: string_field(&search_json, &["query"]).to_string(),
-            retrieval_shadow_mode: search_retrieval_shadow_mode,
-            legacy_search_retrieval_mode: string_field(&search_json, &["retrieval", "mode"])
-                .to_string(),
-            semantic_doc_count: u64_field(&search_json, &["retrieval", "semantic_doc_count"]),
-            indexed_symbol_hits: array_len(&search_json, &["indexed_symbol_hits"]),
-            repo_text_hits: array_len(&search_json, &["repo_text_hits"]),
+            query: "AppController".into(),
+            retrieval_state: search.retrieval.state.clone(),
+            full_retrieval_state: full_search.retrieval.state.clone(),
+            evidence_rows: search.evidence.as_slice().len(),
+            symbol_rows: search
+                .evidence
+                .as_slice()
+                .iter()
+                .filter(|row| row.symbol_id.is_some())
+                .count(),
             top_symbol_id: top_symbol_id.to_string(),
-            top_symbol_name: top_symbol_name.to_string(),
+            top_symbol_name: string_field(&symbol_json, &["symbol", "node", "display_name"])
+                .to_string(),
         },
         symbol: SymbolStats {
             display_name: string_field(&symbol_json, &["symbol", "node", "display_name"])
@@ -1538,8 +1784,9 @@ fn codestory_repo_release_e2e_emits_stats() {
         "strict grounding should reuse the prepared full retrieval state"
     );
     assert_eq!(
-        stats.search.retrieval_shadow_mode, "full",
-        "search should expose full retrieval shadow"
+        stats.search.full_retrieval_state,
+        RetrievalStateV3Dto::Full,
+        "full search should expose its prepared retrieval state"
     );
     assert!(
         stats.retrieval_manifest.symbol_doc_count > 0,
@@ -1587,7 +1834,7 @@ fn codestory_repo_release_e2e_emits_stats() {
         "symbol lookup should resolve the same top hit returned by search"
     );
     assert!(
-        stats.search.indexed_symbol_hits > 0,
+        stats.search.symbol_rows > 0,
         "search should return indexed hits"
     );
     assert!(

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -2266,9 +2266,13 @@ impl WorkspaceIndexer {
             .saturating_add(source_prepare_ms);
 
         let parse_started = Instant::now();
+        #[cfg(test)]
+        let resolution_work = proof_resolution::resolution_work_counter();
         let parse_results: Vec<PreparedIndexJobResult> = parse_jobs
             .par_iter()
             .map(|prepared_input| {
+                #[cfg(test)]
+                let _resolution_work = proof_resolution::inherit_resolution_work(&resolution_work);
                 #[cfg(test)]
                 if let Some(hook) = &self.pipeline_test_hooks.before_parse_job {
                     hook(_chunk_index);

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -1529,9 +1529,9 @@ impl<'a> ProjectionWriter<'a> {
                     .cleanup_ms
                     .saturating_add(duration_ms_u64(cleanup_started.elapsed()));
             }
-        } else if self.mode == codestory_workspace::BuildMode::Incremental
-            && !local_storage.files.is_empty()
-        {
+        } else if !local_storage.files.is_empty() {
+            // Full refresh and newly indexed files both publish graph work.
+            // Only the existing incremental identity-only branch can reuse it.
             self.stats.graph_projection_changed = true;
         }
         let owning_file_ids = self

--- a/crates/codestory-indexer/src/proof_resolution.rs
+++ b/crates/codestory-indexer/src/proof_resolution.rs
@@ -93,8 +93,36 @@ pub fn bash_resolution_work() -> BashResolutionWork {
 }
 
 #[cfg(test)]
-static JAVA_KOTLIN_RESOLUTION_WORK: std::sync::atomic::AtomicUsize =
-    std::sync::atomic::AtomicUsize::new(0);
+type ResolutionWorkCounter = std::sync::Arc<std::sync::atomic::AtomicUsize>;
+
+#[cfg(test)]
+thread_local! {
+    static JAVA_KOTLIN_RESOLUTION_WORK: std::cell::RefCell<Option<ResolutionWorkCounter>> = const {
+        std::cell::RefCell::new(None)
+    };
+}
+
+#[cfg(test)]
+pub(super) fn resolution_work_counter() -> Option<ResolutionWorkCounter> {
+    JAVA_KOTLIN_RESOLUTION_WORK.with(|work| work.borrow().clone())
+}
+
+#[cfg(test)]
+pub(super) struct ResolutionWorkScope(Option<ResolutionWorkCounter>);
+
+#[cfg(test)]
+impl Drop for ResolutionWorkScope {
+    fn drop(&mut self) {
+        JAVA_KOTLIN_RESOLUTION_WORK.with(|work| work.replace(self.0.take()));
+    }
+}
+
+#[cfg(test)]
+pub(super) fn inherit_resolution_work(
+    counter: &Option<ResolutionWorkCounter>,
+) -> ResolutionWorkScope {
+    ResolutionWorkScope(JAVA_KOTLIN_RESOLUTION_WORK.with(|work| work.replace(counter.clone())))
+}
 
 #[inline]
 fn count_rust_resolution_work(amount: usize) {
@@ -153,19 +181,31 @@ fn python_resolution_work() -> usize {
 #[inline]
 fn count_java_kotlin_resolution_work(amount: usize) {
     #[cfg(test)]
-    let _ = JAVA_KOTLIN_RESOLUTION_WORK.fetch_add(amount, std::sync::atomic::Ordering::Relaxed);
+    JAVA_KOTLIN_RESOLUTION_WORK.with(|work| {
+        if let Some(counter) = work.borrow().as_ref() {
+            counter.fetch_add(amount, std::sync::atomic::Ordering::Relaxed);
+        }
+    });
     #[cfg(not(test))]
     let _ = amount;
 }
 
 #[cfg(test)]
 fn reset_java_kotlin_resolution_work() {
-    JAVA_KOTLIN_RESOLUTION_WORK.store(0, std::sync::atomic::Ordering::Relaxed);
+    JAVA_KOTLIN_RESOLUTION_WORK.with(|work| {
+        work.replace(Some(std::sync::Arc::new(
+            std::sync::atomic::AtomicUsize::new(0),
+        )));
+    });
 }
 
 #[cfg(test)]
 fn java_kotlin_resolution_work() -> usize {
-    JAVA_KOTLIN_RESOLUTION_WORK.load(std::sync::atomic::Ordering::Relaxed)
+    JAVA_KOTLIN_RESOLUTION_WORK.with(|work| {
+        work.borrow().as_ref().map_or(0, |counter| {
+            counter.load(std::sync::atomic::Ordering::Relaxed)
+        })
+    })
 }
 
 #[inline]
@@ -20142,6 +20182,81 @@ mod java_kotlin_complexity_tests {
     use codestory_workspace::{BuildMode, RefreshInfo};
     use std::fs;
     use tree_sitter::Parser;
+
+    #[test]
+    fn overlapping_resolution_work_measurements_are_isolated() {
+        let barrier = std::sync::Barrier::new(2);
+        std::thread::scope(|scope| {
+            let handles = [11, 31].map(|amount| {
+                let barrier = &barrier;
+                scope.spawn(move || {
+                    reset_java_kotlin_resolution_work();
+                    barrier.wait();
+                    count_java_kotlin_resolution_work(amount);
+                    barrier.wait();
+                    assert_eq!(java_kotlin_resolution_work(), amount);
+                })
+            });
+            for handle in handles {
+                handle.join().expect("independent measurement must succeed");
+            }
+        });
+    }
+
+    #[test]
+    fn resolution_work_follows_owned_workers_and_restores_their_scope() {
+        reset_java_kotlin_resolution_work();
+        let counter = resolution_work_counter();
+        std::thread::spawn(move || {
+            reset_java_kotlin_resolution_work();
+            count_java_kotlin_resolution_work(3);
+            {
+                let _scope = inherit_resolution_work(&counter);
+                count_java_kotlin_resolution_work(7);
+            }
+            assert_eq!(java_kotlin_resolution_work(), 3);
+        })
+        .join()
+        .expect("worker measurement");
+        assert_eq!(java_kotlin_resolution_work(), 7);
+    }
+
+    #[test]
+    fn workspace_parser_jobs_inherit_the_measurement_owner() -> Result<()> {
+        let project = tempfile::tempdir()?;
+        let mut paths = Vec::new();
+        for index in 0..3 {
+            let path = project.path().join(format!("part_{index}.rs"));
+            fs::write(&path, format!("fn part_{index}() {{}}\n"))?;
+            paths.push(path);
+        }
+        reset_java_kotlin_resolution_work();
+        let expected = resolution_work_counter().expect("measurement owner");
+        let indexer = crate::WorkspaceIndexer::new(project.path().to_path_buf())
+            .with_pipeline_test_hooks(crate::FullRefreshPipelineTestHooks {
+                before_parse_job: Some(std::sync::Arc::new(move |_| {
+                    let actual = resolution_work_counter().expect("parser job must inherit owner");
+                    assert!(std::sync::Arc::ptr_eq(&actual, &expected));
+                    count_java_kotlin_resolution_work(7);
+                })),
+                ..Default::default()
+            });
+        let mut store = Store::open_build(project.path().join("stage.sqlite"))?;
+        let stats = indexer.run(
+            &mut store,
+            &codestory_workspace::RefreshExecutionPlan {
+                mode: BuildMode::FullRefresh,
+                files_to_index: paths,
+                files_to_remove: Vec::new(),
+                existing_file_ids: HashMap::new(),
+            },
+            &EventBus::new(),
+            None,
+        )?;
+        assert_eq!(stats.full_refresh_queue_capacity, 1);
+        assert_eq!(java_kotlin_resolution_work(), 21);
+        Ok(())
+    }
 
     fn measured_work(language: &str, source: &str) -> usize {
         let mut parser = Parser::new();

--- a/crates/codestory-indexer/src/tests/mod.rs
+++ b/crates/codestory-indexer/src/tests/mod.rs
@@ -1845,6 +1845,72 @@ fn test_full_refresh_batches_artifact_cache_writes_per_file_chunk() -> Result<()
 }
 
 #[test]
+fn test_full_refresh_resolves_flushed_calls_in_serial_pipeline_and_cache_replay() -> Result<()> {
+    let dir = tempdir()?;
+    let caller = dir.path().join("caller.go");
+    let target = dir.path().join("target.go");
+    std::fs::write(&caller, "package sample\nfunc begin() { finish() }\n")?;
+    std::fs::write(&target, "package sample\nfunc finish() {}\n")?;
+    let plan = codestory_workspace::RefreshExecutionPlan {
+        mode: codestory_workspace::BuildMode::FullRefresh,
+        files_to_index: vec![caller, target.clone()],
+        files_to_remove: vec![],
+        existing_file_ids: HashMap::new(),
+    };
+    let indexer = WorkspaceIndexer::new(dir.path().to_path_buf()).with_batch_config(
+        IncrementalIndexingConfig {
+            file_batch_size: 1,
+            ..IncrementalIndexingConfig::default()
+        },
+    );
+    let pipeline_path = dir.path().join("pipeline.sqlite");
+    let mut serial = Storage::new_in_memory()?;
+    let mut pipeline = Storage::open_build(&pipeline_path)?;
+    let mut replay = Storage::open_build(dir.path().join("replay.sqlite"))?;
+    for (label, storage) in [("serial", &mut serial), ("pipeline", &mut pipeline)] {
+        let stats = indexer.run(storage, &plan, &EventBus::new(), None)?;
+        assert!(
+            stats.graph_projection_changed,
+            "{label}: fresh graph was flushed"
+        );
+        assert!(
+            stats.resolution_ran,
+            "{label}: full refresh must resolve its graph"
+        );
+        let nodes = storage.get_nodes()?;
+        let target_file = storage.get_files_by_paths(std::slice::from_ref(&target))?[&target].id;
+        let definition = nodes
+            .iter()
+            .find(|node| {
+                node.kind == NodeKind::FUNCTION
+                    && node.file_node_id == Some(NodeId(target_file))
+                    && node
+                        .qualified_name
+                        .as_deref()
+                        .is_some_and(|name| name.ends_with("finish"))
+            })
+            .expect("the other file must contain the definition");
+        assert!(
+            storage.get_edges()?.iter().any(|edge| {
+                edge.kind == EdgeKind::CALL && edge.resolved_target == Some(definition.id)
+            }),
+            "{label}: post-flush resolution must reach the other file's definition"
+        );
+    }
+    assert!(replay.copy_index_artifact_cache_from(&pipeline_path)? > 0);
+    let stats = indexer.run(&mut replay, &plan, &EventBus::new(), None)?;
+    assert!(stats.artifact_cache_hits > 0);
+    assert!(stats.graph_projection_changed);
+    assert!(
+        stats.resolution_ran,
+        "cache replay rebuilds a graph that still needs resolution"
+    );
+    assert_projection_snapshots_equal(&serial, &pipeline, "pipelined")?;
+    assert_projection_snapshots_equal(&serial, &replay, "cache-replayed")?;
+    Ok(())
+}
+
+#[test]
 fn test_file_backed_full_refresh_uses_bounded_projection_pipeline() -> Result<()> {
     use codestory_store::Store as Storage;
     use std::fs;

--- a/crates/codestory-indexer/src/tests/mod.rs
+++ b/crates/codestory-indexer/src/tests/mod.rs
@@ -1869,6 +1869,10 @@ fn test_full_refresh_resolves_flushed_calls_in_serial_pipeline_and_cache_replay(
     let mut replay = Storage::open_build(dir.path().join("replay.sqlite"))?;
     for (label, storage) in [("serial", &mut serial), ("pipeline", &mut pipeline)] {
         let stats = indexer.run(storage, &plan, &EventBus::new(), None)?;
+        assert_eq!(
+            stats.full_refresh_queue_capacity,
+            usize::from(label == "pipeline")
+        );
         assert!(
             stats.graph_projection_changed,
             "{label}: fresh graph was flushed"
@@ -1900,6 +1904,7 @@ fn test_full_refresh_resolves_flushed_calls_in_serial_pipeline_and_cache_replay(
     assert!(replay.copy_index_artifact_cache_from(&pipeline_path)? > 0);
     let stats = indexer.run(&mut replay, &plan, &EventBus::new(), None)?;
     assert!(stats.artifact_cache_hits > 0);
+    assert_eq!(stats.full_refresh_queue_capacity, 1);
     assert!(stats.graph_projection_changed);
     assert!(
         stats.resolution_ran,
@@ -3116,6 +3121,8 @@ fn test_empty_full_refresh_reports_adaptive_chunk_config() -> Result<()> {
     assert_eq!(stats.full_refresh_chunk_budget_overruns, 0);
     assert_eq!(stats.projection_batch_transactions, 0);
     assert_eq!(stats.projection_batch_wall_ms, 0);
+    assert!(!stats.graph_projection_changed);
+    assert!(!stats.resolution_ran);
     Ok(())
 }
 
@@ -3705,6 +3712,11 @@ fn test_full_refresh_cancellation_after_writer_acceptance_drains_that_chunk() ->
     assert!(cancel_token.is_cancelled());
     assert_eq!(stats.full_refresh_chunks_produced, 1);
     assert_eq!(stats.full_refresh_chunks_persisted, 1);
+    assert!(stats.graph_projection_changed);
+    assert!(
+        !stats.resolution_ran,
+        "cancelled work must not enter resolution"
+    );
     let names = storage
         .get_nodes()?
         .into_iter()


### PR DESCRIPTION
# Restore relationship resolution during full indexing

Full refresh flushed graph rows without running ordinary call/import/override resolution. The projection writer marked only incremental graph changes, although both full-refresh execution modes require the flag before resolution. This PR repairs that scheduling defect without changing parsers, resolution rules, confidence thresholds, packet ranking, or release surfaces.

Closes #2133. Refs #2116.

## Changes

- Mark nonempty full-refresh graph work at the owning projection boundary. Preserve empty/no-op and cancellation behavior.
- Exercise real cross-file resolution through serial, pipelined, and cache-replay indexing.
- Replace a test-only global counter with operation-scoped counters inherited explicitly by parser workers. Concurrent measurements remain concurrent.
- Update repository telemetry to read the public v3 search projection. Distinguish symbolic and full retrieval, authenticate their publication identities, and preserve every command receipt before assertions. A supplied CLI binary avoids changing the worktree's target path.
- Add the user-visible Unreleased indexing correction.

## Accepted source

Head `835971b0719a112c4670e06386cc314ad7ea4f7f`; tree `cab90f0e619a870acdffcc3f91f983a4078105b2`; base `cd062c70527013fec221312537ca1bda3bb64519`.

Independent exact-head verification reran five causal mutants at their intended runtime assertions, then restored clean source. Complete indexer library before and after: 348 passed, one ignored. Cancellation passed. The telemetry reader suite passed all 12 tests, including hostile projection/publication cases. Receipt SHA-256: `feec07abc78f5fcf9b0795ea751bee4ce77770e6881248b19626d606935b982e`.

The unchanged product source also retains passing full fidelity (8), full language coverage (13), and warnings-denied indexer checks from the preceding source freeze. The telemetry-only child passed its warnings-denied check, formatting, whitespace, and applicable exact-head CI. No broad release qualification ran.

## Actual repository measurement

The ordinary release CLI completed all 13 operations against the real repository. The independent verifier reconstructed every command, source/binary binding, interval, and public search identity.

- Full index: 34.665 seconds; repeat full index: 35.642 seconds. These are not incremental-refresh measurements.
- Ordinary resolution: 2.897 / 2.833 seconds, with 59,093 resolved calls and 14,693 imports in each run.
- Fresh CLI exact symbolic search: 1.418 seconds; full search: 5.184 seconds. Persistent installed p95 is unmeasured.
- Full-index unattributed wall remains visible at 7.576 / 7.663 seconds. This does not establish the 99% incremental accounting SLO.

Complete stats SHA-256: `ad9cbc00bb3113f0fb7e1468dff0995dba0fe84581781004b89a24d169acae5c`. The earlier failed stats run is preserved; its reader expected the retired search shape.

## Review and risk

Review the projection writer's change flag, then the serial/pipeline/cache-replay regression. Other code changes are test measurement ownership and the v3 telemetry consumer. Restored resolution performs real additional work, now measured. No query-performance or packet-accuracy gate is claimed.

A separate replay on private copies of the twelve retained graphs supplied 4,499 previously missing targets without changing edge/source identities. The repaired Certain-only graph improved answer-aware source feasibility from 37.16% to 63.00%, still below acceptance; complete-set rate remains only 34.72%. Those are contaminated development diagnostics, not actual selection or product qualification. All previous experiment failures and stops remain preserved.
