### PR TITLE
Keep probe conditions in behavioral conclusions

### DIFF
--- a/plugins/codestory/skills/codestory-grounding/SKILL.md
+++ b/plugins/codestory/skills/codestory-grounding/SKILL.md
@@ -84,7 +84,8 @@ send both. Batch known source windows with `snippet.paths` when useful.
   verification code is outside the default MCP surface. Do not synthesize a
   typed proof contract from English or infer proof authority from graph edges.
 - Runtime, deployment, security and rendered-UI claims need their corresponding
-  external evidence. Keep a plausible source explanation distinct from an
+  external evidence. Keep conclusions within the relevant inputs, guards and
+  environment actually checked. Distinguish broader source inference from
   observed execution or effective policy.
 
 ## Experimental packets


### PR DESCRIPTION
Behavioral conclusions can overstate a bounded probe when they omit a relevant guard, input or environment condition. The canonical skill now says to keep conclusions within those conditions and distinguish broader source inference from observed execution.

This tightens the existing runtime-evidence bullet. Navigation stays adaptive; there are no repository names, task-specific probes, expected answers, fixed routes or new mandatory experiments. The changed file is embedded in the CLI guide resource, so a later candidate archive must receive new package/runtime identity checks even though no Rust source changed.

Readback, `git diff --check`, and documentation links pass (89 files, 321 relative links). Independent exact-head scope review accepts this change (`086eba439a7d7483481edcdc4abc132bd057495141a8aee7503e150105ef07ff`). All required CI passed on that exact source head, including the draft source, Linux contract, plugin static, documentation and issue-link checks. These checks do not establish model adoption, correctness or input savings. Run08 remains failed under all original thresholds.

Head: `c5b02859844fcb95a2a033f9491fc6be4e12f9a7`. Tree: `0d7190400beca468070ee05f6d79657c16e2bc38`. Base: `37e0e05d6aebc70c474b1efb2bb279fac791f923`. Worktree: `/Users/albert/.codex/worktrees/0176-probe-conditions/CodeStory`.

The prospective evaluator source-observation correction is an external, separately versioned evidence artifact; it is not part of this source PR and does not regrade existing results.

Closes #2162. Refs #2135.
