### PR TITLE
avoid duplicate evidence in code-mode output

### DIFF
--- a/plugins/codestory/skills/codestory-grounding/SKILL.md
+++ b/plugins/codestory/skills/codestory-grounding/SKILL.md
@@ -14,6 +14,11 @@ Every CodeStory call selects its repository with an absolute `project` root.
 Keep project, source and publication identities attached when combining results
 across repositories; never rely on a global active project.
 
+In code-mode hosts, display each payload once. MCP results can repeat identical
+JSON in text and structured content. Keep the complete payload, errors, metadata
+and any distinct content; omit only an exact duplicate. Use the
+[code-mode display example](references/code-mode.md) when printing tool results.
+
 ## Investigation loop
 
 Choose the smallest useful operation. A named file can be read directly with

--- a/plugins/codestory/skills/codestory-grounding/references/code-mode.md
+++ b/plugins/codestory/skills/codestory-grounding/references/code-mode.md
@@ -1,0 +1,37 @@
+# Displaying CodeStory results in code mode
+
+Some hosts expose both `content` and `structuredContent` (or
+`structured_content`) to JavaScript. Printing the whole wrapper can put the
+same JSON payload into the model context twice.
+
+Use one complete representation while retaining every other returned field.
+This example removes only plain text blocks that exactly match the serialized structured
+payload. Different spacing, key ordering or numeric spelling leaves the text
+in place; parsing it first could discard precision that only the text retains. Distinct text, annotations, images,
+resources, error flags and metadata stay intact. Keep the original result for
+programmatic use.
+
+After a CodeStory call returns `result`, the following works in a code-mode
+cell with a `text` output helper:
+
+```javascript
+function withoutDuplicateJsonText(result) {
+  const payload = result?.structuredContent ?? result?.structured_content;
+  if (payload === undefined || !Array.isArray(result?.content)) return result;
+  const serialized = JSON.stringify(payload);
+  const content = result.content.filter(part => {
+    if (part?.type !== 'text' || Object.keys(part).some(key => !['type', 'text'].includes(key))) return true;
+    return part.text !== serialized;
+  });
+  if (content.length === result.content.length) return result;
+  const displayed = { ...result };
+  if (content.length) displayed.content = content;
+  else delete displayed.content;
+  return displayed;
+}
+text(withoutDuplicateJsonText(result));
+```
+
+This is a host display step. Tool requests, public response schemas, source
+evidence and availability limits remain unchanged. A text-only response stays
+as returned; do not replace it with an empty structured-content placeholder.


### PR DESCRIPTION
Code-mode agents can print a complete MCP result containing the same JSON twice, as text and structured content. The 0.17.6 maintenance comparison passed correctness but exceeded its input-context limit. Captured traces and a local actual-Codex replay demonstrate the duplicate output independently of the task answers.

The canonical guidance now explains how to display each payload once and includes an executable example. It removes a plain text block only when its bytes exactly equal the serialized structured payload. It keeps distinct or annotated content, errors, identities, metadata and unknown fields, and never mutates the original result. Numeric spelling, whitespace and key-order differences remain intact. Public MCP responses and text-only clients are unchanged.

Review the entrypoint paragraph and copyable example together. Documentation links and skill validation passed. The documented behavior preserves all 31 captured candidate tool results while reducing their combined rendered JSON from 448,479 to 228,463 bytes. The actual-host deterministic replay fell from 24,850 to 11,883 model-visible bytes with exact payload parity, zero external model requests and no native runtime calls. Those measurements prove rendering behavior, not model adoption or a passing maintenance panel.

Base: `5ebbd902c20b0979d9a2e423d235a5166e698353`. Head: `0ee3d74411f500dfd4cbff91cd80d28beb5309a1`. Tree: `8935f07f93045c3956edf28f87b47355c094ea02`. Worktree: `/Users/albert/.codex/worktrees/0176-code-mode-output/CodeStory`. Independent exact-head review passed 42 hostile cases; receipt SHA-256 `ec7c9bb38b0e826467dc338ebe3f99284be0ff826ad4bdadf7ae9a1a41bd4dc7`. The full local call-and-result exchange, including the helper source, shrank from 28,502 to 14,080 serialized bytes. PR CI is pending; the PR remains draft. Next proof target is the integrated installed package followed by one complete comparison with unchanged tasks, model and acceptance thresholds. Both earlier failed comparisons remain retained. No source stabilization, calibration, qualification or promotion is claimed.

Closes #2154
Refs #2135
