### PR TITLE
document selective code-mode tool discovery

### DIFF
--- a/plugins/codestory/skills/codestory-grounding/SKILL.md
+++ b/plugins/codestory/skills/codestory-grounding/SKILL.md
@@ -14,10 +14,13 @@ Every CodeStory call selects its repository with an absolute `project` root.
 Keep project, source and publication identities attached when combining results
 across repositories; never rely on a global active project.
 
-In code-mode hosts, display each payload once. MCP results can repeat identical
-JSON in text and structured content. Keep the complete payload, errors, metadata
-and any distinct content; omit only an exact duplicate. Use the
-[code-mode display example](references/code-mode.md) when printing tool results.
+In code-mode hosts, inspect the declaration for the operation you choose. If you
+need a tool inventory first, print names, then expand the selected declarations;
+keep each declaration complete and inspect further ones when useful. See the
+[code-mode examples](references/code-mode.md) for discovery and result display.
+Display each result payload once. MCP results can repeat identical JSON in text
+and structured content. Keep the complete payload, errors, metadata and any
+distinct content; omit only an exact duplicate.
 
 ## Investigation loop
 

--- a/plugins/codestory/skills/codestory-grounding/references/code-mode.md
+++ b/plugins/codestory/skills/codestory-grounding/references/code-mode.md
@@ -1,4 +1,31 @@
-# Displaying CodeStory results in code mode
+# CodeStory discovery and results in code mode
+
+## Inspect selected tool declarations
+
+When the needed operation is known, inspect its exact callable declaration.
+If you need an inventory first, print tool names, then inspect the declarations
+for the operations you choose. All operations remain available.
+
+In hosts exposing `ALL_TOOLS`, a names-only inventory avoids printing every
+request and response schema:
+
+```javascript
+text(ALL_TOOLS.filter(tool => /codestory/i.test(tool.name)).map(tool => tool.name));
+```
+
+After choosing an operation, match its actual exposed name exactly. This example
+selects search; choose any operation or set of operations the task needs:
+
+```javascript
+const selectedNames = new Set(["mcp__codestory__search"]);
+text(ALL_TOOLS.filter(tool => selectedNames.has(tool.name)));
+```
+
+Keep each selected declaration complete. Inspect further declarations when they
+become useful. A plugin-wide predicate over names and descriptions can print
+many unused declarations; discovery does not require displaying all of them.
+
+## Display each result payload once
 
 Some hosts expose both `content` and `structuredContent` (or
 `structured_content`) to JavaScript. Printing the whole wrapper can put the


### PR DESCRIPTION
Code-mode discovery now shows how to list tool names and inspect complete declarations for the operations the agent selects. This avoids printing unused catalogue declarations while preserving access to every operation, adaptive navigation and complete result payloads.

The change is confined to the canonical skill and its existing code-mode reference. Review the names-only inventory, exact-name selection example and retained result-deduplication section. Search is illustrative; there is no fixed route or operation allowlist.

Validation: both pages read back, `git diff --check` passed, and the documentation checker passed 89 files / 321 relative links. Independent mechanism review executed the proposal against 25 captured catalogues and verified all 376 individual selections preserve complete declarations. Exact-source independent review passed on the head below: all 376 selections over 25 captured catalogues preserve complete declarations, and the previous result-deduplication code and prose are byte unchanged. Required CI is pending; this PR remains draft. Review receipt SHA-256: `14a96dbec50f39975c39df97a57c24923922a843696a5b1d27e15a3d6c4e0b4a`.

Base `2c766ed1e7d405d9b574e9591f08caa3f1fe1d5c`; head `f2e73924d70aea752cf9459ba679c1863029d755`; tree `66d1a6f2e7e7a4bb5f1d9291443d5db0b9e49fe5`. Worktree `/Users/albert/.codex/worktrees/0176-code-mode-discovery/CodeStory`; branch `codex/0176-code-mode-discovery`; owner: release implementation coordinator.

This does not establish model adoption, input-token savings, answer correctness or release qualification. Retained failed comparisons remain unchanged. After integration, the embedded guidance requires a newly built and installed candidate and a fresh 36-session comparison under the unchanged release rules. No broad proof dispatch from this support PR.

Closes #2164. Refs #2135.
