### PR TITLE
Make the global framework catalog optional in file listings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - Agents can search, inspect source and follow relationships in any useful
   order, using native tools whenever needed. Packets remain optional experiments
   and do not decide whether an investigation is complete.
+- File listings keep project coverage details concise. Request the global
+  framework capability catalog with `--include-framework-coverage` or the
+  matching MCP option when checking framework support limits.
 - **Breaking interface change:** search, context and packet adopt publication
   schema 3. Consumers must read evidence identities, status and gaps instead of
   older hit/support/disposition shapes. Obsolete packet inputs are rejected;

--- a/crates/codestory-cli/src/app/source_commands/source_read.rs
+++ b/crates/codestory-cli/src/app/source_commands/source_read.rs
@@ -132,6 +132,7 @@ pub(in crate::app) fn run_files(cmd: FilesCommand) -> Result<()> {
         let output = runtime
             .browser
             .indexed_files(IndexedFilesRequest {
+                include_framework_coverage: cmd.include_framework_coverage,
                 path_contains: cmd.path.clone(),
                 language: cmd.language.clone(),
                 role: cmd.role.map(Into::into),

--- a/crates/codestory-cli/src/app/tests/lifecycle/files_affected.rs
+++ b/crates/codestory-cli/src/app/tests/lifecycle/files_affected.rs
@@ -13,6 +13,7 @@ fn files_markdown_reports_incomplete_reason_text() {
         project_root: "C:/repo".to_string(),
         usable: true,
         summary: IndexedFilesSummaryDto {
+            framework_route_coverage_included: None,
             file_count: 1,
             indexed_file_count: 1,
             filtered_file_count: 1,
@@ -62,6 +63,7 @@ fn files_markdown_labels_verified_policy_exclusions_as_non_graph_evidence() {
             project_root: "/repo".into(),
             usable: true,
             summary: IndexedFilesSummaryDto {
+                framework_route_coverage_included: None,
                 file_count: 1,
                 indexed_file_count: 1,
                 filtered_file_count: 1,

--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -1456,6 +1456,11 @@ pub(crate) enum ExploreProfile {
 
 #[derive(Args, Debug)]
 pub(crate) struct FilesCommand {
+    #[arg(
+        long,
+        help = "Include the global framework route capability catalog and its limitations."
+    )]
+    pub(crate) include_framework_coverage: bool,
     #[arg(long, default_value = ".", help = "Repository root to query.")]
     pub(crate) project: PathBuf,
     #[arg(

--- a/crates/codestory-cli/src/stdio_catalog.rs
+++ b/crates/codestory-cli/src/stdio_catalog.rs
@@ -2082,6 +2082,11 @@ static SYMBOLS_INPUT_SCHEMA: SchemaObject = SchemaObject::object(
 static FILES_INPUT_SCHEMA: SchemaObject = SchemaObject::object(
     "List indexed files from the existing local index.",
     &[
+        SchemaProperty::boolean(
+            "include_framework_coverage",
+            "Include the global framework capability catalog and its limitations.",
+        )
+        .with_default(ValueLiteral::Boolean(false)),
         SchemaProperty::string("path", "Only include files whose path contains this text."),
         SchemaProperty::string("language", "Only include files for this language."),
         SchemaProperty::string("role", "Only include files with this inferred role.")
@@ -3025,6 +3030,7 @@ mod tests {
             project_root: "/repo".to_string(),
             usable: true,
             summary: codestory_contracts::api::IndexedFilesSummaryDto {
+                framework_route_coverage_included: None,
                 file_count: 0,
                 indexed_file_count: 0,
                 filtered_file_count: 0,
@@ -3043,6 +3049,14 @@ mod tests {
             files: Vec::new(),
         };
         let payload = serde_json::to_value(&files).expect("serialize indexed files");
+        assert!(
+            payload["summary"]
+                .get("framework_route_coverage_included")
+                .is_none()
+        );
+        let legacy: codestory_contracts::api::IndexedFilesDto =
+            serde_json::from_value(payload.clone()).expect("older inventory response");
+        assert_eq!(legacy.summary.framework_route_coverage_included, None);
         assert_eq!(
             payload.get("policy_exclusions"),
             Some(&json!([])),

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -4015,6 +4015,10 @@ fn handle_stdio_files(runtime: &RuntimeContext, request: &serde_json::Value) -> 
     runtime
         .browser
         .indexed_files(IndexedFilesRequest {
+            include_framework_coverage: request
+                .pointer("/params/arguments/include_framework_coverage")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false),
             path_contains: request
                 .pointer("/params/arguments/path")
                 .and_then(|value| value.as_str())

--- a/crates/codestory-cli/tests/cli_golden_path.rs
+++ b/crates/codestory-cli/tests/cli_golden_path.rs
@@ -1591,6 +1591,49 @@ fn files_json_reports_structural_support_tiers_for_cargo_and_compose() {
         &["files", "--refresh", "none", "--format", "json"],
     );
 
+    assert_eq!(
+        files["summary"]["framework_route_coverage_included"],
+        serde_json::json!(false)
+    );
+    assert_eq!(
+        files["summary"]["framework_route_coverage"],
+        serde_json::json!([])
+    );
+    let full = run_cli_json(
+        workspace.path(),
+        cache_dir.path(),
+        &[
+            "files",
+            "--refresh",
+            "none",
+            "--format",
+            "json",
+            "--include-framework-coverage",
+        ],
+    );
+    assert_eq!(
+        full["summary"]["framework_route_coverage_included"],
+        serde_json::json!(true)
+    );
+    assert!(
+        full["summary"]["framework_route_coverage"]
+            .as_array()
+            .is_some_and(|rows| !rows.is_empty())
+    );
+    for field in [
+        "files",
+        "coverage_gaps",
+        "policy_exclusions",
+        "project_root",
+        "usable",
+    ] {
+        assert_eq!(files.get(field), full.get(field), "{field}");
+    }
+    assert_eq!(
+        files["summary"]["language_counts"],
+        full["summary"]["language_counts"]
+    );
+
     assert!(
         files["summary"]["language_counts"]
             .as_array()

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -305,6 +305,95 @@ fn public_v3_negotiates_revision_native_evidence_discovery() {
 }
 
 #[test]
+fn files_framework_catalog_is_explicit_in_every_mcp_revision() {
+    let fixture = indexed_fixture();
+    for revision in ["2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25"] {
+        let mut server = spawn_stdio_server(&fixture);
+        let init = send_json(
+            &mut server,
+            json!({
+                "jsonrpc":"2.0", "id":"files-init", "method":"initialize",
+                "params":{"protocolVersion":revision}
+            }),
+        );
+        assert_success_envelope(&init, json!("files-init"));
+        let mut outputs = Vec::new();
+        for (id, requested) in [
+            ("default", None),
+            ("false", Some(false)),
+            ("true", Some(true)),
+        ] {
+            let mut arguments = json!({"project":fixture.workspace.path(), "limit":1});
+            if let Some(requested) = requested {
+                arguments["include_framework_coverage"] = json!(requested);
+            }
+            let response = send_json(
+                &mut server,
+                json!({
+                    "jsonrpc":"2.0", "id":id, "method":"tools/call",
+                    "params":{"name":"files", "arguments":arguments}
+                }),
+            );
+            let result = assert_success_envelope(&response, json!(id));
+            assert_ne!(result.get("isError"), Some(&json!(true)), "{response}");
+            let payload: Value = serde_json::from_str(
+                result["content"][0]["text"]
+                    .as_str()
+                    .expect("JSON fallback"),
+            )
+            .expect("file inventory");
+            if revision >= "2025-06-18" {
+                assert_eq!(result["structuredContent"], payload);
+            }
+            assert_eq!(
+                payload["summary"]["framework_route_coverage_included"],
+                json!(requested.unwrap_or(false))
+            );
+            assert_eq!(
+                payload["summary"]["framework_route_coverage"]
+                    .as_array()
+                    .unwrap()
+                    .is_empty(),
+                requested != Some(true)
+            );
+            outputs.push(payload);
+        }
+        assert_eq!(outputs[0], outputs[1]);
+        for field in [
+            "files",
+            "coverage_gaps",
+            "policy_exclusions",
+            "project_root",
+            "usable",
+        ] {
+            assert_eq!(
+                outputs[0].get(field),
+                outputs[2].get(field),
+                "{revision}: {field}"
+            );
+        }
+        for field in [
+            "file_count",
+            "indexed_file_count",
+            "filtered_file_count",
+            "visible_file_count",
+            "incomplete_file_count",
+            "error_file_count",
+            "policy_exclusion_count",
+            "incomplete_reason_counts",
+            "truncated",
+            "language_counts",
+        ] {
+            assert_eq!(
+                outputs[0]["summary"].get(field),
+                outputs[2]["summary"].get(field),
+                "{revision}: {field}"
+            );
+        }
+    }
+}
+
+#[test]
 fn native_v3_rejects_the_launcher_invalid_argument_parity_matrix() {
     for revision in ["2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25"] {
         let fixture = unindexed_fixture();
@@ -329,6 +418,13 @@ fn native_v3_rejects_the_launcher_invalid_argument_parity_matrix() {
         let mut overflow_probes = exact_path_probes.clone();
         overflow_probes.push(json!({"kind":"exact_path","path":"src/overflow.rs"}));
         let cases = vec![
+            (
+                "files-framework-type",
+                "files",
+                json!({"project":project,"include_framework_coverage":"yes"}),
+                "/arguments/include_framework_coverage",
+                "invalid_type",
+            ),
             (
                 "status-project-type",
                 "status",

--- a/crates/codestory-contracts/src/api/dto.rs
+++ b/crates/codestory-contracts/src/api/dto.rs
@@ -1212,6 +1212,9 @@ pub enum IndexedFileRoleDto {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]
 pub struct IndexedFilesRequest {
+    /// Include the global capability catalog, independent of this project's inventory.
+    #[serde(default)]
+    pub include_framework_coverage: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub path_contains: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1307,6 +1310,9 @@ pub struct IndexedFilesSummaryDto {
     pub language_counts: Vec<IndexedFileLanguageCountDto>,
     #[serde(default)]
     pub framework_route_coverage: Vec<FrameworkRouteCoverageDto>,
+    /// None denotes an older response that did not declare whether the catalog was included.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub framework_route_coverage_included: Option<bool>,
     #[serde(default)]
     pub coverage_notes: Vec<String>,
 }

--- a/crates/codestory-runtime/src/index_coverage.rs
+++ b/crates/codestory-runtime/src/index_coverage.rs
@@ -695,6 +695,7 @@ pub(crate) fn indexed_files_from_storage(
     source_index_policy: &SourceIndexPolicy,
     req: IndexedFilesRequest,
 ) -> Result<IndexedFilesDto, ApiError> {
+    let include_framework_coverage = req.include_framework_coverage;
     let inventory = IndexedFilesInventory::load(storage, root, source_index_policy)?;
     let aggregation = IndexedFilesAggregation::from_inventory(root, &inventory);
     let selection = IndexedFilesSelection::from_inventory(root, inventory, req);
@@ -719,6 +720,12 @@ pub(crate) fn indexed_files_from_storage(
             selection.policy_exclusion_count
         ));
     }
+    if !include_framework_coverage {
+        coverage_notes.push(
+            "Global framework capability catalog omitted; request include_framework_coverage for its limitations. File inventory does not establish route coverage."
+                .to_string(),
+        );
+    }
 
     Ok(IndexedFilesDto {
         project_root: root.to_string_lossy().to_string(),
@@ -734,7 +741,12 @@ pub(crate) fn indexed_files_from_storage(
             incomplete_reason_counts: aggregation.incomplete_reason_counts,
             truncated: selection.truncated,
             language_counts: aggregation.language_counts,
-            framework_route_coverage: framework_route_coverage_matrix(),
+            framework_route_coverage: if include_framework_coverage {
+                framework_route_coverage_matrix()
+            } else {
+                Vec::new()
+            },
+            framework_route_coverage_included: Some(include_framework_coverage),
             coverage_notes,
         },
         coverage_gaps: aggregation.coverage_gaps,

--- a/crates/codestory-runtime/src/tests.rs
+++ b/crates/codestory-runtime/src/tests.rs
@@ -2230,12 +2230,22 @@ fn indexed_files_reports_incomplete_reason_counts() {
         .expect("open project");
     let output = controller
         .indexed_files(IndexedFilesRequest {
+            include_framework_coverage: false,
             path_contains: None,
             language: None,
             role: None,
             limit: Some(50),
         })
         .expect("indexed files");
+
+    assert!(
+        output.summary.framework_route_coverage.is_empty(),
+        "default inventory returned {} global framework entries ({} serialized bytes)",
+        output.summary.framework_route_coverage.len(),
+        serde_json::to_vec(&output.summary.framework_route_coverage)
+            .unwrap()
+            .len()
+    );
 
     assert_eq!(output.summary.incomplete_file_count, 2);
     assert_eq!(output.summary.error_file_count, 1);
@@ -2264,6 +2274,56 @@ fn indexed_files_reports_incomplete_reason_counts() {
     assert!(!partial.retryable);
     assert!(partial.verified_source);
     assert!(partial.projection_available);
+
+    for filter in [
+        serde_json::json!({}),
+        serde_json::json!({"path_contains":"unknown"}),
+        serde_json::json!({"language":"rust", "limit":1}),
+        serde_json::json!({"role":"source"}),
+        serde_json::json!({"role":"test"}),
+        serde_json::json!({"path_contains":"absent"}),
+    ] {
+        let request: IndexedFilesRequest = serde_json::from_value(filter).expect("default request");
+        assert!(!request.include_framework_coverage);
+        let compact = controller
+            .indexed_files(request.clone())
+            .expect("compact inventory");
+        let mut full = controller
+            .indexed_files(IndexedFilesRequest {
+                include_framework_coverage: true,
+                ..request
+            })
+            .expect("inventory with capability catalog");
+        assert_eq!(
+            compact.summary.framework_route_coverage_included,
+            Some(false)
+        );
+        assert_eq!(full.summary.framework_route_coverage_included, Some(true));
+        assert!(compact.summary.framework_route_coverage.is_empty());
+        assert_eq!(
+            serde_json::to_value(&full.summary.framework_route_coverage).unwrap(),
+            serde_json::to_value(framework_route_coverage_matrix()).unwrap()
+        );
+        assert_eq!(
+            &compact.summary.coverage_notes[..full.summary.coverage_notes.len()],
+            &full.summary.coverage_notes
+        );
+        assert_eq!(
+            compact.summary.coverage_notes.len(),
+            full.summary.coverage_notes.len() + 1
+        );
+        let compact_bytes = serde_json::to_vec(&compact).unwrap().len();
+        let full_bytes = serde_json::to_vec(&full).unwrap().len();
+        eprintln!("file inventory bytes: compact={compact_bytes}, with_catalog={full_bytes}");
+        assert!(compact_bytes < full_bytes);
+        full.summary.framework_route_coverage.clear();
+        full.summary.framework_route_coverage_included = Some(false);
+        full.summary.coverage_notes = compact.summary.coverage_notes.clone();
+        assert_eq!(
+            serde_json::to_value(&compact).unwrap(),
+            serde_json::to_value(&full).unwrap()
+        );
+    }
 }
 
 #[test]
@@ -3204,6 +3264,7 @@ fn full_refresh_publishes_structural_unit_exclusion_without_graph_claims() {
     );
     let files = controller
         .indexed_files(IndexedFilesRequest {
+            include_framework_coverage: false,
             path_contains: Some("evidence-generated.json".into()),
             language: None,
             role: None,
@@ -3537,6 +3598,7 @@ fn structural_unit_policy_change_invalidates_exclusion_and_forces_reevaluation()
     );
     let error = admitting_controller
         .indexed_files(IndexedFilesRequest {
+            include_framework_coverage: false,
             path_contains: None,
             language: None,
             role: None,
@@ -3649,6 +3711,7 @@ fn first_full_refresh_publishes_verified_oversized_exclusion_without_graph_cover
     );
     let files = controller
         .indexed_files(IndexedFilesRequest {
+            include_framework_coverage: false,
             path_contains: Some("rust_tictactoe.rs".into()),
             language: None,
             role: None,
@@ -3661,6 +3724,7 @@ fn first_full_refresh_publishes_verified_oversized_exclusion_without_graph_cover
     assert!(!files.policy_exclusions[0].semantic_coverage);
     let all_files = controller
         .indexed_files(IndexedFilesRequest {
+            include_framework_coverage: false,
             path_contains: None,
             language: None,
             role: None,
@@ -3922,6 +3986,7 @@ fn non_default_source_policy_cap_is_shared_by_planning_indexer_publication_and_r
     assert_eq!(published.exclusion_count, 1);
     let files = controller
         .indexed_files(IndexedFilesRequest {
+            include_framework_coverage: false,
             path_contains: Some("large.rs".into()),
             language: None,
             role: None,
@@ -3929,6 +3994,27 @@ fn non_default_source_policy_cap_is_shared_by_planning_indexer_publication_and_r
         })
         .expect("matching policy reader accepts the manifest");
     assert_eq!(files.policy_exclusions[0].byte_cap, 64);
+    let with_catalog = controller
+        .indexed_files(IndexedFilesRequest {
+            include_framework_coverage: true,
+            path_contains: Some("large.rs".into()),
+            language: None,
+            role: None,
+            limit: None,
+        })
+        .expect("catalog does not change policy coverage");
+    assert_eq!(
+        serde_json::to_value(&files.policy_exclusions).unwrap(),
+        serde_json::to_value(&with_catalog.policy_exclusions).unwrap()
+    );
+    assert_eq!(
+        serde_json::to_value(&files.coverage_gaps).unwrap(),
+        serde_json::to_value(&with_catalog.coverage_gaps).unwrap()
+    );
+    assert_eq!(
+        files.summary.policy_exclusion_count,
+        with_catalog.summary.policy_exclusion_count
+    );
 
     for incompatible in [
         SourceIndexPolicy::oversized(65),
@@ -3956,6 +4042,7 @@ fn non_default_source_policy_cap_is_shared_by_planning_indexer_publication_and_r
         );
         let error = reader
             .indexed_files(IndexedFilesRequest {
+                include_framework_coverage: false,
                 path_contains: None,
                 language: None,
                 role: None,

--- a/crates/codestory-runtime/src/tests/activation_coverage_tests.rs
+++ b/crates/codestory-runtime/src/tests/activation_coverage_tests.rs
@@ -121,6 +121,7 @@ fn malformed_source_publication_preserves_bytes_without_projection_authority() {
             drop(storage);
             let public_files = controller
                 .indexed_files(IndexedFilesRequest {
+                    include_framework_coverage: false,
                     path_contains: Some(name.into()),
                     language: None,
                     role: None,
@@ -289,6 +290,7 @@ fn full_refresh_publishes_verified_generic_tagged_template_parser_partial() {
         .expect("strict reader must admit the completed search generation");
     let diagnostics = controller
         .indexed_files(IndexedFilesRequest {
+            include_framework_coverage: false,
             path_contains: Some("job-store.ts".to_string()),
             language: None,
             role: None,

--- a/docs/testing/framework-route-coverage.md
+++ b/docs/testing/framework-route-coverage.md
@@ -10,7 +10,8 @@ single heuristic hit. Language support tiers are defined separately in
 ## Current Route Extraction Scope
 
 These bullets list extractor coverage or tracked fixture targets, not full
-framework parity; use `summary.framework_route_coverage` for per-framework
+framework parity; request `files --include-framework-coverage` and use
+`summary.framework_route_coverage` for per-framework
 status, confidence floor, handler-link support, known gaps, and promotability.
 
 - JavaScript/TypeScript: Express module-scope route calls on source-ordered app
@@ -119,7 +120,7 @@ a static path.
 4. For data bridge work, assert collection registration nodes, operation-aware
    usage edges, and the relevant `payload:<operation>:<slug>:...` callsite
    identity.
-5. Run `codestory-cli files --project <fixture> --format json` and inspect
+5. Run `codestory-cli files --project <fixture> --format json --include-framework-coverage` and inspect
    `summary.framework_route_coverage` for framework, language, status,
    coverage evidence, confidence floor, handler-link support, unsupported
    patterns, known gaps, and promotable status.

--- a/docs/users/upgrading.md
+++ b/docs/users/upgrading.md
@@ -55,6 +55,19 @@ host's MCP bindings. Nullable excerpts and line bounds stay nullable; a missing
 result is not an absence proof. `repo_text: "off"` requires an existing complete
 core publication and does not prepare embeddings.
 
+## Request the framework catalog when needed
+
+`files` still returns project file counts, language support tiers, errors,
+exclusions and coverage gaps by default. Its global framework capability
+catalog is now opt-in: pass `include_framework_coverage: true` through MCP or
+`--include-framework-coverage` on the CLI. This returns the complete catalog,
+independent of file filters.
+
+When `summary.framework_route_coverage_included` is false, the empty
+`framework_route_coverage` array means the catalog was omitted. It does not
+mean that no frameworks are supported. Older responses lack the inclusion
+marker; do not infer their inclusion state from a missing marker.
+
 ## Update packet requests
 
 | Removed input | Replacement |

--- a/plugins/codestory/generated-mcp-catalog.json
+++ b/plugins/codestory/generated-mcp-catalog.json
@@ -10,15 +10,15 @@
     ],
     "preferredMcpProtocolVersion": "2025-11-25",
     "discoveryContracts": {
-      "2024-11-05": "9775c1046298791674e8fe715700c890d095659152e5211c2fb61a181aa41d9f",
-      "2025-03-26": "f787b3e94c668b3d20cc0379605b989daefc99810717cd6895ea1f4efc72cbd3",
-      "2025-06-18": "3e932f14d8a218ef9245774fa468ce765a1f7b963bfbea54e756ce82a36c8391",
-      "2025-11-25": "a1929a789fac71298a3ed6b34217d30d9a626b7168531283b9d308935ae4434d"
+      "2024-11-05": "de5a0c7d0a1c024dc3ff4fa3cddcc56f940849ac30ae7c4811c4aaf91874282a",
+      "2025-03-26": "4440f4544930c84c476e9f786188e6658a8f6f9c1203989c6fee4683be7beb38",
+      "2025-06-18": "400577bca4552e5172e98415ef51f23cc8269b66b3072186f8194df96dba9bf9",
+      "2025-11-25": "e7e7304d0d3664f7f26467e79d67d6c9b8f7878ef471e8c57657b1dae38bb815"
     }
   },
   "revisionProfiles": {
     "2024-11-05": {
-      "discoveryContractSha256": "9775c1046298791674e8fe715700c890d095659152e5211c2fb61a181aa41d9f",
+      "discoveryContractSha256": "de5a0c7d0a1c024dc3ff4fa3cddcc56f940849ac30ae7c4811c4aaf91874282a",
       "tools": [
         {
           "description": "Inspect CodeStory readiness for the requested repository when diagnostics are needed. CodeStory effect: observational and does not activate managed state.",
@@ -408,6 +408,11 @@
             "additionalProperties": false,
             "description": "List indexed files from the existing local index.",
             "properties": {
+              "include_framework_coverage": {
+                "default": false,
+                "description": "Include the global framework capability catalog and its limitations.",
+                "type": "boolean"
+              },
               "language": {
                 "description": "Only include files for this language.",
                 "type": "string"
@@ -1547,7 +1552,7 @@
       ]
     },
     "2025-03-26": {
-      "discoveryContractSha256": "f787b3e94c668b3d20cc0379605b989daefc99810717cd6895ea1f4efc72cbd3",
+      "discoveryContractSha256": "4440f4544930c84c476e9f786188e6658a8f6f9c1203989c6fee4683be7beb38",
       "tools": [
         {
           "annotations": {
@@ -1967,6 +1972,11 @@
             "additionalProperties": false,
             "description": "List indexed files from the existing local index.",
             "properties": {
+              "include_framework_coverage": {
+                "default": false,
+                "description": "Include the global framework capability catalog and its limitations.",
+                "type": "boolean"
+              },
               "language": {
                 "description": "Only include files for this language.",
                 "type": "string"
@@ -3196,7 +3206,7 @@
       ]
     },
     "2025-06-18": {
-      "discoveryContractSha256": "3e932f14d8a218ef9245774fa468ce765a1f7b963bfbea54e756ce82a36c8391",
+      "discoveryContractSha256": "400577bca4552e5172e98415ef51f23cc8269b66b3072186f8194df96dba9bf9",
       "tools": [
         {
           "_meta": {
@@ -5413,6 +5423,11 @@
             "additionalProperties": false,
             "description": "List indexed files from the existing local index.",
             "properties": {
+              "include_framework_coverage": {
+                "default": false,
+                "description": "Include the global framework capability catalog and its limitations.",
+                "type": "boolean"
+              },
               "language": {
                 "description": "Only include files for this language.",
                 "type": "string"
@@ -11576,7 +11591,7 @@
       ]
     },
     "2025-11-25": {
-      "discoveryContractSha256": "a1929a789fac71298a3ed6b34217d30d9a626b7168531283b9d308935ae4434d",
+      "discoveryContractSha256": "e7e7304d0d3664f7f26467e79d67d6c9b8f7878ef471e8c57657b1dae38bb815",
       "tools": [
         {
           "_meta": {
@@ -13793,6 +13808,11 @@
             "additionalProperties": false,
             "description": "List indexed files from the existing local index.",
             "properties": {
+              "include_framework_coverage": {
+                "default": false,
+                "description": "Include the global framework capability catalog and its limitations.",
+                "type": "boolean"
+              },
               "language": {
                 "description": "Only include files for this language.",
                 "type": "string"
@@ -22172,6 +22192,11 @@
         "additionalProperties": false,
         "description": "List indexed files from the existing local index.",
         "properties": {
+          "include_framework_coverage": {
+            "default": false,
+            "description": "Include the global framework capability catalog and its limitations.",
+            "type": "boolean"
+          },
           "language": {
             "description": "Only include files for this language.",
             "type": "string"

--- a/plugins/codestory/skills/codestory-grounding/references/files.md
+++ b/plugins/codestory/skills/codestory-grounding/references/files.md
@@ -16,13 +16,15 @@ CLI flags. Every call requires `project` (absolute repository root).
 | Inventory | MCP `files` with `project` | Language counts and a capped file list. |
 | Coverage check | MCP `files` with `language` | File rows for that language. |
 | Test discovery | MCP `files` with `role=test` | Test-like files inferred from path/name conventions. |
+| Framework support limits | MCP `files` with `include_framework_coverage=true` | The complete global capability catalog, independent of file filters. |
 
 ## Notes
 
 - MCP `files` has no `refresh` field. The catalog tool refreshes the local map
   before dispatch and does not wait for broad search.
 - Treat `index usable` with incomplete or error counts as a partial-coverage signal, not a failure.
-- `summary.framework_route_coverage` is the support matrix for framework route extraction. It includes `status`, `coverage_evidence`, `confidence_floor`, `handler_link_support`, `unsupported_patterns`, `known_gaps`, and `promotable`. Treat `partial`, `heuristic`, text-only handler support, and `promotable=false` as review prompts, not proof of full framework parity.
+- Default file listings omit the global framework catalog. `summary.framework_route_coverage_included=false` means it was not requested, not that no framework is supported. Project-specific counts, language tiers, exclusions and coverage gaps remain present.
+- Request `include_framework_coverage=true` to populate `summary.framework_route_coverage` and set its inclusion marker to true. The catalog includes `status`, `coverage_evidence`, `confidence_floor`, `handler_link_support`, `unsupported_patterns`, `known_gaps`, and `promotable`. Treat `partial`, `heuristic`, text-only handler support, and `promotable=false` as review prompts, not proof of full framework parity.
 - Route coverage statuses:
   - `supported`: fixture-backed behavior is passing and documented coverage is met.
   - `heuristic`: pattern-backed evidence that needs source review.

--- a/plugins/codestory/skills/codestory-grounding/references/generated-mcp-syntax.md
+++ b/plugins/codestory/skills/codestory-grounding/references/generated-mcp-syntax.md
@@ -24,7 +24,7 @@ There is no MCP `index`, `doctor`, `ready`, `explore`, `drill`, `query`,
 | `packet` | `question` | `budget`, typed `probes`, `latency_budget_ms`, continuation `parent_packet_id` / `option_ids` / generation pins | Experimental bounded evidence selection. No `include_evidence`, `task_class`, or `extra_probes`. |
 | `search` | `query` | `limit`, `repo_text` (`auto`/`on`/`off`) | Discovery for adaptive source and relationship inspection. |
 | `ground` | | `budget` (`strict`/`balanced`/`max`) | First call may refresh the local map. |
-| `files` | | `language`, `path`, `role`, `limit` | Refreshes the local map before dispatch. No `refresh` field. |
+| `files` | | `language`, `path`, `role`, `limit`, `include_framework_coverage` | Refreshes the local map before dispatch. No `refresh` field. |
 | `affected` | exactly one of `paths`, `changed_paths`, `change_records` | `depth`, `filter` | Never discovers git changes. |
 | `symbol` | `query` or `id` | `choose` | |
 | `trail` | `query` or `id` | `direction` (`incoming`/`outgoing`/`both`), `depth`, `max_nodes`, `story`, `choose` | There is no `mode` field. |


### PR DESCRIPTION
File lookups included the same 10 KiB catalog of 26 web frameworks in every response, including filtered lookups in projects unrelated to those frameworks. Default listings now keep the project inventory and coverage evidence while making that global catalog optional.

Pass `include_framework_coverage: true` through MCP or `--include-framework-coverage` on the CLI to receive the complete existing catalog. `summary.framework_route_coverage_included` explicitly distinguishes inclusion from omission; older responses without this marker deserialize as unknown. Default responses retain every file row, language tier, incomplete/error count, reason, policy exclusion, coverage gap and existing coverage note. A further note discloses the omitted catalog. No framework is selected by project, language, task terms or inferred relevance.

The owning change is in `IndexedFilesRequest` and `indexed_files_from_storage`. CLI and MCP only parse the option. The generated catalog, compact MCP syntax, files reference and upgrade/coverage docs describe the new default. Consumers that relied on the global catalog must now request it.

The generic incomplete-index fixture failed before the fix because its default result carried 26 entries (10,272 serialized catalog bytes). Afterward its whole default result is 1,592 bytes versus 11,708 with the catalog; six filter combinations preserve identical project evidence. A policy-exclusion fixture also verifies both modes. These are serialized response measurements, not model token savings or a passing maintenance panel.

Focused checks pass on this head: runtime inventory and policy fixtures; contracts (124); CLI catalog (6); complete stdio protocol suite (66), including all four revisions and input rejection; CLI invocation (1); Markdown (2); clippy for contracts/runtime/CLI libraries and tests; generated syntax; plugin-static; documentation links; formatting and diff checks. Independent hostile execution passed on this exact head: 144 runtime requests across four inventory states and twelve filters, missing-publication and policy-mismatch rejection, 32 malformed MCP requests before activation, 36 valid MCP requests across all revisions, and CLI default/opt-in/rejection behavior. The opt-in catalog matches the captured pre-change catalog byte-for-byte. Three independent tests passed; the implementation owner verified all 29 artifact bindings. Exact-head CI passes: Ubuntu draft source checks, Linux contracts and durability, rustdoc, plugin static, links, and closing-issue checks. The Windows manifest lane was skipped; no Windows proof is claimed here.

Independent acceptance receipt SHA256: `79d2c3c296277edad60a1689f2d9b55f796bbb14308f40f23fd4c1721ef427f7`.

Head: `4457ad9b84d8c82894af25865c750c5ced26aa61`. Tree: `79886a0ddac024cd0ce5d31cd0618d248eae2e8f`. Base: `0e9355da47b84c9caa69848a34610a65cd0bac43` (includes the independently accepted context-source repair).

Run07 remains failed under the unchanged input-context gate. No new model comparison, release source stabilization, calibration, archive qualification or publication has started. A fresh comparison requires the integrated candidate, installed host canaries, accepted lineage and reviewed resource bindings.

Closes #2160. Refs #2135.
