### PR TITLE
preserve schema-31 cache during generation upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@
   embedding request, reducing client/server overhead without changing the
   model, dense coverage, stored vectors, or search ranking.
 
+- Upgrading a 0.17.5 cache can publish its rebuilt index while preserving the
+  previous schema and user annotations. The retained old generation no longer
+  has to match the new index schema.
+
 ## 0.17.5
 
 Cursor still dropped `files`, `snippet`, and preparing `packet`/`search`/`context` results: empty `policy_exclusions` were omitted, batched snippets used a ranges document, and the shared `codestory_preparing` envelope was undeclared.

--- a/crates/codestory-store/src/snapshot_store.rs
+++ b/crates/codestory-store/src/snapshot_store.rs
@@ -595,6 +595,12 @@ mod tests {
 
     #[test]
     fn full_replacement_publishes_generation_pointer_without_backup_or_restore() {
+        for previous_schema in [31, crate::CURRENT_SCHEMA_VERSION] {
+            assert_full_replacement_preserves_previous_schema(previous_schema);
+        }
+    }
+
+    fn assert_full_replacement_preserves_previous_schema(previous_schema: u32) {
         let temp = fresh_temp_root("full-replacement-telemetry");
         let live_path = temp.join("live.sqlite");
         {
@@ -621,6 +627,14 @@ mod tests {
                 .expect("identify previous live publication");
             publish_empty_source_policy(&mut live, &publication);
         }
+
+        {
+            let previous = rusqlite::Connection::open(&live_path).expect("open predecessor");
+            previous
+                .pragma_update(None, "user_version", previous_schema)
+                .expect("set supported predecessor schema");
+        }
+        let old_bytes = fs::read(&live_path).expect("read legacy database");
 
         let mut staged = SnapshotStore::open_staged(&live_path).expect("open replacement stage");
         staged
@@ -680,10 +694,23 @@ mod tests {
             .expect("read pointer")
             .expect("published pointer");
         assert_eq!(pointer.active.generation_id, "new-generation");
-        assert_eq!(
-            pointer.rollback.expect("rollback").generation_id,
-            "old-generation"
-        );
+        let rollback = pointer.rollback.expect("rollback");
+        assert_eq!(rollback.generation_id, "old-generation");
+        let layout = crate::CorePublicationLayout::from_storage_path(&live_path).expect("layout");
+        let rollback_path = layout
+            .generation_database_path(&rollback.generation_id)
+            .expect("rollback path");
+        let rollback_db = rusqlite::Connection::open_with_flags(
+            rollback_path,
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+        )
+        .expect("read retained predecessor");
+        let retained_schema: u32 = rollback_db
+            .pragma_query_value(None, "user_version", |row| row.get(0))
+            .expect("retained schema");
+        assert_eq!(retained_schema, previous_schema);
+        assert_eq!(fs::read(&live_path).expect("legacy bytes"), old_bytes);
+        drop(rollback_db);
 
         let _ = fs::remove_dir_all(&temp);
     }

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -1518,6 +1518,14 @@ fn read_recovery_database_identity(
     };
     match schema_version {
         0 => Ok(None),
+        INCOMPLETE_INCREMENTAL_SCHEMA_VERSION
+            if contract == RecoveryDatabaseContract::CurrentPromotion =>
+        {
+            Err(promotion_error(format!(
+                "SQLite predecessor {} is incomplete and cannot become a rollback generation",
+                path.display()
+            )))
+        }
         INCOMPLETE_INCREMENTAL_SCHEMA_VERSION if has_incomplete_incremental_marker(&conn)? => {
             read_index_publication(&conn)
         }
@@ -7001,9 +7009,13 @@ impl Storage {
                     let identity = core_generation_identity(&previous, previous_bytes);
                     let materialized = layout
                         .materialize_existing_generation(live_path, &identity.generation_id)?;
-                    let materialized_publication = require_complete_promotion_database_identity(
+                    // This is the unchanged predecessor, not a new candidate.
+                    // Preserve its supported legacy schema rather than requiring
+                    // the schema of the replacement we already validated above.
+                    let materialized_publication = require_recovery_database_identity(
                         &materialized,
                         "Migrated immutable rollback generation",
+                        RecoveryDatabaseContract::CurrentPromotion,
                     )?;
                     if materialized_publication != previous {
                         return Err(promotion_error(

--- a/crates/codestory-store/src/storage_impl/tests/mod.rs
+++ b/crates/codestory-store/src/storage_impl/tests/mod.rs
@@ -7484,6 +7484,32 @@ fn promotion_recovery_rejects_unsupported_and_unmarked_schema_identities() {
 }
 
 #[test]
+fn immutable_migration_does_not_publish_an_incomplete_legacy_predecessor() {
+    let root = tempfile::tempdir().expect("migration root");
+    let live = root.path().join("codestory.db");
+    seed_promotion_file(&live, 1, "old.rs").expect("complete predecessor");
+    let layout = crate::CorePublicationLayout::from_storage_path(&live).expect("layout");
+    let candidate = layout.create_staging_database_path().expect("stage");
+    seed_promotion_file(&candidate, 2, "new.rs").expect("complete replacement");
+    {
+        let previous = Storage::open(&live).expect("open predecessor");
+        previous
+            .begin_incremental_run()
+            .expect("mark interrupted writer");
+    }
+    let before = durable_sqlite_state(&live);
+    let error = Storage::promote_staged_snapshot(&candidate, &live)
+        .expect_err("incomplete predecessor cannot become a complete rollback generation");
+    assert!(error.to_string().contains("incomplete"), "{error}");
+    assert_eq!(durable_sqlite_state(&live), before);
+    assert!(layout.read_pointer().expect("pointer").is_none());
+    assert!(
+        candidate.exists(),
+        "failed candidate remains available for diagnosis"
+    );
+}
+
+#[test]
 fn promotion_journal_binds_source_policy_exclusion_count_and_digest() -> Result<(), StorageError> {
     let previous_path = unique_temp_db_path("promotion-policy-previous");
     let candidate_path = unique_temp_db_path("promotion-policy-candidate");


### PR DESCRIPTION
An archive-authenticated 0.17.5 cache could rebuild successfully but fail publication because preservation of its schema-31 predecessor incorrectly required schema 32. Normal upgrade now preserves the old database through the existing recovery identity contract while continuing to require the current schema for the new candidate.

The change is confined to predecessor validation in the store. It rejects incomplete legacy databases before promotion, preserves the legacy bytes and identity for rollback, and leaves candidate validation strict.

Closes #2138. Refs #2135.

Validation: the schema-31 replacement regression failed before the fix and passes afterward. The complete store suite passes (319 tests), including incomplete-source rejection and immutable-generation checks. Archive-to-candidate live revalidation and independent acceptance are pending; this draft does not claim release or installed-runtime qualification.

Base: a8ca9db6a29b57f5a9e35e1a598c42883bfa256b. Head: 2c9913f0a4352abee49642c39983bc2f3b1bf98e. Worktree: /Users/albert/.codex/worktrees/0176-cache-upgrade/CodeStory. Role: implementation. Next proof target: preserved archive-created cache upgraded with this exact source binary.
