### PR TITLE
Clarify context evidence and source inspection

### DIFF
--- a/plugins/codestory/skills/codestory-grounding/SKILL.md
+++ b/plugins/codestory/skills/codestory-grounding/SKILL.md
@@ -26,7 +26,10 @@ host tools; an exact name can be searched; an unfamiliar repository may benefit
 from `ground` or `files`. No preliminary status or packet call is required.
 
 1. Locate candidates using an exact selector, text or behavior description.
-2. Inspect relevant source through `snippet`, `context` or ordinary host reads.
+2. Inspect relevant source through `snippet` or ordinary host reads.
+   `context` collects evidence around a target; its rows may contain only
+   locations. Read the source when returned excerpts do not show the code
+   needed for the claim.
    Copy returned opaque symbol IDs unchanged; resolve ambiguity using paths,
    scope and source instead of guessing an ID from a display name.
 3. Follow relevant callers, callees, references or other explicit relationships.
@@ -47,7 +50,8 @@ not an instruction to execute.
 | --- | --- |
 | Repository orientation or coverage | `ground` for a compact map; `files` for indexed files and coverage. |
 | Discover or disambiguate candidates | `search`; preserve an explicitly supplied symbol query unchanged. Use `repo_text: "off"` for existing core-only symbol search without embedding preparation. |
-| Inspect a selected target | `context` with a concrete `query` or a returned `symbol_id` as `id`; `snippet` for source windows; host reads for any relevant source or artifact. |
+| Collect evidence around a selected target | `context` with a concrete `query` or a returned `symbol_id` as `id`; inspect the excerpts and their limits. |
+| Inspect source text | `snippet` for source windows; host reads for any relevant source or artifact. A location alone does not show the implementation. |
 | Follow relationships | `callers`, `callees`, `references`, `trace` or `trail`; node-based `neighbors`, `shortest_path` and `query_subgraph` require actual returned node IDs. |
 | Inspect identities | `symbol`, `symbols`, `definition` and `get_node`. Names, IDs and source locations have different roles; keep their types intact. |
 | Review a diff | `affected` with explicit changed `paths`, `changed_paths` or `change_records`. Obtain the diff with host Git tools; this tool does not discover it. |

--- a/plugins/codestory/skills/codestory-grounding/references/context.md
+++ b/plugins/codestory/skills/codestory-grounding/references/context.md
@@ -3,7 +3,10 @@
 Builds target context around one concrete retrieval target (`query` must name a
 symbol, file, literal, API path, module, or behavior term, not a broad
 question). Fails closed unless full retrieval is ready. Use `search` for
-discovery, then inspect selected targets and follow their relationships.
+discovery, then collect evidence around selected targets and follow their
+relationships. Returned rows may contain only symbol locations or short
+excerpts. Use `snippet` or host reads when the needed implementation text is
+absent; a resolved target is not itself a source read.
 
 ## Syntax
 


### PR DESCRIPTION
The grounding skill recommended `context` as source inspection even when its evidence rows contained only symbol locations. The main investigation loop and operation table now match the existing v3 contract: use `snippet` or host reads for implementation text, and inspect `context` excerpts only for what they actually contain.

Review the two guidance pages. Useful context excerpts, adaptive navigation, opaque IDs and ordinary source access remain supported. Runtime behavior and response schemas are unchanged. The observed interaction supports this clarification but does not prove wording was its sole cause or predict the next comparison result.

Validation on `606e65703d5c587086ce99a897f236ef53441eba` (tree `5043283315d3a7419a67e52a00e0551d3168619a`): skill validation, document links (89 pages, 321 relative links) and diff checks pass. Plugin static passed 140 tests with one skip. Independent exact-head review accepted the four response shapes and preserved scope/identity rules; all eight evidence bindings were rechecked. CI passed, including the 21m23s draft source check, Linux contracts, plugin static and document/issue checks. No broad release proof is started by this support PR.

The run06 comparison remains failed and unchanged: candidate 8/12, published 9/12, native 10/12. A new complete comparison is required after integration; no earlier result is rescored or pooled.

Closes #2156. Refs #2135.
