### PR TITLE
recognize core generations in retrieval status

### DIFF
--- a/crates/codestory-retrieval/src/lexical_index.rs
+++ b/crates/codestory-retrieval/src/lexical_index.rs
@@ -3584,8 +3584,8 @@ fn lexical_source_policy(
             storage_path.display()
         );
     }
-    let storage =
-        Store::open_read_only(storage_path).context("open storage for lexical source policy")?;
+    let storage = Store::open_observational(storage_path)
+        .context("observe storage for lexical source policy")?;
     let publication = storage
         .get_complete_index_publication()
         .context("load complete core publication for lexical source policy")?
@@ -5560,6 +5560,44 @@ mod tests {
             format!("{error:#}")
                 .contains("complete core publication for lexical source policy is missing")
         );
+    }
+
+    #[test]
+    fn pinned_source_policy_observation_does_not_materialize_sqlite_sidecars() {
+        let project = TempDir::new().expect("project");
+        let cache = TempDir::new().expect("cache");
+        let storage_path = cache.path().join("codestory.db");
+        crate::test_support::publish_empty_complete_core_fixture(project.path(), &storage_path)
+            .expect("complete core");
+        let before = std::fs::read(&storage_path).expect("core bytes");
+        assert_eq!(std::fs::read_dir(cache.path()).expect("entries").count(), 1);
+
+        lexical_source_policy(project.path(), Some(&storage_path)).expect("source policy");
+
+        assert_eq!(
+            std::fs::read(&storage_path).expect("unchanged core"),
+            before
+        );
+        assert_eq!(std::fs::read_dir(cache.path()).expect("entries").count(), 1);
+
+        let journal = std::path::PathBuf::from(format!(
+            "{}{}",
+            storage_path.display(),
+            codestory_contracts::owned_artifacts::PROMOTION_PREPARED_JOURNAL_SUFFIX,
+        ));
+        std::fs::write(&journal, b"pending recovery").expect("pending promotion");
+        let error = lexical_source_policy(project.path(), Some(&storage_path))
+            .expect_err("policy observation cannot recover a promotion");
+        assert!(format!("{error:#}").contains("promotion recovery is pending"));
+        assert_eq!(
+            std::fs::read(&journal).expect("unchanged journal"),
+            b"pending recovery"
+        );
+        assert_eq!(
+            std::fs::read(&storage_path).expect("unchanged core"),
+            before
+        );
+        assert_eq!(std::fs::read_dir(cache.path()).expect("entries").count(), 2);
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/sidecar.rs
+++ b/crates/codestory-retrieval/src/sidecar.rs
@@ -662,6 +662,13 @@ mod tests {
             .upsert_retrieval_index_manifest(&manifest)
             .expect("legacy retrieval manifest");
         let before = std::fs::read(&storage_path).expect("legacy bytes");
+        let cache_entries = || {
+            std::fs::read_dir(cache.path())
+                .expect("cache entries")
+                .map(|entry| entry.expect("cache entry").file_name())
+                .collect::<std::collections::BTreeSet<_>>()
+        };
+        let entries_before = cache_entries();
         for strict in [false, true] {
             let report = status_with_runtime(
                 project.path(),
@@ -680,6 +687,11 @@ mod tests {
         assert_eq!(
             std::fs::read(&storage_path).expect("unchanged legacy bytes"),
             before
+        );
+        assert_eq!(
+            cache_entries(),
+            entries_before,
+            "status must not create SQLite sidecars"
         );
     }
 

--- a/crates/codestory-retrieval/src/sidecar.rs
+++ b/crates/codestory-retrieval/src/sidecar.rs
@@ -227,7 +227,10 @@ fn status_with_runtime(
     let embedding_device = embedding_snapshot.device;
     let project_id = sidecar_project_id_for_runtime(project_root, &runtime)?;
 
-    if let Some(path) = storage_path.filter(|path| path.exists()) {
+    if let Some(path) = storage_path
+        && codestory_store::core_database_exists(path)
+            .context("resolve core publication for retrieval status")?
+    {
         let storage = Store::open_observational(path)
             .context("open storage observationally for retrieval manifest")?;
         let manifest = storage
@@ -574,6 +577,156 @@ fn manifest_contract_drift_should_win(reason: &str) -> bool {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    #[test]
+    fn status_reads_generation_only_manifest_without_creating_legacy_database() {
+        let _env = crate::test_support::env_lock();
+        let project = TempDir::new().expect("project");
+        let cache = TempDir::new().expect("cache");
+        let storage_path = cache.path().join("codestory.db");
+        let stage =
+            codestory_store::SnapshotStore::staged_path(&storage_path).expect("staged path");
+        crate::test_support::publish_empty_complete_core_fixture(project.path(), &stage)
+            .expect("complete staged core");
+        codestory_store::CorePublishTransaction::begin_from_stage(&storage_path, stage)
+            .expect("publication transaction")
+            .commit_rehydrate(&storage_path)
+            .expect("publish generation");
+        let runtime = SidecarRuntimeConfig::local();
+        let project_id =
+            sidecar_project_id_for_runtime(project.path(), &runtime).expect("project id");
+        let manifest = crate::test_support::retrieval_manifest_fixture(&project_id, "fixture");
+        Store::open_observational(&storage_path)
+            .expect("published store")
+            .upsert_retrieval_index_manifest(&manifest)
+            .expect("publish retrieval manifest");
+        assert!(!storage_path.exists());
+
+        for strict in [false, true] {
+            let report = status_with_runtime(
+                project.path(),
+                Some(&storage_path),
+                strict,
+                runtime.clone(),
+                SidecarHealthScope::Full,
+            )
+            .expect("status");
+            assert_eq!(
+                report.manifest.as_ref().map(|value| &value.project_id),
+                Some(&project_id)
+            );
+            assert!(
+                !report.is_live_ready(),
+                "a manifest alone cannot establish readiness"
+            );
+            assert!(
+                !storage_path.exists(),
+                "status must not create a legacy database"
+            );
+        }
+
+        let generation =
+            codestory_store::resolve_core_database_path(&storage_path).expect("active generation");
+        std::fs::remove_file(&generation).expect("remove active generation");
+        for strict in [false, true] {
+            assert!(
+                status_with_runtime(
+                    project.path(),
+                    Some(&storage_path),
+                    strict,
+                    runtime.clone(),
+                    SidecarHealthScope::Full,
+                )
+                .is_err(),
+                "a dangling publication must fail closed"
+            );
+        }
+        assert!(!storage_path.exists());
+        assert!(!generation.exists());
+    }
+
+    #[test]
+    fn status_preserves_legacy_manifest_observation() {
+        let _env = crate::test_support::env_lock();
+        let project = TempDir::new().expect("project");
+        let cache = TempDir::new().expect("cache");
+        let storage_path = cache.path().join("codestory.db");
+        crate::test_support::publish_empty_complete_core_fixture(project.path(), &storage_path)
+            .expect("complete legacy core");
+        let runtime = SidecarRuntimeConfig::local();
+        let project_id =
+            sidecar_project_id_for_runtime(project.path(), &runtime).expect("project id");
+        let manifest = crate::test_support::retrieval_manifest_fixture(&project_id, "fixture");
+        Store::open(&storage_path)
+            .expect("legacy store")
+            .upsert_retrieval_index_manifest(&manifest)
+            .expect("legacy retrieval manifest");
+        let before = std::fs::read(&storage_path).expect("legacy bytes");
+        for strict in [false, true] {
+            let report = status_with_runtime(
+                project.path(),
+                Some(&storage_path),
+                strict,
+                runtime.clone(),
+                SidecarHealthScope::Full,
+            )
+            .expect("legacy status");
+            assert_eq!(
+                report.manifest.as_ref().map(|value| &value.project_id),
+                Some(&project_id)
+            );
+            assert!(!report.is_live_ready());
+        }
+        assert_eq!(
+            std::fs::read(&storage_path).expect("unchanged legacy bytes"),
+            before
+        );
+    }
+
+    #[test]
+    fn status_does_not_create_missing_or_repair_corrupt_publications() {
+        let _env = crate::test_support::env_lock();
+        let project = TempDir::new().expect("project");
+        let cache = TempDir::new().expect("cache");
+        let storage_path = cache.path().join("missing").join("codestory.db");
+        let runtime = SidecarRuntimeConfig::local();
+        for strict in [false, true] {
+            let report = status_with_runtime(
+                project.path(),
+                Some(&storage_path),
+                strict,
+                runtime.clone(),
+                SidecarHealthScope::Full,
+            )
+            .expect("missing status");
+            assert!(report.manifest.is_none());
+            assert!(!report.is_live_ready());
+        }
+        assert!(!storage_path.parent().expect("parent").exists());
+
+        let layout = codestory_store::CorePublicationLayout::from_storage_path(&storage_path)
+            .expect("layout");
+        let pointer = layout.publication_path();
+        std::fs::create_dir_all(pointer.parent().expect("pointer parent")).expect("parent");
+        std::fs::write(&pointer, "{broken").expect("corrupt pointer");
+        for strict in [false, true] {
+            assert!(
+                status_with_runtime(
+                    project.path(),
+                    Some(&storage_path),
+                    strict,
+                    runtime.clone(),
+                    SidecarHealthScope::Full,
+                )
+                .is_err()
+            );
+        }
+        assert_eq!(
+            std::fs::read_to_string(pointer).expect("unchanged pointer"),
+            "{broken"
+        );
+        assert!(!storage_path.exists());
+    }
 
     #[test]
     fn strict_readiness_ignores_storage_owned_search_metadata() {

--- a/crates/codestory-runtime/src/services.rs
+++ b/crates/codestory-runtime/src/services.rs
@@ -3672,7 +3672,32 @@ pub(crate) mod activation_tests {
                 .ready_lease_present,
             "the restored lease must match before publication removal"
         );
-        fs::remove_file(&fixture.storage_path).expect("remove publication for hostile state");
+        fs::remove_file(&fixture.storage_path).expect("remove legacy database for hostile state");
+        assert!(
+            codestory_store::core_database_exists(&fixture.storage_path)
+                .expect("resolve retained generation"),
+            "removing the legacy file must not remove the active generation"
+        );
+        assert_observational(
+            "generation-only publication",
+            crate::activation_status::ReadyLeaseEvidence {
+                ready_lease_present: true,
+                ready_lease_admission_basis: "complete_source_observation".to_string(),
+                ready_lease_observer_epoch_coherence: "coherent".to_string(),
+                ready_lease_memo_holds_observations: true,
+            },
+            "full",
+        );
+
+        let layout =
+            codestory_store::CorePublicationLayout::from_storage_path(&fixture.storage_path)
+                .expect("publication layout");
+        fs::remove_file(layout.publication_path()).expect("remove active publication pointer");
+        assert!(
+            !codestory_store::core_database_exists(&fixture.storage_path)
+                .expect("observe missing publication"),
+            "unreferenced generation files must not count as an active publication"
+        );
         assert_observational(
             "missing publication",
             crate::activation_status::ReadyLeaseEvidence {


### PR DESCRIPTION
Fresh installed search can prepare retrieval from an immutable core generation without a leftover legacy database file. Previously readiness skipped a matching retrieval manifest when the logical `codestory.db` path was absent, even after successful native embedding. Strict readiness also reopened legacy source-policy storage through a reader that could create SQLite sidecars.

Existence now uses the store-owned publication resolver, and source-policy reads use its observational API. Existing source, artifact, manifest, policy and engine checks remain in place. Missing generations, corrupt pointers and pending promotion recovery fail closed. Review the two production changes in `sidecar.rs` and `lexical_index.rs`.

Both regressions failed before their respective fixes. The complete retrieval suite passed on final confirmation: 410 library and 6 integration tests, with 3 existing tests ignored. One earlier full run failed an unrelated SCIP cache-reuse assertion; its isolated diagnostic and the unchanged default-parallel suite passed. The original failure is retained; shared four-entry cache eviction is a source-based explanation, not independently instrumented proof. Independent production and installed acceptance passed on `7aa80fc6`: 16 hostile full/descriptor observations preserve cache paths and bytes; ordinary managed fresh, warm and restarted search reach full Metal retrieval without a legacy flat database. Damaged-pointer status rejects without cache mutation or native execution. The synthetic mismatched-target descriptor fixture lacks lexical artifacts, so it does not independently prove identity rejection with otherwise healthy artifacts. Linux CI also exposed a fixture that removed only the legacy file while labelling the still-valid generation as missing. The revised fixture checks generation-only readiness, then removes the actual publication pointer and proves unavailable status; all cache-preservation assertions remain unchanged. The complete runtime services suite passes all 61 tests. This final delta changes tests only. No source stabilization, package qualification or release acceptance is claimed.

Source `fce371208dd6bb772a5a0269c32468323abc6552`, tree `be34a04201d9b277ce5166fc6fac06a04af0cac9`, base `975020e3d4ca35be0696ee895446bcc2e2426a0f`. Worktree `/Users/albert/.codex/worktrees/0176-generation-readiness/CodeStory`. Root implements; the independent verifier owns the eight-state full/descriptor matrix and fresh installed search/restart. The final test-only delta was independently executed and accepted on `fce37120`; production and the shared observer assertions remain byte-identical to the accepted source. Required CI remains pending before merge; the final integration archive must repeat the same fresh installed search before the maintenance panel. All 36 maintenance model sessions remain unstarted.

Closes #2148. Refs #2135.
