### PR TITLE
add ordinary installed navigation benchmark profile

### DIFF
--- a/docs/testing/installed-navigation-profile.md
+++ b/docs/testing/installed-navigation-profile.md
@@ -1,0 +1,54 @@
+# Installed navigation comparisons
+
+The `--installed-navigation` profile in `scripts/codestory-agent-ab-benchmark.mjs`
+compares ordinary installed CodeStory plugins with native repository tools. It
+uses Terra at low reasoning, the same workspace-write sandbox in each arm, and a
+ten-minute session timeout. It adds no investigation prelude or approval override.
+Historical benchmark profiles retain their existing contracts.
+
+An independent evaluator freezes the task manifest and keeps answer keys outside
+it. The manifest names pinned complete repository clones, tasks, arms, repeats,
+and the complete ordered session schedule. The maintenance profile requires three
+repositories, six tasks, two repeats and three arms; discovery, relationships and
+edit/refresh each receive two tasks.
+
+Prepare isolated Codex homes using normal marketplace installation. A native
+home has no plugins; each CodeStory home has exactly one enabled plugin. Keep
+these templates free of sessions, memories and host instructions. Record the
+installed package digest, exact source commit, executable digest and ordered
+`tools/list` digest in the installation receipt. Source-build development
+receipts and published archives are different provenance tiers; identify them
+literally. A local mirror may supply authenticated release archives without
+changing the launcher. Binary and custom MCP-server overrides are unsupported.
+
+The installation JSON binds to the task manifest's SHA-256, contains the `arms`
+map and freezes `budget.max_sessions` and `budget.max_wall_ms`. A pilot can also
+set its original `budget.deadline_utc`. Each arm names `codex_home_template`;
+CodeStory arms additionally name `plugin_relative_path`, `package_sha256`,
+`source_commit`, `runtime_sha256`, `version`, `tools_sha256` and optionally
+`release_directory`. An optional `auth_file` is copied privately into isolated
+homes; credentials are never written into results.
+
+Run deterministic checks before model execution:
+
+```sh
+node scripts/codestory-agent-ab-benchmark.mjs --installed-navigation \
+  --manifest /absolute/tasks.json --installations /absolute/installations.json \
+  --out /absolute/new-preflight-directory --preflight-only
+```
+
+Omit `--preflight-only` and use a new output directory for the comparison. Every
+arm must pass installation, launcher, schema and edit/refresh canaries before any
+model starts. Sessions get fresh whole checkouts and state, including separate
+embedding qualification namespaces. The runner records prompts, effective
+configuration, package identity, canary traffic, model transcripts, usage, timing
+and failures. Output directories are never overwritten or silently resumed.
+Independent correctness grading and release acceptance follow execution; process
+success alone does not establish either.
+
+Focused verification:
+
+```sh
+node --test scripts/installed-navigation-profile.test.mjs
+node scripts/codestory-agent-ab-benchmark.mjs --self-test
+```

--- a/docs/testing/installed-navigation-profile.md
+++ b/docs/testing/installed-navigation-profile.md
@@ -24,8 +24,9 @@ changing the launcher. Binary and custom MCP-server overrides are unsupported.
 The installation JSON binds to the task manifest's SHA-256, contains the `arms`
 map and freezes `budget.max_sessions` and `budget.max_wall_ms`. A pilot can also
 set its original `budget.deadline_utc`. Each arm names `codex_home_template`;
-CodeStory arms additionally name `plugin_relative_path`, `package_sha256`,
-`source_commit`, `runtime_sha256`, `version`, `tools_sha256` and optionally
+CodeStory arms additionally name `marketplace_name`, `plugin_relative_path`,
+`package_sha256`, `source_commit`, `runtime_sha256`, `runtime_source`,
+`schema_version`, `version`, `tools_sha256` and optionally
 `release_directory`. An optional `auth_file` is copied privately into isolated
 homes; credentials are never written into results.
 
@@ -42,7 +43,8 @@ arm must pass installation, launcher, schema and edit/refresh canaries before an
 model starts. Sessions get fresh whole checkouts and state, including separate
 embedding qualification namespaces. The runner records prompts, effective
 configuration, package identity, canary traffic, model transcripts, usage, timing
-and failures. Output directories are never overwritten or silently resumed.
+and failures. Every scheduled session has a durable row, including preparation,
+spawn and budget failures. Output directories are never overwritten or silently resumed.
 Independent correctness grading and release acceptance follow execution; process
 success alone does not establish either.
 

--- a/docs/testing/installed-navigation-profile.md
+++ b/docs/testing/installed-navigation-profile.md
@@ -51,6 +51,6 @@ success alone does not establish either.
 Focused verification:
 
 ```sh
-node --test scripts/installed-navigation-profile.test.mjs
+node --test scripts/tests/installed-navigation-profile.test.mjs
 node scripts/codestory-agent-ab-benchmark.mjs --self-test
 ```

--- a/docs/testing/installed-navigation-profile.md
+++ b/docs/testing/installed-navigation-profile.md
@@ -4,6 +4,10 @@ The `--installed-navigation` profile in `scripts/codestory-agent-ab-benchmark.mj
 compares ordinary installed CodeStory plugins with native repository tools. It
 uses Terra at low reasoning, the same workspace-write sandbox in each arm, and a
 ten-minute session timeout. It adds no investigation prelude or approval override.
+Authenticated accounts can discover remote plugins even with an empty isolated
+Codex home. This profile passes `--disable remote_plugin` to inventory and model
+execution in every arm. It records that setting explicitly; installed local
+CodeStory plugins and native source-reading tools remain available.
 Historical benchmark profiles retain their existing contracts.
 
 An independent evaluator freezes the task manifest and keeps answer keys outside

--- a/scripts/codestory-agent-ab-benchmark.mjs
+++ b/scripts/codestory-agent-ab-benchmark.mjs
@@ -7519,6 +7519,11 @@ function createSequencedStdioSession(command, args, options) {
     terminate("SIGTERM");
   }
   function dispatchResponse(response) {
+    if (options.onNotification && response?.jsonrpc === "2.0"
+      && typeof response.method === "string" && !Object.hasOwn(response, "id")) {
+      options.onNotification(response);
+      return;
+    }
     if (queuedResponses.length >= 4) {
       fail("fail", "retrieval-engine stdio emitted too many unmatched responses");
       return;
@@ -15057,6 +15062,13 @@ async function runAgentBenchmarkPipeline({
 }
 
 async function main() {
+  if (process.argv.includes("--installed-navigation")) {
+    const { runInstalledNavigation } = await import("./installed-navigation-profile.mjs");
+    await runInstalledNavigation(process.argv.slice(2), {
+      runProcess, createSequencedStdioSession, extractUsage, analyzeTranscript,
+    });
+    return;
+  }
   const opts = parseArgs(process.argv.slice(2));
   if (opts.selfTest) {
     runSelfTest();
@@ -15414,6 +15426,8 @@ async function main() {
 }
 
 export {
+  createSequencedStdioSession,
+  extractUsage,
   aggregateShardRuns,
   agentRunnerEnv,
   analyzeTranscript,

--- a/scripts/installed-navigation-profile.mjs
+++ b/scripts/installed-navigation-profile.mjs
@@ -1,0 +1,216 @@
+import { createHash, randomBytes } from 'node:crypto';
+import { cp, mkdir, readFile, writeFile, stat, realpath } from 'node:fs/promises';
+import path from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { parseArgs } from 'node:util';
+import { setTimeout as delay } from 'node:timers/promises';
+import { directoryDigest } from '../.github/scripts/install-codestory-marketplace-proof.mjs';
+
+const sha = bytes => createHash('sha256').update(bytes).digest('hex');
+const json = async file => JSON.parse(await readFile(file, 'utf8'));
+const save = (file, value) => writeFile(file, `${JSON.stringify(value, null, 2)}\n`);
+const requireThat = (condition, message) => { if (!condition) throw new Error(message); };
+const relative = value => typeof value === 'string' && value.length > 0 && !path.isAbsolute(value)
+  && !value.split(/[\\/]/).some(part => part === '..' || part === '');
+
+export function validateManifest(manifest) {
+  requireThat(manifest.schema_version === 1, 'unsupported navigation manifest');
+  requireThat(manifest.model?.name === 'gpt-5.6-terra' && manifest.model?.reasoning_effort === 'low', 'navigation model must be Terra low');
+  requireThat(Array.isArray(manifest.repositories) && Array.isArray(manifest.tasks) && Array.isArray(manifest.sessions), 'manifest needs repositories, tasks and sessions');
+  const repos = new Map(manifest.repositories.map(repo => [repo.id, repo]));
+  const tasks = new Map(manifest.tasks.map(task => [task.id, task]));
+  requireThat(repos.size === manifest.repositories.length && tasks.size === manifest.tasks.length, 'duplicate repository or task');
+  for (const repo of repos.values()) requireThat(/^[a-f0-9]{40}$/.test(repo.commit) && /^[a-f0-9]{40}$/.test(repo.tree) && path.isAbsolute(repo.seed_clone), 'repository needs pinned commit, tree and seed clone');
+  for (const task of tasks.values()) requireThat(repos.has(task.repository_id) && typeof task.prompt === 'string' && task.prompt.length > 0 && ['read_only', 'change'].includes(task.effect_mode), 'invalid navigation task');
+  requireThat(new Set(manifest.arms).size === manifest.arms.length && manifest.arms.includes('native'), 'unique arms including native required');
+  const seen = new Set();
+  const ids = new Set();
+  manifest.sessions.forEach((row, index) => {
+    requireThat(row.sequence === index + 1 && /^[a-zA-Z0-9_-]+$/.test(row.session_id) && !ids.has(row.session_id), 'invalid sequence or duplicate session id');
+    ids.add(row.session_id);
+    requireThat(tasks.has(row.task_id) && manifest.arms.includes(row.arm) && Number.isInteger(row.repeat) && row.repeat > 0 && row.repeat <= manifest.repeats, 'invalid session');
+    const key = `${row.task_id}:${row.arm}:${row.repeat}`;
+    requireThat(!seen.has(key), 'duplicate task/arm/repeat'); seen.add(key);
+  });
+  requireThat(seen.size === tasks.size * manifest.arms.length * manifest.repeats, 'incomplete navigation schedule');
+  if (manifest.profile === 'codestory-0176-navigation-maintenance') {
+    requireThat(repos.size === 3 && tasks.size === 6 && manifest.repeats === 2 && manifest.sessions.length === 36, 'maintenance panel requires 3 repositories, 6 tasks, 36 sessions');
+    for (const category of ['discovery', 'relationship', 'edit_refresh']) requireThat([...tasks.values()].filter(task => task.category === category).length === 2, 'maintenance category allocation changed');
+  }
+  return { repos, tasks };
+}
+
+export function navigationCommand(codex, project, output) {
+  return { command: codex, args: ['exec', '--model', 'gpt-5.6-terra', '--config', 'model_reasoning_effort="low"', '--sandbox', 'workspace-write', '--cd', project, '--json', '--output-last-message', output, '-'] };
+}
+
+export function navigationEnvironment(parent, root, nonce) {
+  const env = Object.fromEntries(Object.entries(parent).filter(([key]) => !/^(CODEX_|CODESTORY_|CLAUDE_|COPILOT_|PLUGIN_|OPENAI_API_KEY$)/.test(key)));
+  return { ...env, HOME: path.join(root, 'home'), USERPROFILE: path.join(root, 'home'),
+    CODEX_HOME: path.join(root, 'codex'), TMPDIR: path.join(root, 'tmp'),
+    XDG_CACHE_HOME: path.join(root, 'home/.cache'), XDG_CONFIG_HOME: path.join(root, 'home/.config'),
+    CODESTORY_CACHE_ROOT: path.join(root, 'cache'), CODESTORY_STDIO_CACHE_ROOT: path.join(root, 'cache'),
+    CODESTORY_EMBED_ALLOW_CPU: '0',
+    CODESTORY_EMBED_QUALIFICATION_DIR: path.join(root, 'qualification'),
+    CODESTORY_EMBED_QUALIFICATION_NONCE: nonce };
+}
+
+async function checkedProcess(runProcess, command, args, options) {
+  const result = await runProcess(command, args, { timeoutMs: 90_000, ...options });
+  requireThat(result.status === 'pass', `${path.basename(command)} failed: ${result.stderr}`);
+  return result.stdout.trim();
+}
+
+async function prepareSession(row, manifest, installation, output, codex, helpers) {
+  const task = manifest.tasks.find(task => task.id === row.task_id);
+  const repo = manifest.repositories.find(repo => repo.id === task.repository_id);
+  const root = path.join(output, row.session_id);
+  await mkdir(root); // Existing attempts are never overwritten or silently resumed.
+  const env = navigationEnvironment(process.env, root, randomBytes(32).toString('hex'));
+  for (const folder of ['home', 'codex', 'tmp', 'cache', 'qualification']) await mkdir(path.join(root, folder), { mode: 0o700 });
+  const project = path.join(root, 'repository');
+  const git = args => checkedProcess(helpers.runProcess, 'git', ['-c', 'core.hooksPath=/dev/null', ...args], { env });
+  requireThat(await git(['-C', repo.seed_clone, 'rev-parse', repo.commit]) === repo.commit, 'seed commit mismatch');
+  await git(['clone', '--no-hardlinks', '--no-checkout', repo.seed_clone, project]);
+  await git(['-C', project, 'checkout', '--detach', repo.commit]);
+  requireThat(await git(['-C', project, 'rev-parse', 'HEAD^{tree}']) === repo.tree, 'checkout tree mismatch');
+  const arm = installation.arms[row.arm];
+  requireThat(arm && path.isAbsolute(arm.codex_home_template), 'missing isolated installation template');
+  await cp(arm.codex_home_template, env.CODEX_HOME, { recursive: true, force: true, dereference: false });
+  // The template is a fresh installation, never a prior agent run. Auth stays private.
+  for (const forbidden of ['sessions', 'memories', 'AGENTS.md']) {
+    requireThat(!await stat(path.join(env.CODEX_HOME, forbidden)).then(() => true, () => false), `template contains ${forbidden}`);
+  }
+  if (installation.auth_file) await cp(installation.auth_file, path.join(env.CODEX_HOME, 'auth.json'));
+  const config = await readFile(path.join(env.CODEX_HOME, 'config.toml'), 'utf8');
+  requireThat(!/approval_policy|ignore_user_config|developer_instructions|model_instructions_file|mcp_servers|sandbox_mode|shell_environment_policy/.test(config), 'installation config contains a policy or server override');
+  const listingRaw = await checkedProcess(helpers.runProcess, codex, ['plugin', 'list', '--json'], { env });
+  const listing = JSON.parse(listingRaw);
+  const installed = listing.installed ?? [];
+  let pluginRoot = null;
+  if (row.arm === 'native') requireThat(installed.length === 0, 'native arm contains plugins');
+  else {
+    requireThat(installed.length === 1 && relative(arm.plugin_relative_path), 'expected one installed CodeStory plugin');
+    pluginRoot = path.join(env.CODEX_HOME, arm.plugin_relative_path);
+    requireThat((await realpath(pluginRoot)).startsWith(`${await realpath(env.CODEX_HOME)}${path.sep}`), 'plugin escaped isolated home');
+    requireThat(directoryDigest(pluginRoot) === arm.package_sha256, 'installed package drift');
+    env.CODESTORY_PLUGIN_DATA = path.join(env.CODEX_HOME, 'plugins/data', `codestory-${installed[0].marketplaceName}`);
+    await mkdir(env.CODESTORY_PLUGIN_DATA, { recursive: true, mode: 0o700 });
+    requireThat(/^[a-f0-9]{40}$/.test(arm.source_commit) && /^[a-f0-9]{64}$/.test(arm.runtime_sha256), 'missing source/runtime identity');
+    // Local release mirrors are allowed; binary override paths are deliberately unsupported.
+    if (arm.release_directory) env.CODESTORY_PLUGIN_RELEASE_DIR = arm.release_directory;
+  }
+  const effective = { schema_version: 1, session: row, model: manifest.model, timeout_ms: 600_000,
+    sandbox: 'workspace-write', project, source_commit: repo.commit, source_tree: repo.tree,
+    package: arm, configuration: config, plugin_listing: listing, environment: Object.fromEntries(Object.entries(env).filter(([key]) => /^(HOME|USERPROFILE|TMPDIR|CODEX_HOME|CODESTORY_)/.test(key))) };
+  await save(path.join(root, 'effective-config.json'), effective);
+  return { root, env, project, pluginRoot, task, arm, effective };
+}
+
+async function operationCanary(session, helpers) {
+  const { root, env, pluginRoot, arm } = session;
+  if (!pluginRoot) return { status: 'pass', surface: 'native', operations: ['git clone', 'git checkout', 'plugin inventory'] };
+  const project = path.join(root, 'operation-canary');
+  await mkdir(project);
+  await writeFile(path.join(project, 'index.js'), 'export function navigationCanary() { return "BEFORE_REFRESH"; }\n');
+  await checkedProcess(helpers.runProcess, 'git', ['-c', 'core.hooksPath=/dev/null', 'init', project], { env });
+  const transcript = [];
+  const channel = helpers.createSequencedStdioSession(process.execPath, [path.join(pluginRoot, 'scripts/codestory-mcp.cjs')], { env, timeoutMs: 90_000, onNotification: notification => transcript.push({ notification }) });
+  let id = 0;
+  const request = async (method, params) => {
+    const sent = { jsonrpc: '2.0', id: ++id, method, params };
+    const received = await channel.request(sent); transcript.push({ sent, received });
+    requireThat(!received.error && !received.result?.isError, `canary ${method} failed: ${JSON.stringify(received)}`);
+    return received.result;
+  };
+  try {
+    const init = await request('initialize', { protocolVersion: '2025-11-25', capabilities: {}, clientInfo: { name: 'installed-navigation-canary', version: '1' } });
+    requireThat(init.serverInfo?.version === arm.version, 'installed runtime version mismatch');
+    channel.send({ jsonrpc: '2.0', method: 'notifications/initialized' });
+    const catalog = await request('tools/list', {});
+    requireThat(Array.isArray(catalog.tools) && catalog.tools.every(tool => tool.inputSchema?.type === 'object'), 'invalid tool schemas');
+    requireThat(sha(JSON.stringify(catalog.tools)) === arm.tools_sha256, 'installed tool catalog mismatch');
+    const call = async (name, args) => {
+      const deadline = performance.now() + 75_000;
+      while (true) {
+        const result = await request('tools/call', { name, arguments: { project, ...args } });
+        const state = result.structuredContent;
+        if (!['preparing', 'updating'].includes(state?.state)) return result;
+        requireThat(performance.now() < deadline, 'managed preparation exceeded canary budget');
+        await delay(Math.min(5000, Math.max(100, state.retry_after_ms ?? 1000)));
+      }
+    };
+    await call('files', {});
+    const before = await call('snippet', { path: 'index.js', start_line: 1, end_line: 1 });
+    requireThat(JSON.stringify(before).includes('BEFORE_REFRESH'), 'source-read canary failed');
+    await writeFile(path.join(project, 'index.js'), 'export function navigationCanary() { return "AFTER_REFRESH"; }\n');
+    await call('files', {});
+    const after = await call('snippet', { path: 'index.js', start_line: 1, end_line: 1 });
+    requireThat(JSON.stringify(after).includes('AFTER_REFRESH') && !JSON.stringify(after).includes('BEFORE_REFRESH'), 'refresh returned stale source');
+    requireThat(JSON.stringify(transcript).includes(arm.runtime_sha256), 'runtime executable digest missing or mismatched');
+    await channel.close();
+    return { status: 'pass', surface: 'installed-plugin', catalog_sha256: arm.tools_sha256, runtime_sha256: arm.runtime_sha256 };
+  } finally {
+    await channel.stop();
+    await save(path.join(root, 'canary-transcript.json'), transcript);
+    await writeFile(path.join(root, 'canary-stderr.txt'), channel.stderr());
+  }
+}
+
+export async function runInstalledNavigation(argv, helpers) {
+  const { values } = parseArgs({ args: argv, options: {
+    'installed-navigation': { type: 'boolean' }, manifest: { type: 'string' }, installations: { type: 'string' },
+    out: { type: 'string' }, codex: { type: 'string', default: 'codex' },
+    'preflight-only': { type: 'boolean', default: false },
+  }, strict: true });
+  requireThat(values.manifest && values.installations && values.out, '--manifest, --installations and --out required');
+  const manifestBytes = await readFile(values.manifest);
+  const manifest = JSON.parse(manifestBytes);
+  validateManifest(manifest);
+  const installationBytes = await readFile(values.installations);
+  const installation = JSON.parse(installationBytes);
+  requireThat(installation.manifest_sha256 === sha(manifestBytes), 'installation receipt targets another manifest');
+  requireThat(installation.budget?.max_sessions >= manifest.sessions.length && installation.budget?.max_wall_ms >= manifest.sessions.length * 600_000, 'frozen budget must cover all ten-minute sessions');
+  const output = path.resolve(values.out);
+  await mkdir(output); // No overwrite/resume: failures stay in their original attempt.
+  const runStart = performance.now();
+  const remainingMs = () => Math.min(installation.budget.max_wall_ms - (performance.now() - runStart), installation.budget.deadline_utc ? Date.parse(installation.budget.deadline_utc) - Date.now() : Infinity);
+  requireThat(remainingMs() > 0, 'navigation budget expired');
+  const prepared = [];
+  // Every arm must pass deterministic checks before any model starts.
+  for (const armName of manifest.arms) {
+    const example = manifest.sessions.find(row => row.arm === armName);
+    const session = await prepareSession({ ...example, session_id: `preflight-${armName}` }, manifest, installation, output, values.codex, helpers);
+    const canary = await operationCanary(session, helpers);
+    prepared.push({ arm: armName, canary, effective_config_sha256: sha(await readFile(path.join(session.root, 'effective-config.json'))) });
+    await save(path.join(output, 'preflight.json'), prepared);
+  }
+  if (values['preflight-only']) return;
+  const results = [];
+  for (const row of manifest.sessions) {
+    requireThat(remainingMs() > 0, 'navigation elapsed budget exhausted');
+    const started = performance.now();
+    const session = await prepareSession(row, manifest, installation, output, values.codex, helpers);
+    const invocation = navigationCommand(values.codex, session.project, path.join(session.root, 'answer.md'));
+    const preparationMs = performance.now() - started;
+    await writeFile(path.join(session.root, 'prompt.txt'), session.task.prompt);
+    const run = await helpers.runProcess(invocation.command, invocation.args, { cwd: session.project, env: session.env,
+      stdin: session.task.prompt, timeoutMs: Math.min(600_000, remainingMs()), killProcessTree: true, maxOutputBytes: 64 * 1024 * 1024 });
+    await writeFile(path.join(session.root, 'transcript.jsonl'), run.stdout);
+    await writeFile(path.join(session.root, 'stderr.txt'), run.stderr);
+    const events = []; const malformed = [];
+    for (const line of run.stdout.split('\n').filter(Boolean)) { try { events.push(JSON.parse(line)); } catch { malformed.push(line); } }
+    const usage = helpers.extractUsage(events);
+    const result = { ...row, status: run.status, exit_code: run.exitCode, timed_out: run.timedOut,
+      preparation_ms: preparationMs, whole_task_wall_ms: performance.now() - started,
+      usage, telemetry_complete: malformed.length === 0 && usage.input_tokens != null && events.some(event => event.type === 'turn.completed'),
+      transcript_sha256: sha(run.stdout), malformed_lines: malformed.length,
+      analysis: helpers.analyzeTranscript(events, session.project), grading: 'pending_independent_evaluator' };
+    await save(path.join(session.root, 'result.json'), result); results.push(result);
+    await save(path.join(output, 'summary.json'), { schema_version: 1, profile: manifest.profile,
+      manifest_sha256: sha(manifestBytes), installations_sha256: sha(installationBytes),
+      expected_sessions: manifest.sessions.length, completed_sessions: results.length, results,
+      acceptance: 'pending_independent_evaluator', elapsed_ms: performance.now() - runStart });
+    // A failed model attempt remains counted; subsequent scheduled arms still execute.
+  }
+}

--- a/scripts/installed-navigation-profile.mjs
+++ b/scripts/installed-navigation-profile.mjs
@@ -1,5 +1,5 @@
 import { createHash, randomBytes } from 'node:crypto';
-import { cp, mkdir, readFile, writeFile, stat, realpath } from 'node:fs/promises';
+import { cp, mkdir, readFile, writeFile, stat, realpath, readdir, lstat } from 'node:fs/promises';
 import path from 'node:path';
 import { performance } from 'node:perf_hooks';
 import { parseArgs } from 'node:util';
@@ -7,11 +7,9 @@ import { setTimeout as delay } from 'node:timers/promises';
 import { directoryDigest } from '../.github/scripts/install-codestory-marketplace-proof.mjs';
 
 const sha = bytes => createHash('sha256').update(bytes).digest('hex');
-const json = async file => JSON.parse(await readFile(file, 'utf8'));
 const save = (file, value) => writeFile(file, `${JSON.stringify(value, null, 2)}\n`);
 const requireThat = (condition, message) => { if (!condition) throw new Error(message); };
-const relative = value => typeof value === 'string' && value.length > 0 && !path.isAbsolute(value)
-  && !value.split(/[\\/]/).some(part => part === '..' || part === '');
+const safeId = value => typeof value === 'string' && /^[a-zA-Z0-9_-]+$/.test(value);
 
 export function validateManifest(manifest) {
   requireThat(manifest.schema_version === 1, 'unsupported navigation manifest');
@@ -22,11 +20,11 @@ export function validateManifest(manifest) {
   requireThat(repos.size === manifest.repositories.length && tasks.size === manifest.tasks.length, 'duplicate repository or task');
   for (const repo of repos.values()) requireThat(/^[a-f0-9]{40}$/.test(repo.commit) && /^[a-f0-9]{40}$/.test(repo.tree) && path.isAbsolute(repo.seed_clone), 'repository needs pinned commit, tree and seed clone');
   for (const task of tasks.values()) requireThat(repos.has(task.repository_id) && typeof task.prompt === 'string' && task.prompt.length > 0 && ['read_only', 'change'].includes(task.effect_mode), 'invalid navigation task');
-  requireThat(new Set(manifest.arms).size === manifest.arms.length && manifest.arms.includes('native'), 'unique arms including native required');
+  requireThat(Array.isArray(manifest.arms) && manifest.arms.every(safeId) && new Set(manifest.arms).size === manifest.arms.length && manifest.arms.includes('native'), 'unique arms including native required');
   const seen = new Set();
   const ids = new Set();
   manifest.sessions.forEach((row, index) => {
-    requireThat(row.sequence === index + 1 && /^[a-zA-Z0-9_-]+$/.test(row.session_id) && !ids.has(row.session_id), 'invalid sequence or duplicate session id');
+    requireThat(row.sequence === index + 1 && safeId(row.session_id) && !ids.has(row.session_id), 'invalid sequence or duplicate session id');
     ids.add(row.session_id);
     requireThat(tasks.has(row.task_id) && manifest.arms.includes(row.arm) && Number.isInteger(row.repeat) && row.repeat > 0 && row.repeat <= manifest.repeats, 'invalid session');
     const key = `${row.task_id}:${row.arm}:${row.repeat}`;
@@ -38,6 +36,54 @@ export function validateManifest(manifest) {
     for (const category of ['discovery', 'relationship', 'edit_refresh']) requireThat([...tasks.values()].filter(task => task.category === category).length === 2, 'maintenance category allocation changed');
   }
   return { repos, tasks };
+}
+
+export function validateTemplateConfig(config, armName, arm) {
+  let section = null;
+  for (const raw of config.split('\n')) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    requireThat(armName !== 'native', 'native template contains host configuration');
+    if (line.startsWith('[')) {
+      if (line === `[marketplaces.${arm.marketplace_name}]`) section = 'marketplace';
+      else if (line === `[plugins."codestory@${arm.marketplace_name}"]`) section = 'plugin';
+      else throw new Error(`unexpected installation configuration section: ${line}`);
+    } else {
+      requireThat((section === 'plugin' && line === 'enabled = true')
+        || (section === 'marketplace' && /^(source_type|source|ref) = "[^"\n]*"$/.test(line)), 'installation configuration contains a policy override');
+    }
+  }
+}
+
+export function validateInventory(installed, armName, arm) {
+  requireThat(Array.isArray(installed), 'missing plugin inventory');
+  if (armName === 'native') return requireThat(installed.length === 0, 'native arm contains plugins');
+  requireThat(installed.length === 1, 'expected one installed CodeStory plugin');
+  const plugin = installed[0];
+  requireThat(plugin.name === 'codestory' && plugin.pluginId === `codestory@${arm.marketplace_name}`
+    && plugin.marketplaceName === arm.marketplace_name && plugin.version === arm.version
+    && plugin.installed === true && plugin.enabled === true, 'Codex did not expose the expected enabled plugin');
+}
+
+export function validateRuntime(result, arm) {
+  const publication = result?._meta?.codestory_publication;
+  const runtime = publication?.contract_runtime;
+  requireThat(publication?.schema_version === arm.schema_version && publication?.served_from === 'complete_publication'
+    && typeof publication?.core_publication?.generation_id === 'string'
+    && runtime?.cli_sha256 === arm.runtime_sha256 && runtime?.cli_source === arm.runtime_source
+    && runtime?.cli_version === arm.version && runtime?.plugin_cli_version === arm.version
+    && runtime?.plugin_version === arm.version && runtime?.pinned_pair_matches === true
+    && runtime?.known_override_skew_channel === false, 'typed installed runtime/publication identity mismatch');
+}
+
+export function validateSourceRead(result, project, marker) {
+  const ranges = result?.structuredContent?.ranges;
+  requireThat(Array.isArray(ranges) && ranges.length === 1, 'source-read canary needs exactly one range');
+  const range = ranges[0];
+  requireThat(range.path === path.join(project, 'index.js') && range.start_line === 1 && range.end_line === 1
+    && range.snippet_truncated === false && typeof range.snippet === 'string'
+    && range.snippet.includes(`export function navigationCanary() { return "${marker}"; }`)
+    && !range.snippet.includes(marker === 'BEFORE_REFRESH' ? 'AFTER_REFRESH' : 'BEFORE_REFRESH'), 'source-read canary returned missing, mixed or stale source');
 }
 
 export function navigationCommand(codex, project, output) {
@@ -76,30 +122,35 @@ async function prepareSession(row, manifest, installation, output, codex, helper
   requireThat(await git(['-C', project, 'rev-parse', 'HEAD^{tree}']) === repo.tree, 'checkout tree mismatch');
   const arm = installation.arms[row.arm];
   requireThat(arm && path.isAbsolute(arm.codex_home_template), 'missing isolated installation template');
-  await cp(arm.codex_home_template, env.CODEX_HOME, { recursive: true, force: true, dereference: false });
-  // The template is a fresh installation, never a prior agent run. Auth stays private.
-  for (const forbidden of ['sessions', 'memories', 'AGENTS.md']) {
-    requireThat(!await stat(path.join(env.CODEX_HOME, forbidden)).then(() => true, () => false), `template contains ${forbidden}`);
+  // Copy only installation-owned material; reject host instructions before copying.
+  for (const entry of await readdir(arm.codex_home_template, { withFileTypes: true })) {
+    requireThat(['config.toml', 'plugins', 'tmp', '.tmp'].includes(entry.name) && !entry.isSymbolicLink(), `unexpected template entry: ${entry.name}`);
   }
-  if (installation.auth_file) await cp(installation.auth_file, path.join(env.CODEX_HOME, 'auth.json'));
-  const config = await readFile(path.join(env.CODEX_HOME, 'config.toml'), 'utf8');
-  requireThat(!/approval_policy|ignore_user_config|developer_instructions|model_instructions_file|mcp_servers|sandbox_mode|shell_environment_policy/.test(config), 'installation config contains a policy or server override');
-  const listingRaw = await checkedProcess(helpers.runProcess, codex, ['plugin', 'list', '--json'], { env });
-  const listing = JSON.parse(listingRaw);
-  const installed = listing.installed ?? [];
+  const config = await readFile(path.join(arm.codex_home_template, 'config.toml'), 'utf8');
+  validateTemplateConfig(config, row.arm, arm);
+  await writeFile(path.join(env.CODEX_HOME, 'config.toml'), config);
   let pluginRoot = null;
-  if (row.arm === 'native') requireThat(installed.length === 0, 'native arm contains plugins');
-  else {
-    requireThat(installed.length === 1 && relative(arm.plugin_relative_path), 'expected one installed CodeStory plugin');
-    pluginRoot = path.join(env.CODEX_HOME, arm.plugin_relative_path);
-    requireThat((await realpath(pluginRoot)).startsWith(`${await realpath(env.CODEX_HOME)}${path.sep}`), 'plugin escaped isolated home');
-    requireThat(directoryDigest(pluginRoot) === arm.package_sha256, 'installed package drift');
-    env.CODESTORY_PLUGIN_DATA = path.join(env.CODEX_HOME, 'plugins/data', `codestory-${installed[0].marketplaceName}`);
+  if (row.arm !== 'native') {
+    requireThat(safeId(arm.marketplace_name) && /^\d+\.\d+\.\d+$/.test(arm.version), 'invalid installed identity');
+    const expectedPath = `plugins/cache/${arm.marketplace_name}/codestory/${arm.version}`;
+    requireThat(arm.plugin_relative_path === expectedPath, 'unexpected installed package path');
+    const sourcePlugin = path.join(arm.codex_home_template, expectedPath);
+    requireThat(!(await lstat(sourcePlugin)).isSymbolicLink(), 'template plugin is a symlink');
+    requireThat((await realpath(sourcePlugin)).startsWith(`${await realpath(arm.codex_home_template)}${path.sep}`), 'template plugin escaped isolated home');
+    requireThat(directoryDigest(sourcePlugin) === arm.package_sha256, 'installed package drift');
+    pluginRoot = path.join(env.CODEX_HOME, expectedPath);
+    await cp(sourcePlugin, pluginRoot, { recursive: true, dereference: false });
+    requireThat(directoryDigest(pluginRoot) === arm.package_sha256, 'copied installed package drift');
+    env.CODESTORY_PLUGIN_DATA = path.join(env.CODEX_HOME, 'plugins/data', `codestory-${arm.marketplace_name}`);
     await mkdir(env.CODESTORY_PLUGIN_DATA, { recursive: true, mode: 0o700 });
-    requireThat(/^[a-f0-9]{40}$/.test(arm.source_commit) && /^[a-f0-9]{64}$/.test(arm.runtime_sha256), 'missing source/runtime identity');
-    // Local release mirrors are allowed; binary override paths are deliberately unsupported.
+    requireThat(/^[a-f0-9]{40}$/.test(arm.source_commit) && /^[a-f0-9]{64}$/.test(arm.runtime_sha256)
+      && [2, 3].includes(arm.schema_version) && ['managed', 'local_dev_override'].includes(arm.runtime_source), 'missing source/runtime identity');
     if (arm.release_directory) env.CODESTORY_PLUGIN_RELEASE_DIR = arm.release_directory;
   }
+  if (installation.auth_file) await cp(installation.auth_file, path.join(env.CODEX_HOME, 'auth.json'));
+  const listingRaw = await checkedProcess(helpers.runProcess, codex, ['plugin', 'list', '--json'], { env });
+  const listing = JSON.parse(listingRaw);
+  validateInventory(listing.installed, row.arm, arm);
   const effective = { schema_version: 1, session: row, model: manifest.model, timeout_ms: 600_000,
     sandbox: 'workspace-write', project, source_commit: repo.commit, source_tree: repo.tree,
     package: arm, configuration: config, plugin_listing: listing, environment: Object.fromEntries(Object.entries(env).filter(([key]) => /^(HOME|USERPROFILE|TMPDIR|CODEX_HOME|CODESTORY_)/.test(key))) };
@@ -135,19 +186,18 @@ async function operationCanary(session, helpers) {
       while (true) {
         const result = await request('tools/call', { name, arguments: { project, ...args } });
         const state = result.structuredContent;
-        if (!['preparing', 'updating'].includes(state?.state)) return result;
+        if (!['preparing', 'updating'].includes(state?.state)) { validateRuntime(result, arm); return result; }
         requireThat(performance.now() < deadline, 'managed preparation exceeded canary budget');
         await delay(Math.min(5000, Math.max(100, state.retry_after_ms ?? 1000)));
       }
     };
     await call('files', {});
     const before = await call('snippet', { path: 'index.js', start_line: 1, end_line: 1 });
-    requireThat(JSON.stringify(before).includes('BEFORE_REFRESH'), 'source-read canary failed');
+    validateSourceRead(before, project, 'BEFORE_REFRESH');
     await writeFile(path.join(project, 'index.js'), 'export function navigationCanary() { return "AFTER_REFRESH"; }\n');
     await call('files', {});
     const after = await call('snippet', { path: 'index.js', start_line: 1, end_line: 1 });
-    requireThat(JSON.stringify(after).includes('AFTER_REFRESH') && !JSON.stringify(after).includes('BEFORE_REFRESH'), 'refresh returned stale source');
-    requireThat(JSON.stringify(transcript).includes(arm.runtime_sha256), 'runtime executable digest missing or mismatched');
+    validateSourceRead(after, project, 'AFTER_REFRESH');
     await channel.close();
     return { status: 'pass', surface: 'installed-plugin', catalog_sha256: arm.tools_sha256, runtime_sha256: arm.runtime_sha256 };
   } finally {
@@ -175,42 +225,82 @@ export async function runInstalledNavigation(argv, helpers) {
   await mkdir(output); // No overwrite/resume: failures stay in their original attempt.
   const runStart = performance.now();
   const remainingMs = () => Math.min(installation.budget.max_wall_ms - (performance.now() - runStart), installation.budget.deadline_utc ? Date.parse(installation.budget.deadline_utc) - Date.now() : Infinity);
-  requireThat(remainingMs() > 0, 'navigation budget expired');
+  const allowance = requested => {
+    const available = Math.floor(Math.min(requested, remainingMs()));
+    requireThat(available > 0, 'navigation elapsed budget exhausted');
+    return available;
+  };
+  const bounded = { ...helpers,
+    runProcess: async (command, args, options = {}) => {
+      const result = await helpers.runProcess(command, args, { ...options, timeoutMs: allowance(options.timeoutMs ?? 90_000) });
+      return result;
+    },
+    createSequencedStdioSession: (command, args, options) => {
+      const channel = helpers.createSequencedStdioSession(command, args, { ...options, timeoutMs: allowance(options.timeoutMs) });
+      return { ...channel, request: async request => { allowance(1); const result = await channel.request(request); return result; } };
+    },
+  };
   const prepared = [];
-  // Every arm must pass deterministic checks before any model starts.
-  for (const armName of manifest.arms) {
-    const example = manifest.sessions.find(row => row.arm === armName);
-    const session = await prepareSession({ ...example, session_id: `preflight-${armName}` }, manifest, installation, output, values.codex, helpers);
-    const canary = await operationCanary(session, helpers);
-    prepared.push({ arm: armName, canary, effective_config_sha256: sha(await readFile(path.join(session.root, 'effective-config.json'))) });
-    await save(path.join(output, 'preflight.json'), prepared);
+  const results = manifest.sessions.map(row => ({ ...row, status: 'not_run', model_attempted: false, whole_task_wall_ms: 0, telemetry_complete: false }));
+  const persist = () => save(path.join(output, 'summary.json'), { schema_version: 1, profile: manifest.profile,
+    manifest_sha256: sha(manifestBytes), installations_sha256: sha(installationBytes),
+    expected_sessions: manifest.sessions.length, recorded_sessions: results.filter(row => row.status !== 'not_run').length, model_attempts: results.filter(row => row.model_attempted).length,
+    results, preflight: prepared, acceptance: 'pending_independent_evaluator', elapsed_ms: performance.now() - runStart });
+  await persist();
+  try {
+    // Every arm must pass deterministic checks before any model starts.
+    for (const armName of manifest.arms) {
+      allowance(1);
+      const example = manifest.sessions.find(row => row.arm === armName);
+      const session = await prepareSession({ ...example, session_id: `preflight-${armName}` }, manifest, installation, output, values.codex, bounded);
+      const canary = await operationCanary(session, bounded);
+      allowance(1);
+      prepared.push({ arm: armName, canary, effective_config_sha256: sha(await readFile(path.join(session.root, 'effective-config.json'))) });
+      await save(path.join(output, 'preflight.json'), prepared);
+    }
+  } catch (error) {
+    prepared.push({ status: 'fail', error: error.message });
+    for (const row of results) { row.status = 'not_run_preflight_failed'; row.error = error.message; }
+    await save(path.join(output, 'preflight.json'), prepared); await persist(); throw error;
   }
-  if (values['preflight-only']) return;
-  const results = [];
-  for (const row of manifest.sessions) {
-    requireThat(remainingMs() > 0, 'navigation elapsed budget exhausted');
+  if (values['preflight-only']) { await persist(); return; }
+  for (const [index, row] of manifest.sessions.entries()) {
     const started = performance.now();
-    const session = await prepareSession(row, manifest, installation, output, values.codex, helpers);
-    const invocation = navigationCommand(values.codex, session.project, path.join(session.root, 'answer.md'));
-    const preparationMs = performance.now() - started;
-    await writeFile(path.join(session.root, 'prompt.txt'), session.task.prompt);
-    const run = await helpers.runProcess(invocation.command, invocation.args, { cwd: session.project, env: session.env,
-      stdin: session.task.prompt, timeoutMs: Math.min(600_000, remainingMs()), killProcessTree: true, maxOutputBytes: 64 * 1024 * 1024 });
-    await writeFile(path.join(session.root, 'transcript.jsonl'), run.stdout);
-    await writeFile(path.join(session.root, 'stderr.txt'), run.stderr);
-    const events = []; const malformed = [];
-    for (const line of run.stdout.split('\n').filter(Boolean)) { try { events.push(JSON.parse(line)); } catch { malformed.push(line); } }
-    const usage = helpers.extractUsage(events);
-    const result = { ...row, status: run.status, exit_code: run.exitCode, timed_out: run.timedOut,
-      preparation_ms: preparationMs, whole_task_wall_ms: performance.now() - started,
-      usage, telemetry_complete: malformed.length === 0 && usage.input_tokens != null && events.some(event => event.type === 'turn.completed'),
-      transcript_sha256: sha(run.stdout), malformed_lines: malformed.length,
-      analysis: helpers.analyzeTranscript(events, session.project), grading: 'pending_independent_evaluator' };
-    await save(path.join(session.root, 'result.json'), result); results.push(result);
-    await save(path.join(output, 'summary.json'), { schema_version: 1, profile: manifest.profile,
-      manifest_sha256: sha(manifestBytes), installations_sha256: sha(installationBytes),
-      expected_sessions: manifest.sessions.length, completed_sessions: results.length, results,
-      acceptance: 'pending_independent_evaluator', elapsed_ms: performance.now() - runStart });
-    // A failed model attempt remains counted; subsequent scheduled arms still execute.
+    const root = path.join(output, row.session_id);
+    let phase = 'preparation';
+    const result = { ...row, status: 'preparation_failed', model_attempted: false, telemetry_complete: false,
+      usage: { input_tokens: null, output_tokens: null, total_tokens: null }, grading: 'pending_independent_evaluator' };
+    let stdout = ''; let stderr = '';
+    try {
+      allowance(1);
+      const session = await prepareSession(row, manifest, installation, output, values.codex, bounded);
+      const invocation = navigationCommand(values.codex, session.project, path.join(root, 'answer.md'));
+      result.preparation_ms = performance.now() - started;
+      await writeFile(path.join(root, 'prompt.txt'), session.task.prompt);
+      allowance(1); // No model process may start after preparation consumes the budget.
+      phase = 'model'; result.model_attempted = true;
+      const run = await bounded.runProcess(invocation.command, invocation.args, { cwd: session.project, env: session.env,
+        stdin: session.task.prompt, timeoutMs: 600_000, killProcessTree: true, maxOutputBytes: 64 * 1024 * 1024 });
+      stdout = run.stdout; stderr = run.stderr;
+      const events = []; const malformed = [];
+      for (const line of stdout.split('\n').filter(Boolean)) { try { events.push(JSON.parse(line)); } catch { malformed.push(line); } }
+      const usage = helpers.extractUsage(events);
+      Object.assign(result, { status: run.status, exit_code: run.exitCode, timed_out: run.timedOut, usage,
+        telemetry_complete: malformed.length === 0 && ['input_tokens', 'output_tokens', 'total_tokens'].every(key => Number.isFinite(usage[key]) && usage[key] >= 0)
+          && events.some(event => event.type === 'turn.completed'),
+        malformed_lines: malformed.length, analysis: helpers.analyzeTranscript(events, session.project) });
+    } catch (error) {
+      result.status = remainingMs() <= 0 ? 'budget_exhausted' : `${phase}_failed`;
+      result.error = error.message; stderr += `${error.message}\n`;
+    } finally {
+      result.whole_task_wall_ms = performance.now() - started;
+      result.transcript_sha256 = sha(stdout);
+      await mkdir(root, { recursive: true });
+      await writeFile(path.join(root, 'transcript.jsonl'), stdout);
+      await writeFile(path.join(root, 'stderr.txt'), stderr);
+      await save(path.join(root, 'result.json'), result);
+      results[index] = result; await persist();
+    }
+    // Failed attempts and unstarted budget rows retain their places in the denominator.
   }
 }

--- a/scripts/installed-navigation-profile.mjs
+++ b/scripts/installed-navigation-profile.mjs
@@ -87,7 +87,7 @@ export function validateSourceRead(result, project, marker) {
 }
 
 export function navigationCommand(codex, project, output) {
-  return { command: codex, args: ['exec', '--model', 'gpt-5.6-terra', '--config', 'model_reasoning_effort="low"', '--sandbox', 'workspace-write', '--cd', project, '--json', '--output-last-message', output, '-'] };
+  return { command: codex, args: ['exec', '--disable', 'remote_plugin', '--model', 'gpt-5.6-terra', '--config', 'model_reasoning_effort="low"', '--sandbox', 'workspace-write', '--cd', project, '--json', '--output-last-message', output, '-'] };
 }
 
 export function navigationEnvironment(parent, root, nonce) {
@@ -148,11 +148,11 @@ async function prepareSession(row, manifest, installation, output, codex, helper
     if (arm.release_directory) env.CODESTORY_PLUGIN_RELEASE_DIR = arm.release_directory;
   }
   if (installation.auth_file) await cp(installation.auth_file, path.join(env.CODEX_HOME, 'auth.json'));
-  const listingRaw = await checkedProcess(helpers.runProcess, codex, ['plugin', 'list', '--json'], { env });
+  const listingRaw = await checkedProcess(helpers.runProcess, codex, ['plugin', 'list', '--json', '--disable', 'remote_plugin'], { env });
   const listing = JSON.parse(listingRaw);
   validateInventory(listing.installed, row.arm, arm);
   const effective = { schema_version: 1, session: row, model: manifest.model, timeout_ms: 600_000,
-    sandbox: 'workspace-write', project, source_commit: repo.commit, source_tree: repo.tree,
+    sandbox: 'workspace-write', host_features: { remote_plugin: false }, project, source_commit: repo.commit, source_tree: repo.tree,
     package: arm, configuration: config, plugin_listing: listing, environment: Object.fromEntries(Object.entries(env).filter(([key]) => /^(HOME|USERPROFILE|TMPDIR|CODEX_HOME|CODESTORY_)/.test(key))) };
   await save(path.join(root, 'effective-config.json'), effective);
   return { root, env, project, pluginRoot, task, arm, effective };

--- a/scripts/installed-navigation-profile.test.mjs
+++ b/scripts/installed-navigation-profile.test.mjs
@@ -1,0 +1,49 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { validateManifest, navigationCommand, navigationEnvironment } from './installed-navigation-profile.mjs';
+
+const fixture = () => ({ schema_version: 1, profile: 'pilot', model: { name: 'gpt-5.6-terra', reasoning_effort: 'low' },
+  repositories: [{ id: 'r', commit: 'a'.repeat(40), tree: 'b'.repeat(40), seed_clone: '/tmp/seed' }],
+  tasks: [{ id: 't', repository_id: 'r', effect_mode: 'read_only', prompt: 'Inspect source.' }],
+  arms: ['native', 'published'], repeats: 1,
+  sessions: [{ sequence: 1, session_id: 't-native', task_id: 't', arm: 'native', repeat: 1 }, { sequence: 2, session_id: 't-published', task_id: 't', arm: 'published', repeat: 1 }] });
+
+test('complete manifest accepts equal native and installed arms', () => assert.equal(validateManifest(fixture()).tasks.size, 1));
+test('schedule and source mutations fail closed before execution', () => {
+  for (const mutate of [
+    m => m.sessions.pop(),
+    m => { m.sessions[1].arm = 'native'; },
+    m => { m.sessions[1].session_id = m.sessions[0].session_id; },
+    m => { m.sessions[0].session_id = '../escape'; },
+    m => { m.sessions[0].repeat = 2; },
+    m => { m.sessions[0].sequence = 2; },
+    m => { m.repositories[0].commit = 'main'; },
+    m => { m.model.reasoning_effort = 'xhigh'; },
+    m => { m.tasks[0].repository_id = 'missing'; },
+    m => { m.profile = 'codestory-0176-navigation-maintenance'; },
+  ]) { const manifest = fixture(); mutate(manifest); assert.throws(() => validateManifest(manifest)); }
+});
+test('same normal sandbox and low reasoning without approval override or tool restrictions', () => {
+  const { args } = navigationCommand('codex', '/checkout', '/output/answer.md');
+  assert.deepEqual(args, ['exec', '--model', 'gpt-5.6-terra', '--config', 'model_reasoning_effort="low"', '--sandbox', 'workspace-write', '--cd', '/checkout', '--json', '--output-last-message', '/output/answer.md', '-']);
+});
+test('runtime and host overrides cannot escape the isolated session', () => {
+  const env = navigationEnvironment({ PATH: '/bin', HOME: '/real', CODEX_HOME: '/real/.codex', CODESTORY_CLI: '/wrong/binary', CODESTORY_PLUGIN_DATA: '/shared', CODESTORY_EMBED_QUALIFICATION_DIR: '/shared', OPENAI_API_KEY: 'never-retain', PLUGIN_DATA: '/shared' }, '/isolated', 'nonce');
+  assert.equal(env.HOME, '/isolated/home');
+  assert.equal(env.CODEX_HOME, '/isolated/codex');
+  assert.equal(env.CODESTORY_EMBED_QUALIFICATION_DIR, '/isolated/qualification');
+  assert.equal(env.PATH, '/bin');
+  for (const key of ['CODESTORY_CLI', 'CODESTORY_PLUGIN_DATA', 'OPENAI_API_KEY', 'PLUGIN_DATA']) assert.equal(env[key], undefined);
+});
+
+test('ordinary launcher notifications are retained without consuming a response', async () => {
+  const { createSequencedStdioSession } = await import('./codestory-agent-ab-benchmark.mjs');
+  const notifications = [];
+  const script = `process.stdin.on('data', b => { const request=JSON.parse(String(b)); process.stdout.write(JSON.stringify({jsonrpc:'2.0',method:'notifications/tools/list_changed'})+'\\n'); process.stdout.write(JSON.stringify({jsonrpc:'2.0',id:request.id,result:{ok:true}})+'\\n'); }); process.stdin.on('end',()=>process.exit(0));`;
+  const channel = createSequencedStdioSession(process.execPath, ['-e', script], { timeoutMs: 5000, onNotification: value => notifications.push(value) });
+  try {
+    assert.deepEqual((await channel.request({jsonrpc:'2.0',id:1,method:'tools/list'})).result, {ok:true});
+    assert.equal(notifications[0].method, 'notifications/tools/list_changed');
+    await channel.close();
+  } finally { await channel.stop(); }
+});

--- a/scripts/installed-navigation-profile.test.mjs
+++ b/scripts/installed-navigation-profile.test.mjs
@@ -47,3 +47,84 @@ test('ordinary launcher notifications are retained without consuming a response'
     await channel.close();
   } finally { await channel.stop(); }
 });
+
+test('typed canary rejects diagnostic substitutes, mixed source, and runtime drift', async () => {
+  const { validateRuntime, validateSourceRead, validateInventory, validateTemplateConfig } = await import('./installed-navigation-profile.mjs');
+  const arm = { marketplace_name: 'fixture', version: '0.17.5', schema_version: 2, runtime_source: 'managed', runtime_sha256: 'c'.repeat(64) };
+  const result = { _meta: { codestory_publication: { schema_version: 2, served_from: 'complete_publication', core_publication: { generation_id: 'g' }, contract_runtime: { cli_sha256: arm.runtime_sha256, cli_source: 'managed', cli_version: arm.version, plugin_cli_version: arm.version, plugin_version: arm.version, pinned_pair_matches: true, known_override_skew_channel: false } } }, structuredContent: { ranges: [{ path: '/repo/index.js', start_line: 1, end_line: 1, snippet_truncated: false, snippet: 'export function navigationCanary() { return "BEFORE_REFRESH"; }' }] } };
+  validateRuntime(result, arm); validateSourceRead(result, '/repo', 'BEFORE_REFRESH');
+  for (const mutate of [
+    r => { r.structuredContent.ranges = []; r.diagnostic = JSON.stringify(result); },
+    r => { r.structuredContent.ranges[0].path = '/wrong/index.js'; },
+    r => { r.structuredContent.ranges[0].snippet += 'AFTER_REFRESH'; },
+    r => { r.structuredContent.ranges[0].snippet_truncated = true; },
+  ]) { const bad = structuredClone(result); mutate(bad); assert.throws(() => validateSourceRead(bad, '/repo', 'BEFORE_REFRESH')); }
+  for (const field of ['cli_sha256', 'cli_source', 'cli_version', 'plugin_version', 'pinned_pair_matches', 'known_override_skew_channel']) {
+    const bad = structuredClone(result); bad._meta.codestory_publication.contract_runtime[field] = 'wrong'; bad.diagnostic = JSON.stringify(result);
+    assert.throws(() => validateRuntime(bad, arm));
+  }
+  const plugin = { name: 'codestory', marketplaceName: 'fixture', pluginId: 'codestory@fixture', version: arm.version, installed: true, enabled: true };
+  validateInventory([plugin], 'published', arm);
+  for (const field of Object.keys(plugin)) assert.throws(() => validateInventory([{...plugin, [field]: 'wrong'}], 'published', arm));
+  assert.throws(() => validateTemplateConfig('[mcp_servers.injected]\ncommand = "fake"', 'published', arm));
+  assert.throws(() => validateTemplateConfig('[plugins."codestory@fixture"]\nenabled = false', 'published', arm));
+});
+
+test('arm names cannot escape preflight output', () => {
+  const manifest = fixture(); manifest.arms[1] = 'x/../../escape'; manifest.sessions[1].arm = manifest.arms[1];
+  assert.throws(() => validateManifest(manifest));
+});
+
+async function accountingFixture(t, option) {
+  const fs = await import('node:fs/promises'); const os = await import('node:os'); const path = await import('node:path');
+  const { createHash } = await import('node:crypto');
+  const { runInstalledNavigation } = await import('./installed-navigation-profile.mjs');
+  const { extractUsage } = await import('./codestory-agent-ab-benchmark.mjs');
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'navigation-test-'));
+  t.after(() => fs.rm(root, {recursive:true,force:true}));
+  const template = path.join(root, 'template'); await fs.mkdir(template); await fs.writeFile(path.join(template, 'config.toml'), '');
+  if (option === 'skills') { await fs.mkdir(path.join(template, 'skills')); }
+  const manifest = fixture(); manifest.arms = ['native']; manifest.repeats = 2;
+  manifest.sessions = [1,2].map((repeat, index) => ({sequence:index+1,session_id:`native-${repeat}`,task_id:'t',arm:'native',repeat}));
+  const bytes = JSON.stringify(manifest); await fs.writeFile(path.join(root, 'manifest.json'), bytes);
+  const originalNow = Date.now; let now = originalNow();
+  const installation = { manifest_sha256:createHash('sha256').update(bytes).digest('hex'), budget:{max_sessions:2,max_wall_ms:1200000}, arms:{native:{codex_home_template:template}} };
+  if (option.startsWith('deadline')) { installation.budget.deadline_utc = new Date(now + 10000).toISOString(); Date.now = () => now; }
+  await fs.writeFile(path.join(root, 'installations.json'), JSON.stringify(installation));
+  let attempts = 0;
+  const pass = stdout => ({status:'pass',stdout,stderr:'',exitCode:0,timedOut:false});
+  const helpers = { extractUsage, analyzeTranscript:()=>({}), runProcess:async(command,args,options) => {
+    if (command === 'git') {
+      if (args.includes('clone')) await fs.mkdir(args.at(-1), {recursive:true});
+      return pass(args.includes('rev-parse') ? args.at(-1)==='HEAD^{tree}' ? 'b'.repeat(40) : 'a'.repeat(40) : '');
+    }
+    if (args[0] === 'plugin') {
+      const preflight = options.env.CODEX_HOME.includes('preflight-');
+      if (option === 'deadline-preflight' && preflight || option === 'deadline-preparation' && !preflight) now += 20000;
+      if (option === 'preparation' && options.env.CODEX_HOME.includes('native-1')) return {...pass(''),status:'fail',stderr:'inventory unavailable'};
+      return pass('{"installed":[]}');
+    }
+    attempts++; assert.ok(options.timeoutMs > 0 && options.timeoutMs <= 600000);
+    if (option === 'spawn') throw new Error('spawn unavailable');
+    const usage = option === 'usage' ? {input_tokens:11} : {input_tokens:11,output_tokens:7,total_tokens:18};
+    return {...pass(`${JSON.stringify({type:'turn.completed',usage})}\n`), ...(option === 'model-failure' ? {status:'fail',exitCode:1} : {})};
+  } };
+  let error;
+  try { await runInstalledNavigation(['--manifest',path.join(root,'manifest.json'),'--installations',path.join(root,'installations.json'),'--out',path.join(root,'out')],helpers); }
+  catch (caught) { error = caught; } finally { Date.now = originalNow; }
+  return { attempts, error, summary:JSON.parse(await fs.readFile(path.join(root,'out/summary.json'),'utf8')) };
+}
+
+test('failure and budget matrix retains every row without launching after expiry', async t => {
+  for (const option of ['skills','deadline-preflight','deadline-preparation','preparation','spawn','usage','model-failure']) {
+    const result = await accountingFixture(t, option);
+    assert.equal(result.summary.results.length, 2);
+    assert.ok(result.summary.results.every(row => row.status !== 'not_run'));
+    if (['skills','deadline-preflight','deadline-preparation'].includes(option)) assert.equal(result.attempts, 0);
+    else if (option === 'preparation') { assert.equal(result.attempts, 1); assert.equal(result.summary.results[0].status,'preparation_failed'); assert.equal(result.summary.results[1].status,'pass'); }
+    else assert.equal(result.attempts, 2);
+    if (option === 'usage') assert.ok(result.summary.results.every(row => row.telemetry_complete === false));
+    if (option === 'spawn') assert.ok(result.summary.results.every(row => row.status === 'model_failed'));
+    if (option === 'model-failure') assert.ok(result.summary.results.every(row => row.status === 'fail'));
+  }
+});

--- a/scripts/tests/installed-navigation-profile.test.mjs
+++ b/scripts/tests/installed-navigation-profile.test.mjs
@@ -25,7 +25,7 @@ test('schedule and source mutations fail closed before execution', () => {
 });
 test('same normal sandbox and low reasoning without approval override or tool restrictions', () => {
   const { args } = navigationCommand('codex', '/checkout', '/output/answer.md');
-  assert.deepEqual(args, ['exec', '--model', 'gpt-5.6-terra', '--config', 'model_reasoning_effort="low"', '--sandbox', 'workspace-write', '--cd', '/checkout', '--json', '--output-last-message', '/output/answer.md', '-']);
+  assert.deepEqual(args, ['exec', '--disable', 'remote_plugin', '--model', 'gpt-5.6-terra', '--config', 'model_reasoning_effort="low"', '--sandbox', 'workspace-write', '--cd', '/checkout', '--json', '--output-last-message', '/output/answer.md', '-']);
 });
 test('runtime and host overrides cannot escape the isolated session', () => {
   const env = navigationEnvironment({ PATH: '/bin', HOME: '/real', CODEX_HOME: '/real/.codex', CODESTORY_CLI: '/wrong/binary', CODESTORY_PLUGIN_DATA: '/shared', CODESTORY_EMBED_QUALIFICATION_DIR: '/shared', OPENAI_API_KEY: 'never-retain', PLUGIN_DATA: '/shared' }, '/isolated', 'nonce');
@@ -99,12 +99,13 @@ async function accountingFixture(t, option) {
       return pass(args.includes('rev-parse') ? args.at(-1)==='HEAD^{tree}' ? 'b'.repeat(40) : 'a'.repeat(40) : '');
     }
     if (args[0] === 'plugin') {
+      assert.ok(args.includes('--disable') && args.includes('remote_plugin'));
       const preflight = options.env.CODEX_HOME.includes('preflight-');
       if (option === 'deadline-preflight' && preflight || option === 'deadline-preparation' && !preflight) now += 20000;
       if (option === 'preparation' && options.env.CODEX_HOME.includes('native-1')) return {...pass(''),status:'fail',stderr:'inventory unavailable'};
       return pass('{"installed":[]}');
     }
-    attempts++; assert.ok(options.timeoutMs > 0 && options.timeoutMs <= 600000);
+    attempts++; assert.ok(args.includes('--disable') && args.includes('remote_plugin')); assert.ok(options.timeoutMs > 0 && options.timeoutMs <= 600000);
     if (option === 'spawn') throw new Error('spawn unavailable');
     const usage = option === 'usage' ? {input_tokens:11} : {input_tokens:11,output_tokens:7,total_tokens:18};
     return {...pass(`${JSON.stringify({type:'turn.completed',usage})}\n`), ...(option === 'model-failure' ? {status:'fail',exitCode:1} : {})};

--- a/scripts/tests/installed-navigation-profile.test.mjs
+++ b/scripts/tests/installed-navigation-profile.test.mjs
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { validateManifest, navigationCommand, navigationEnvironment } from './installed-navigation-profile.mjs';
+import { validateManifest, navigationCommand, navigationEnvironment } from '../installed-navigation-profile.mjs';
 
 const fixture = () => ({ schema_version: 1, profile: 'pilot', model: { name: 'gpt-5.6-terra', reasoning_effort: 'low' },
   repositories: [{ id: 'r', commit: 'a'.repeat(40), tree: 'b'.repeat(40), seed_clone: '/tmp/seed' }],
@@ -37,7 +37,7 @@ test('runtime and host overrides cannot escape the isolated session', () => {
 });
 
 test('ordinary launcher notifications are retained without consuming a response', async () => {
-  const { createSequencedStdioSession } = await import('./codestory-agent-ab-benchmark.mjs');
+  const { createSequencedStdioSession } = await import('../codestory-agent-ab-benchmark.mjs');
   const notifications = [];
   const script = `process.stdin.on('data', b => { const request=JSON.parse(String(b)); process.stdout.write(JSON.stringify({jsonrpc:'2.0',method:'notifications/tools/list_changed'})+'\\n'); process.stdout.write(JSON.stringify({jsonrpc:'2.0',id:request.id,result:{ok:true}})+'\\n'); }); process.stdin.on('end',()=>process.exit(0));`;
   const channel = createSequencedStdioSession(process.execPath, ['-e', script], { timeoutMs: 5000, onNotification: value => notifications.push(value) });
@@ -49,7 +49,7 @@ test('ordinary launcher notifications are retained without consuming a response'
 });
 
 test('typed canary rejects diagnostic substitutes, mixed source, and runtime drift', async () => {
-  const { validateRuntime, validateSourceRead, validateInventory, validateTemplateConfig } = await import('./installed-navigation-profile.mjs');
+  const { validateRuntime, validateSourceRead, validateInventory, validateTemplateConfig } = await import('../installed-navigation-profile.mjs');
   const arm = { marketplace_name: 'fixture', version: '0.17.5', schema_version: 2, runtime_source: 'managed', runtime_sha256: 'c'.repeat(64) };
   const result = { _meta: { codestory_publication: { schema_version: 2, served_from: 'complete_publication', core_publication: { generation_id: 'g' }, contract_runtime: { cli_sha256: arm.runtime_sha256, cli_source: 'managed', cli_version: arm.version, plugin_cli_version: arm.version, plugin_version: arm.version, pinned_pair_matches: true, known_override_skew_channel: false } } }, structuredContent: { ranges: [{ path: '/repo/index.js', start_line: 1, end_line: 1, snippet_truncated: false, snippet: 'export function navigationCanary() { return "BEFORE_REFRESH"; }' }] } };
   validateRuntime(result, arm); validateSourceRead(result, '/repo', 'BEFORE_REFRESH');
@@ -78,8 +78,8 @@ test('arm names cannot escape preflight output', () => {
 async function accountingFixture(t, option) {
   const fs = await import('node:fs/promises'); const os = await import('node:os'); const path = await import('node:path');
   const { createHash } = await import('node:crypto');
-  const { runInstalledNavigation } = await import('./installed-navigation-profile.mjs');
-  const { extractUsage } = await import('./codestory-agent-ab-benchmark.mjs');
+  const { runInstalledNavigation } = await import('../installed-navigation-profile.mjs');
+  const { extractUsage } = await import('../codestory-agent-ab-benchmark.mjs');
   const root = await fs.mkdtemp(path.join(os.tmpdir(), 'navigation-test-'));
   t.after(() => fs.rm(root, {recursive:true,force:true}));
   const template = path.join(root, 'template'); await fs.mkdir(template); await fs.writeFile(path.join(template, 'config.toml'), '');


### PR DESCRIPTION
The maintenance comparison needs agents to use ordinary installed CodeStory packages with unrestricted source navigation. Existing benchmark profiles impose packet policy and higher reasoning. This adds an opt-in installed-navigation profile while leaving their contracts intact.

The profile uses a frozen manifest, Terra low, equal workspace-write permissions and ten-minute sessions. Fresh checkouts and isolated homes separate every attempt. Normal launcher/schema/source-read/edit-refresh canaries run before model use. Raw transcripts, failed attempts, configuration, installed identities, timings and token accounting remain available to the independent evaluator; correctness is never inferred from process success.

Closes #2140. Refs #2135.

Validation: five focused tests, unchanged historical runner self-test, documentation links and diff checks pass. An actual installed published-0.17.5 plugin passed native/installed preflight, normal managed archive provisioning and source reads before/after refresh. Initial failed harness attempts remain in local evidence. Independent hostile verification is pending. No model sessions, release acceptance, or final-candidate installed-runtime claim yet.

Worktree: /Users/albert/.codex/worktrees/0176-navigation-runner/CodeStory. Base: a8ca9db6a29b57f5a9e35e1a598c42883bfa256b. Head: 94e62c66 (full immutable head recorded in Git). Role: sole implementation owner. Next proof target: exact-head hostile harness review followed by installed pilot and final-source maintenance panel. Usage and installation receipt format: docs/testing/installed-navigation-profile.md.
