### PR TITLE
verify installed navigation through the actual Codex host

### DIFF
--- a/docs/testing/installed-navigation-profile.md
+++ b/docs/testing/installed-navigation-profile.md
@@ -23,7 +23,17 @@ installed package digest, exact source commit, executable digest and ordered
 `tools/list` digest in the installation receipt. Source-build development
 receipts and published archives are different provenance tiers; identify them
 literally. A local mirror may supply authenticated release archives without
-changing the launcher. Binary and custom MCP-server overrides are unsupported.
+changing the launcher. Templates must not contain binary or custom-server overrides.
+
+The runner registers the authenticated installed launcher explicitly in each
+CodeStory arm's Codex configuration. It preserves the installed command, arguments,
+working directory and timeouts, and forwards only isolated infrastructure settings.
+The plugin stays enabled for its unchanged guidance and hooks; only its duplicate
+MCP registration is disabled. This tests an explicit host registration of the
+installed launcher, not the default plugin registration's environment forwarding.
+The latter can discard parent variables, including the archive mirror and private
+embedding namespace. Host-environment observation supports macOS and Linux;
+other hosts fail preflight before model execution.
 
 The installation JSON binds to the task manifest's SHA-256, contains the `arms`
 map and freezes `budget.max_sessions` and `budget.max_wall_ms`. A pilot can also
@@ -44,11 +54,17 @@ node scripts/codestory-agent-ab-benchmark.mjs --installed-navigation \
 
 Omit `--preflight-only` and use a new output directory for the comparison. Every
 arm must pass installation, launcher, schema and edit/refresh canaries before any
-model starts. Sessions get fresh whole checkouts and state, including separate
+model starts. Canaries use Codex's zero-model app-server MCP path and verify the
+actual child environment, full retrieval, native identity, private native
+completion with CPU fallback disabled, and changed source after refresh. Each
+participant also gets an environment and catalog check without activating its
+project. Sessions get fresh whole checkouts and state, including separate
 embedding qualification namespaces. The runner records prompts, effective
 configuration, package identity, canary traffic, model transcripts, usage, timing
 and failures. Every scheduled session has a durable row, including preparation,
 spawn and budget failures. Output directories are never overwritten or silently resumed.
+Managed-runtime provisioning and identity failures are recorded separately from
+model exit status. Two equivalent runtime failures stop the remaining attempts.
 Independent correctness grading and release acceptance follow execution; process
 success alone does not establish either.
 

--- a/docs/testing/installed-navigation-profile.md
+++ b/docs/testing/installed-navigation-profile.md
@@ -58,7 +58,9 @@ model starts. Canaries use Codex's zero-model app-server MCP path and verify the
 actual child environment, full retrieval, native identity, private native
 completion with CPU fallback disabled, and changed source after refresh. Each
 participant also gets an environment and catalog check without activating its
-project. Sessions get fresh whole checkouts and state, including separate
+project. Receipts capture the selected checkout's trust entry that Codex adds
+during normal startup; any other configuration change rejects the check.
+Sessions get fresh whole checkouts and state, including separate
 embedding qualification namespaces. The runner records prompts, effective
 configuration, package identity, canary traffic, model transcripts, usage, timing
 and failures. Every scheduled session has a durable row, including preparation,

--- a/scripts/codestory-agent-ab-benchmark.mjs
+++ b/scripts/codestory-agent-ab-benchmark.mjs
@@ -7476,6 +7476,7 @@ function mergeRetrievalStatusWithEngineDiagnostics(retrievalStatus, diagnostics)
 function createSequencedStdioSession(command, args, options) {
   const child = (options.spawnProcess ?? spawn)(command, args, {
     env: options.env,
+    cwd: options.cwd,
     shell: false,
     stdio: ["pipe", "pipe", "pipe"],
     windowsHide: true,
@@ -7519,7 +7520,7 @@ function createSequencedStdioSession(command, args, options) {
     terminate("SIGTERM");
   }
   function dispatchResponse(response) {
-    if (options.onNotification && response?.jsonrpc === "2.0"
+    if (options.onNotification && (response?.jsonrpc === "2.0" || options.protocol === "app-server")
       && typeof response.method === "string" && !Object.hasOwn(response, "id")) {
       options.onNotification(response);
       return;
@@ -7535,10 +7536,10 @@ function createSequencedStdioSession(command, args, options) {
 
   child.stdout.on("data", (chunk) => {
     stdoutBytes += chunk.length;
-    if (stdoutBytes > 1_048_576) {
+    if (stdoutBytes > (options.maxOutputBytes ?? 1_048_576)) {
       stdoutBuffer = trimTail(stdoutBuffer, 4096);
       child.stdout.pause();
-      fail("fail", "retrieval-engine stdio response exceeded 1 MiB");
+      fail("fail", `retrieval-engine stdio response exceeded ${options.maxOutputBytes ? `${options.maxOutputBytes} bytes` : "1 MiB"}`);
       return;
     }
     stdoutBuffer += stdoutDecoder.write(chunk);
@@ -7612,7 +7613,7 @@ function createSequencedStdioSession(command, args, options) {
     const response = await nextResponse();
     const ownsResult = Object.prototype.hasOwnProperty.call(response ?? {}, "result");
     const ownsError = Object.prototype.hasOwnProperty.call(response ?? {}, "error");
-    if (response?.jsonrpc !== "2.0" || response?.id !== payload.id || ownsResult === ownsError) {
+    if ((response?.jsonrpc !== "2.0" && options.protocol !== "app-server") || response?.id !== payload.id || ownsResult === ownsError) {
       fail(
         "fail",
         `retrieval-engine stdio response envelope mismatch for id=${JSON.stringify(payload.id)}`,
@@ -7641,7 +7642,7 @@ function createSequencedStdioSession(command, args, options) {
     clearTimeout(timeoutTimer);
     options.signal?.removeEventListener("abort", onAbort);
   }
-  return { request, send, close, stop, stderr: () => stderr };
+  return { request, send, close, stop, pid: child.pid, stderr: () => stderr };
 }
 
 async function codestoryDoctorSnapshot(

--- a/scripts/installed-navigation-profile.mjs
+++ b/scripts/installed-navigation-profile.mjs
@@ -37,6 +37,13 @@ export function validateChildEnvironment(actual, expected) {
   for (const [key, value] of Object.entries(expected)) requireThat(actual[key] === value, `actual MCP child environment mismatch: ${key}`);
 }
 
+export function hostConfigurationUpdates(before, after, project) {
+  if (before.trim() === after.trim()) return [];
+  const trust = `[projects.${JSON.stringify(project)}]\ntrust_level = "trusted"`;
+  requireThat(after.trim() === [before.trim(), trust].filter(Boolean).join('\n\n'), 'actual host changed configuration outside its selected-project trust entry');
+  return ['selected_project_trust'];
+}
+
 export function toolPayload(result) {
   requireThat(result && result.isError !== true, 'actual-host MCP tool failed');
   const value = result.structuredContent ?? result.structured_content
@@ -286,8 +293,11 @@ async function withInstalledHost(session, helpers, name, action) {
     const call = (tool, args) => request('mcpServer/tool/call', { threadId, server: 'codestory', tool, arguments: args });
     const result = await action(call);
     const config = await readFile(path.join(env.CODEX_HOME, 'config.toml'), 'utf8');
-    requireThat(config === session.effective.configuration, 'actual host configuration changed during preflight');
-    return { ...result, host_registration: 'explicit_installed_launcher', configuration_sha256: sha(config), child, model_turns: 0 };
+    const hostUpdates = hostConfigurationUpdates(session.effective.configuration, config, session.project);
+    session.effective.configuration = config;
+    await save(path.join(root, 'effective-config.json'), session.effective);
+    return { ...result, host_registration: 'explicit_installed_launcher', configuration_sha256: sha(config),
+      host_owned_configuration_updates: hostUpdates, child, model_turns: 0 };
   } finally {
     await channel.stop();
     await save(path.join(root, `${name}-transcript.json`), transcript);

--- a/scripts/installed-navigation-profile.mjs
+++ b/scripts/installed-navigation-profile.mjs
@@ -231,7 +231,7 @@ async function prepareSession(row, manifest, installation, output, codex, helper
   validateInventory(listing.installed, row.arm, arm);
   const effective = { schema_version: 1, session: row, model: manifest.model, timeout_ms: 600_000,
     sandbox: 'workspace-write', host_features: { remote_plugin: false }, project, source_commit: repo.commit, source_tree: repo.tree,
-    package: arm, configuration: config, plugin_listing: listing, environment: Object.fromEntries(Object.entries(env).filter(([key]) => /^(HOME|USERPROFILE|TMPDIR|CODEX_HOME|CODESTORY_)/.test(key))) };
+    package: arm, configuration: config, plugin_listing: listing, environment: Object.fromEntries(HOST_ENVIRONMENT.filter(key => env[key] !== undefined).map(key => [key, env[key]])) };
   await save(path.join(root, 'effective-config.json'), effective);
   return { root, env, project, pluginRoot, task, arm, effective, codex };
 }
@@ -285,7 +285,9 @@ async function withInstalledHost(session, helpers, name, action) {
     const child = await observeChildEnvironment(channel, session, helpers);
     const call = (tool, args) => request('mcpServer/tool/call', { threadId, server: 'codestory', tool, arguments: args });
     const result = await action(call);
-    return { ...result, host_registration: 'explicit_installed_launcher', child, model_turns: 0 };
+    const config = await readFile(path.join(env.CODEX_HOME, 'config.toml'), 'utf8');
+    requireThat(config === session.effective.configuration, 'actual host configuration changed during preflight');
+    return { ...result, host_registration: 'explicit_installed_launcher', configuration_sha256: sha(config), child, model_turns: 0 };
   } finally {
     await channel.stop();
     await save(path.join(root, `${name}-transcript.json`), transcript);

--- a/scripts/installed-navigation-profile.mjs
+++ b/scripts/installed-navigation-profile.mjs
@@ -10,6 +10,81 @@ const sha = bytes => createHash('sha256').update(bytes).digest('hex');
 const save = (file, value) => writeFile(file, `${JSON.stringify(value, null, 2)}\n`);
 const requireThat = (condition, message) => { if (!condition) throw new Error(message); };
 const safeId = value => typeof value === 'string' && /^[a-zA-Z0-9_-]+$/.test(value);
+const HOST_ENVIRONMENT = ['HOME', 'USERPROFILE', 'TMPDIR', 'CODEX_HOME', 'XDG_CACHE_HOME', 'XDG_CONFIG_HOME',
+  'CODESTORY_PLUGIN_DATA', 'CODESTORY_PLUGIN_RELEASE_DIR', 'CODESTORY_CACHE_ROOT', 'CODESTORY_STDIO_CACHE_ROOT',
+  'CODESTORY_EMBED_ALLOW_CPU', 'CODESTORY_EMBED_QUALIFICATION_DIR', 'CODESTORY_EMBED_QUALIFICATION_NONCE'];
+const canonical = value => Array.isArray(value) ? value.map(canonical)
+  : value && typeof value === 'object' ? Object.fromEntries(Object.keys(value).sort().map(key => [key, canonical(value[key])])) : value;
+
+export function installedHostConfig(server, pluginRoot, arm, env) {
+  requireThat(server?.command === 'node' && Array.isArray(server.args) && server.args.length === 1
+    && server.args[0] === './scripts/codestory-mcp.cjs' && server.cwd === '.'
+    && Object.keys(server.env ?? {}).length === 0 && !(server.env_vars?.length), 'unsupported installed launcher transport');
+  const allowed = new Set(['command', 'args', 'cwd', 'env', 'tool_timeout_sec', 'startup_timeout_sec']);
+  requireThat(Object.keys(server).every(key => allowed.has(key)), 'unrecognized installed launcher setting');
+  const lines = [`[plugins."codestory@${arm.marketplace_name}".mcp_servers.codestory]`, 'enabled = false', '',
+    '[mcp_servers.codestory]', `command = ${JSON.stringify(server.command)}`,
+    `args = ${JSON.stringify([path.join(pluginRoot, 'scripts/codestory-mcp.cjs')])}`, `cwd = ${JSON.stringify(pluginRoot)}`];
+  for (const key of ['tool_timeout_sec', 'startup_timeout_sec']) if (server[key] !== undefined) {
+    requireThat(Number.isFinite(server[key]) && server[key] > 0, 'invalid installed launcher timeout');
+    lines.push(`${key} = ${server[key]}`);
+  }
+  lines.push(`env_vars = ${JSON.stringify(HOST_ENVIRONMENT.filter(key => env[key] !== undefined))}`);
+  return `\n${lines.join('\n')}\n`;
+}
+
+export function validateChildEnvironment(actual, expected) {
+  for (const [key, value] of Object.entries(expected)) requireThat(actual[key] === value, `actual MCP child environment mismatch: ${key}`);
+}
+
+export function toolPayload(result) {
+  requireThat(result && result.isError !== true, 'actual-host MCP tool failed');
+  const value = result.structuredContent ?? result.structured_content
+    ?? JSON.parse(result.content?.find(item => item.type === 'text')?.text ?? 'null');
+  requireThat(value && value.code !== 'codestory_unavailable' && value.state !== 'unavailable', 'actual-host CodeStory unavailable');
+  return value;
+}
+
+export function validateHostCatalog(inventory, expected, arm) {
+  const servers = inventory.data?.filter(server => server.name === 'codestory' || server.serverInfo?.name === 'codestory') ?? [];
+  requireThat(servers.length === 1 && servers[0].runtimeStatus === 'connected' && servers[0].pluginId === null
+    && servers[0].serverInfo?.version === arm.version, 'expected one explicitly registered installed CodeStory server');
+  const actual = servers[0].tools;
+  requireThat(actual && Object.keys(actual).length === expected.length
+    && expected.every(tool => {
+      // Codex's MCP Tool decoder drops the old non-standard top-level safety field.
+      // Standard annotations and v3 namespaced metadata must still match exactly.
+      const projected = { ...tool };
+      if (arm.schema_version === 2) delete projected.safety;
+      return JSON.stringify(canonical(actual[tool.name])) === JSON.stringify(canonical(projected));
+    }), 'actual host tool catalog mismatch');
+}
+
+export function auditParticipantRuntime(events, arm) {
+  const audit = { calls: 0, identity_stamps: 0, failures: [] };
+  for (const event of events) {
+    const item = event.item;
+    if (event.type !== 'item.completed' || item?.type !== 'mcp_tool_call' || item.server !== 'codestory') continue;
+    audit.calls++;
+    const result = item.result;
+    let payload = result?.structuredContent ?? result?.structured_content;
+    if (!payload) { try { payload = JSON.parse(result?.content?.find(part => part.type === 'text')?.text ?? 'null'); } catch { /* Non-JSON tool errors remain in the transcript. */ } }
+    if (payload?.code === 'codestory_unavailable' && /^managed_cli_/.test(payload.failure ?? '')) {
+      audit.failures.push({ tool: item.tool, code: String(payload.failure).split(':').slice(0, 2).join(':') });
+    }
+    const publication = result?._meta?.codestory_publication;
+    const runtime = publication?.contract_runtime;
+    if (runtime) {
+      if (publication.schema_version !== arm.schema_version || runtime.cli_sha256 !== arm.runtime_sha256
+        || runtime.cli_source !== arm.runtime_source || runtime.cli_version !== arm.version
+        || runtime.plugin_cli_version !== arm.version || runtime.plugin_version !== arm.version
+        || runtime.pinned_pair_matches !== true || runtime.known_override_skew_channel !== false) {
+        audit.failures.push({ tool: item.tool, code: 'runtime_identity_mismatch' });
+      } else audit.identity_stamps++;
+    }
+  }
+  return audit;
+}
 
 export function validateManifest(manifest) {
   requireThat(manifest.schema_version === 1, 'unsupported navigation manifest');
@@ -126,9 +201,8 @@ async function prepareSession(row, manifest, installation, output, codex, helper
   for (const entry of await readdir(arm.codex_home_template, { withFileTypes: true })) {
     requireThat(['config.toml', 'plugins', 'tmp', '.tmp'].includes(entry.name) && !entry.isSymbolicLink(), `unexpected template entry: ${entry.name}`);
   }
-  const config = await readFile(path.join(arm.codex_home_template, 'config.toml'), 'utf8');
+  let config = await readFile(path.join(arm.codex_home_template, 'config.toml'), 'utf8');
   validateTemplateConfig(config, row.arm, arm);
-  await writeFile(path.join(env.CODEX_HOME, 'config.toml'), config);
   let pluginRoot = null;
   if (row.arm !== 'native') {
     requireThat(safeId(arm.marketplace_name) && /^\d+\.\d+\.\d+$/.test(arm.version), 'invalid installed identity');
@@ -146,7 +220,11 @@ async function prepareSession(row, manifest, installation, output, codex, helper
     requireThat(/^[a-f0-9]{40}$/.test(arm.source_commit) && /^[a-f0-9]{64}$/.test(arm.runtime_sha256)
       && [2, 3].includes(arm.schema_version) && ['managed', 'local_dev_override'].includes(arm.runtime_source), 'missing source/runtime identity');
     if (arm.release_directory) env.CODESTORY_PLUGIN_RELEASE_DIR = arm.release_directory;
+    const transport = JSON.parse(await readFile(path.join(pluginRoot, '.mcp.json'), 'utf8'));
+    requireThat(Object.keys(transport.mcpServers ?? {}).join() === 'codestory', 'unexpected installed MCP server registration');
+    config += installedHostConfig(transport.mcpServers.codestory, pluginRoot, arm, env);
   }
+  await writeFile(path.join(env.CODEX_HOME, 'config.toml'), config);
   if (installation.auth_file) await cp(installation.auth_file, path.join(env.CODEX_HOME, 'auth.json'));
   const listingRaw = await checkedProcess(helpers.runProcess, codex, ['plugin', 'list', '--json', '--disable', 'remote_plugin'], { env });
   const listing = JSON.parse(listingRaw);
@@ -155,7 +233,64 @@ async function prepareSession(row, manifest, installation, output, codex, helper
     sandbox: 'workspace-write', host_features: { remote_plugin: false }, project, source_commit: repo.commit, source_tree: repo.tree,
     package: arm, configuration: config, plugin_listing: listing, environment: Object.fromEntries(Object.entries(env).filter(([key]) => /^(HOME|USERPROFILE|TMPDIR|CODEX_HOME|CODESTORY_)/.test(key))) };
   await save(path.join(root, 'effective-config.json'), effective);
-  return { root, env, project, pluginRoot, task, arm, effective };
+  return { root, env, project, pluginRoot, task, arm, effective, codex };
+}
+
+async function observeChildEnvironment(channel, session, helpers) {
+  requireThat(['darwin', 'linux'].includes(process.platform), 'actual MCP environment observation requires macOS or Linux');
+  const output = await checkedProcess(helpers.runProcess, 'ps', ['-axo', 'pid=,ppid=,command='], { env: session.env });
+  const rows = output.split('\n').map(line => line.trim().match(/^(\d+)\s+(\d+)\s+(.*)$/)).filter(Boolean)
+    .map(match => ({ pid: Number(match[1]), parent: Number(match[2]), command: match[3] }));
+  const parents = new Map(rows.map(row => [row.pid, row.parent]));
+  const descendant = pid => { const seen = new Set(); while (parents.has(pid) && !seen.has(pid)) { seen.add(pid); pid = parents.get(pid); if (pid === channel.pid) return true; } return false; };
+  const children = rows.filter(row => descendant(row.pid) && row.command.includes(path.join(session.pluginRoot, 'scripts/codestory-mcp.cjs')));
+  requireThat(children.length === 1, 'expected one actual installed MCP child');
+  const expected = Object.fromEntries(HOST_ENVIRONMENT.filter(key => session.env[key] !== undefined).map(key => [key, session.env[key]]));
+  const actual = {};
+  if (process.platform === 'linux') {
+    const entries = (await readFile(`/proc/${children[0].pid}/environ`, 'utf8')).split('\0');
+    for (const key of Object.keys(expected)) actual[key] = entries.find(entry => entry.startsWith(`${key}=`))?.slice(key.length + 1);
+  } else {
+    // Keep the raw process environment in memory only; persist just these isolated controls.
+    const raw = await checkedProcess(helpers.runProcess, 'ps', ['eww', '-p', String(children[0].pid), '-o', 'command='], { env: session.env });
+    for (const key of Object.keys(expected)) actual[key] = raw.match(new RegExp(`(?:^| )${key}=(.*?)(?= [A-Za-z_][A-Za-z0-9_]*=|$)`))?.[1];
+  }
+  validateChildEnvironment(actual, expected);
+  return { pid: children[0].pid, environment_sha256: sha(JSON.stringify(canonical(actual))), verified_names: Object.keys(expected) };
+}
+
+async function withInstalledHost(session, helpers, name, action) {
+  const { root, env, pluginRoot, arm, codex } = session;
+  const transcript = [];
+  const channel = helpers.createSequencedStdioSession(codex, ['app-server', '--disable', 'remote_plugin', '--stdio'],
+    { env, cwd: session.project, protocol: 'app-server', timeoutMs: 90_000, maxOutputBytes: 16 * 1024 * 1024,
+      onNotification: notification => transcript.push({ notification }) });
+  let id = 0;
+  const request = async (method, params) => {
+    const sent = { id: ++id, method, params };
+    const received = await channel.request(sent); transcript.push({ sent, received });
+    requireThat(!received.error, `actual host ${method} failed: ${JSON.stringify(received.error)}`);
+    return received.result;
+  };
+  try {
+    await request('initialize', { clientInfo: { name: 'installed-navigation-canary', version: '1' }, capabilities: { experimentalApi: true } });
+    channel.send({ method: 'initialized' });
+    const started = await request('thread/start', { cwd: session.project, model: 'gpt-5.6-terra', sandbox: 'workspace-write', ephemeral: true, config: { model_reasoning_effort: 'low' } });
+    const threadId = started.thread?.id;
+    requireThat(typeof threadId === 'string', 'actual host did not create an ephemeral inspection context');
+    const inventory = await request('mcpServerStatus/list', { threadId });
+    const catalog = JSON.parse(await readFile(path.join(pluginRoot, 'generated-mcp-catalog.json'), 'utf8'));
+    requireThat(sha(JSON.stringify(catalog.tools)) === arm.tools_sha256, 'installed catalog receipt mismatch');
+    validateHostCatalog(inventory, catalog.tools, arm);
+    const child = await observeChildEnvironment(channel, session, helpers);
+    const call = (tool, args) => request('mcpServer/tool/call', { threadId, server: 'codestory', tool, arguments: args });
+    const result = await action(call);
+    return { ...result, host_registration: 'explicit_installed_launcher', child, model_turns: 0 };
+  } finally {
+    await channel.stop();
+    await save(path.join(root, `${name}-transcript.json`), transcript);
+    await writeFile(path.join(root, `${name}-stderr.txt`), channel.stderr());
+  }
 }
 
 async function operationCanary(session, helpers) {
@@ -165,46 +300,36 @@ async function operationCanary(session, helpers) {
   await mkdir(project);
   await writeFile(path.join(project, 'index.js'), 'export function navigationCanary() { return "BEFORE_REFRESH"; }\n');
   await checkedProcess(helpers.runProcess, 'git', ['-c', 'core.hooksPath=/dev/null', 'init', project], { env });
-  const transcript = [];
-  const channel = helpers.createSequencedStdioSession(process.execPath, [path.join(pluginRoot, 'scripts/codestory-mcp.cjs')], { env, timeoutMs: 90_000, onNotification: notification => transcript.push({ notification }) });
-  let id = 0;
-  const request = async (method, params) => {
-    const sent = { jsonrpc: '2.0', id: ++id, method, params };
-    const received = await channel.request(sent); transcript.push({ sent, received });
-    requireThat(!received.error && !received.result?.isError, `canary ${method} failed: ${JSON.stringify(received)}`);
-    return received.result;
-  };
-  try {
-    const init = await request('initialize', { protocolVersion: '2025-11-25', capabilities: {}, clientInfo: { name: 'installed-navigation-canary', version: '1' } });
-    requireThat(init.serverInfo?.version === arm.version, 'installed runtime version mismatch');
-    channel.send({ jsonrpc: '2.0', method: 'notifications/initialized' });
-    const catalog = await request('tools/list', {});
-    requireThat(Array.isArray(catalog.tools) && catalog.tools.every(tool => tool.inputSchema?.type === 'object'), 'invalid tool schemas');
-    requireThat(sha(JSON.stringify(catalog.tools)) === arm.tools_sha256, 'installed tool catalog mismatch');
+  return withInstalledHost(session, helpers, 'canary', async hostCall => {
     const call = async (name, args) => {
       const deadline = performance.now() + 75_000;
       while (true) {
-        const result = await request('tools/call', { name, arguments: { project, ...args } });
-        const state = result.structuredContent;
-        if (!['preparing', 'updating'].includes(state?.state)) { validateRuntime(result, arm); return result; }
+        const result = await hostCall(name, { project, ...args });
+        const state = toolPayload(result);
+        if (!['preparing', 'updating'].includes(state?.state)) { validateRuntime(result, arm); return { ...result, structuredContent: state }; }
         requireThat(performance.now() < deadline, 'managed preparation exceeded canary budget');
         await delay(Math.min(5000, Math.max(100, state.retry_after_ms ?? 1000)));
       }
     };
-    await call('files', {});
+    await call('search', { query: 'navigationCanary' });
+    const readiness = toolPayload(await hostCall('status', { project }));
+    requireThat(readiness.live_ready === true && readiness.retrieval_mode === 'full', 'actual host search did not prove full retrieval');
     const before = await call('snippet', { path: 'index.js', start_line: 1, end_line: 1 });
     validateSourceRead(before, project, 'BEFORE_REFRESH');
     await writeFile(path.join(project, 'index.js'), 'export function navigationCanary() { return "AFTER_REFRESH"; }\n');
     await call('files', {});
     const after = await call('snippet', { path: 'index.js', start_line: 1, end_line: 1 });
     validateSourceRead(after, project, 'AFTER_REFRESH');
-    await channel.close();
-    return { status: 'pass', surface: 'installed-plugin', catalog_sha256: arm.tools_sha256, runtime_sha256: arm.runtime_sha256 };
-  } finally {
-    await channel.stop();
-    await save(path.join(root, 'canary-transcript.json'), transcript);
-    await writeFile(path.join(root, 'canary-stderr.txt'), channel.stderr());
-  }
+    const eventsFile = path.join(env.CODESTORY_EMBED_QUALIFICATION_DIR, `${env.CODESTORY_EMBED_QUALIFICATION_NONCE}.events.jsonl`);
+    requireThat(!(await lstat(eventsFile)).isSymbolicLink(), 'private native event receipt is a symlink');
+    const eventsBytes = await readFile(eventsFile);
+    const events = eventsBytes.toString('utf8').trim().split('\n').map(line => JSON.parse(line));
+    const completed = events.filter(event => event.action === 'completed_tokens' && event.status === 'completed')
+      .reduce((total, event) => total + Number(event.details?.completed_tokens ?? 0), 0);
+    requireThat(Number.isFinite(completed) && completed > 0 && env.CODESTORY_EMBED_ALLOW_CPU === '0', 'missing private native completion with CPU fallback disabled');
+    return { status: 'pass', surface: 'installed-plugin', catalog_sha256: arm.tools_sha256, runtime_sha256: arm.runtime_sha256,
+      private_native_completed_tokens: completed, native_events_sha256: sha(eventsBytes), cpu_fallback_allowed: false };
+  });
 }
 
 export async function runInstalledNavigation(argv, helpers) {
@@ -241,6 +366,7 @@ export async function runInstalledNavigation(argv, helpers) {
     },
   };
   const prepared = [];
+  const infrastructureFailures = new Map();
   const results = manifest.sessions.map(row => ({ ...row, status: 'not_run', model_attempted: false, whole_task_wall_ms: 0, telemetry_complete: false }));
   const persist = () => save(path.join(output, 'summary.json'), { schema_version: 1, profile: manifest.profile,
     manifest_sha256: sha(manifestBytes), installations_sha256: sha(installationBytes),
@@ -274,6 +400,10 @@ export async function runInstalledNavigation(argv, helpers) {
     try {
       allowance(1);
       const session = await prepareSession(row, manifest, installation, output, values.codex, bounded);
+      if (session.pluginRoot) {
+        const host = await withInstalledHost(session, bounded, 'participant-host', async () => ({ status: 'pass', catalog_sha256: session.arm.tools_sha256 }));
+        await save(path.join(root, 'participant-host.json'), host);
+      }
       const invocation = navigationCommand(values.codex, session.project, path.join(root, 'answer.md'));
       result.preparation_ms = performance.now() - started;
       await writeFile(path.join(root, 'prompt.txt'), session.task.prompt);
@@ -289,6 +419,14 @@ export async function runInstalledNavigation(argv, helpers) {
         telemetry_complete: malformed.length === 0 && ['input_tokens', 'output_tokens', 'total_tokens'].every(key => Number.isFinite(usage[key]) && usage[key] >= 0)
           && events.some(event => event.type === 'turn.completed'),
         malformed_lines: malformed.length, analysis: helpers.analyzeTranscript(events, session.project) });
+      if (session.pluginRoot) {
+        result.host_runtime = auditParticipantRuntime(events, session.arm);
+        if (result.host_runtime.failures.length) {
+          result.execution_status = result.status; result.status = 'runtime_failed';
+          const key = `${row.arm}:${result.host_runtime.failures[0].code}`;
+          infrastructureFailures.set(key, (infrastructureFailures.get(key) ?? 0) + 1);
+        }
+      }
     } catch (error) {
       result.status = remainingMs() <= 0 ? 'budget_exhausted' : `${phase}_failed`;
       result.error = error.message; stderr += `${error.message}\n`;
@@ -300,6 +438,10 @@ export async function runInstalledNavigation(argv, helpers) {
       await writeFile(path.join(root, 'stderr.txt'), stderr);
       await save(path.join(root, 'result.json'), result);
       results[index] = result; await persist();
+    }
+    if ([...infrastructureFailures.values()].some(count => count >= 2)) {
+      for (const pending of results.slice(index + 1)) { pending.status = 'not_run_runtime_failed'; pending.error = 'two equivalent actual-host runtime failures'; }
+      await persist(); return;
     }
     // Failed attempts and unstarted budget rows retain their places in the denominator.
   }

--- a/scripts/tests/installed-navigation-profile.test.mjs
+++ b/scripts/tests/installed-navigation-profile.test.mjs
@@ -66,6 +66,15 @@ test('actual host boundary rejects missing controls and successful envelopes car
   assert.deepEqual(toolPayload({structured_content:{kind:'preparing',state:'preparing'}}),{kind:'preparing',state:'preparing'});
 });
 
+test('host configuration records only the ordinary selected-checkout trust addition', async () => {
+  const { hostConfigurationUpdates }=await import('../installed-navigation-profile.mjs');
+  const before='[mcp_servers.codestory]\ncommand = "node"\n';
+  const trust='[projects."/isolated/repository"]\ntrust_level = "trusted"\n';
+  assert.deepEqual(hostConfigurationUpdates(before,before,'/isolated/repository'),[]);
+  assert.deepEqual(hostConfigurationUpdates(before,before+'\n'+trust,'/isolated/repository'),['selected_project_trust']);
+  for(const after of [(before+'\n'+trust).replace('/isolated/repository','/another'),(before+'\n'+trust).replace('"node"','"wrong"'),before+'\napproval_policy = "never"\n',before+'\n'+trust+'\n[projects."/another"]\ntrust_level = "trusted"\n'])assert.throws(()=>hostConfigurationUpdates(before,after,'/isolated/repository'));
+});
+
 test('ordinary launcher notifications are retained without consuming a response', async () => {
   const { createSequencedStdioSession } = await import('../codestory-agent-ab-benchmark.mjs');
   const notifications = [];

--- a/scripts/tests/installed-navigation-profile.test.mjs
+++ b/scripts/tests/installed-navigation-profile.test.mjs
@@ -36,6 +36,36 @@ test('runtime and host overrides cannot escape the isolated session', () => {
   for (const key of ['CODESTORY_CLI', 'CODESTORY_PLUGIN_DATA', 'OPENAI_API_KEY', 'PLUGIN_DATA']) assert.equal(env[key], undefined);
 });
 
+test('explicit host registration preserves installed transport and forwards only isolated controls', async () => {
+  const { installedHostConfig } = await import('../installed-navigation-profile.mjs');
+  const env = navigationEnvironment({ PATH: '/bin' }, '/isolated', 'nonce');
+  env.CODESTORY_PLUGIN_DATA = '/isolated/data';
+  env.CODESTORY_PLUGIN_RELEASE_DIR = '/archives';
+  env.CODESTORY_CLI = '/forbidden';
+  const config = installedHostConfig({ command: 'node', args: ['./scripts/codestory-mcp.cjs'], cwd: '.', env: {}, tool_timeout_sec: 300 }, '/installed', { marketplace_name: 'fixture' }, env);
+  assert.match(config, /\[plugins\."codestory@fixture"\.mcp_servers\.codestory\]\nenabled = false/);
+  assert.match(config, /\[mcp_servers\.codestory\]/);
+  assert.match(config, /tool_timeout_sec = 300/);
+  assert.match(config, /CODESTORY_PLUGIN_RELEASE_DIR/);
+  assert.match(config, /CODESTORY_EMBED_QUALIFICATION_NONCE/);
+  assert.doesNotMatch(config, /CODESTORY_CLI|approval|enabled_tools|disabled_tools|shell_environment/);
+  for (const bad of [{command:'node',args:['./scripts/codestory-mcp.cjs'],cwd:'.',env:{CODESTORY_CLI:'/wrong'}}, {command:'node',args:['../escape.cjs'],cwd:'.',env:{}}]) {
+    assert.throws(() => installedHostConfig(bad, '/installed', {marketplace_name:'fixture'}, env));
+  }
+});
+
+test('actual host boundary rejects missing controls and successful envelopes carrying unavailable tools', async () => {
+  const { validateChildEnvironment, toolPayload } = await import('../installed-navigation-profile.mjs');
+  const expected = { HOME:'/isolated/home', CODESTORY_PLUGIN_RELEASE_DIR:'/archives', CODESTORY_EMBED_QUALIFICATION_DIR:'/isolated/qualification', CODESTORY_EMBED_QUALIFICATION_NONCE:'nonce', CODESTORY_EMBED_ALLOW_CPU:'0' };
+  validateChildEnvironment(expected, expected);
+  for (const key of Object.keys(expected)) {
+    const actual={...expected};delete actual[key];assert.throws(()=>validateChildEnvironment(actual,expected));
+    actual[key]='/shared';assert.throws(()=>validateChildEnvironment(actual,expected));
+  }
+  for (const result of [{isError:true,content:[]}, {content:[{type:'text',text:JSON.stringify({code:'codestory_unavailable',failure:'managed_cli_asset_fetch_failed'})}]}])assert.throws(()=>toolPayload(result));
+  assert.deepEqual(toolPayload({structured_content:{kind:'preparing',state:'preparing'}}),{kind:'preparing',state:'preparing'});
+});
+
 test('ordinary launcher notifications are retained without consuming a response', async () => {
   const { createSequencedStdioSession } = await import('../codestory-agent-ab-benchmark.mjs');
   const notifications = [];
@@ -46,6 +76,35 @@ test('ordinary launcher notifications are retained without consuming a response'
     assert.equal(notifications[0].method, 'notifications/tools/list_changed');
     await channel.close();
   } finally { await channel.stop(); }
+});
+
+test('app-server transport handles versionless notifications without changing MCP defaults', async () => {
+  const { createSequencedStdioSession } = await import('../codestory-agent-ab-benchmark.mjs');
+  const notifications=[];
+  const script=`process.stdin.on('data', b=>{const r=JSON.parse(String(b));process.stdout.write(JSON.stringify({method:'thread/started',params:{}})+'\\n'+JSON.stringify({id:r.id,result:{ok:true}})+'\\n');});process.stdin.on('end',()=>process.exit(0));`;
+  const channel=createSequencedStdioSession(process.execPath,['-e',script],{protocol:'app-server',timeoutMs:5000,onNotification:n=>notifications.push(n)});
+  try { assert.deepEqual((await channel.request({id:1,method:'initialize'})).result,{ok:true});assert.equal(notifications[0].method,'thread/started');await channel.close(); }
+  finally { await channel.stop(); }
+});
+
+test('host catalog and participant runtime guards reject duplicates, changed tools, and nested provisioning failures', async () => {
+  const { validateHostCatalog, auditParticipantRuntime }=await import('../installed-navigation-profile.mjs');
+  const tool={name:'search',inputSchema:{type:'object'}};
+  const arm={version:'0.17.6',schema_version:3,runtime_source:'managed',runtime_sha256:'a'.repeat(64)};
+  const server={name:'codestory',runtimeStatus:'connected',pluginId:null,serverInfo:{name:'codestory',version:arm.version},tools:{search:tool}};
+  validateHostCatalog({data:[server]},[tool],arm);
+  validateHostCatalog({data:[server]},[{...tool,safety:{effect:'read_only'}}],{...arm,schema_version:2});
+  assert.throws(()=>validateHostCatalog({data:[server]},[{...tool,annotations:{readOnlyHint:false}}],{...arm,schema_version:2}));
+  for(const data of [[server,{...server,name:'duplicate'}],[{...server,tools:{}}],[{...server,pluginId:'unexpected'}]])assert.throws(()=>validateHostCatalog({data},[tool],arm));
+  const event=result=>({type:'item.completed',item:{type:'mcp_tool_call',server:'codestory',tool:'search',result,status:'completed'}});
+  const failed=event({content:[{type:'text',text:JSON.stringify({code:'codestory_unavailable',failure:'managed_cli_provision_failed:managed_cli_asset_fetch_failed'})}]});
+  const identity={schema_version:3,contract_runtime:{cli_sha256:arm.runtime_sha256,cli_source:'managed',cli_version:arm.version,plugin_cli_version:arm.version,plugin_version:arm.version,pinned_pair_matches:true,known_override_skew_channel:false}};
+  const good=event({_meta:{codestory_publication:identity}});
+  assert.deepEqual(auditParticipantRuntime([good],arm),{calls:1,identity_stamps:1,failures:[]});
+  assert.equal(auditParticipantRuntime([failed],arm).failures[0].code,'managed_cli_provision_failed:managed_cli_asset_fetch_failed');
+  const bad=structuredClone(good);bad.item.result._meta.codestory_publication.contract_runtime.cli_sha256='wrong';
+  assert.equal(auditParticipantRuntime([bad],arm).failures[0].code,'runtime_identity_mismatch');
+  assert.deepEqual(auditParticipantRuntime([],arm),{calls:0,identity_stamps:0,failures:[]});
 });
 
 test('typed canary rejects diagnostic substitutes, mixed source, and runtime drift', async () => {


### PR DESCRIPTION
The installed-navigation comparison now tests the same Codex host path that participants use. Previously its direct-node canary preserved the candidate archive and isolation environment, while Codex discarded those variables for plugin MCP children. All twelve candidate participants consequently failed provisioning despite a green preflight.

Receipts allow and capture only Codex's normal trust entry for the selected checkout; transport, environment, approval and unrelated trust changes reject. The profile keeps the installed plugin and its guidance unchanged, registers its authenticated launcher explicitly in each CodeStory arm's isolated Codex configuration, and disables only duplicate MCP registration. It preserves declared timeouts and forwards thirteen infrastructure controls. Zero-model app-server checks verify the actual child environment, exact host-visible catalog, native runtime identity, full retrieval and source reinspection after refresh. Fresh participant environments are checked without activating their project. Provisioning and runtime-identity failures remain in recorded results, and two equivalent failures stop later attempts.

Closes #2150. Refs #2135.

Review `scripts/installed-navigation-profile.mjs` for generated host configuration and execution gates, then the opt-in app-server protocol support in the existing stdio helper. The v2 catalog comparison accounts only for Codex dropping the old non-standard top-level `safety` field; standard schemas, annotations and v3 metadata still compare exactly. Host-environment observation currently supports macOS and Linux and fails preflight elsewhere.

Source: `9ac008cb8b852b4deaae1fa5e09d7ea1d04d4cda`, tree `04d850698db1e04abc80b430b33e4272925363eb`, based on integration `17f1999fff0c0541ab85b3357f4bae87f739e16c`. Worktree: `/Users/albert/.codex/worktrees/0176-host-environment/CodeStory`. Implementation owner: this release lane; independent verifier: compatibility review. No native, product plugin, guidance, model or rubric changes.

Validation completed on the implementation: actual-host failure reproduced with zero model turns; 206 focused tests passed before the receipt refinements, and all thirteen profile checks pass on the final head; benchmark self-test, documentation links and diff checks passed. The revised three-arm canary passed in 14 seconds with zero model turns, all thirteen child controls verified, unchanged package/runtime digests, full retrieval, private native completion with CPU fallback disabled, and changed source after refresh. Independent exact-head acceptance passed: 61 hostile validator cases, actual missing-forwarding and wrong-package rejection, three actual prepared-participant host checks without project activation, 36-row stop accounting after two simulated runtime failures, and the complete three-arm actual-host canary. Required CI is green on this head. Native completion is authenticated with CPU fallback disabled; named Metal-device selection carries the unchanged C3 receipt.

The first 36-session comparison is preserved as invalid, including every attempt and all measured cost. Its aggregate correctness and efficiency cannot qualify the release. No replacement participants, source stabilization, calibration or qualification have started. Next proof target is independent acceptance of this head, then the integrated candidate's authenticated installation and bounded replacement comparison.
