### PR TITLE
Clarify behavioral checks and 0.17.6 release benefits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,47 +4,44 @@
 
 ## 0.17.6
 
-- Context responses include verified focused source snippets that were
-  previously omitted. Truncated snippets report their retained line ranges
-  and limits.
-- Agents can search, inspect source and follow relationships in any useful
-  order, using native tools whenever needed. Packets remain optional experiments
-  and do not decide whether an investigation is complete.
-- File listings keep project coverage details concise. Request the global
-  framework capability catalog with `--include-framework-coverage` or the
-  matching MCP option when checking framework support limits.
-- **Breaking interface change:** search, context and packet adopt publication
-  schema 3. Consumers must read evidence identities, status and gaps instead of
-  older hit/support/disposition shapes. Obsolete packet inputs are rejected;
-  `--diagnostics-out` replaces `--step-trace-out`. See the
-  [upgrade guide](docs/users/upgrading.md) for migration and rollback examples.
-- Core-only `search --repo-text off` reads the existing complete symbol index
-  without preparing embeddings, including when retrieval catalogs are
-  unwritable. An unindexed project returns `project_unavailable` without
-  creating a cache.
-- Full indexing resolves calls and imports after writing the source graph,
-  including when reusing cached parser output. Relationships no longer require
-  a later incremental edit to become available.
-- Malformed text configuration files no longer block the whole repository
-  index. Their source remains visible with explicit coverage gaps, and stale
-  structural claims are removed. JSONC comments and trailing commas work in
-  supported configuration files; ordinary JSON remains strict.
-- Pointer-returning C and C++ functions and variable-bound JavaScript,
-  TypeScript and TSX functions retain their full definitions. A function
-  expression's private name no longer resolves to an unrelated outer function.
-- Normal cache upgrades preserve bookmarks and annotations while moving from
-  schema 31 to immutable schema-32 generations. Failed or interrupted
-  publication preserves the previous complete generation for recovery.
-- Cold indexing sends more documents through each bounded embedding request
-  while retaining the same model, vectors and dense coverage. Packet assembly
-  reuses the retrieval result that established admission.
-- Experimental packets retain at most sixteen evidence rows and a 16 KiB
-  serialized result. Missing or oversized evidence produces explicit gaps;
-  evidence availability never asserts answer sufficiency.
-- MCP discovery and results agree with each supported protocol profile. Older
-  profiles receive JSON text and modern profiles receive matching structured
-  content. `affected` also reports same-package tests as focused hints when
-  graph traversal does not reach them.
+CodeStory 0.17.6 lets agents choose how to investigate a repository and puts
+more of the relevant source in their results. Search, inspect code and follow
+relationships in the order the task needs, with native tools available
+throughout.
+
+- **Inspect useful source directly.** Context results include focused source
+  snippets with verified line ranges and clear truncation limits. C and C++
+  functions returning pointers, and functions assigned to variables in
+  JavaScript, TypeScript and TSX, retain their complete definitions.
+- **Follow relationships from the first index.** Calls and imports are
+  available after full indexing, including when parser results are reused.
+  Affected-code results also suggest relevant tests in the same package.
+- **Keep working past broken configuration files.** Malformed text
+  configuration no longer blocks the whole repository index. Unsupported or
+  broken content is reported as a coverage gap. Supported JSONC files accept
+  comments and trailing commas; ordinary JSON remains strict.
+- **Reuse work and keep navigation focused.** Indexing reuses unchanged
+  components and exact vectors, and packets reuse completed retrieval work.
+  Core-only `search --repo-text off` searches an existing symbol index without
+  starting embeddings. File listings focus on project coverage; the full
+  framework catalog remains available on request.
+- **Keep bookmarks through upgrades and interruptions.** Cache upgrades
+  preserve bookmarks and annotations. If publishing an updated index fails or
+  is interrupted, the previous complete index remains available for recovery.
+
+### Upgrading
+
+**Breaking interface change:** search, context and packet responses move to
+publication schema 3. Custom clients must use evidence identities, status and
+gaps in place of the previous hit, support and disposition shapes. Obsolete
+packet arguments are rejected, and `--diagnostics-out` replaces
+`--step-trace-out`. MCP responses use the format required by each supported
+protocol profile.
+
+See the [upgrade guide](docs/users/upgrading.md) for migration examples and the
+rollback procedure, which uses a preserved pre-upgrade cache copy. Packets
+remain optional experiments, bounded to sixteen evidence rows and 16 KiB;
+their results do not decide whether an investigation is complete.
 
 ## 0.17.5
 

--- a/plugins/codestory/skills/codestory-grounding/SKILL.md
+++ b/plugins/codestory/skills/codestory-grounding/SKILL.md
@@ -87,9 +87,15 @@ send both. Batch known source windows with `snippet.paths` when useful.
   verification code is outside the default MCP surface. Do not synthesize a
   typed proof contract from English or infer proof authority from graph edges.
 - Runtime, deployment, security and rendered-UI claims need their corresponding
-  external evidence. Keep conclusions within the relevant inputs, guards and
-  environment actually checked. Distinguish broader source inference from
-  observed execution or effective policy.
+  external evidence. For a behavioral probe, separate setup, the operation being
+  checked and observations of its effects. Observe state after the operation;
+  account for observations that can themselves change it. Use independent
+  setups when earlier operations or observations would affect later checks.
+  Compare the actual output with the conclusion before reporting it. Keep
+  conclusions within the relevant inputs, guards and environment actually
+  checked. If the output cannot distinguish relevant causes, report that
+  uncertainty. Distinguish broader source inference from observed execution or
+  effective policy.
 
 ## Experimental packets
 


### PR DESCRIPTION
Behavioral probes can misreport a state change when they collect the observation before the operation, or when inspecting state changes it. The canonical guide now separates setup, operation and observation, uses independent setups when checks interfere, and requires conclusions to match the captured output. Existing evidence, scope, guard and uncertainty boundaries remain.

The 0.17.6 changelog now leads with what users gain: flexible investigation, useful source excerpts, relationships after the first index, indexing through broken configuration, reuse and recovery. A separate upgrade section keeps the breaking schema-3 transition and preserved-cache rollback procedure visible. It adds no accuracy or measured performance claim.

Closes #2166. Refs #2135.

## Review

Head: `a4833a48968f795aa4ad38e42ed93e5574339ed9`  
Tree: `c1cf168de3736906653d806f3713afc8c74d0ab2`  
Base: `d9f67f47572982c9b6c103a12b28d35917424a9a`

Only `plugins/codestory/skills/codestory-grounding/SKILL.md` and the 0.17.6 section of `CHANGELOG.md` change. The implementation worktree is `/Users/albert/.codex/worktrees/0176-release-guidance/CodeStory`, branch `codex/0176-release-guidance`. The release owner implements; one independent verifier reviews the exact diff. No other source or workflow change is currently planned before the replacement candidate.

Independent causal review reproduced both captured erroneous probe outputs on Python 3.14.6 and showed that a separate observation after the operation reverses the claimed result. Five external mechanism cases cover evaluation order, observation side effects, compound operations, guards and ambiguous output. The reviewer accepted a bounded measurement-method revision; the implementation owner reverified all 83 evidence bindings. Review SHA-256: `0885e5637a68e90bcdb2b9eb9618c3eadaa2cf2e30237f28f4006721d5ed15bd`. Historical participant interpreter paths corroborate the Python version; no exact participant Python binary hash was retained.

## Verification and limits

- Changed pages read back; `git diff --check` passes.
- Documentation link check passes: 89 files, 321 relative links.
- Plugin-static checks: 140 pass, one skip, zero failures.
- Exact-head independent review accepted with no findings; all 16 bound files were reverified by the implementation owner. Review SHA-256: `59d45a37f20e635adf1e59d8a03872cad77952a1686be6367d531f29fe7865df`. Required CI passed on this exact head: Ubuntu draft source checks, plugin static tests, Linux contracts, documentation links and the closing-issue guard. The Windows missing-manifest job was skipped as designed. The PR is ready to merge.

This is guidance and release-note work, not a retrieval or evaluator fix. It does not prove guidance adoption, repair all answer omissions, or make the prior comparison pass. Run10 stays failed, and every prior grade and frozen rule remains unchanged. No source-stabilization, calibration or qualification run is authorized by this support PR. After all known changes are integrated, a newly built and normally installed candidate needs fresh accepted bindings and the unchanged complete panel. Combined maintainer approval remains required after qualification and before promotion.
