### PR TITLE
fix managed activation of incompatible caches

### DIFF
--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -4658,7 +4658,8 @@ fn malformed_affected_on_cold_project_does_not_activate_before_legacy_retry() {
         .as_str()
         .expect("cold status storage path");
     assert!(
-        !Path::new(storage_path).exists(),
+        !codestory_runtime::core_database_exists(Path::new(storage_path))
+            .expect("inspect cold core storage"),
         "malformed affected input must not create storage before activation: {cold_status}"
     );
 
@@ -4677,7 +4678,27 @@ fn malformed_affected_on_cold_project_does_not_activate_before_legacy_retry() {
     let result = assert_tool_success(&legacy, json!("affected-cold-legacy"));
     assert_eq!(result["changed_paths"], json!(["src/runtime.rs"]));
     assert_eq!(result["matched_file_count"], json!(1));
-    assert!(Path::new(storage_path).exists());
+    assert!(
+        codestory_runtime::core_database_exists(Path::new(storage_path))
+            .expect("inspect activated core storage")
+    );
+    let activated_status = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "affected-activated-status",
+            "method": "resources/read",
+            "params": {"uri": "codestory://status", "project": fixture.workspace.path()}
+        }),
+    );
+    let activated_status = json_resource_content(
+        assert_success_envelope(&activated_status, json!("affected-activated-status")),
+        "codestory://status",
+    );
+    assert!(
+        activated_status["index_publication"].is_object(),
+        "the valid retry must publish a complete core generation: {activated_status}"
+    );
 }
 
 #[test]

--- a/crates/codestory-runtime/src/controller_indexing.rs
+++ b/crates/codestory-runtime/src/controller_indexing.rs
@@ -754,7 +754,10 @@ impl AppController {
     }
 
     fn recover_failed_indexing(&self, storage_path: &Path, refresh_runtime_caches: bool) {
-        if refresh_runtime_caches && let Ok(mut storage) = Storage::open(storage_path) {
+        // Failure recovery may restore caches from a compatible publication,
+        // but must never migrate the predecessor that the failed refresh kept.
+        if refresh_runtime_caches && let Ok(mut storage) = Storage::open_observational(storage_path)
+        {
             let incomplete = storage.has_incomplete_incremental_run().unwrap_or(true);
             if !incomplete {
                 self.clear_search_state();

--- a/crates/codestory-runtime/src/services.rs
+++ b/crates/codestory-runtime/src/services.rs
@@ -3286,6 +3286,9 @@ mod freshness_gate_tests {
 }
 
 #[cfg(test)]
+mod activation_upgrade_tests;
+
+#[cfg(test)]
 pub(crate) mod activation_tests {
     use super::*;
     use crate::Runtime;
@@ -5087,142 +5090,6 @@ pub(crate) mod activation_tests {
             snapshot.capabilities.local_navigation,
             ActivationCapabilityState::Ready
         );
-    }
-
-    fn legacy_activation_fixture() -> (tempfile::TempDir, tempfile::TempDir, PathBuf) {
-        let project = tempfile::tempdir().expect("project");
-        let seed_cache = tempfile::tempdir().expect("seed cache");
-        let cache = tempfile::tempdir().expect("legacy cache");
-        fs::write(
-            project.path().join("lib.rs"),
-            "pub fn legacy_value() -> i32 { 28 }\n",
-        )
-        .expect("write source");
-        let seed_path = seed_cache.path().join("codestory.db");
-        let runtime = Runtime::new();
-        runtime
-            .project_service()
-            .open_project_summary_with_storage_path(project.path().to_path_buf(), seed_path.clone())
-            .expect("open seed");
-        runtime
-            .index_service()
-            .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
-            .expect("publish seed");
-        let storage_path = cache.path().join("codestory.db");
-        fs::copy(
-            codestory_store::resolve_core_database_path(&seed_path).unwrap(),
-            &storage_path,
-        )
-        .expect("copy legacy flat database");
-        let mut permissions = fs::metadata(&storage_path).unwrap().permissions();
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            permissions.set_mode(0o600);
-        }
-        #[cfg(not(unix))]
-        permissions.set_readonly(false);
-        fs::set_permissions(&storage_path, permissions).unwrap();
-        let connection = rusqlite::Connection::open(&storage_path).unwrap();
-        connection.execute_batch(&format!(
-            "PRAGMA user_version = {}; UPDATE index_artifact_cache SET cache_key = 'legacy-' || cache_key,
-             artifact_blob = CAST(json_remove(CAST(artifact_blob AS TEXT), '$.resolution_file',
-             '$.resolution_input_schema_version', '$.call_resolution_inputs') AS BLOB);
-             DELETE FROM proof_resolution_publication; PRAGMA wal_checkpoint(TRUNCATE);",
-            codestory_store::CURRENT_SCHEMA_VERSION - 1,
-        )).expect("simulate prior schema and parser artifacts");
-        drop(connection);
-        (project, cache, storage_path)
-    }
-
-    #[test]
-    fn activation_rebuilds_legacy_cache_before_opening_it() {
-        let (project, _cache, storage_path) = legacy_activation_fixture();
-        let before = fs::read(&storage_path).unwrap();
-        let runtime = Runtime::new();
-        runtime
-            .activation_service()
-            .activate_core_only(
-                project.path(),
-                &storage_path,
-                Arc::new(AtomicBool::new(false)),
-            )
-            .expect("managed activation rebuilds legacy parser inputs");
-        assert_eq!(
-            fs::read(&storage_path).unwrap(),
-            before,
-            "legacy rollback bytes remain unchanged"
-        );
-        let store = Store::open_read_only(&storage_path).unwrap();
-        let publication = store.get_complete_index_publication().unwrap().unwrap();
-        assert_eq!(
-            publication.mode,
-            codestory_store::IndexPublicationMode::Full
-        );
-        store
-            .validate_proof_resolution_publication(&publication)
-            .unwrap();
-        store
-            .validate_structural_text_unit_publication(&publication)
-            .unwrap();
-        drop(store);
-        Runtime::new()
-            .activation_service()
-            .activate_core_only(
-                project.path(),
-                &storage_path,
-                Arc::new(AtomicBool::new(false)),
-            )
-            .expect("healthy new generation remains reusable");
-        assert_eq!(
-            Store::database_index_publication(&storage_path).unwrap(),
-            Some(publication)
-        );
-    }
-
-    #[test]
-    fn activation_failed_legacy_rebuild_preserves_original_database() {
-        for action in [
-            crate::PublicationTestAction::Fail,
-            crate::PublicationTestAction::Cancel,
-        ] {
-            let (project, _cache, storage_path) = legacy_activation_fixture();
-            let before = fs::read(&storage_path).unwrap();
-            let service = Runtime::new().activation_service();
-            let operation = ActivationOperation {
-                service: service.clone(),
-                operation_id: "legacy-rebuild-fault".to_string(),
-                cancelled: Arc::new(AtomicBool::new(false)),
-            };
-            crate::arm_publication_test_fault(crate::PublicationTestBoundary::SearchBuild, action);
-            service
-                .activate_once(
-                    &operation,
-                    project.path().to_path_buf(),
-                    storage_path.clone(),
-                    ActivationGoal::CoreOnly,
-                )
-                .expect_err("prepublication failure must reject replacement");
-            assert!(
-                fs::read(&storage_path).unwrap() == before,
-                "failed upgrade preserves legacy bytes at {action:?}"
-            );
-            assert_eq!(
-                Store::database_schema_version_observational(&storage_path).unwrap(),
-                codestory_store::CURRENT_SCHEMA_VERSION - 1
-            );
-            assert!(
-                !storage_path
-                    .parent()
-                    .unwrap()
-                    .join("core/publication.json")
-                    .exists()
-            );
-            assert!(
-                crate::PUBLICATION_TEST_FAULT.with(|fault| fault.borrow().is_none()),
-                "activation reached the injected publication boundary"
-            );
-        }
     }
 
     #[test]

--- a/crates/codestory-runtime/src/services.rs
+++ b/crates/codestory-runtime/src/services.rs
@@ -1544,11 +1544,31 @@ impl ActivationService {
         // retrieval fence are a current source snapshot; another repository
         // walk would prove the same thing again.
         let source_observer_before_probe = self.controller.observed_source_epoch(&project_root);
-        let summary = self
+        // Inspect compatibility before opening the live database: opening a
+        // legacy flat cache can migrate it in place and hide the need to
+        // rebuild parser artifacts. Recovery binds paths without opening the
+        // predecessor; the full refresh stages and publishes its replacement.
+        let summary = match self
             .controller
-            .open_project_summary_with_storage_path(project_root.clone(), storage_path.clone())?;
-        let mut precomputed_core_probe = (summary.publication.is_some()
-            && summary.stats.node_count > 0)
+            .ensure_incremental_refresh_compatible_at(&project_root, &storage_path)
+        {
+            Ok(()) => Some(self.controller.open_project_summary_with_storage_path(
+                project_root.clone(),
+                storage_path.clone(),
+            )?),
+            Err(error)
+                if error.code == crate::index_incremental::FULL_REFRESH_REQUIRED_ERROR_CODE =>
+            {
+                self.controller
+                    .bind_project_paths_for_refresh(project_root.clone(), storage_path.clone())?;
+                None
+            }
+            Err(error) => return Err(error),
+        };
+        let has_complete_core = summary
+            .as_ref()
+            .is_some_and(|summary| summary.publication.is_some() && summary.stats.node_count > 0);
+        let mut precomputed_core_probe = has_complete_core
             .then(|| self.controller.probe_incremental_plan_for_activation())
             .transpose()?;
         let complete_incremental_source_inventory = precomputed_core_probe
@@ -1560,13 +1580,12 @@ impl ActivationService {
         operation.set_stage(ActivationStage::CoreFreshness);
         let core_refresh_started = Instant::now();
         let mut refreshed_core = None;
-        let core_stale = summary.publication.is_none()
-            || summary.stats.node_count == 0
+        let core_stale = !has_complete_core
             || precomputed_core_probe
                 .as_ref()
                 .is_none_or(|probe| !probe.short_circuited());
         if core_stale {
-            let mode = if summary.publication.is_none() || summary.stats.node_count == 0 {
+            let mode = if !has_complete_core {
                 IndexMode::Full
             } else {
                 IndexMode::Incremental
@@ -1591,19 +1610,19 @@ impl ActivationService {
         }
         let local_ready = match refreshed_core.as_ref() {
             Some((_, stats)) => stats.node_count > 0 && stats.fatal_error_count == 0,
-            None => {
-                summary.publication.is_some()
-                    && summary.stats.node_count > 0
+            None => summary.as_ref().is_some_and(|summary| {
+                has_complete_core
                     && summary.stats.fatal_error_count == 0
                     && precomputed_core_probe
                         .as_ref()
                         .is_some_and(|probe| probe.short_circuited())
-            }
+            }),
         };
         let core_refresh_ms =
             u64::try_from(core_refresh_started.elapsed().as_millis()).unwrap_or(u64::MAX);
         if !local_ready {
-            if summary.stats.node_count > 0
+            if let Some(summary) = summary.as_ref()
+                && summary.stats.node_count > 0
                 && summary.stats.fatal_error_count == 0
                 && let Some(publication) = summary.publication.clone()
             {
@@ -1617,7 +1636,11 @@ impl ActivationService {
         let local_publication = refreshed_core
             .as_ref()
             .map(|(publication, _)| publication.clone())
-            .or_else(|| summary.publication.clone())
+            .or_else(|| {
+                summary
+                    .as_ref()
+                    .and_then(|summary| summary.publication.clone())
+            })
             .expect("fresh complete core has a publication identity");
         operation.set_local_publication(local_publication.clone());
 
@@ -5064,6 +5087,142 @@ pub(crate) mod activation_tests {
             snapshot.capabilities.local_navigation,
             ActivationCapabilityState::Ready
         );
+    }
+
+    fn legacy_activation_fixture() -> (tempfile::TempDir, tempfile::TempDir, PathBuf) {
+        let project = tempfile::tempdir().expect("project");
+        let seed_cache = tempfile::tempdir().expect("seed cache");
+        let cache = tempfile::tempdir().expect("legacy cache");
+        fs::write(
+            project.path().join("lib.rs"),
+            "pub fn legacy_value() -> i32 { 28 }\n",
+        )
+        .expect("write source");
+        let seed_path = seed_cache.path().join("codestory.db");
+        let runtime = Runtime::new();
+        runtime
+            .project_service()
+            .open_project_summary_with_storage_path(project.path().to_path_buf(), seed_path.clone())
+            .expect("open seed");
+        runtime
+            .index_service()
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+            .expect("publish seed");
+        let storage_path = cache.path().join("codestory.db");
+        fs::copy(
+            codestory_store::resolve_core_database_path(&seed_path).unwrap(),
+            &storage_path,
+        )
+        .expect("copy legacy flat database");
+        let mut permissions = fs::metadata(&storage_path).unwrap().permissions();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            permissions.set_mode(0o600);
+        }
+        #[cfg(not(unix))]
+        permissions.set_readonly(false);
+        fs::set_permissions(&storage_path, permissions).unwrap();
+        let connection = rusqlite::Connection::open(&storage_path).unwrap();
+        connection.execute_batch(&format!(
+            "PRAGMA user_version = {}; UPDATE index_artifact_cache SET cache_key = 'legacy-' || cache_key,
+             artifact_blob = CAST(json_remove(CAST(artifact_blob AS TEXT), '$.resolution_file',
+             '$.resolution_input_schema_version', '$.call_resolution_inputs') AS BLOB);
+             DELETE FROM proof_resolution_publication; PRAGMA wal_checkpoint(TRUNCATE);",
+            codestory_store::CURRENT_SCHEMA_VERSION - 1,
+        )).expect("simulate prior schema and parser artifacts");
+        drop(connection);
+        (project, cache, storage_path)
+    }
+
+    #[test]
+    fn activation_rebuilds_legacy_cache_before_opening_it() {
+        let (project, _cache, storage_path) = legacy_activation_fixture();
+        let before = fs::read(&storage_path).unwrap();
+        let runtime = Runtime::new();
+        runtime
+            .activation_service()
+            .activate_core_only(
+                project.path(),
+                &storage_path,
+                Arc::new(AtomicBool::new(false)),
+            )
+            .expect("managed activation rebuilds legacy parser inputs");
+        assert_eq!(
+            fs::read(&storage_path).unwrap(),
+            before,
+            "legacy rollback bytes remain unchanged"
+        );
+        let store = Store::open_read_only(&storage_path).unwrap();
+        let publication = store.get_complete_index_publication().unwrap().unwrap();
+        assert_eq!(
+            publication.mode,
+            codestory_store::IndexPublicationMode::Full
+        );
+        store
+            .validate_proof_resolution_publication(&publication)
+            .unwrap();
+        store
+            .validate_structural_text_unit_publication(&publication)
+            .unwrap();
+        drop(store);
+        Runtime::new()
+            .activation_service()
+            .activate_core_only(
+                project.path(),
+                &storage_path,
+                Arc::new(AtomicBool::new(false)),
+            )
+            .expect("healthy new generation remains reusable");
+        assert_eq!(
+            Store::database_index_publication(&storage_path).unwrap(),
+            Some(publication)
+        );
+    }
+
+    #[test]
+    fn activation_failed_legacy_rebuild_preserves_original_database() {
+        for action in [
+            crate::PublicationTestAction::Fail,
+            crate::PublicationTestAction::Cancel,
+        ] {
+            let (project, _cache, storage_path) = legacy_activation_fixture();
+            let before = fs::read(&storage_path).unwrap();
+            let service = Runtime::new().activation_service();
+            let operation = ActivationOperation {
+                service: service.clone(),
+                operation_id: "legacy-rebuild-fault".to_string(),
+                cancelled: Arc::new(AtomicBool::new(false)),
+            };
+            crate::arm_publication_test_fault(crate::PublicationTestBoundary::SearchBuild, action);
+            service
+                .activate_once(
+                    &operation,
+                    project.path().to_path_buf(),
+                    storage_path.clone(),
+                    ActivationGoal::CoreOnly,
+                )
+                .expect_err("prepublication failure must reject replacement");
+            assert!(
+                fs::read(&storage_path).unwrap() == before,
+                "failed upgrade preserves legacy bytes at {action:?}"
+            );
+            assert_eq!(
+                Store::database_schema_version_observational(&storage_path).unwrap(),
+                codestory_store::CURRENT_SCHEMA_VERSION - 1
+            );
+            assert!(
+                !storage_path
+                    .parent()
+                    .unwrap()
+                    .join("core/publication.json")
+                    .exists()
+            );
+            assert!(
+                crate::PUBLICATION_TEST_FAULT.with(|fault| fault.borrow().is_none()),
+                "activation reached the injected publication boundary"
+            );
+        }
     }
 
     #[test]

--- a/crates/codestory-runtime/src/services/activation_upgrade_tests.rs
+++ b/crates/codestory-runtime/src/services/activation_upgrade_tests.rs
@@ -1,0 +1,139 @@
+use super::*;
+use crate::Runtime;
+use std::fs;
+
+fn legacy_activation_fixture() -> (tempfile::TempDir, tempfile::TempDir, PathBuf) {
+    let project = tempfile::tempdir().expect("project");
+    let seed_cache = tempfile::tempdir().expect("seed cache");
+    let cache = tempfile::tempdir().expect("legacy cache");
+    fs::write(
+        project.path().join("lib.rs"),
+        "pub fn legacy_value() -> i32 { 28 }\n",
+    )
+    .expect("write source");
+    let seed_path = seed_cache.path().join("codestory.db");
+    let runtime = Runtime::new();
+    runtime
+        .project_service()
+        .open_project_summary_with_storage_path(project.path().to_path_buf(), seed_path.clone())
+        .expect("open seed");
+    runtime
+        .index_service()
+        .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+        .expect("publish seed");
+    let storage_path = cache.path().join("codestory.db");
+    fs::copy(
+        codestory_store::resolve_core_database_path(&seed_path).unwrap(),
+        &storage_path,
+    )
+    .expect("copy legacy flat database");
+    let mut permissions = fs::metadata(&storage_path).unwrap().permissions();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        permissions.set_mode(0o600);
+    }
+    #[cfg(not(unix))]
+    permissions.set_readonly(false);
+    fs::set_permissions(&storage_path, permissions).unwrap();
+    let connection = rusqlite::Connection::open(&storage_path).unwrap();
+    connection.execute_batch(&format!(
+        "PRAGMA user_version = {}; UPDATE index_artifact_cache SET cache_key = 'legacy-' || cache_key,
+         artifact_blob = CAST(json_remove(CAST(artifact_blob AS TEXT), '$.resolution_file',
+         '$.resolution_input_schema_version', '$.call_resolution_inputs') AS BLOB);
+         DELETE FROM proof_resolution_publication; PRAGMA wal_checkpoint(TRUNCATE);",
+        codestory_store::CURRENT_SCHEMA_VERSION - 1,
+    )).expect("simulate prior schema and parser artifacts");
+    drop(connection);
+    (project, cache, storage_path)
+}
+
+#[test]
+fn activation_rebuilds_legacy_cache_before_opening_it() {
+    let (project, _cache, storage_path) = legacy_activation_fixture();
+    let before = fs::read(&storage_path).unwrap();
+    let runtime = Runtime::new();
+    runtime
+        .activation_service()
+        .activate_core_only(
+            project.path(),
+            &storage_path,
+            Arc::new(AtomicBool::new(false)),
+        )
+        .expect("managed activation rebuilds legacy parser inputs");
+    assert_eq!(
+        fs::read(&storage_path).unwrap(),
+        before,
+        "legacy rollback bytes remain unchanged"
+    );
+    let store = Store::open_read_only(&storage_path).unwrap();
+    let publication = store.get_complete_index_publication().unwrap().unwrap();
+    assert_eq!(
+        publication.mode,
+        codestory_store::IndexPublicationMode::Full
+    );
+    store
+        .validate_proof_resolution_publication(&publication)
+        .unwrap();
+    store
+        .validate_structural_text_unit_publication(&publication)
+        .unwrap();
+    drop(store);
+    Runtime::new()
+        .activation_service()
+        .activate_core_only(
+            project.path(),
+            &storage_path,
+            Arc::new(AtomicBool::new(false)),
+        )
+        .expect("healthy new generation remains reusable");
+    assert_eq!(
+        Store::database_index_publication(&storage_path).unwrap(),
+        Some(publication)
+    );
+}
+
+#[test]
+fn activation_failed_legacy_rebuild_preserves_original_database() {
+    for action in [
+        crate::PublicationTestAction::Fail,
+        crate::PublicationTestAction::Cancel,
+    ] {
+        let (project, _cache, storage_path) = legacy_activation_fixture();
+        let before = fs::read(&storage_path).unwrap();
+        let service = Runtime::new().activation_service();
+        let operation = ActivationOperation {
+            service: service.clone(),
+            operation_id: "legacy-rebuild-fault".to_string(),
+            cancelled: Arc::new(AtomicBool::new(false)),
+        };
+        crate::arm_publication_test_fault(crate::PublicationTestBoundary::SearchBuild, action);
+        service
+            .activate_once(
+                &operation,
+                project.path().to_path_buf(),
+                storage_path.clone(),
+                ActivationGoal::CoreOnly,
+            )
+            .expect_err("prepublication failure must reject replacement");
+        assert!(
+            fs::read(&storage_path).unwrap() == before,
+            "failed upgrade preserves legacy bytes at {action:?}"
+        );
+        assert_eq!(
+            Store::database_schema_version_observational(&storage_path).unwrap(),
+            codestory_store::CURRENT_SCHEMA_VERSION - 1
+        );
+        assert!(
+            !storage_path
+                .parent()
+                .unwrap()
+                .join("core/publication.json")
+                .exists()
+        );
+        assert!(
+            crate::PUBLICATION_TEST_FAULT.with(|fault| fault.borrow().is_none()),
+            "activation reached the injected publication boundary"
+        );
+    }
+}


### PR DESCRIPTION
Ordinary MCP activation now selects a full rebuild before opening an incompatible cache. Previously, opening a 0.17.5 cache migrated its schema in place, then incremental activation failed because older parser artifacts lacked resolution coverage. Failure recovery also opened that predecessor mutably; it now observes it without migration.

The runtime reuses its existing compatibility and path-binding methods. Compatible publications retain incremental preparation and reuse. Full replacement and strict validation remain in their existing owners.

Closes #2146. Refs #2135.

Review `ActivationService::activate_once` in services.rs and `recover_failed_indexing` in controller_indexing.rs. The explicit test-only services/activation_upgrade_tests.rs module models a legacy flat database with old parser artifacts, checks replacement/reuse, and injects failure and cancellation before publication. The cold affected protocol test resolves published core storage instead of assuming a flat database exists, while retaining its invalid-input no-activation guard.

Source head: `3d536789b18f200ab0ac3c64e098e429306c69f0`; tree: `ccfd42215e1942e3fb534c6213b6c9437c04f152`; base: `1f273b3e2193bea4fe275147fd0b36486da91185`.

Local validation: the managed-upgrade regression reproduced the installed parser-coverage failure before the fix. Final checks pass 61 service tests, 56 architecture tests, generalization and runtime-configuration guards, formatting and diff checks. The complete 65-test stdio suite and six HTTP tests pass; CLI-search contracts pass five tests with eight existing ignored tests. Explicit old-schema and structural incompatibility rejection tests and both publication fault matrices pass.

Independent executable review passed ten actual MCP/CLI cases and both injected failure/cancellation actions at 0e0450fc. These cover archive-derived schema-31 upgrade, preserved bytes and annotations, reuse across restart, incremental edits, structural incompatibility, filesystem failure, invalid/future/corrupt state, and explicit incremental rejection. The later changes correct a protocol assertion and move fixtures behind a test-only module; independent mechanical review confirms unchanged production behavior and assertions. All required final-head CI checks pass, including Ubuntu draft source checks, Linux contracts and architecture, rustdoc, and the closing-issue guard.

The compatibility receipt used an exact source-built debug binary through the real MCP launcher. This is source evidence. The integrated replacement archive must pass the ordinary installed MCP upgrade, refresh, annotations, rollback and accelerated retrieval checks before the frozen comparison. No maintenance model session, source stabilization, calibration, qualification, or release publication has started. Existing release notes already cover the cache-upgrade claim.
