### PR TITLE
Preserve search relevance order in v3 responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ throughout.
 - **Follow relationships from the first index.** Calls and imports are
   available after full indexing, including when parser results are reused.
   Affected-code results also suggest relevant tests in the same package.
+- **Follow search results in relevance order.** Results keep their relevance
+  order across the CLI and agent responses.
 - **Keep working past broken configuration files.** Malformed text
   configuration no longer blocks the whole repository index. Unsupported or
   broken content is reported as a coverage gap. Supported JSONC files accept

--- a/crates/codestory-runtime/src/agent/packet_projection_v3.rs
+++ b/crates/codestory-runtime/src/agent/packet_projection_v3.rs
@@ -415,9 +415,11 @@ pub(crate) fn build_context_projection_v3(
 pub(crate) fn build_search_projection_v3(
     input: &FinalizedSearchProjectionInputV3,
 ) -> Result<SearchProjectionV3Dto, ProjectionBuildErrorV3> {
-    let mut evidence = input.evidence.clone();
-    evidence.sort_by(|left, right| left.identity.cmp(&right.identity));
-    reject_duplicate_evidence_v3(&evidence, |row| &row.identity)?;
+    let evidence = input.evidence.clone();
+    // Runtime owns relevance order; opaque identities only order validation.
+    let mut identity_order: Vec<_> = evidence.iter().collect();
+    identity_order.sort_by(|left, right| left.identity.cmp(&right.identity));
+    reject_duplicate_evidence_v3(&identity_order, |row| &row.identity)?;
     let gaps = canonical_gaps_v3(&input.gaps)?;
     let continuation = canonical_continuation_v3(input.continuation.as_ref(), &gaps)?;
     let diagnostic_rows =
@@ -731,11 +733,12 @@ mod tests {
             BoundedVecV3, ContextEvidenceRowV3Dto, ContextProjectionKindV3Dto, ContextTargetV3Dto,
             ContinuationStateV3Dto, DiagnosticArtifactKindV3Dto, DiagnosticArtifactV3Dto,
             DiagnosticCategoryV3Dto, DiagnosticCodeTextV3, DiagnosticRowV3Dto,
-            DiagnosticsCapabilityV3Dto, EvidenceAvailabilityV3Dto, EvidenceIdentityV3Dto,
-            EvidenceKindV3Dto, GapIdentityV3Dto, GapKindV3Dto, IdentityTextV3, MessageTextV3,
-            PACKET_EVIDENCE_ROWS_MAX_V3, PacketEvidenceRowV3Dto, PacketProjectionV3Dto, PathTextV3,
-            ProjectionGapRowV3Dto, PublicationIdentityV3Dto, RetrievalStateDescriptorV3Dto,
-            RetrievalStateV3Dto, SearchEvidenceRowV3Dto, SearchProjectionKindV3Dto, SummaryTextV3,
+            DiagnosticsCapabilityV3Dto, EVIDENCE_ROWS_MAX_V3, EvidenceAvailabilityV3Dto,
+            EvidenceIdentityV3Dto, EvidenceKindV3Dto, ExcerptTextV3, GapIdentityV3Dto,
+            GapKindV3Dto, IdentityTextV3, MessageTextV3, PACKET_EVIDENCE_ROWS_MAX_V3,
+            PacketEvidenceRowV3Dto, PacketProjectionV3Dto, PathTextV3, ProjectionGapRowV3Dto,
+            PublicationIdentityV3Dto, RetrievalStateDescriptorV3Dto, RetrievalStateV3Dto,
+            SearchEvidenceRowV3Dto, SearchProjectionKindV3Dto, SummaryTextV3,
         },
     };
 
@@ -1598,8 +1601,92 @@ mod tests {
         )
     }
 
+    fn search_input_fixture(
+        evidence: Vec<SearchEvidenceRowV3Dto>,
+    ) -> FinalizedSearchProjectionInputV3 {
+        let record = record_fixture("ranked source candidates");
+        FinalizedSearchProjectionInputV3::new(
+            packet_identity(&record),
+            publication(&record),
+            record.retrieval().clone(),
+            evidence,
+            Vec::new(),
+            None,
+            DiagnosticsCapabilityV3Dto::Unavailable,
+            Vec::new(),
+        )
+    }
+
+    fn ranked_search_rows(count: usize, opaque_ids: bool) -> Vec<SearchEvidenceRowV3Dto> {
+        (0..count)
+            .map(|index| SearchEvidenceRowV3Dto {
+                identity: EvidenceIdentityV3Dto {
+                    evidence_id: identity(&if opaque_ids {
+                        format!("opaque-{:03}", count - index)
+                    } else {
+                        format!("search-{index}-selected")
+                    }),
+                },
+                path: PathTextV3::new(format!("src/definition_{index}.rs")).unwrap(),
+                symbol_id: None,
+                start_line: Some(index as u32 + 1),
+                end_line: None,
+                excerpt: Some(ExcerptTextV3::new(format!("fn item_{index}() {{}}")).unwrap()),
+            })
+            .collect()
+    }
+
     #[test]
-    fn packet_projection_v3_context_and_search_canonicalize_and_reject_dangling_references() {
+    fn search_projection_v3_preserves_ranked_rows_across_identity_boundaries() {
+        for opaque_ids in [false, true] {
+            for count in [0, 1, 9, 10, 11, 50, EVIDENCE_ROWS_MAX_V3] {
+                let rows = ranked_search_rows(count, opaque_ids);
+                let input = search_input_fixture(rows.clone());
+                let projected = build_search_projection_v3(&input).expect("bounded ranked search");
+                assert_eq!(
+                    projected.evidence.as_slice(),
+                    rows.as_slice(),
+                    "preserve every ranked row and field: count={count}, opaque_ids={opaque_ids}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn search_projection_v3_rejects_nonadjacent_duplicates_canonically() {
+        for (ids, expected) in [
+            (vec!["z", "middle", "z"], "z"),
+            (vec!["z", "a", "z", "a"], "a"),
+        ] {
+            let mut rows = ranked_search_rows(ids.len(), false);
+            for (row, id) in rows.iter_mut().zip(ids) {
+                row.identity.evidence_id = identity(id);
+            }
+            assert_eq!(
+                build_search_projection_v3(&search_input_fixture(rows)),
+                Err(ProjectionBuildErrorV3::InvalidInput(
+                    ProjectionInputErrorV3::DuplicateEvidenceIdentity(expected.to_owned())
+                ))
+            );
+        }
+    }
+
+    #[test]
+    fn search_projection_v3_rejects_rows_beyond_the_public_bound() {
+        let count = EVIDENCE_ROWS_MAX_V3 + 1;
+        assert_eq!(
+            build_search_projection_v3(&search_input_fixture(ranked_search_rows(count, false))),
+            Err(ProjectionBuildErrorV3::BoundViolation(
+                BoundViolationV3::TooManyItems {
+                    maximum: EVIDENCE_ROWS_MAX_V3,
+                    actual: count,
+                }
+            ))
+        );
+    }
+
+    #[test]
+    fn packet_projection_v3_context_and_search_validate_closed_references() {
         let record = record_fixture("finalized typed context and search");
         let context_input = context_input_fixture(&record);
         let context = build_context_projection_v3(&context_input).expect("canonical context");
@@ -1733,7 +1820,7 @@ mod tests {
             DiagnosticsCapabilityV3Dto::Unavailable,
             context_input.diagnostic_rows.clone(),
         );
-        let search = build_search_projection_v3(&search_input).expect("canonical search");
+        let search = build_search_projection_v3(&search_input).expect("ranked search");
         assert_eq!(
             search
                 .evidence
@@ -1741,7 +1828,7 @@ mod tests {
                 .iter()
                 .map(|row| row.identity.evidence_id.as_str())
                 .collect::<Vec<_>>(),
-            ["evidence-a", "evidence-b"]
+            ["evidence-b", "evidence-a"]
         );
 
         let mut zero_round_continuation = search_input.clone();

--- a/plugins/codestory/skills/codestory-grounding/references/search.md
+++ b/plugins/codestory/skills/codestory-grounding/references/search.md
@@ -26,6 +26,8 @@ V3 JSON contains `identity`, `publication`, `status`, `evidence`, `gaps`,
 `retrieval`, `continuation` and `diagnostics`. Each evidence row includes its own
 identity, path, optional symbol ID, optional line bounds and optional excerpt.
 The older top-level `hits` and `query_assessment` are not the public v3 shape.
+Evidence rows retain the search engine's relevance order; their opaque
+identities are not sort keys.
 
 Use a returned non-null `symbol_id` with `context.id`, `snippet` or a relation
 operation. Inspect paths and source when several candidates are plausible;


### PR DESCRIPTION
Search results with eleven or more hits could arrive out of relevance order because the v3 response builder sorted opaque evidence IDs as text: `0, 1, 10, ... 2`. The builder now preserves the order selected by search and validates duplicate identities on a separate sorted reference list. No result field, identity, ranking policy or tool schema changes.

The fix is confined to the search projection. Context and packet ordering, duplicate-error selection, row limits, publication and diagnostic validation stay intact. The search reference and 0.17.6 release notes describe the visible behavior.

Validation: the new regression fails on the base at eleven rows; all sixteen projection tests pass after the repair, including opaque-ID order, nonadjacent duplicates and the 256/257-row boundary. Runtime library clippy, formatting, diff and documentation-link checks pass. Independent exact-head review passes all 17 projection tests, including an additional full-field/envelope case; three compiled negative controls fail as intended. Review SHA-256: `c30b8ff909ee4f2597224ead4f59547a1d8d9113a7d523018c48c3b5019ccd89`. Required CI passed. On merged candidate `48c7f9eaa03f1f36b5830603bdd28cb78219acb5`, a fresh ordinary installed-host comparison returned the same sixteen source locations and excerpts: the old package returned producer ranks `0,1,10…15,2…9`, and the repaired package returned `0…15`. Runtime identity, full retrieval and native execution passed in both arms with CPU fallback disabled and zero model turns. No new model comparison or release proof has started. The existing Run12 failure is preserved, and this fix does not establish its cause or predict a passing rerun.

Review `build_search_projection_v3` and the three regression tests in `packet_projection_v3.rs`. Base `3e84af3079077e64f336fbd892a24acb3b64f72f`; head `ccafbfeb7d52b90c8061d7744075abe5bf86da04`; tree `e60f24662425ec482332cb025bb5703039768219`. Worktree `/Users/albert/.codex/worktrees/0176-search-result-order/CodeStory`, branch `codex/0176-search-result-order`; implementation owner is the maintenance lane. Exact-head independent acceptance and CI completed before merge. The merge preserves the reviewed tree.

Closes #2172. Refs #2135.
