### PR TITLE
fix cold-start provisioning retry responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ throughout.
   Affected-code results also suggest relevant tests in the same package.
 - **Follow search results in relevance order.** Results keep their relevance
   order across the CLI and agent responses.
+- **Retry during CLI installation.** Hosts that validate MCP responses can
+  accept the retry guidance while the CLI installs.
 - **Keep working past broken configuration files.** Malformed text
   configuration no longer blocks the whole repository index. Unsupported or
   broken content is reported as a coverage gap. Supported JSONC files accept

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -3950,6 +3950,10 @@ function failOpenToolResult(tool, status, argumentsValue = {}) {
       kind: 'preparing',
       state: 'preparing',
       retry_after_ms: provisioningOperation.retry_after_ms,
+      minimum_next: {
+        kind: 'retry_same_request',
+        after_ms: provisioningOperation.retry_after_ms,
+      },
       operation: provisioningOperation,
     };
     return {

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -537,16 +537,35 @@ test("fail-open preparing is a successful revision-native result in every profil
     const toolResult = frames[1].result;
     const text = JSON.parse(toolResult.content[0].text);
     assert.equal(toolResult.isError, false, `${revision} preparing must not be a tool error`);
-    assert.deepEqual(Object.keys(text).sort(), ["kind", "operation", "retry_after_ms", "state"]);
+    assert.deepEqual(Object.keys(text).sort(), ["kind", "minimum_next", "operation", "retry_after_ms", "state"]);
     assert.equal(text.kind, "preparing");
     assert.equal(text.state, "preparing");
     assert.ok(text.retry_after_ms > 0);
+    assert.deepEqual(text.minimum_next, { kind: "retry_same_request", after_ms: text.retry_after_ms });
     assert.equal(typeof text.operation, "object");
     if (revision === "2024-11-05" || revision === "2025-03-26") {
       assert.equal(toolResult.structuredContent, undefined);
     } else {
       assert.deepEqual(toolResult.structuredContent, text);
     }
+  }
+});
+
+test("managed provisioning replies satisfy every non-status tool output schema", () => {
+  const status = { managed_retrieval: { state: "preparing" }, warnings: [], readiness: [] };
+  const tools = generatedCatalog.tools.filter((tool) => tool.name !== "status");
+  assert.equal(tools.length, 19);
+  for (const tool of tools) {
+    const result = launcherTest.failOpenToolResult(tool.name, status, { project: repoRoot });
+    assert.deepEqual(
+      launcherTest.validatePublishedSchemaValue(tool.outputSchema, result.structuredContent, "/result"),
+      [],
+      `${tool.name} provisioning response must satisfy its published output schema`,
+    );
+    assert.deepEqual(result.structuredContent.minimum_next, {
+      kind: "retry_same_request",
+      after_ms: result.structuredContent.retry_after_ms,
+    });
   }
 });
 
@@ -1379,6 +1398,7 @@ test("preparing fail-open surfaces share one progress-derived retry hint", () =>
     const ground = launcherTest.failOpenToolResult("ground", preparingStatus, { project: repoRoot });
     assert.equal(ground.structuredContent.retry_after_ms, 3000);
     assert.equal(ground.structuredContent.operation.retry_after_ms, 3000);
+    assert.equal(ground.structuredContent.minimum_next.after_ms, 3000);
     const status = launcherTest.failOpenToolResult("status", preparingStatus, { project: repoRoot });
     assert.equal(status.structuredContent.retry_after_ms, 3000);
     assert.equal(status.structuredContent.current_operation.retry_after_ms, 3000);
@@ -5136,7 +5156,7 @@ test("mcp launcher serves diagnostics while managed provisioning runs, then hand
     assert.equal(coldGround.result.structuredContent, undefined);
     assert.deepEqual(
       Object.keys(coldGroundPreparing).sort(),
-      ["kind", "operation", "retry_after_ms", "state"],
+      ["kind", "minimum_next", "operation", "retry_after_ms", "state"],
     );
     assert.equal(coldGroundPreparing.kind, "preparing");
     assert.equal(coldGroundPreparing.state, "preparing");


### PR DESCRIPTION
Cold-start tool calls now return the retry instruction required by their published output schemas. A fresh installed C14 host returned a managed-runtime provisioning reply without `minimum_next`, so a schema-validating caller rejected it before indexing began. The shared builder affected all nineteen non-status tools.

The response now includes `retry_same_request` with `after_ms` taken from the existing retry hint. Tool schemas, readiness behavior and observational status handling are unchanged. Legacy text replies and modern structured replies carry the same retry information.

Review the four-line response-builder change, then the regression that validates all nineteen tools and the four protocol-profile checks, including a non-default retry delay.

Validation at `48881a42749dd1a94188883be262c9d985f223fc` (base `48c7f9eaa03f1f36b5830603bdd28cb78219acb5`): the regression failed before the fix; focused checks passed afterward; plugin-static passed 141 checks with one platform skip; diff whitespace and documentation links passed. Independent exact-head review passed 76 dynamic-delay and 76 protocol cases; all three deliberate mutations were detected and eight status snapshots matched baseline. Root verified all 359 evidence bindings. Required plugin-static, Linux contract and issue-link CI passed on the same reviewed head. Windows-manifest-missing was skipped by workflow routing.

This patch does not yet have new installed-host proof and does not claim to fix the maintenance panel's input-context failure. After integration, an isolated package and the same cold-start interaction will verify the affected surface. No comparison rerun or broad release proof is triggered here.

Closes #2175
Refs #2135
Refs #2173
