### PR TITLE
Preserve named arguments in code-mode schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+Code-mode hosts can see named navigation arguments, including project routing
+and snippet ranges, when a tool accepts alternative selectors.
+
 ## 0.17.6
 
 CodeStory 0.17.6 lets agents choose how to investigate a repository and puts

--- a/crates/codestory-cli/src/stdio_arguments.rs
+++ b/crates/codestory-cli/src/stdio_arguments.rs
@@ -401,19 +401,30 @@ fn validate_combinators(
             ));
         }
     }
-    if let Some(constraints) = schema.get("allOf").and_then(Value::as_array)
-        && let Some(failed) = constraints
-            .iter()
-            .find(|constraint| !accepts(constraint, value))
-    {
-        if constraints.len() == 1 {
-            validate_value(failed, value, pointer, out);
+    if let Some(constraints) = schema.get("allOf").and_then(Value::as_array) {
+        // Split-budget clauses are one user-facing constraint. Ordinary
+        // intersections preserve every leaf diagnostic, including project routing.
+        let combined_budget = constraints.len() > 1
+            && constraints.iter().all(|constraint| {
+                constraint
+                    .pointer("/not/required")
+                    .is_some_and(Value::is_array)
+            });
+        if combined_budget {
+            if let Some(failed) = constraints
+                .iter()
+                .find(|constraint| !accepts(constraint, value))
+            {
+                out.push(combined_constraint_violation(
+                    constraints.len(),
+                    failed,
+                    pointer,
+                ));
+            }
         } else {
-            out.push(combined_constraint_violation(
-                constraints.len(),
-                failed,
-                pointer,
-            ));
+            for constraint in constraints {
+                validate_value(constraint, value, pointer, out);
+            }
         }
     }
     if let Some(forbidden) = schema.get("not")
@@ -647,9 +658,17 @@ mod tests {
     fn every_tool_declares_a_published_input_schema() {
         for tool in crate::stdio_catalog::tool_names() {
             let schema = crate::stdio_catalog::tool_input_schema(tool).expect("published schema");
-            assert_eq!(
-                schema.get("additionalProperties"),
-                Some(&json!(false)),
+            let mut violations = Vec::new();
+            validate_value(
+                schema,
+                &json!({"undeclared_argument": true}),
+                "/arguments",
+                &mut violations,
+            );
+            assert!(
+                violations
+                    .iter()
+                    .any(|violation| violation.code == "unknown_property"),
                 "{tool} must deny undeclared arguments"
             );
         }
@@ -703,6 +722,51 @@ mod tests {
             ),
             vec!["unknown_property", "invalid_selector"]
         );
+    }
+
+    #[test]
+    fn composed_selectors_preserve_all_argument_diagnostics() {
+        let common = json!({
+            "type": "object", "additionalProperties": false, "required": ["project"],
+            "properties": {
+                "project": {"type": "string", "minLength": 1},
+                "id": {"type": "string", "minLength": 1},
+                "query": {"type": "string", "minLength": 1}
+            }
+        });
+        let selectors = json!({"oneOf": [{"required": ["id"]}, {"required": ["query"]}]});
+        let mut flat = common.clone();
+        flat.as_object_mut()
+            .unwrap()
+            .extend(selectors.as_object().unwrap().clone());
+        let composed = json!({"type": "object", "allOf": [common, selectors]});
+        for value in [
+            json!(null),
+            json!([]),
+            json!(1),
+            json!("x"),
+            json!({}),
+            json!({"id": "a"}),
+            json!({"project": "", "id": ""}),
+            json!({"project": "/repo", "id": "a", "query": "b", "extra": true}),
+            json!({"project": "/repo", "query": "b"}),
+        ] {
+            let mut before = Vec::new();
+            let mut after = Vec::new();
+            validate_value(&flat, &value, "/arguments", &mut before);
+            validate_value(&composed, &value, "/arguments", &mut after);
+            assert_eq!(
+                before
+                    .iter()
+                    .map(ArgumentViolation::to_json)
+                    .collect::<Vec<_>>(),
+                after
+                    .iter()
+                    .map(ArgumentViolation::to_json)
+                    .collect::<Vec<_>>(),
+                "{value}"
+            );
+        }
     }
 
     #[test]
@@ -1501,6 +1565,21 @@ const ARGUMENT_SYNONYMS: &[&[&str]] = &[
     &["depth", "max_depth"],
 ];
 
+fn schema_declares_property(schema: &Value, name: &str) -> bool {
+    schema
+        .get("properties")
+        .and_then(Value::as_object)
+        .is_some_and(|properties| properties.contains_key(name))
+        || schema
+            .get("allOf")
+            .and_then(Value::as_array)
+            .is_some_and(|branches| {
+                branches
+                    .iter()
+                    .any(|branch| schema_declares_property(branch, name))
+            })
+}
+
 /// Rewrite supplied argument names to the spelling this tool's schema declares.
 ///
 /// Only ever renames when exactly one member of a synonym group is declared and the caller
@@ -1511,14 +1590,13 @@ pub(crate) fn reconcile_argument_synonyms(tool: &str, arguments: &mut Value) {
     let Some(schema) = crate::stdio_catalog::tool_input_schema(tool) else {
         return;
     };
-    let Some(declared) = schema.get("properties").and_then(Value::as_object) else {
-        return;
-    };
     let Some(supplied) = arguments.as_object_mut() else {
         return;
     };
     for group in ARGUMENT_SYNONYMS {
-        let mut accepted = group.iter().filter(|name| declared.contains_key(**name));
+        let mut accepted = group
+            .iter()
+            .filter(|name| schema_declares_property(schema, name));
         let (Some(canonical), None) = (accepted.next(), accepted.next()) else {
             continue;
         };

--- a/crates/codestory-cli/src/stdio_catalog.rs
+++ b/crates/codestory-cli/src/stdio_catalog.rs
@@ -114,7 +114,10 @@ impl ToolSpec {
         let mut tool = Map::from_iter([
             ("name".to_string(), json!(self.name)),
             ("description".to_string(), json!(self.description)),
-            ("inputSchema".to_string(), input_schema),
+            (
+                "inputSchema".to_string(),
+                compose_input_selectors(input_schema),
+            ),
             ("safety".to_string(), self.safety.to_json()),
             ("annotations".to_string(), self.safety.annotations_json()),
         ]);
@@ -126,6 +129,58 @@ impl ToolSpec {
         }
         Value::Object(tool)
     }
+}
+
+/// Keep common named arguments visible to hosts that project `oneOf` as a union.
+/// Only selector-only object unions need factoring; tagged unions keep their
+/// branch-local properties. Traverse schema positions, never defaults or examples.
+fn compose_input_selectors(mut schema: Value) -> Value {
+    let Some(object) = schema.as_object_mut() else {
+        return schema;
+    };
+    if let Some(properties) = object.get_mut("properties").and_then(Value::as_object_mut) {
+        for property in properties.values_mut() {
+            *property = compose_input_selectors(property.take());
+        }
+    }
+    for keyword in ["items", "not"] {
+        if let Some(child) = object.get_mut(keyword) {
+            *child = compose_input_selectors(child.take());
+        }
+    }
+    for keyword in ["allOf", "anyOf", "oneOf"] {
+        if let Some(children) = object.get_mut(keyword).and_then(Value::as_array_mut) {
+            for child in children {
+                *child = compose_input_selectors(child.take());
+            }
+        }
+    }
+    let selector_union = object
+        .get("oneOf")
+        .and_then(Value::as_array)
+        .is_some_and(|branches| {
+            !branches.is_empty()
+                && branches.iter().all(|branch| {
+                    branch.as_object().is_some_and(|branch| {
+                        branch.len() == 1 && branch.get("required").is_some_and(Value::is_array)
+                    })
+                })
+        });
+    if object.get("type") != Some(&json!("object"))
+        || !object.get("properties").is_some_and(Value::is_object)
+        || !selector_union
+    {
+        return schema;
+    }
+    let mut constraints = Map::new();
+    for keyword in ["anyOf", "oneOf", "allOf", "not"] {
+        if let Some(value) = object.remove(keyword) {
+            constraints.insert(keyword.to_string(), value);
+        }
+    }
+    // The outer type keeps invalid scalar inputs from reaching selector-only
+    // branches, which have no type constraint of their own.
+    json!({"type": "object", "allOf": [schema, constraints]})
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -2685,6 +2740,32 @@ pub(crate) fn prompt_get_json(name: &str) -> Result<Value> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn selector_composition_exposes_named_arguments_without_rewriting_data_or_tagged_unions() {
+        let tagged = json!({"oneOf": [
+            {"type": "object", "properties": {"kind": {"const": "a"}}, "required": ["kind"]},
+            {"type": "object", "properties": {"kind": {"const": "b"}}, "required": ["kind"]}
+        ]});
+        let data = json!({"type": "object", "properties": {}, "oneOf": [{"required": ["x"]}]});
+        let schema = json!({
+            "type": "object", "additionalProperties": false,
+            "properties": {"oneOf": {"default": data}, "tagged": tagged,
+                "items": {"type": "array", "items": {
+                    "type": "object", "properties": {"id": {"type": "string"}, "query": {"type": "string"}},
+                    "oneOf": [{"required": ["id"]}, {"required": ["query"]}]
+                }}},
+            "required": ["items"], "oneOf": [{"required": ["oneOf"]}, {"required": ["tagged"]}]
+        });
+        let composed = compose_input_selectors(schema);
+        assert_eq!(composed["type"], "object");
+        let common = &composed["allOf"][0];
+        assert_eq!(common["properties"]["oneOf"]["default"], data);
+        assert_eq!(common["properties"]["tagged"], tagged);
+        assert!(common["properties"]["items"]["items"]["allOf"][0]["properties"]["id"].is_object());
+        assert_eq!(common["required"], json!(["items"]));
+        assert_eq!(compose_input_selectors(composed.clone()), composed);
+    }
 
     fn packet_probe_schema() -> Value {
         let catalog = tools_list_json();

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -1399,9 +1399,18 @@ fn required_on_any_branch(schema: &Value, field: &str) -> bool {
         })
 }
 
+fn schema_value<'a>(schema: &'a Value, pointer: &str) -> Option<&'a Value> {
+    schema.pointer(pointer).or_else(|| {
+        schema
+            .get("allOf")
+            .and_then(Value::as_array)?
+            .iter()
+            .find_map(|branch| schema_value(branch, pointer))
+    })
+}
+
 fn required_fields(schema: &Value) -> BTreeSet<&str> {
-    schema
-        .get("required")
+    schema_value(schema, "/required")
         .and_then(Value::as_array)
         .unwrap_or_else(|| panic!("schema should include required fields: {schema}"))
         .iter()
@@ -1414,14 +1423,12 @@ fn required_fields(schema: &Value) -> BTreeSet<&str> {
 }
 
 fn schema_property<'a>(schema: &'a Value, name: &str) -> &'a Value {
-    schema
-        .pointer(&format!("/properties/{name}"))
+    schema_value(schema, &format!("/properties/{name}"))
         .unwrap_or_else(|| panic!("schema should include property {name}: {schema}"))
 }
 
 fn assert_schema_enum_values(schema: &Value, pointer: &str, expected: &[&str]) {
-    let values: BTreeSet<_> = schema
-        .pointer(pointer)
+    let values: BTreeSet<_> = schema_value(schema, pointer)
         .and_then(Value::as_array)
         .unwrap_or_else(|| panic!("schema should include enum array at {pointer}: {schema}"))
         .iter()
@@ -2271,7 +2278,7 @@ fn multi_project_stdio_routes_interleaved_requests_by_explicit_project() {
             .expect("tools array")
             .iter()
             .all(|tool| {
-                tool.pointer("/inputSchema/required")
+                schema_value(&tool["inputSchema"], "/required")
                     .and_then(Value::as_array)
                     .is_some_and(|required| required.contains(&json!("project")))
             }),
@@ -2944,12 +2951,14 @@ fn tool_catalog_input_schemas_capture_stable_arguments() {
         "affected.filter should be a string: {affected}"
     );
     assert!(
-        affected.get("anyOf").is_none(),
+        schema_value(affected, "/anyOf").is_none(),
         "affected exact-one input contract should not be described as anyOf: {affected}"
     );
-    let affected_one_of = affected["oneOf"].as_array().unwrap_or_else(|| {
-        panic!("affected should require exactly one path source via oneOf: {affected}")
-    });
+    let affected_one_of = schema_value(affected, "/oneOf")
+        .and_then(Value::as_array)
+        .unwrap_or_else(|| {
+            panic!("affected should require exactly one path source via oneOf: {affected}")
+        });
     assert!(
         affected_one_of
             .iter()
@@ -6444,7 +6453,7 @@ fn cold_ground_uses_local_capability_while_search_prepares_embedding_runtime() {
         }),
     );
     let error = assert_tool_preparing_or_unavailable(&search, json!("cold-search-unavailable"));
-    assert_eq!(error["tool"], json!("search"));
+    assert_eq!(error["tool"], json!("search"), "search result: {error}");
     assert!(
         error["diagnostics_uri"]
             .as_str()

--- a/plugins/codestory/generated-mcp-catalog.json
+++ b/plugins/codestory/generated-mcp-catalog.json
@@ -10,15 +10,15 @@
     ],
     "preferredMcpProtocolVersion": "2025-11-25",
     "discoveryContracts": {
-      "2024-11-05": "de5a0c7d0a1c024dc3ff4fa3cddcc56f940849ac30ae7c4811c4aaf91874282a",
-      "2025-03-26": "4440f4544930c84c476e9f786188e6658a8f6f9c1203989c6fee4683be7beb38",
-      "2025-06-18": "400577bca4552e5172e98415ef51f23cc8269b66b3072186f8194df96dba9bf9",
-      "2025-11-25": "e7e7304d0d3664f7f26467e79d67d6c9b8f7878ef471e8c57657b1dae38bb815"
+      "2024-11-05": "d24bec8284385c2e54657d3a070892e0f80dff6e0f7643a5815c3c785c99b93b",
+      "2025-03-26": "bb9c8f4a92824a1a7fc957fdce7afb396923bdcae432485d832e46d8a0918b68",
+      "2025-06-18": "bb1d1bed64295ed30b4cc3b34dd93ff30f897668a8470689351ef13c3c653333",
+      "2025-11-25": "bc504546354df593b0fced962f29299c2a700553e5d3d3310065b87b239b24f1"
     }
   },
   "revisionProfiles": {
     "2024-11-05": {
-      "discoveryContractSha256": "de5a0c7d0a1c024dc3ff4fa3cddcc56f940849ac30ae7c4811c4aaf91874282a",
+      "discoveryContractSha256": "d24bec8284385c2e54657d3a070892e0f80dff6e0f7643a5815c3c785c99b93b",
       "tools": [
         {
           "description": "Inspect CodeStory readiness for the requested repository when diagnostics are needed. CodeStory effect: observational and does not activate managed state.",
@@ -455,111 +455,118 @@
         {
           "description": "Analyze one explicit path source against the last complete local index while preserving bounded stale and error evidence. Cold or partial state may trigger managed indexing before dispatch. Prefer paths, use changed_paths for compatibility or change_records for status-rich input. Never discovers git changes and does not wait for broad search. CodeStory effect: may activate project-local managed cache, indexing, or network-backed retrieval state.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Analyze exactly one explicit path source against the last complete local index.",
-            "oneOf": [
+            "allOf": [
               {
-                "required": [
-                  "paths"
-                ]
-              },
-              {
-                "required": [
-                  "changed_paths"
-                ]
-              },
-              {
-                "required": [
-                  "change_records"
-                ]
-              }
-            ],
-            "properties": {
-              "change_records": {
-                "description": "Changed file records with path, kind, optional status, and optional previous_path.",
-                "items": {
-                  "additionalProperties": false,
-                  "description": "Changed file record.",
-                  "properties": {
-                    "kind": {
-                      "description": "Change kind.",
-                      "enum": [
-                        "added",
-                        "modified",
-                        "deleted",
-                        "renamed",
-                        "copied",
-                        "untracked",
-                        "unknown"
+                "additionalProperties": false,
+                "description": "Analyze exactly one explicit path source against the last complete local index.",
+                "properties": {
+                  "change_records": {
+                    "description": "Changed file records with path, kind, optional status, and optional previous_path.",
+                    "items": {
+                      "additionalProperties": false,
+                      "description": "Changed file record.",
+                      "properties": {
+                        "kind": {
+                          "description": "Change kind.",
+                          "enum": [
+                            "added",
+                            "modified",
+                            "deleted",
+                            "renamed",
+                            "copied",
+                            "untracked",
+                            "unknown"
+                          ],
+                          "type": "string"
+                        },
+                        "path": {
+                          "description": "Changed repo-relative path.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "previous_path": {
+                          "description": "Optional previous path accepted only for renamed or copied records; it can seed bounded proxy graph evidence when the current path is not indexed.",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "status": {
+                          "description": "Optional raw git-style status such as M, A, D, R100, C100, or ??.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "path",
+                        "kind"
                       ],
-                      "type": "string"
+                      "type": "object"
                     },
-                    "path": {
-                      "description": "Changed repo-relative path.",
+                    "maxItems": 200,
+                    "minItems": 1,
+                    "type": "array"
+                  },
+                  "changed_paths": {
+                    "description": "Compatibility alias for project-relative paths to analyze.",
+                    "items": {
                       "minLength": 1,
                       "type": "string"
                     },
-                    "previous_path": {
-                      "description": "Optional previous path accepted only for renamed or copied records; it can seed bounded proxy graph evidence when the current path is not indexed.",
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "status": {
-                      "description": "Optional raw git-style status such as M, A, D, R100, C100, or ??.",
-                      "type": "string"
-                    }
+                    "maxItems": 200,
+                    "minItems": 1,
+                    "type": "array"
                   },
-                  "required": [
-                    "path",
-                    "kind"
-                  ],
-                  "type": "object"
+                  "depth": {
+                    "default": 2,
+                    "description": "Dependent graph walk depth.",
+                    "maximum": 8,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "filter": {
+                    "description": "Optional impacted-symbol filter by path or display-name substring.",
+                    "type": "string"
+                  },
+                  "paths": {
+                    "description": "Preferred simple input: project-relative paths to analyze.",
+                    "items": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "maxItems": 200,
+                    "minItems": 1,
+                    "type": "array"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
                 },
-                "maxItems": 200,
-                "minItems": 1,
-                "type": "array"
+                "required": [
+                  "project"
+                ],
+                "type": "object"
               },
-              "changed_paths": {
-                "description": "Compatibility alias for project-relative paths to analyze.",
-                "items": {
-                  "minLength": 1,
-                  "type": "string"
-                },
-                "maxItems": 200,
-                "minItems": 1,
-                "type": "array"
-              },
-              "depth": {
-                "default": 2,
-                "description": "Dependent graph walk depth.",
-                "maximum": 8,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "filter": {
-                "description": "Optional impacted-symbol filter by path or display-name substring.",
-                "type": "string"
-              },
-              "paths": {
-                "description": "Preferred simple input: project-relative paths to analyze.",
-                "items": {
-                  "minLength": 1,
-                  "type": "string"
-                },
-                "maxItems": 200,
-                "minItems": 1,
-                "type": "array"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
+              {
+                "oneOf": [
+                  {
+                    "required": [
+                      "paths"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "changed_paths"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "change_records"
+                    ]
+                  }
+                ]
               }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -568,45 +575,52 @@
         {
           "description": "Resolve a symbol id or query and return details. CodeStory effect: may activate project-local managed cache, indexing, or network-backed retrieval state.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Resolve a symbol by query or stable node id.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Resolve a symbol by query or stable node id.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
+                  "project"
+                ],
+                "type": "object"
               },
               {
-                "required": [
-                  "id"
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
                 ]
               }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
-              }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -615,74 +629,81 @@
         {
           "description": "Return a graph trail around a symbol. CodeStory effect: may activate project-local managed cache, indexing, or network-backed retrieval state.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Return a graph trail around a symbol id or query.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Return a graph trail around a symbol id or query.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "depth": {
+                    "default": 2,
+                    "description": "Trail depth.",
+                    "maximum": 10,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "direction": {
+                    "default": "both",
+                    "description": "Trail direction.",
+                    "enum": [
+                      "incoming",
+                      "outgoing",
+                      "both"
+                    ],
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "max_nodes": {
+                    "default": 120,
+                    "description": "Maximum graph nodes returned.",
+                    "maximum": 120,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "story": {
+                    "default": false,
+                    "description": "Include a readable trail story DTO.",
+                    "type": "boolean"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
-              },
-              {
-                "required": [
-                  "id"
-                ]
-              }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "depth": {
-                "default": 2,
-                "description": "Trail depth.",
-                "maximum": 10,
-                "minimum": 0,
-                "type": "integer"
-              },
-              "direction": {
-                "default": "both",
-                "description": "Trail direction.",
-                "enum": [
-                  "incoming",
-                  "outgoing",
-                  "both"
+                  "project"
                 ],
-                "type": "string"
+                "type": "object"
               },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "max_nodes": {
-                "default": 120,
-                "description": "Maximum graph nodes returned.",
-                "maximum": 120,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "story": {
-                "default": false,
-                "description": "Include a readable trail story DTO.",
-                "type": "boolean"
+              {
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
+                ]
               }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -691,59 +712,66 @@
         {
           "description": "Return a bounded incoming caller graph around a symbol. CodeStory effect: may activate project-local managed cache, indexing, or network-backed retrieval state.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Return a bounded local graph alias around one node.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Return a bounded local graph alias around one node.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "depth": {
+                    "default": 1,
+                    "description": "Graph depth.",
+                    "maximum": 3,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "max_nodes": {
+                    "default": 50,
+                    "description": "Maximum graph nodes returned.",
+                    "maximum": 120,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
+                  "project"
+                ],
+                "type": "object"
               },
               {
-                "required": [
-                  "id"
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
                 ]
               }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "depth": {
-                "default": 1,
-                "description": "Graph depth.",
-                "maximum": 3,
-                "minimum": 0,
-                "type": "integer"
-              },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "max_nodes": {
-                "default": 50,
-                "description": "Maximum graph nodes returned.",
-                "maximum": 120,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
-              }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -752,59 +780,66 @@
         {
           "description": "Return a bounded outgoing callee graph around a symbol. CodeStory effect: may activate project-local managed cache, indexing, or network-backed retrieval state.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Return a bounded local graph alias around one node.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Return a bounded local graph alias around one node.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "depth": {
+                    "default": 1,
+                    "description": "Graph depth.",
+                    "maximum": 3,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "max_nodes": {
+                    "default": 50,
+                    "description": "Maximum graph nodes returned.",
+                    "maximum": 120,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
+                  "project"
+                ],
+                "type": "object"
               },
               {
-                "required": [
-                  "id"
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
                 ]
               }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "depth": {
-                "default": 1,
-                "description": "Graph depth.",
-                "maximum": 3,
-                "minimum": 0,
-                "type": "integer"
-              },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "max_nodes": {
-                "default": 50,
-                "description": "Maximum graph nodes returned.",
-                "maximum": 120,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
-              }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -813,74 +848,81 @@
         {
           "description": "Return a readable trace around a symbol. CodeStory effect: may activate project-local managed cache, indexing, or network-backed retrieval state.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Return a readable trace around a symbol id or query.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Return a readable trace around a symbol id or query.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "depth": {
+                    "default": 2,
+                    "description": "Trail depth.",
+                    "maximum": 10,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "direction": {
+                    "default": "both",
+                    "description": "Trail direction.",
+                    "enum": [
+                      "incoming",
+                      "outgoing",
+                      "both"
+                    ],
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "max_nodes": {
+                    "default": 120,
+                    "description": "Maximum graph nodes returned.",
+                    "maximum": 120,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "story": {
+                    "default": true,
+                    "description": "Include a readable trail story DTO.",
+                    "type": "boolean"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
-              },
-              {
-                "required": [
-                  "id"
-                ]
-              }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "depth": {
-                "default": 2,
-                "description": "Trail depth.",
-                "maximum": 10,
-                "minimum": 0,
-                "type": "integer"
-              },
-              "direction": {
-                "default": "both",
-                "description": "Trail direction.",
-                "enum": [
-                  "incoming",
-                  "outgoing",
-                  "both"
+                  "project"
                 ],
-                "type": "string"
+                "type": "object"
               },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "max_nodes": {
-                "default": 120,
-                "description": "Maximum graph nodes returned.",
-                "maximum": 120,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "story": {
-                "default": true,
-                "description": "Include a readable trail story DTO.",
-                "type": "boolean"
+              {
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
+                ]
               }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -889,45 +931,52 @@
         {
           "description": "Return one stable graph node with file references for source inspection and relationship navigation. CodeStory effect: may activate project-local managed cache, indexing, or network-backed retrieval state.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Resolve a single indexed graph node by stable id or query.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Resolve a single indexed graph node by stable id or query.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
+                  "project"
+                ],
+                "type": "object"
               },
               {
-                "required": [
-                  "id"
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
                 ]
               }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
-              }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -936,69 +985,76 @@
         {
           "description": "Return a bounded graph neighborhood around one node. CodeStory effect: may activate project-local managed cache, indexing, or network-backed retrieval state.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Return a bounded graph neighborhood around one node.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Return a bounded graph neighborhood around one node.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "depth": {
+                    "default": 1,
+                    "description": "Graph depth.",
+                    "maximum": 3,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "direction": {
+                    "default": "both",
+                    "description": "Graph direction.",
+                    "enum": [
+                      "incoming",
+                      "outgoing",
+                      "both"
+                    ],
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "max_nodes": {
+                    "default": 50,
+                    "description": "Maximum graph nodes returned.",
+                    "maximum": 120,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
-              },
-              {
-                "required": [
-                  "id"
-                ]
-              }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "depth": {
-                "default": 1,
-                "description": "Graph depth.",
-                "maximum": 3,
-                "minimum": 0,
-                "type": "integer"
-              },
-              "direction": {
-                "default": "both",
-                "description": "Graph direction.",
-                "enum": [
-                  "incoming",
-                  "outgoing",
-                  "both"
+                  "project"
                 ],
-                "type": "string"
+                "type": "object"
               },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "max_nodes": {
-                "default": 50,
-                "description": "Maximum graph nodes returned.",
-                "maximum": 120,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
+              {
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
+                ]
               }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -1052,69 +1108,76 @@
         {
           "description": "Return a bounded subgraph around one resolved node for relationship navigation. CodeStory effect: may activate project-local managed cache, indexing, or network-backed retrieval state.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Return a bounded graph subgraph around one resolved node.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Return a bounded graph subgraph around one resolved node.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "depth": {
+                    "default": 2,
+                    "description": "Graph depth.",
+                    "maximum": 3,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "direction": {
+                    "default": "both",
+                    "description": "Graph direction.",
+                    "enum": [
+                      "incoming",
+                      "outgoing",
+                      "both"
+                    ],
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "max_nodes": {
+                    "default": 80,
+                    "description": "Maximum graph nodes returned.",
+                    "maximum": 120,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
-              },
-              {
-                "required": [
-                  "id"
-                ]
-              }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "depth": {
-                "default": 2,
-                "description": "Graph depth.",
-                "maximum": 3,
-                "minimum": 0,
-                "type": "integer"
-              },
-              "direction": {
-                "default": "both",
-                "description": "Graph direction.",
-                "enum": [
-                  "incoming",
-                  "outgoing",
-                  "both"
+                  "project"
                 ],
-                "type": "string"
+                "type": "object"
               },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "max_nodes": {
-                "default": 80,
-                "description": "Maximum graph nodes returned.",
-                "maximum": 120,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
+              {
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
+                ]
               }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -1123,45 +1186,52 @@
         {
           "description": "Return definition metadata for a symbol id or query. CodeStory effect: may activate project-local managed cache, indexing, or network-backed retrieval state.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Resolve a symbol by query or stable node id.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Resolve a symbol by query or stable node id.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
+                  "project"
+                ],
+                "type": "object"
               },
               {
-                "required": [
-                  "id"
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
                 ]
               }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
-              }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -1170,45 +1240,52 @@
         {
           "description": "Return incoming references for a symbol id or query. CodeStory effect: may activate project-local managed cache, indexing, or network-backed retrieval state.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Resolve a symbol by query or stable node id.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Resolve a symbol by query or stable node id.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
+                  "project"
+                ],
+                "type": "object"
               },
               {
-                "required": [
-                  "id"
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
                 ]
               }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
-              }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -1248,176 +1325,190 @@
         {
           "description": "Read line-numbered source for a selected symbol or path. Use `paths` to inspect several file ranges in one call; ordinary host source reads are also available. CodeStory effect: may activate project-local managed cache, indexing, or network-backed retrieval state.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Return bounded source: either resolve one symbol, or read line ranges from files named by earlier evidence.",
-            "oneOf": [
+            "allOf": [
               {
-                "required": [
-                  "query"
-                ]
-              },
-              {
-                "required": [
-                  "id"
-                ]
-              },
-              {
-                "required": [
-                  "paths"
-                ]
-              },
-              {
-                "required": [
-                  "path"
-                ]
-              },
-              {
-                "required": [
-                  "file_path"
-                ]
-              },
-              {
-                "required": [
-                  "symbol_id"
-                ]
-              }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "context": {
-                "default": 4,
-                "description": "Surrounding context lines above and below the selected source range.",
-                "maximum": 200,
-                "minimum": 0,
-                "type": "integer"
-              },
-              "end_line": {
-                "description": "Last line to return with top-level `path`. Defaults to a bounded window after the start.",
-                "maximum": 1000000,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "file_path": {
-                "description": "Alias for `path`. Hits report this field name.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "function_body": {
-                "description": "CLI-compatible scope selector; true requests `function_body`, false requests `line_context`.",
-                "type": "boolean"
-              },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "line": {
-                "description": "1-based line from a search, trail, or packet hit. Used with `path`.",
-                "maximum": 1000000,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "lines": {
-                "description": "Agent-friendly compatibility alias for `context`.",
-                "maximum": 200,
-                "minimum": 0,
-                "type": "integer"
-              },
-              "path": {
-                "description": "Single-file alias for `paths`: repository-relative path as returned in `file_path`. Combine with `line`.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "paths": {
-                "description": "File ranges to read in one call, instead of resolving a symbol. Line-numbered and bounded in total; use the paths and lines that search, trail, or packet already returned.",
-                "items": {
-                  "additionalProperties": false,
-                  "description": "One file range to read. Paste `file_path` and `line` straight from a search, trail, or packet hit.",
-                  "oneOf": [
-                    {
-                      "required": [
-                        "path"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "file_path"
-                      ]
-                    }
-                  ],
-                  "properties": {
-                    "end_line": {
-                      "description": "Last line to return, 1-based. Defaults to a bounded window after the start.",
-                      "maximum": 1000000,
-                      "minimum": 1,
-                      "type": "integer"
-                    },
-                    "file_path": {
-                      "description": "Alias for `path`. Hits report this field name.",
-                      "minLength": 1,
-                      "type": "string"
-                    },
-                    "line": {
-                      "description": "Line of interest, 1-based, as returned in `line`. A window is returned around it.",
-                      "maximum": 1000000,
-                      "minimum": 1,
-                      "type": "integer"
-                    },
-                    "path": {
-                      "description": "Repository-relative file path, as returned in `file_path`.",
-                      "minLength": 1,
-                      "type": "string"
-                    },
-                    "start_line": {
-                      "description": "First line to return, 1-based. Alternative to `line`.",
-                      "maximum": 1000000,
-                      "minimum": 1,
-                      "type": "integer"
-                    }
+                "additionalProperties": false,
+                "description": "Return bounded source: either resolve one symbol, or read line ranges from files named by earlier evidence.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
                   },
-                  "required": [],
-                  "type": "object"
+                  "context": {
+                    "default": 4,
+                    "description": "Surrounding context lines above and below the selected source range.",
+                    "maximum": 200,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "end_line": {
+                    "description": "Last line to return with top-level `path`. Defaults to a bounded window after the start.",
+                    "maximum": 1000000,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "file_path": {
+                    "description": "Alias for `path`. Hits report this field name.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "function_body": {
+                    "description": "CLI-compatible scope selector; true requests `function_body`, false requests `line_context`.",
+                    "type": "boolean"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "line": {
+                    "description": "1-based line from a search, trail, or packet hit. Used with `path`.",
+                    "maximum": 1000000,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "lines": {
+                    "description": "Agent-friendly compatibility alias for `context`.",
+                    "maximum": 200,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "path": {
+                    "description": "Single-file alias for `paths`: repository-relative path as returned in `file_path`. Combine with `line`.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "paths": {
+                    "description": "File ranges to read in one call, instead of resolving a symbol. Line-numbered and bounded in total; use the paths and lines that search, trail, or packet already returned.",
+                    "items": {
+                      "allOf": [
+                        {
+                          "additionalProperties": false,
+                          "description": "One file range to read. Paste `file_path` and `line` straight from a search, trail, or packet hit.",
+                          "properties": {
+                            "end_line": {
+                              "description": "Last line to return, 1-based. Defaults to a bounded window after the start.",
+                              "maximum": 1000000,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "file_path": {
+                              "description": "Alias for `path`. Hits report this field name.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "line": {
+                              "description": "Line of interest, 1-based, as returned in `line`. A window is returned around it.",
+                              "maximum": 1000000,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "path": {
+                              "description": "Repository-relative file path, as returned in `file_path`.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "start_line": {
+                              "description": "First line to return, 1-based. Alternative to `line`.",
+                              "maximum": 1000000,
+                              "minimum": 1,
+                              "type": "integer"
+                            }
+                          },
+                          "required": [],
+                          "type": "object"
+                        },
+                        {
+                          "oneOf": [
+                            {
+                              "required": [
+                                "path"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "file_path"
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "scope": {
+                    "default": "line_context",
+                    "description": "Snippet scope.",
+                    "enum": [
+                      "line_context",
+                      "function_body"
+                    ],
+                    "type": "string"
+                  },
+                  "start_line": {
+                    "description": "First line to return with top-level `path`. Alternative to `line`.",
+                    "maximum": 1000000,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "symbol_id": {
+                    "description": "Alias for `id`. Hits report this field name.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
                 },
-                "type": "array"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "scope": {
-                "default": "line_context",
-                "description": "Snippet scope.",
-                "enum": [
-                  "line_context",
-                  "function_body"
+                "required": [
+                  "project"
                 ],
-                "type": "string"
+                "type": "object"
               },
-              "start_line": {
-                "description": "First line to return with top-level `path`. Alternative to `line`.",
-                "maximum": 1000000,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "symbol_id": {
-                "description": "Alias for `id`. Hits report this field name.",
-                "minLength": 1,
-                "type": "string"
+              {
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "paths"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "path"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "file_path"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "symbol_id"
+                    ]
+                  }
+                ]
               }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -1426,61 +1517,68 @@
         {
           "description": "Build closed source and graph evidence for one concrete target; not broad question answering. CodeStory effect: may activate project-local managed cache, indexing, or network-backed retrieval state.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Build a deep evidence packet for one concrete retrieval target.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Build a deep evidence packet for one concrete retrieval target.",
+                "properties": {
+                  "bookmark": {
+                    "description": "Saved bookmark id to build context around.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "Stable node id to build context around.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "include_evidence": {
+                    "default": true,
+                    "description": "Include citation edge ids and score details.",
+                    "type": "boolean"
+                  },
+                  "max_results": {
+                    "default": 8,
+                    "description": "Maximum retrieval results.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Concrete symbol, file, literal, API path, module, or behavior term.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
+                  "project"
+                ],
+                "type": "object"
               },
               {
-                "required": [
-                  "id"
-                ]
-              },
-              {
-                "required": [
-                  "bookmark"
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "bookmark"
+                    ]
+                  }
                 ]
               }
-            ],
-            "properties": {
-              "bookmark": {
-                "description": "Saved bookmark id to build context around.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "id": {
-                "description": "Stable node id to build context around.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "include_evidence": {
-                "default": true,
-                "description": "Include citation edge ids and score details.",
-                "type": "boolean"
-              },
-              "max_results": {
-                "default": 8,
-                "description": "Maximum retrieval results.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Concrete symbol, file, literal, API path, module, or behavior term.",
-                "minLength": 1,
-                "type": "string"
-              }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -1552,7 +1650,7 @@
       ]
     },
     "2025-03-26": {
-      "discoveryContractSha256": "4440f4544930c84c476e9f786188e6658a8f6f9c1203989c6fee4683be7beb38",
+      "discoveryContractSha256": "bb9c8f4a92824a1a7fc957fdce7afb396923bdcae432485d832e46d8a0918b68",
       "tools": [
         {
           "annotations": {
@@ -2025,111 +2123,118 @@
           },
           "description": "Analyze one explicit path source against the last complete local index while preserving bounded stale and error evidence. Cold or partial state may trigger managed indexing before dispatch. Prefer paths, use changed_paths for compatibility or change_records for status-rich input. Never discovers git changes and does not wait for broad search. CodeStory effect: may activate project-local managed cache, indexing, or network-backed retrieval state.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Analyze exactly one explicit path source against the last complete local index.",
-            "oneOf": [
+            "allOf": [
               {
-                "required": [
-                  "paths"
-                ]
-              },
-              {
-                "required": [
-                  "changed_paths"
-                ]
-              },
-              {
-                "required": [
-                  "change_records"
-                ]
-              }
-            ],
-            "properties": {
-              "change_records": {
-                "description": "Changed file records with path, kind, optional status, and optional previous_path.",
-                "items": {
-                  "additionalProperties": false,
-                  "description": "Changed file record.",
-                  "properties": {
-                    "kind": {
-                      "description": "Change kind.",
-                      "enum": [
-                        "added",
-                        "modified",
-                        "deleted",
-                        "renamed",
-                        "copied",
-                        "untracked",
-                        "unknown"
+                "additionalProperties": false,
+                "description": "Analyze exactly one explicit path source against the last complete local index.",
+                "properties": {
+                  "change_records": {
+                    "description": "Changed file records with path, kind, optional status, and optional previous_path.",
+                    "items": {
+                      "additionalProperties": false,
+                      "description": "Changed file record.",
+                      "properties": {
+                        "kind": {
+                          "description": "Change kind.",
+                          "enum": [
+                            "added",
+                            "modified",
+                            "deleted",
+                            "renamed",
+                            "copied",
+                            "untracked",
+                            "unknown"
+                          ],
+                          "type": "string"
+                        },
+                        "path": {
+                          "description": "Changed repo-relative path.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "previous_path": {
+                          "description": "Optional previous path accepted only for renamed or copied records; it can seed bounded proxy graph evidence when the current path is not indexed.",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "status": {
+                          "description": "Optional raw git-style status such as M, A, D, R100, C100, or ??.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "path",
+                        "kind"
                       ],
-                      "type": "string"
+                      "type": "object"
                     },
-                    "path": {
-                      "description": "Changed repo-relative path.",
+                    "maxItems": 200,
+                    "minItems": 1,
+                    "type": "array"
+                  },
+                  "changed_paths": {
+                    "description": "Compatibility alias for project-relative paths to analyze.",
+                    "items": {
                       "minLength": 1,
                       "type": "string"
                     },
-                    "previous_path": {
-                      "description": "Optional previous path accepted only for renamed or copied records; it can seed bounded proxy graph evidence when the current path is not indexed.",
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "status": {
-                      "description": "Optional raw git-style status such as M, A, D, R100, C100, or ??.",
-                      "type": "string"
-                    }
+                    "maxItems": 200,
+                    "minItems": 1,
+                    "type": "array"
                   },
-                  "required": [
-                    "path",
-                    "kind"
-                  ],
-                  "type": "object"
+                  "depth": {
+                    "default": 2,
+                    "description": "Dependent graph walk depth.",
+                    "maximum": 8,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "filter": {
+                    "description": "Optional impacted-symbol filter by path or display-name substring.",
+                    "type": "string"
+                  },
+                  "paths": {
+                    "description": "Preferred simple input: project-relative paths to analyze.",
+                    "items": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "maxItems": 200,
+                    "minItems": 1,
+                    "type": "array"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
                 },
-                "maxItems": 200,
-                "minItems": 1,
-                "type": "array"
+                "required": [
+                  "project"
+                ],
+                "type": "object"
               },
-              "changed_paths": {
-                "description": "Compatibility alias for project-relative paths to analyze.",
-                "items": {
-                  "minLength": 1,
-                  "type": "string"
-                },
-                "maxItems": 200,
-                "minItems": 1,
-                "type": "array"
-              },
-              "depth": {
-                "default": 2,
-                "description": "Dependent graph walk depth.",
-                "maximum": 8,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "filter": {
-                "description": "Optional impacted-symbol filter by path or display-name substring.",
-                "type": "string"
-              },
-              "paths": {
-                "description": "Preferred simple input: project-relative paths to analyze.",
-                "items": {
-                  "minLength": 1,
-                  "type": "string"
-                },
-                "maxItems": 200,
-                "minItems": 1,
-                "type": "array"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
+              {
+                "oneOf": [
+                  {
+                    "required": [
+                      "paths"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "changed_paths"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "change_records"
+                    ]
+                  }
+                ]
               }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -2144,45 +2249,52 @@
           },
           "description": "Resolve a symbol id or query and return details. CodeStory effect: may activate project-local managed cache, indexing, or network-backed retrieval state.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Resolve a symbol by query or stable node id.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Resolve a symbol by query or stable node id.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
+                  "project"
+                ],
+                "type": "object"
               },
               {
-                "required": [
-                  "id"
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
                 ]
               }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
-              }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -2197,74 +2309,81 @@
           },
           "description": "Return a graph trail around a symbol. CodeStory effect: may activate project-local managed cache, indexing, or network-backed retrieval state.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Return a graph trail around a symbol id or query.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Return a graph trail around a symbol id or query.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "depth": {
+                    "default": 2,
+                    "description": "Trail depth.",
+                    "maximum": 10,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "direction": {
+                    "default": "both",
+                    "description": "Trail direction.",
+                    "enum": [
+                      "incoming",
+                      "outgoing",
+                      "both"
+                    ],
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "max_nodes": {
+                    "default": 120,
+                    "description": "Maximum graph nodes returned.",
+                    "maximum": 120,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "story": {
+                    "default": false,
+                    "description": "Include a readable trail story DTO.",
+                    "type": "boolean"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
-              },
-              {
-                "required": [
-                  "id"
-                ]
-              }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "depth": {
-                "default": 2,
-                "description": "Trail depth.",
-                "maximum": 10,
-                "minimum": 0,
-                "type": "integer"
-              },
-              "direction": {
-                "default": "both",
-                "description": "Trail direction.",
-                "enum": [
-                  "incoming",
-                  "outgoing",
-                  "both"
+                  "project"
                 ],
-                "type": "string"
+                "type": "object"
               },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "max_nodes": {
-                "default": 120,
-                "description": "Maximum graph nodes returned.",
-                "maximum": 120,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "story": {
-                "default": false,
-                "description": "Include a readable trail story DTO.",
-                "type": "boolean"
+              {
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
+                ]
               }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -2279,59 +2398,66 @@
           },
           "description": "Return a bounded incoming caller graph around a symbol. CodeStory effect: may activate project-local managed cache, indexing, or network-backed retrieval state.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Return a bounded local graph alias around one node.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Return a bounded local graph alias around one node.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "depth": {
+                    "default": 1,
+                    "description": "Graph depth.",
+                    "maximum": 3,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "max_nodes": {
+                    "default": 50,
+                    "description": "Maximum graph nodes returned.",
+                    "maximum": 120,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
+                  "project"
+                ],
+                "type": "object"
               },
               {
-                "required": [
-                  "id"
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
                 ]
               }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "depth": {
-                "default": 1,
-                "description": "Graph depth.",
-                "maximum": 3,
-                "minimum": 0,
-                "type": "integer"
-              },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "max_nodes": {
-                "default": 50,
-                "description": "Maximum graph nodes returned.",
-                "maximum": 120,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
-              }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -2346,59 +2472,66 @@
           },
           "description": "Return a bounded outgoing callee graph around a symbol. CodeStory effect: may activate project-local managed cache, indexing, or network-backed retrieval state.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Return a bounded local graph alias around one node.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Return a bounded local graph alias around one node.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "depth": {
+                    "default": 1,
+                    "description": "Graph depth.",
+                    "maximum": 3,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "max_nodes": {
+                    "default": 50,
+                    "description": "Maximum graph nodes returned.",
+                    "maximum": 120,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
+                  "project"
+                ],
+                "type": "object"
               },
               {
-                "required": [
-                  "id"
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
                 ]
               }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "depth": {
-                "default": 1,
-                "description": "Graph depth.",
-                "maximum": 3,
-                "minimum": 0,
-                "type": "integer"
-              },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "max_nodes": {
-                "default": 50,
-                "description": "Maximum graph nodes returned.",
-                "maximum": 120,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
-              }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -2413,74 +2546,81 @@
           },
           "description": "Return a readable trace around a symbol. CodeStory effect: may activate project-local managed cache, indexing, or network-backed retrieval state.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Return a readable trace around a symbol id or query.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Return a readable trace around a symbol id or query.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "depth": {
+                    "default": 2,
+                    "description": "Trail depth.",
+                    "maximum": 10,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "direction": {
+                    "default": "both",
+                    "description": "Trail direction.",
+                    "enum": [
+                      "incoming",
+                      "outgoing",
+                      "both"
+                    ],
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "max_nodes": {
+                    "default": 120,
+                    "description": "Maximum graph nodes returned.",
+                    "maximum": 120,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "story": {
+                    "default": true,
+                    "description": "Include a readable trail story DTO.",
+                    "type": "boolean"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
-              },
-              {
-                "required": [
-                  "id"
-                ]
-              }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "depth": {
-                "default": 2,
-                "description": "Trail depth.",
-                "maximum": 10,
-                "minimum": 0,
-                "type": "integer"
-              },
-              "direction": {
-                "default": "both",
-                "description": "Trail direction.",
-                "enum": [
-                  "incoming",
-                  "outgoing",
-                  "both"
+                  "project"
                 ],
-                "type": "string"
+                "type": "object"
               },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "max_nodes": {
-                "default": 120,
-                "description": "Maximum graph nodes returned.",
-                "maximum": 120,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "story": {
-                "default": true,
-                "description": "Include a readable trail story DTO.",
-                "type": "boolean"
+              {
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
+                ]
               }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -2495,45 +2635,52 @@
           },
           "description": "Return one stable graph node with file references for source inspection and relationship navigation. CodeStory effect: may activate project-local managed cache, indexing, or network-backed retrieval state.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Resolve a single indexed graph node by stable id or query.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Resolve a single indexed graph node by stable id or query.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
+                  "project"
+                ],
+                "type": "object"
               },
               {
-                "required": [
-                  "id"
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
                 ]
               }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
-              }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -2548,69 +2695,76 @@
           },
           "description": "Return a bounded graph neighborhood around one node. CodeStory effect: may activate project-local managed cache, indexing, or network-backed retrieval state.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Return a bounded graph neighborhood around one node.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Return a bounded graph neighborhood around one node.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "depth": {
+                    "default": 1,
+                    "description": "Graph depth.",
+                    "maximum": 3,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "direction": {
+                    "default": "both",
+                    "description": "Graph direction.",
+                    "enum": [
+                      "incoming",
+                      "outgoing",
+                      "both"
+                    ],
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "max_nodes": {
+                    "default": 50,
+                    "description": "Maximum graph nodes returned.",
+                    "maximum": 120,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
-              },
-              {
-                "required": [
-                  "id"
-                ]
-              }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "depth": {
-                "default": 1,
-                "description": "Graph depth.",
-                "maximum": 3,
-                "minimum": 0,
-                "type": "integer"
-              },
-              "direction": {
-                "default": "both",
-                "description": "Graph direction.",
-                "enum": [
-                  "incoming",
-                  "outgoing",
-                  "both"
+                  "project"
                 ],
-                "type": "string"
+                "type": "object"
               },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "max_nodes": {
-                "default": 50,
-                "description": "Maximum graph nodes returned.",
-                "maximum": 120,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
+              {
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
+                ]
               }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -2676,69 +2830,76 @@
           },
           "description": "Return a bounded subgraph around one resolved node for relationship navigation. CodeStory effect: may activate project-local managed cache, indexing, or network-backed retrieval state.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Return a bounded graph subgraph around one resolved node.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Return a bounded graph subgraph around one resolved node.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "depth": {
+                    "default": 2,
+                    "description": "Graph depth.",
+                    "maximum": 3,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "direction": {
+                    "default": "both",
+                    "description": "Graph direction.",
+                    "enum": [
+                      "incoming",
+                      "outgoing",
+                      "both"
+                    ],
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "max_nodes": {
+                    "default": 80,
+                    "description": "Maximum graph nodes returned.",
+                    "maximum": 120,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
-              },
-              {
-                "required": [
-                  "id"
-                ]
-              }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "depth": {
-                "default": 2,
-                "description": "Graph depth.",
-                "maximum": 3,
-                "minimum": 0,
-                "type": "integer"
-              },
-              "direction": {
-                "default": "both",
-                "description": "Graph direction.",
-                "enum": [
-                  "incoming",
-                  "outgoing",
-                  "both"
+                  "project"
                 ],
-                "type": "string"
+                "type": "object"
               },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "max_nodes": {
-                "default": 80,
-                "description": "Maximum graph nodes returned.",
-                "maximum": 120,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
+              {
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
+                ]
               }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -2753,45 +2914,52 @@
           },
           "description": "Return definition metadata for a symbol id or query. CodeStory effect: may activate project-local managed cache, indexing, or network-backed retrieval state.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Resolve a symbol by query or stable node id.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Resolve a symbol by query or stable node id.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
+                  "project"
+                ],
+                "type": "object"
               },
               {
-                "required": [
-                  "id"
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
                 ]
               }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
-              }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -2806,45 +2974,52 @@
           },
           "description": "Return incoming references for a symbol id or query. CodeStory effect: may activate project-local managed cache, indexing, or network-backed retrieval state.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Resolve a symbol by query or stable node id.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Resolve a symbol by query or stable node id.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
+                  "project"
+                ],
+                "type": "object"
               },
               {
-                "required": [
-                  "id"
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
                 ]
               }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
-              }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -2896,176 +3071,190 @@
           },
           "description": "Read line-numbered source for a selected symbol or path. Use `paths` to inspect several file ranges in one call; ordinary host source reads are also available. CodeStory effect: may activate project-local managed cache, indexing, or network-backed retrieval state.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Return bounded source: either resolve one symbol, or read line ranges from files named by earlier evidence.",
-            "oneOf": [
+            "allOf": [
               {
-                "required": [
-                  "query"
-                ]
-              },
-              {
-                "required": [
-                  "id"
-                ]
-              },
-              {
-                "required": [
-                  "paths"
-                ]
-              },
-              {
-                "required": [
-                  "path"
-                ]
-              },
-              {
-                "required": [
-                  "file_path"
-                ]
-              },
-              {
-                "required": [
-                  "symbol_id"
-                ]
-              }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "context": {
-                "default": 4,
-                "description": "Surrounding context lines above and below the selected source range.",
-                "maximum": 200,
-                "minimum": 0,
-                "type": "integer"
-              },
-              "end_line": {
-                "description": "Last line to return with top-level `path`. Defaults to a bounded window after the start.",
-                "maximum": 1000000,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "file_path": {
-                "description": "Alias for `path`. Hits report this field name.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "function_body": {
-                "description": "CLI-compatible scope selector; true requests `function_body`, false requests `line_context`.",
-                "type": "boolean"
-              },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "line": {
-                "description": "1-based line from a search, trail, or packet hit. Used with `path`.",
-                "maximum": 1000000,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "lines": {
-                "description": "Agent-friendly compatibility alias for `context`.",
-                "maximum": 200,
-                "minimum": 0,
-                "type": "integer"
-              },
-              "path": {
-                "description": "Single-file alias for `paths`: repository-relative path as returned in `file_path`. Combine with `line`.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "paths": {
-                "description": "File ranges to read in one call, instead of resolving a symbol. Line-numbered and bounded in total; use the paths and lines that search, trail, or packet already returned.",
-                "items": {
-                  "additionalProperties": false,
-                  "description": "One file range to read. Paste `file_path` and `line` straight from a search, trail, or packet hit.",
-                  "oneOf": [
-                    {
-                      "required": [
-                        "path"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "file_path"
-                      ]
-                    }
-                  ],
-                  "properties": {
-                    "end_line": {
-                      "description": "Last line to return, 1-based. Defaults to a bounded window after the start.",
-                      "maximum": 1000000,
-                      "minimum": 1,
-                      "type": "integer"
-                    },
-                    "file_path": {
-                      "description": "Alias for `path`. Hits report this field name.",
-                      "minLength": 1,
-                      "type": "string"
-                    },
-                    "line": {
-                      "description": "Line of interest, 1-based, as returned in `line`. A window is returned around it.",
-                      "maximum": 1000000,
-                      "minimum": 1,
-                      "type": "integer"
-                    },
-                    "path": {
-                      "description": "Repository-relative file path, as returned in `file_path`.",
-                      "minLength": 1,
-                      "type": "string"
-                    },
-                    "start_line": {
-                      "description": "First line to return, 1-based. Alternative to `line`.",
-                      "maximum": 1000000,
-                      "minimum": 1,
-                      "type": "integer"
-                    }
+                "additionalProperties": false,
+                "description": "Return bounded source: either resolve one symbol, or read line ranges from files named by earlier evidence.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
                   },
-                  "required": [],
-                  "type": "object"
+                  "context": {
+                    "default": 4,
+                    "description": "Surrounding context lines above and below the selected source range.",
+                    "maximum": 200,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "end_line": {
+                    "description": "Last line to return with top-level `path`. Defaults to a bounded window after the start.",
+                    "maximum": 1000000,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "file_path": {
+                    "description": "Alias for `path`. Hits report this field name.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "function_body": {
+                    "description": "CLI-compatible scope selector; true requests `function_body`, false requests `line_context`.",
+                    "type": "boolean"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "line": {
+                    "description": "1-based line from a search, trail, or packet hit. Used with `path`.",
+                    "maximum": 1000000,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "lines": {
+                    "description": "Agent-friendly compatibility alias for `context`.",
+                    "maximum": 200,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "path": {
+                    "description": "Single-file alias for `paths`: repository-relative path as returned in `file_path`. Combine with `line`.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "paths": {
+                    "description": "File ranges to read in one call, instead of resolving a symbol. Line-numbered and bounded in total; use the paths and lines that search, trail, or packet already returned.",
+                    "items": {
+                      "allOf": [
+                        {
+                          "additionalProperties": false,
+                          "description": "One file range to read. Paste `file_path` and `line` straight from a search, trail, or packet hit.",
+                          "properties": {
+                            "end_line": {
+                              "description": "Last line to return, 1-based. Defaults to a bounded window after the start.",
+                              "maximum": 1000000,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "file_path": {
+                              "description": "Alias for `path`. Hits report this field name.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "line": {
+                              "description": "Line of interest, 1-based, as returned in `line`. A window is returned around it.",
+                              "maximum": 1000000,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "path": {
+                              "description": "Repository-relative file path, as returned in `file_path`.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "start_line": {
+                              "description": "First line to return, 1-based. Alternative to `line`.",
+                              "maximum": 1000000,
+                              "minimum": 1,
+                              "type": "integer"
+                            }
+                          },
+                          "required": [],
+                          "type": "object"
+                        },
+                        {
+                          "oneOf": [
+                            {
+                              "required": [
+                                "path"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "file_path"
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "scope": {
+                    "default": "line_context",
+                    "description": "Snippet scope.",
+                    "enum": [
+                      "line_context",
+                      "function_body"
+                    ],
+                    "type": "string"
+                  },
+                  "start_line": {
+                    "description": "First line to return with top-level `path`. Alternative to `line`.",
+                    "maximum": 1000000,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "symbol_id": {
+                    "description": "Alias for `id`. Hits report this field name.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
                 },
-                "type": "array"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "scope": {
-                "default": "line_context",
-                "description": "Snippet scope.",
-                "enum": [
-                  "line_context",
-                  "function_body"
+                "required": [
+                  "project"
                 ],
-                "type": "string"
+                "type": "object"
               },
-              "start_line": {
-                "description": "First line to return with top-level `path`. Alternative to `line`.",
-                "maximum": 1000000,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "symbol_id": {
-                "description": "Alias for `id`. Hits report this field name.",
-                "minLength": 1,
-                "type": "string"
+              {
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "paths"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "path"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "file_path"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "symbol_id"
+                    ]
+                  }
+                ]
               }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -3080,61 +3269,68 @@
           },
           "description": "Build closed source and graph evidence for one concrete target; not broad question answering. CodeStory effect: may activate project-local managed cache, indexing, or network-backed retrieval state.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Build a deep evidence packet for one concrete retrieval target.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Build a deep evidence packet for one concrete retrieval target.",
+                "properties": {
+                  "bookmark": {
+                    "description": "Saved bookmark id to build context around.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "Stable node id to build context around.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "include_evidence": {
+                    "default": true,
+                    "description": "Include citation edge ids and score details.",
+                    "type": "boolean"
+                  },
+                  "max_results": {
+                    "default": 8,
+                    "description": "Maximum retrieval results.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Concrete symbol, file, literal, API path, module, or behavior term.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
+                  "project"
+                ],
+                "type": "object"
               },
               {
-                "required": [
-                  "id"
-                ]
-              },
-              {
-                "required": [
-                  "bookmark"
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "bookmark"
+                    ]
+                  }
                 ]
               }
-            ],
-            "properties": {
-              "bookmark": {
-                "description": "Saved bookmark id to build context around.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "id": {
-                "description": "Stable node id to build context around.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "include_evidence": {
-                "default": true,
-                "description": "Include citation edge ids and score details.",
-                "type": "boolean"
-              },
-              "max_results": {
-                "default": 8,
-                "description": "Maximum retrieval results.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Concrete symbol, file, literal, API path, module, or behavior term.",
-                "minLength": 1,
-                "type": "string"
-              }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -3206,7 +3402,7 @@
       ]
     },
     "2025-06-18": {
-      "discoveryContractSha256": "400577bca4552e5172e98415ef51f23cc8269b66b3072186f8194df96dba9bf9",
+      "discoveryContractSha256": "bb1d1bed64295ed30b4cc3b34dd93ff30f897668a8470689351ef13c3c653333",
       "tools": [
         {
           "_meta": {
@@ -5881,111 +6077,118 @@
           },
           "description": "Analyze one explicit path source against the last complete local index while preserving bounded stale and error evidence. Cold or partial state may trigger managed indexing before dispatch. Prefer paths, use changed_paths for compatibility or change_records for status-rich input. Never discovers git changes and does not wait for broad search.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Analyze exactly one explicit path source against the last complete local index.",
-            "oneOf": [
+            "allOf": [
               {
-                "required": [
-                  "paths"
-                ]
-              },
-              {
-                "required": [
-                  "changed_paths"
-                ]
-              },
-              {
-                "required": [
-                  "change_records"
-                ]
-              }
-            ],
-            "properties": {
-              "change_records": {
-                "description": "Changed file records with path, kind, optional status, and optional previous_path.",
-                "items": {
-                  "additionalProperties": false,
-                  "description": "Changed file record.",
-                  "properties": {
-                    "kind": {
-                      "description": "Change kind.",
-                      "enum": [
-                        "added",
-                        "modified",
-                        "deleted",
-                        "renamed",
-                        "copied",
-                        "untracked",
-                        "unknown"
+                "additionalProperties": false,
+                "description": "Analyze exactly one explicit path source against the last complete local index.",
+                "properties": {
+                  "change_records": {
+                    "description": "Changed file records with path, kind, optional status, and optional previous_path.",
+                    "items": {
+                      "additionalProperties": false,
+                      "description": "Changed file record.",
+                      "properties": {
+                        "kind": {
+                          "description": "Change kind.",
+                          "enum": [
+                            "added",
+                            "modified",
+                            "deleted",
+                            "renamed",
+                            "copied",
+                            "untracked",
+                            "unknown"
+                          ],
+                          "type": "string"
+                        },
+                        "path": {
+                          "description": "Changed repo-relative path.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "previous_path": {
+                          "description": "Optional previous path accepted only for renamed or copied records; it can seed bounded proxy graph evidence when the current path is not indexed.",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "status": {
+                          "description": "Optional raw git-style status such as M, A, D, R100, C100, or ??.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "path",
+                        "kind"
                       ],
-                      "type": "string"
+                      "type": "object"
                     },
-                    "path": {
-                      "description": "Changed repo-relative path.",
+                    "maxItems": 200,
+                    "minItems": 1,
+                    "type": "array"
+                  },
+                  "changed_paths": {
+                    "description": "Compatibility alias for project-relative paths to analyze.",
+                    "items": {
                       "minLength": 1,
                       "type": "string"
                     },
-                    "previous_path": {
-                      "description": "Optional previous path accepted only for renamed or copied records; it can seed bounded proxy graph evidence when the current path is not indexed.",
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "status": {
-                      "description": "Optional raw git-style status such as M, A, D, R100, C100, or ??.",
-                      "type": "string"
-                    }
+                    "maxItems": 200,
+                    "minItems": 1,
+                    "type": "array"
                   },
-                  "required": [
-                    "path",
-                    "kind"
-                  ],
-                  "type": "object"
+                  "depth": {
+                    "default": 2,
+                    "description": "Dependent graph walk depth.",
+                    "maximum": 8,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "filter": {
+                    "description": "Optional impacted-symbol filter by path or display-name substring.",
+                    "type": "string"
+                  },
+                  "paths": {
+                    "description": "Preferred simple input: project-relative paths to analyze.",
+                    "items": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "maxItems": 200,
+                    "minItems": 1,
+                    "type": "array"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
                 },
-                "maxItems": 200,
-                "minItems": 1,
-                "type": "array"
+                "required": [
+                  "project"
+                ],
+                "type": "object"
               },
-              "changed_paths": {
-                "description": "Compatibility alias for project-relative paths to analyze.",
-                "items": {
-                  "minLength": 1,
-                  "type": "string"
-                },
-                "maxItems": 200,
-                "minItems": 1,
-                "type": "array"
-              },
-              "depth": {
-                "default": 2,
-                "description": "Dependent graph walk depth.",
-                "maximum": 8,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "filter": {
-                "description": "Optional impacted-symbol filter by path or display-name substring.",
-                "type": "string"
-              },
-              "paths": {
-                "description": "Preferred simple input: project-relative paths to analyze.",
-                "items": {
-                  "minLength": 1,
-                  "type": "string"
-                },
-                "maxItems": 200,
-                "minItems": 1,
-                "type": "array"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
+              {
+                "oneOf": [
+                  {
+                    "required": [
+                      "paths"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "changed_paths"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "change_records"
+                    ]
+                  }
+                ]
               }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -6673,45 +6876,52 @@
           },
           "description": "Resolve a symbol id or query and return details.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Resolve a symbol by query or stable node id.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Resolve a symbol by query or stable node id.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
+                  "project"
+                ],
+                "type": "object"
               },
               {
-                "required": [
-                  "id"
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
                 ]
               }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
-              }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -7147,74 +7357,81 @@
           },
           "description": "Return a graph trail around a symbol.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Return a graph trail around a symbol id or query.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Return a graph trail around a symbol id or query.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "depth": {
+                    "default": 2,
+                    "description": "Trail depth.",
+                    "maximum": 10,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "direction": {
+                    "default": "both",
+                    "description": "Trail direction.",
+                    "enum": [
+                      "incoming",
+                      "outgoing",
+                      "both"
+                    ],
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "max_nodes": {
+                    "default": 120,
+                    "description": "Maximum graph nodes returned.",
+                    "maximum": 120,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "story": {
+                    "default": false,
+                    "description": "Include a readable trail story DTO.",
+                    "type": "boolean"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
-              },
-              {
-                "required": [
-                  "id"
-                ]
-              }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "depth": {
-                "default": 2,
-                "description": "Trail depth.",
-                "maximum": 10,
-                "minimum": 0,
-                "type": "integer"
-              },
-              "direction": {
-                "default": "both",
-                "description": "Trail direction.",
-                "enum": [
-                  "incoming",
-                  "outgoing",
-                  "both"
+                  "project"
                 ],
-                "type": "string"
+                "type": "object"
               },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "max_nodes": {
-                "default": 120,
-                "description": "Maximum graph nodes returned.",
-                "maximum": 120,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "story": {
-                "default": false,
-                "description": "Include a readable trail story DTO.",
-                "type": "boolean"
+              {
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
+                ]
               }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -7443,59 +7660,66 @@
           },
           "description": "Return a bounded incoming caller graph around a symbol.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Return a bounded local graph alias around one node.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Return a bounded local graph alias around one node.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "depth": {
+                    "default": 1,
+                    "description": "Graph depth.",
+                    "maximum": 3,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "max_nodes": {
+                    "default": 50,
+                    "description": "Maximum graph nodes returned.",
+                    "maximum": 120,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
+                  "project"
+                ],
+                "type": "object"
               },
               {
-                "required": [
-                  "id"
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
                 ]
               }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "depth": {
-                "default": 1,
-                "description": "Graph depth.",
-                "maximum": 3,
-                "minimum": 0,
-                "type": "integer"
-              },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "max_nodes": {
-                "default": 50,
-                "description": "Maximum graph nodes returned.",
-                "maximum": 120,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
-              }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -7765,59 +7989,66 @@
           },
           "description": "Return a bounded outgoing callee graph around a symbol.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Return a bounded local graph alias around one node.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Return a bounded local graph alias around one node.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "depth": {
+                    "default": 1,
+                    "description": "Graph depth.",
+                    "maximum": 3,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "max_nodes": {
+                    "default": 50,
+                    "description": "Maximum graph nodes returned.",
+                    "maximum": 120,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
+                  "project"
+                ],
+                "type": "object"
               },
               {
-                "required": [
-                  "id"
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
                 ]
               }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "depth": {
-                "default": 1,
-                "description": "Graph depth.",
-                "maximum": 3,
-                "minimum": 0,
-                "type": "integer"
-              },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "max_nodes": {
-                "default": 50,
-                "description": "Maximum graph nodes returned.",
-                "maximum": 120,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
-              }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -8087,74 +8318,81 @@
           },
           "description": "Return a readable trace around a symbol.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Return a readable trace around a symbol id or query.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Return a readable trace around a symbol id or query.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "depth": {
+                    "default": 2,
+                    "description": "Trail depth.",
+                    "maximum": 10,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "direction": {
+                    "default": "both",
+                    "description": "Trail direction.",
+                    "enum": [
+                      "incoming",
+                      "outgoing",
+                      "both"
+                    ],
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "max_nodes": {
+                    "default": 120,
+                    "description": "Maximum graph nodes returned.",
+                    "maximum": 120,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "story": {
+                    "default": true,
+                    "description": "Include a readable trail story DTO.",
+                    "type": "boolean"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
-              },
-              {
-                "required": [
-                  "id"
-                ]
-              }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "depth": {
-                "default": 2,
-                "description": "Trail depth.",
-                "maximum": 10,
-                "minimum": 0,
-                "type": "integer"
-              },
-              "direction": {
-                "default": "both",
-                "description": "Trail direction.",
-                "enum": [
-                  "incoming",
-                  "outgoing",
-                  "both"
+                  "project"
                 ],
-                "type": "string"
+                "type": "object"
               },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "max_nodes": {
-                "default": 120,
-                "description": "Maximum graph nodes returned.",
-                "maximum": 120,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "story": {
-                "default": true,
-                "description": "Include a readable trail story DTO.",
-                "type": "boolean"
+              {
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
+                ]
               }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -8383,45 +8621,52 @@
           },
           "description": "Return one stable graph node with file references for source inspection and relationship navigation.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Resolve a single indexed graph node by stable id or query.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Resolve a single indexed graph node by stable id or query.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
+                  "project"
+                ],
+                "type": "object"
               },
               {
-                "required": [
-                  "id"
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
                 ]
               }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
-              }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -8691,69 +8936,76 @@
           },
           "description": "Return a bounded graph neighborhood around one node.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Return a bounded graph neighborhood around one node.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Return a bounded graph neighborhood around one node.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "depth": {
+                    "default": 1,
+                    "description": "Graph depth.",
+                    "maximum": 3,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "direction": {
+                    "default": "both",
+                    "description": "Graph direction.",
+                    "enum": [
+                      "incoming",
+                      "outgoing",
+                      "both"
+                    ],
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "max_nodes": {
+                    "default": 50,
+                    "description": "Maximum graph nodes returned.",
+                    "maximum": 120,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
-              },
-              {
-                "required": [
-                  "id"
-                ]
-              }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "depth": {
-                "default": 1,
-                "description": "Graph depth.",
-                "maximum": 3,
-                "minimum": 0,
-                "type": "integer"
-              },
-              "direction": {
-                "default": "both",
-                "description": "Graph direction.",
-                "enum": [
-                  "incoming",
-                  "outgoing",
-                  "both"
+                  "project"
                 ],
-                "type": "string"
+                "type": "object"
               },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "max_nodes": {
-                "default": 50,
-                "description": "Maximum graph nodes returned.",
-                "maximum": 120,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
+              {
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
+                ]
               }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -9329,69 +9581,76 @@
           },
           "description": "Return a bounded subgraph around one resolved node for relationship navigation.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Return a bounded graph subgraph around one resolved node.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Return a bounded graph subgraph around one resolved node.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "depth": {
+                    "default": 2,
+                    "description": "Graph depth.",
+                    "maximum": 3,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "direction": {
+                    "default": "both",
+                    "description": "Graph direction.",
+                    "enum": [
+                      "incoming",
+                      "outgoing",
+                      "both"
+                    ],
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "max_nodes": {
+                    "default": 80,
+                    "description": "Maximum graph nodes returned.",
+                    "maximum": 120,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
-              },
-              {
-                "required": [
-                  "id"
-                ]
-              }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "depth": {
-                "default": 2,
-                "description": "Graph depth.",
-                "maximum": 3,
-                "minimum": 0,
-                "type": "integer"
-              },
-              "direction": {
-                "default": "both",
-                "description": "Graph direction.",
-                "enum": [
-                  "incoming",
-                  "outgoing",
-                  "both"
+                  "project"
                 ],
-                "type": "string"
+                "type": "object"
               },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "max_nodes": {
-                "default": 80,
-                "description": "Maximum graph nodes returned.",
-                "maximum": 120,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
+              {
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
+                ]
               }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -9661,45 +9920,52 @@
           },
           "description": "Return definition metadata for a symbol id or query.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Resolve a symbol by query or stable node id.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Resolve a symbol by query or stable node id.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
+                  "project"
+                ],
+                "type": "object"
               },
               {
-                "required": [
-                  "id"
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
                 ]
               }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
-              }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -9953,45 +10219,52 @@
           },
           "description": "Return incoming references for a symbol id or query.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Resolve a symbol by query or stable node id.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Resolve a symbol by query or stable node id.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
+                  "project"
+                ],
+                "type": "object"
               },
               {
-                "required": [
-                  "id"
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
                 ]
               }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
-              }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -10511,176 +10784,190 @@
           },
           "description": "Read line-numbered source for a selected symbol or path. Use `paths` to inspect several file ranges in one call; ordinary host source reads are also available.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Return bounded source: either resolve one symbol, or read line ranges from files named by earlier evidence.",
-            "oneOf": [
+            "allOf": [
               {
-                "required": [
-                  "query"
-                ]
-              },
-              {
-                "required": [
-                  "id"
-                ]
-              },
-              {
-                "required": [
-                  "paths"
-                ]
-              },
-              {
-                "required": [
-                  "path"
-                ]
-              },
-              {
-                "required": [
-                  "file_path"
-                ]
-              },
-              {
-                "required": [
-                  "symbol_id"
-                ]
-              }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "context": {
-                "default": 4,
-                "description": "Surrounding context lines above and below the selected source range.",
-                "maximum": 200,
-                "minimum": 0,
-                "type": "integer"
-              },
-              "end_line": {
-                "description": "Last line to return with top-level `path`. Defaults to a bounded window after the start.",
-                "maximum": 1000000,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "file_path": {
-                "description": "Alias for `path`. Hits report this field name.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "function_body": {
-                "description": "CLI-compatible scope selector; true requests `function_body`, false requests `line_context`.",
-                "type": "boolean"
-              },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "line": {
-                "description": "1-based line from a search, trail, or packet hit. Used with `path`.",
-                "maximum": 1000000,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "lines": {
-                "description": "Agent-friendly compatibility alias for `context`.",
-                "maximum": 200,
-                "minimum": 0,
-                "type": "integer"
-              },
-              "path": {
-                "description": "Single-file alias for `paths`: repository-relative path as returned in `file_path`. Combine with `line`.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "paths": {
-                "description": "File ranges to read in one call, instead of resolving a symbol. Line-numbered and bounded in total; use the paths and lines that search, trail, or packet already returned.",
-                "items": {
-                  "additionalProperties": false,
-                  "description": "One file range to read. Paste `file_path` and `line` straight from a search, trail, or packet hit.",
-                  "oneOf": [
-                    {
-                      "required": [
-                        "path"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "file_path"
-                      ]
-                    }
-                  ],
-                  "properties": {
-                    "end_line": {
-                      "description": "Last line to return, 1-based. Defaults to a bounded window after the start.",
-                      "maximum": 1000000,
-                      "minimum": 1,
-                      "type": "integer"
-                    },
-                    "file_path": {
-                      "description": "Alias for `path`. Hits report this field name.",
-                      "minLength": 1,
-                      "type": "string"
-                    },
-                    "line": {
-                      "description": "Line of interest, 1-based, as returned in `line`. A window is returned around it.",
-                      "maximum": 1000000,
-                      "minimum": 1,
-                      "type": "integer"
-                    },
-                    "path": {
-                      "description": "Repository-relative file path, as returned in `file_path`.",
-                      "minLength": 1,
-                      "type": "string"
-                    },
-                    "start_line": {
-                      "description": "First line to return, 1-based. Alternative to `line`.",
-                      "maximum": 1000000,
-                      "minimum": 1,
-                      "type": "integer"
-                    }
+                "additionalProperties": false,
+                "description": "Return bounded source: either resolve one symbol, or read line ranges from files named by earlier evidence.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
                   },
-                  "required": [],
-                  "type": "object"
+                  "context": {
+                    "default": 4,
+                    "description": "Surrounding context lines above and below the selected source range.",
+                    "maximum": 200,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "end_line": {
+                    "description": "Last line to return with top-level `path`. Defaults to a bounded window after the start.",
+                    "maximum": 1000000,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "file_path": {
+                    "description": "Alias for `path`. Hits report this field name.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "function_body": {
+                    "description": "CLI-compatible scope selector; true requests `function_body`, false requests `line_context`.",
+                    "type": "boolean"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "line": {
+                    "description": "1-based line from a search, trail, or packet hit. Used with `path`.",
+                    "maximum": 1000000,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "lines": {
+                    "description": "Agent-friendly compatibility alias for `context`.",
+                    "maximum": 200,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "path": {
+                    "description": "Single-file alias for `paths`: repository-relative path as returned in `file_path`. Combine with `line`.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "paths": {
+                    "description": "File ranges to read in one call, instead of resolving a symbol. Line-numbered and bounded in total; use the paths and lines that search, trail, or packet already returned.",
+                    "items": {
+                      "allOf": [
+                        {
+                          "additionalProperties": false,
+                          "description": "One file range to read. Paste `file_path` and `line` straight from a search, trail, or packet hit.",
+                          "properties": {
+                            "end_line": {
+                              "description": "Last line to return, 1-based. Defaults to a bounded window after the start.",
+                              "maximum": 1000000,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "file_path": {
+                              "description": "Alias for `path`. Hits report this field name.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "line": {
+                              "description": "Line of interest, 1-based, as returned in `line`. A window is returned around it.",
+                              "maximum": 1000000,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "path": {
+                              "description": "Repository-relative file path, as returned in `file_path`.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "start_line": {
+                              "description": "First line to return, 1-based. Alternative to `line`.",
+                              "maximum": 1000000,
+                              "minimum": 1,
+                              "type": "integer"
+                            }
+                          },
+                          "required": [],
+                          "type": "object"
+                        },
+                        {
+                          "oneOf": [
+                            {
+                              "required": [
+                                "path"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "file_path"
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "scope": {
+                    "default": "line_context",
+                    "description": "Snippet scope.",
+                    "enum": [
+                      "line_context",
+                      "function_body"
+                    ],
+                    "type": "string"
+                  },
+                  "start_line": {
+                    "description": "First line to return with top-level `path`. Alternative to `line`.",
+                    "maximum": 1000000,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "symbol_id": {
+                    "description": "Alias for `id`. Hits report this field name.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
                 },
-                "type": "array"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "scope": {
-                "default": "line_context",
-                "description": "Snippet scope.",
-                "enum": [
-                  "line_context",
-                  "function_body"
+                "required": [
+                  "project"
                 ],
-                "type": "string"
+                "type": "object"
               },
-              "start_line": {
-                "description": "First line to return with top-level `path`. Alternative to `line`.",
-                "maximum": 1000000,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "symbol_id": {
-                "description": "Alias for `id`. Hits report this field name.",
-                "minLength": 1,
-                "type": "string"
+              {
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "paths"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "path"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "file_path"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "symbol_id"
+                    ]
+                  }
+                ]
               }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -10998,61 +11285,68 @@
           },
           "description": "Build closed source and graph evidence for one concrete target; not broad question answering.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Build a deep evidence packet for one concrete retrieval target.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Build a deep evidence packet for one concrete retrieval target.",
+                "properties": {
+                  "bookmark": {
+                    "description": "Saved bookmark id to build context around.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "Stable node id to build context around.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "include_evidence": {
+                    "default": true,
+                    "description": "Include citation edge ids and score details.",
+                    "type": "boolean"
+                  },
+                  "max_results": {
+                    "default": 8,
+                    "description": "Maximum retrieval results.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Concrete symbol, file, literal, API path, module, or behavior term.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
+                  "project"
+                ],
+                "type": "object"
               },
               {
-                "required": [
-                  "id"
-                ]
-              },
-              {
-                "required": [
-                  "bookmark"
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "bookmark"
+                    ]
+                  }
                 ]
               }
-            ],
-            "properties": {
-              "bookmark": {
-                "description": "Saved bookmark id to build context around.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "id": {
-                "description": "Stable node id to build context around.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "include_evidence": {
-                "default": true,
-                "description": "Include citation edge ids and score details.",
-                "type": "boolean"
-              },
-              "max_results": {
-                "default": 8,
-                "description": "Maximum retrieval results.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Concrete symbol, file, literal, API path, module, or behavior term.",
-                "minLength": 1,
-                "type": "string"
-              }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -11591,7 +11885,7 @@
       ]
     },
     "2025-11-25": {
-      "discoveryContractSha256": "e7e7304d0d3664f7f26467e79d67d6c9b8f7878ef471e8c57657b1dae38bb815",
+      "discoveryContractSha256": "bc504546354df593b0fced962f29299c2a700553e5d3d3310065b87b239b24f1",
       "tools": [
         {
           "_meta": {
@@ -14266,111 +14560,118 @@
           },
           "description": "Analyze one explicit path source against the last complete local index while preserving bounded stale and error evidence. Cold or partial state may trigger managed indexing before dispatch. Prefer paths, use changed_paths for compatibility or change_records for status-rich input. Never discovers git changes and does not wait for broad search.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Analyze exactly one explicit path source against the last complete local index.",
-            "oneOf": [
+            "allOf": [
               {
-                "required": [
-                  "paths"
-                ]
-              },
-              {
-                "required": [
-                  "changed_paths"
-                ]
-              },
-              {
-                "required": [
-                  "change_records"
-                ]
-              }
-            ],
-            "properties": {
-              "change_records": {
-                "description": "Changed file records with path, kind, optional status, and optional previous_path.",
-                "items": {
-                  "additionalProperties": false,
-                  "description": "Changed file record.",
-                  "properties": {
-                    "kind": {
-                      "description": "Change kind.",
-                      "enum": [
-                        "added",
-                        "modified",
-                        "deleted",
-                        "renamed",
-                        "copied",
-                        "untracked",
-                        "unknown"
+                "additionalProperties": false,
+                "description": "Analyze exactly one explicit path source against the last complete local index.",
+                "properties": {
+                  "change_records": {
+                    "description": "Changed file records with path, kind, optional status, and optional previous_path.",
+                    "items": {
+                      "additionalProperties": false,
+                      "description": "Changed file record.",
+                      "properties": {
+                        "kind": {
+                          "description": "Change kind.",
+                          "enum": [
+                            "added",
+                            "modified",
+                            "deleted",
+                            "renamed",
+                            "copied",
+                            "untracked",
+                            "unknown"
+                          ],
+                          "type": "string"
+                        },
+                        "path": {
+                          "description": "Changed repo-relative path.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "previous_path": {
+                          "description": "Optional previous path accepted only for renamed or copied records; it can seed bounded proxy graph evidence when the current path is not indexed.",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "status": {
+                          "description": "Optional raw git-style status such as M, A, D, R100, C100, or ??.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "path",
+                        "kind"
                       ],
-                      "type": "string"
+                      "type": "object"
                     },
-                    "path": {
-                      "description": "Changed repo-relative path.",
+                    "maxItems": 200,
+                    "minItems": 1,
+                    "type": "array"
+                  },
+                  "changed_paths": {
+                    "description": "Compatibility alias for project-relative paths to analyze.",
+                    "items": {
                       "minLength": 1,
                       "type": "string"
                     },
-                    "previous_path": {
-                      "description": "Optional previous path accepted only for renamed or copied records; it can seed bounded proxy graph evidence when the current path is not indexed.",
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "status": {
-                      "description": "Optional raw git-style status such as M, A, D, R100, C100, or ??.",
-                      "type": "string"
-                    }
+                    "maxItems": 200,
+                    "minItems": 1,
+                    "type": "array"
                   },
-                  "required": [
-                    "path",
-                    "kind"
-                  ],
-                  "type": "object"
+                  "depth": {
+                    "default": 2,
+                    "description": "Dependent graph walk depth.",
+                    "maximum": 8,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "filter": {
+                    "description": "Optional impacted-symbol filter by path or display-name substring.",
+                    "type": "string"
+                  },
+                  "paths": {
+                    "description": "Preferred simple input: project-relative paths to analyze.",
+                    "items": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "maxItems": 200,
+                    "minItems": 1,
+                    "type": "array"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
                 },
-                "maxItems": 200,
-                "minItems": 1,
-                "type": "array"
+                "required": [
+                  "project"
+                ],
+                "type": "object"
               },
-              "changed_paths": {
-                "description": "Compatibility alias for project-relative paths to analyze.",
-                "items": {
-                  "minLength": 1,
-                  "type": "string"
-                },
-                "maxItems": 200,
-                "minItems": 1,
-                "type": "array"
-              },
-              "depth": {
-                "default": 2,
-                "description": "Dependent graph walk depth.",
-                "maximum": 8,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "filter": {
-                "description": "Optional impacted-symbol filter by path or display-name substring.",
-                "type": "string"
-              },
-              "paths": {
-                "description": "Preferred simple input: project-relative paths to analyze.",
-                "items": {
-                  "minLength": 1,
-                  "type": "string"
-                },
-                "maxItems": 200,
-                "minItems": 1,
-                "type": "array"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
+              {
+                "oneOf": [
+                  {
+                    "required": [
+                      "paths"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "changed_paths"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "change_records"
+                    ]
+                  }
+                ]
               }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -15058,45 +15359,52 @@
           },
           "description": "Resolve a symbol id or query and return details.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Resolve a symbol by query or stable node id.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Resolve a symbol by query or stable node id.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
+                  "project"
+                ],
+                "type": "object"
               },
               {
-                "required": [
-                  "id"
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
                 ]
               }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
-              }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -15532,74 +15840,81 @@
           },
           "description": "Return a graph trail around a symbol.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Return a graph trail around a symbol id or query.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Return a graph trail around a symbol id or query.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "depth": {
+                    "default": 2,
+                    "description": "Trail depth.",
+                    "maximum": 10,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "direction": {
+                    "default": "both",
+                    "description": "Trail direction.",
+                    "enum": [
+                      "incoming",
+                      "outgoing",
+                      "both"
+                    ],
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "max_nodes": {
+                    "default": 120,
+                    "description": "Maximum graph nodes returned.",
+                    "maximum": 120,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "story": {
+                    "default": false,
+                    "description": "Include a readable trail story DTO.",
+                    "type": "boolean"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
-              },
-              {
-                "required": [
-                  "id"
-                ]
-              }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "depth": {
-                "default": 2,
-                "description": "Trail depth.",
-                "maximum": 10,
-                "minimum": 0,
-                "type": "integer"
-              },
-              "direction": {
-                "default": "both",
-                "description": "Trail direction.",
-                "enum": [
-                  "incoming",
-                  "outgoing",
-                  "both"
+                  "project"
                 ],
-                "type": "string"
+                "type": "object"
               },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "max_nodes": {
-                "default": 120,
-                "description": "Maximum graph nodes returned.",
-                "maximum": 120,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "story": {
-                "default": false,
-                "description": "Include a readable trail story DTO.",
-                "type": "boolean"
+              {
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
+                ]
               }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -15828,59 +16143,66 @@
           },
           "description": "Return a bounded incoming caller graph around a symbol.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Return a bounded local graph alias around one node.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Return a bounded local graph alias around one node.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "depth": {
+                    "default": 1,
+                    "description": "Graph depth.",
+                    "maximum": 3,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "max_nodes": {
+                    "default": 50,
+                    "description": "Maximum graph nodes returned.",
+                    "maximum": 120,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
+                  "project"
+                ],
+                "type": "object"
               },
               {
-                "required": [
-                  "id"
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
                 ]
               }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "depth": {
-                "default": 1,
-                "description": "Graph depth.",
-                "maximum": 3,
-                "minimum": 0,
-                "type": "integer"
-              },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "max_nodes": {
-                "default": 50,
-                "description": "Maximum graph nodes returned.",
-                "maximum": 120,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
-              }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -16150,59 +16472,66 @@
           },
           "description": "Return a bounded outgoing callee graph around a symbol.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Return a bounded local graph alias around one node.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Return a bounded local graph alias around one node.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "depth": {
+                    "default": 1,
+                    "description": "Graph depth.",
+                    "maximum": 3,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "max_nodes": {
+                    "default": 50,
+                    "description": "Maximum graph nodes returned.",
+                    "maximum": 120,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
+                  "project"
+                ],
+                "type": "object"
               },
               {
-                "required": [
-                  "id"
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
                 ]
               }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "depth": {
-                "default": 1,
-                "description": "Graph depth.",
-                "maximum": 3,
-                "minimum": 0,
-                "type": "integer"
-              },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "max_nodes": {
-                "default": 50,
-                "description": "Maximum graph nodes returned.",
-                "maximum": 120,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
-              }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -16472,74 +16801,81 @@
           },
           "description": "Return a readable trace around a symbol.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Return a readable trace around a symbol id or query.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Return a readable trace around a symbol id or query.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "depth": {
+                    "default": 2,
+                    "description": "Trail depth.",
+                    "maximum": 10,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "direction": {
+                    "default": "both",
+                    "description": "Trail direction.",
+                    "enum": [
+                      "incoming",
+                      "outgoing",
+                      "both"
+                    ],
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "max_nodes": {
+                    "default": 120,
+                    "description": "Maximum graph nodes returned.",
+                    "maximum": 120,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "story": {
+                    "default": true,
+                    "description": "Include a readable trail story DTO.",
+                    "type": "boolean"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
-              },
-              {
-                "required": [
-                  "id"
-                ]
-              }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "depth": {
-                "default": 2,
-                "description": "Trail depth.",
-                "maximum": 10,
-                "minimum": 0,
-                "type": "integer"
-              },
-              "direction": {
-                "default": "both",
-                "description": "Trail direction.",
-                "enum": [
-                  "incoming",
-                  "outgoing",
-                  "both"
+                  "project"
                 ],
-                "type": "string"
+                "type": "object"
               },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "max_nodes": {
-                "default": 120,
-                "description": "Maximum graph nodes returned.",
-                "maximum": 120,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "story": {
-                "default": true,
-                "description": "Include a readable trail story DTO.",
-                "type": "boolean"
+              {
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
+                ]
               }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -16768,45 +17104,52 @@
           },
           "description": "Return one stable graph node with file references for source inspection and relationship navigation.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Resolve a single indexed graph node by stable id or query.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Resolve a single indexed graph node by stable id or query.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
+                  "project"
+                ],
+                "type": "object"
               },
               {
-                "required": [
-                  "id"
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
                 ]
               }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
-              }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -17076,69 +17419,76 @@
           },
           "description": "Return a bounded graph neighborhood around one node.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Return a bounded graph neighborhood around one node.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Return a bounded graph neighborhood around one node.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "depth": {
+                    "default": 1,
+                    "description": "Graph depth.",
+                    "maximum": 3,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "direction": {
+                    "default": "both",
+                    "description": "Graph direction.",
+                    "enum": [
+                      "incoming",
+                      "outgoing",
+                      "both"
+                    ],
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "max_nodes": {
+                    "default": 50,
+                    "description": "Maximum graph nodes returned.",
+                    "maximum": 120,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
-              },
-              {
-                "required": [
-                  "id"
-                ]
-              }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "depth": {
-                "default": 1,
-                "description": "Graph depth.",
-                "maximum": 3,
-                "minimum": 0,
-                "type": "integer"
-              },
-              "direction": {
-                "default": "both",
-                "description": "Graph direction.",
-                "enum": [
-                  "incoming",
-                  "outgoing",
-                  "both"
+                  "project"
                 ],
-                "type": "string"
+                "type": "object"
               },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "max_nodes": {
-                "default": 50,
-                "description": "Maximum graph nodes returned.",
-                "maximum": 120,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
+              {
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
+                ]
               }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -17714,69 +18064,76 @@
           },
           "description": "Return a bounded subgraph around one resolved node for relationship navigation.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Return a bounded graph subgraph around one resolved node.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Return a bounded graph subgraph around one resolved node.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "depth": {
+                    "default": 2,
+                    "description": "Graph depth.",
+                    "maximum": 3,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "direction": {
+                    "default": "both",
+                    "description": "Graph direction.",
+                    "enum": [
+                      "incoming",
+                      "outgoing",
+                      "both"
+                    ],
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "max_nodes": {
+                    "default": 80,
+                    "description": "Maximum graph nodes returned.",
+                    "maximum": 120,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
-              },
-              {
-                "required": [
-                  "id"
-                ]
-              }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "depth": {
-                "default": 2,
-                "description": "Graph depth.",
-                "maximum": 3,
-                "minimum": 0,
-                "type": "integer"
-              },
-              "direction": {
-                "default": "both",
-                "description": "Graph direction.",
-                "enum": [
-                  "incoming",
-                  "outgoing",
-                  "both"
+                  "project"
                 ],
-                "type": "string"
+                "type": "object"
               },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "max_nodes": {
-                "default": 80,
-                "description": "Maximum graph nodes returned.",
-                "maximum": 120,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
+              {
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
+                ]
               }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -18046,45 +18403,52 @@
           },
           "description": "Return definition metadata for a symbol id or query.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Resolve a symbol by query or stable node id.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Resolve a symbol by query or stable node id.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
+                  "project"
+                ],
+                "type": "object"
               },
               {
-                "required": [
-                  "id"
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
                 ]
               }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
-              }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -18338,45 +18702,52 @@
           },
           "description": "Return incoming references for a symbol id or query.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Resolve a symbol by query or stable node id.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Resolve a symbol by query or stable node id.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
+                  "project"
+                ],
+                "type": "object"
               },
               {
-                "required": [
-                  "id"
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  }
                 ]
               }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
-              }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -18896,176 +19267,190 @@
           },
           "description": "Read line-numbered source for a selected symbol or path. Use `paths` to inspect several file ranges in one call; ordinary host source reads are also available.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Return bounded source: either resolve one symbol, or read line ranges from files named by earlier evidence.",
-            "oneOf": [
+            "allOf": [
               {
-                "required": [
-                  "query"
-                ]
-              },
-              {
-                "required": [
-                  "id"
-                ]
-              },
-              {
-                "required": [
-                  "paths"
-                ]
-              },
-              {
-                "required": [
-                  "path"
-                ]
-              },
-              {
-                "required": [
-                  "file_path"
-                ]
-              },
-              {
-                "required": [
-                  "symbol_id"
-                ]
-              }
-            ],
-            "properties": {
-              "choose": {
-                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "context": {
-                "default": 4,
-                "description": "Surrounding context lines above and below the selected source range.",
-                "maximum": 200,
-                "minimum": 0,
-                "type": "integer"
-              },
-              "end_line": {
-                "description": "Last line to return with top-level `path`. Defaults to a bounded window after the start.",
-                "maximum": 1000000,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "file_path": {
-                "description": "Alias for `path`. Hits report this field name.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "function_body": {
-                "description": "CLI-compatible scope selector; true requests `function_body`, false requests `line_context`.",
-                "type": "boolean"
-              },
-              "id": {
-                "description": "Stable node id.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "line": {
-                "description": "1-based line from a search, trail, or packet hit. Used with `path`.",
-                "maximum": 1000000,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "lines": {
-                "description": "Agent-friendly compatibility alias for `context`.",
-                "maximum": 200,
-                "minimum": 0,
-                "type": "integer"
-              },
-              "path": {
-                "description": "Single-file alias for `paths`: repository-relative path as returned in `file_path`. Combine with `line`.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "paths": {
-                "description": "File ranges to read in one call, instead of resolving a symbol. Line-numbered and bounded in total; use the paths and lines that search, trail, or packet already returned.",
-                "items": {
-                  "additionalProperties": false,
-                  "description": "One file range to read. Paste `file_path` and `line` straight from a search, trail, or packet hit.",
-                  "oneOf": [
-                    {
-                      "required": [
-                        "path"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "file_path"
-                      ]
-                    }
-                  ],
-                  "properties": {
-                    "end_line": {
-                      "description": "Last line to return, 1-based. Defaults to a bounded window after the start.",
-                      "maximum": 1000000,
-                      "minimum": 1,
-                      "type": "integer"
-                    },
-                    "file_path": {
-                      "description": "Alias for `path`. Hits report this field name.",
-                      "minLength": 1,
-                      "type": "string"
-                    },
-                    "line": {
-                      "description": "Line of interest, 1-based, as returned in `line`. A window is returned around it.",
-                      "maximum": 1000000,
-                      "minimum": 1,
-                      "type": "integer"
-                    },
-                    "path": {
-                      "description": "Repository-relative file path, as returned in `file_path`.",
-                      "minLength": 1,
-                      "type": "string"
-                    },
-                    "start_line": {
-                      "description": "First line to return, 1-based. Alternative to `line`.",
-                      "maximum": 1000000,
-                      "minimum": 1,
-                      "type": "integer"
-                    }
+                "additionalProperties": false,
+                "description": "Return bounded source: either resolve one symbol, or read line ranges from files named by earlier evidence.",
+                "properties": {
+                  "choose": {
+                    "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
                   },
-                  "required": [],
-                  "type": "object"
+                  "context": {
+                    "default": 4,
+                    "description": "Surrounding context lines above and below the selected source range.",
+                    "maximum": 200,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "end_line": {
+                    "description": "Last line to return with top-level `path`. Defaults to a bounded window after the start.",
+                    "maximum": 1000000,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "file_path": {
+                    "description": "Alias for `path`. Hits report this field name.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "function_body": {
+                    "description": "CLI-compatible scope selector; true requests `function_body`, false requests `line_context`.",
+                    "type": "boolean"
+                  },
+                  "id": {
+                    "description": "Stable node id.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "line": {
+                    "description": "1-based line from a search, trail, or packet hit. Used with `path`.",
+                    "maximum": 1000000,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "lines": {
+                    "description": "Agent-friendly compatibility alias for `context`.",
+                    "maximum": 200,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "path": {
+                    "description": "Single-file alias for `paths`: repository-relative path as returned in `file_path`. Combine with `line`.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "paths": {
+                    "description": "File ranges to read in one call, instead of resolving a symbol. Line-numbered and bounded in total; use the paths and lines that search, trail, or packet already returned.",
+                    "items": {
+                      "allOf": [
+                        {
+                          "additionalProperties": false,
+                          "description": "One file range to read. Paste `file_path` and `line` straight from a search, trail, or packet hit.",
+                          "properties": {
+                            "end_line": {
+                              "description": "Last line to return, 1-based. Defaults to a bounded window after the start.",
+                              "maximum": 1000000,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "file_path": {
+                              "description": "Alias for `path`. Hits report this field name.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "line": {
+                              "description": "Line of interest, 1-based, as returned in `line`. A window is returned around it.",
+                              "maximum": 1000000,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "path": {
+                              "description": "Repository-relative file path, as returned in `file_path`.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "start_line": {
+                              "description": "First line to return, 1-based. Alternative to `line`.",
+                              "maximum": 1000000,
+                              "minimum": 1,
+                              "type": "integer"
+                            }
+                          },
+                          "required": [],
+                          "type": "object"
+                        },
+                        {
+                          "oneOf": [
+                            {
+                              "required": [
+                                "path"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "file_path"
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Symbol query.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "scope": {
+                    "default": "line_context",
+                    "description": "Snippet scope.",
+                    "enum": [
+                      "line_context",
+                      "function_body"
+                    ],
+                    "type": "string"
+                  },
+                  "start_line": {
+                    "description": "First line to return with top-level `path`. Alternative to `line`.",
+                    "maximum": 1000000,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "symbol_id": {
+                    "description": "Alias for `id`. Hits report this field name.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
                 },
-                "type": "array"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Symbol query.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "scope": {
-                "default": "line_context",
-                "description": "Snippet scope.",
-                "enum": [
-                  "line_context",
-                  "function_body"
+                "required": [
+                  "project"
                 ],
-                "type": "string"
+                "type": "object"
               },
-              "start_line": {
-                "description": "First line to return with top-level `path`. Alternative to `line`.",
-                "maximum": 1000000,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "symbol_id": {
-                "description": "Alias for `id`. Hits report this field name.",
-                "minLength": 1,
-                "type": "string"
+              {
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "paths"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "path"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "file_path"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "symbol_id"
+                    ]
+                  }
+                ]
               }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -19383,61 +19768,68 @@
           },
           "description": "Build closed source and graph evidence for one concrete target; not broad question answering.",
           "inputSchema": {
-            "additionalProperties": false,
-            "description": "Build a deep evidence packet for one concrete retrieval target.",
-            "oneOf": [
+            "allOf": [
               {
+                "additionalProperties": false,
+                "description": "Build a deep evidence packet for one concrete retrieval target.",
+                "properties": {
+                  "bookmark": {
+                    "description": "Saved bookmark id to build context around.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "Stable node id to build context around.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "include_evidence": {
+                    "default": true,
+                    "description": "Include citation edge ids and score details.",
+                    "type": "boolean"
+                  },
+                  "max_results": {
+                    "default": 8,
+                    "description": "Maximum retrieval results.",
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "project": {
+                    "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Concrete symbol, file, literal, API path, module, or behavior term.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
                 "required": [
-                  "query"
-                ]
+                  "project"
+                ],
+                "type": "object"
               },
               {
-                "required": [
-                  "id"
-                ]
-              },
-              {
-                "required": [
-                  "bookmark"
+                "oneOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "bookmark"
+                    ]
+                  }
                 ]
               }
-            ],
-            "properties": {
-              "bookmark": {
-                "description": "Saved bookmark id to build context around.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "id": {
-                "description": "Stable node id to build context around.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "include_evidence": {
-                "default": true,
-                "description": "Include citation edge ids and score details.",
-                "type": "boolean"
-              },
-              "max_results": {
-                "default": 8,
-                "description": "Maximum retrieval results.",
-                "maximum": 50,
-                "minimum": 1,
-                "type": "integer"
-              },
-              "project": {
-                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-                "minLength": 1,
-                "type": "string"
-              },
-              "query": {
-                "description": "Concrete symbol, file, literal, API path, module, or behavior term.",
-                "minLength": 1,
-                "type": "string"
-              }
-            },
-            "required": [
-              "project"
             ],
             "type": "object"
           },
@@ -22650,111 +23042,118 @@
       },
       "description": "Analyze one explicit path source against the last complete local index while preserving bounded stale and error evidence. Cold or partial state may trigger managed indexing before dispatch. Prefer paths, use changed_paths for compatibility or change_records for status-rich input. Never discovers git changes and does not wait for broad search.",
       "inputSchema": {
-        "additionalProperties": false,
-        "description": "Analyze exactly one explicit path source against the last complete local index.",
-        "oneOf": [
+        "allOf": [
           {
-            "required": [
-              "paths"
-            ]
-          },
-          {
-            "required": [
-              "changed_paths"
-            ]
-          },
-          {
-            "required": [
-              "change_records"
-            ]
-          }
-        ],
-        "properties": {
-          "change_records": {
-            "description": "Changed file records with path, kind, optional status, and optional previous_path.",
-            "items": {
-              "additionalProperties": false,
-              "description": "Changed file record.",
-              "properties": {
-                "kind": {
-                  "description": "Change kind.",
-                  "enum": [
-                    "added",
-                    "modified",
-                    "deleted",
-                    "renamed",
-                    "copied",
-                    "untracked",
-                    "unknown"
+            "additionalProperties": false,
+            "description": "Analyze exactly one explicit path source against the last complete local index.",
+            "properties": {
+              "change_records": {
+                "description": "Changed file records with path, kind, optional status, and optional previous_path.",
+                "items": {
+                  "additionalProperties": false,
+                  "description": "Changed file record.",
+                  "properties": {
+                    "kind": {
+                      "description": "Change kind.",
+                      "enum": [
+                        "added",
+                        "modified",
+                        "deleted",
+                        "renamed",
+                        "copied",
+                        "untracked",
+                        "unknown"
+                      ],
+                      "type": "string"
+                    },
+                    "path": {
+                      "description": "Changed repo-relative path.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "previous_path": {
+                      "description": "Optional previous path accepted only for renamed or copied records; it can seed bounded proxy graph evidence when the current path is not indexed.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "status": {
+                      "description": "Optional raw git-style status such as M, A, D, R100, C100, or ??.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "path",
+                    "kind"
                   ],
-                  "type": "string"
+                  "type": "object"
                 },
-                "path": {
-                  "description": "Changed repo-relative path.",
+                "maxItems": 200,
+                "minItems": 1,
+                "type": "array"
+              },
+              "changed_paths": {
+                "description": "Compatibility alias for project-relative paths to analyze.",
+                "items": {
                   "minLength": 1,
                   "type": "string"
                 },
-                "previous_path": {
-                  "description": "Optional previous path accepted only for renamed or copied records; it can seed bounded proxy graph evidence when the current path is not indexed.",
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "status": {
-                  "description": "Optional raw git-style status such as M, A, D, R100, C100, or ??.",
-                  "type": "string"
-                }
+                "maxItems": 200,
+                "minItems": 1,
+                "type": "array"
               },
-              "required": [
-                "path",
-                "kind"
-              ],
-              "type": "object"
+              "depth": {
+                "default": 2,
+                "description": "Dependent graph walk depth.",
+                "maximum": 8,
+                "minimum": 1,
+                "type": "integer"
+              },
+              "filter": {
+                "description": "Optional impacted-symbol filter by path or display-name substring.",
+                "type": "string"
+              },
+              "paths": {
+                "description": "Preferred simple input: project-relative paths to analyze.",
+                "items": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "maxItems": 200,
+                "minItems": 1,
+                "type": "array"
+              },
+              "project": {
+                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                "minLength": 1,
+                "type": "string"
+              }
             },
-            "maxItems": 200,
-            "minItems": 1,
-            "type": "array"
+            "required": [
+              "project"
+            ],
+            "type": "object"
           },
-          "changed_paths": {
-            "description": "Compatibility alias for project-relative paths to analyze.",
-            "items": {
-              "minLength": 1,
-              "type": "string"
-            },
-            "maxItems": 200,
-            "minItems": 1,
-            "type": "array"
-          },
-          "depth": {
-            "default": 2,
-            "description": "Dependent graph walk depth.",
-            "maximum": 8,
-            "minimum": 1,
-            "type": "integer"
-          },
-          "filter": {
-            "description": "Optional impacted-symbol filter by path or display-name substring.",
-            "type": "string"
-          },
-          "paths": {
-            "description": "Preferred simple input: project-relative paths to analyze.",
-            "items": {
-              "minLength": 1,
-              "type": "string"
-            },
-            "maxItems": 200,
-            "minItems": 1,
-            "type": "array"
-          },
-          "project": {
-            "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-            "minLength": 1,
-            "type": "string"
+          {
+            "oneOf": [
+              {
+                "required": [
+                  "paths"
+                ]
+              },
+              {
+                "required": [
+                  "changed_paths"
+                ]
+              },
+              {
+                "required": [
+                  "change_records"
+                ]
+              }
+            ]
           }
-        },
-        "required": [
-          "project"
         ],
         "type": "object"
       },
@@ -23442,45 +23841,52 @@
       },
       "description": "Resolve a symbol id or query and return details.",
       "inputSchema": {
-        "additionalProperties": false,
-        "description": "Resolve a symbol by query or stable node id.",
-        "oneOf": [
+        "allOf": [
           {
+            "additionalProperties": false,
+            "description": "Resolve a symbol by query or stable node id.",
+            "properties": {
+              "choose": {
+                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                "maximum": 50,
+                "minimum": 1,
+                "type": "integer"
+              },
+              "id": {
+                "description": "Stable node id.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "project": {
+                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "query": {
+                "description": "Symbol query.",
+                "minLength": 1,
+                "type": "string"
+              }
+            },
             "required": [
-              "query"
-            ]
+              "project"
+            ],
+            "type": "object"
           },
           {
-            "required": [
-              "id"
+            "oneOf": [
+              {
+                "required": [
+                  "query"
+                ]
+              },
+              {
+                "required": [
+                  "id"
+                ]
+              }
             ]
           }
-        ],
-        "properties": {
-          "choose": {
-            "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-            "maximum": 50,
-            "minimum": 1,
-            "type": "integer"
-          },
-          "id": {
-            "description": "Stable node id.",
-            "minLength": 1,
-            "type": "string"
-          },
-          "project": {
-            "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-            "minLength": 1,
-            "type": "string"
-          },
-          "query": {
-            "description": "Symbol query.",
-            "minLength": 1,
-            "type": "string"
-          }
-        },
-        "required": [
-          "project"
         ],
         "type": "object"
       },
@@ -23916,74 +24322,81 @@
       },
       "description": "Return a graph trail around a symbol.",
       "inputSchema": {
-        "additionalProperties": false,
-        "description": "Return a graph trail around a symbol id or query.",
-        "oneOf": [
+        "allOf": [
           {
+            "additionalProperties": false,
+            "description": "Return a graph trail around a symbol id or query.",
+            "properties": {
+              "choose": {
+                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                "maximum": 50,
+                "minimum": 1,
+                "type": "integer"
+              },
+              "depth": {
+                "default": 2,
+                "description": "Trail depth.",
+                "maximum": 10,
+                "minimum": 0,
+                "type": "integer"
+              },
+              "direction": {
+                "default": "both",
+                "description": "Trail direction.",
+                "enum": [
+                  "incoming",
+                  "outgoing",
+                  "both"
+                ],
+                "type": "string"
+              },
+              "id": {
+                "description": "Stable node id.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "max_nodes": {
+                "default": 120,
+                "description": "Maximum graph nodes returned.",
+                "maximum": 120,
+                "minimum": 1,
+                "type": "integer"
+              },
+              "project": {
+                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "query": {
+                "description": "Symbol query.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "story": {
+                "default": false,
+                "description": "Include a readable trail story DTO.",
+                "type": "boolean"
+              }
+            },
             "required": [
-              "query"
-            ]
-          },
-          {
-            "required": [
-              "id"
-            ]
-          }
-        ],
-        "properties": {
-          "choose": {
-            "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-            "maximum": 50,
-            "minimum": 1,
-            "type": "integer"
-          },
-          "depth": {
-            "default": 2,
-            "description": "Trail depth.",
-            "maximum": 10,
-            "minimum": 0,
-            "type": "integer"
-          },
-          "direction": {
-            "default": "both",
-            "description": "Trail direction.",
-            "enum": [
-              "incoming",
-              "outgoing",
-              "both"
+              "project"
             ],
-            "type": "string"
+            "type": "object"
           },
-          "id": {
-            "description": "Stable node id.",
-            "minLength": 1,
-            "type": "string"
-          },
-          "max_nodes": {
-            "default": 120,
-            "description": "Maximum graph nodes returned.",
-            "maximum": 120,
-            "minimum": 1,
-            "type": "integer"
-          },
-          "project": {
-            "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-            "minLength": 1,
-            "type": "string"
-          },
-          "query": {
-            "description": "Symbol query.",
-            "minLength": 1,
-            "type": "string"
-          },
-          "story": {
-            "default": false,
-            "description": "Include a readable trail story DTO.",
-            "type": "boolean"
+          {
+            "oneOf": [
+              {
+                "required": [
+                  "query"
+                ]
+              },
+              {
+                "required": [
+                  "id"
+                ]
+              }
+            ]
           }
-        },
-        "required": [
-          "project"
         ],
         "type": "object"
       },
@@ -24212,59 +24625,66 @@
       },
       "description": "Return a bounded incoming caller graph around a symbol.",
       "inputSchema": {
-        "additionalProperties": false,
-        "description": "Return a bounded local graph alias around one node.",
-        "oneOf": [
+        "allOf": [
           {
+            "additionalProperties": false,
+            "description": "Return a bounded local graph alias around one node.",
+            "properties": {
+              "choose": {
+                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                "maximum": 50,
+                "minimum": 1,
+                "type": "integer"
+              },
+              "depth": {
+                "default": 1,
+                "description": "Graph depth.",
+                "maximum": 3,
+                "minimum": 0,
+                "type": "integer"
+              },
+              "id": {
+                "description": "Stable node id.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "max_nodes": {
+                "default": 50,
+                "description": "Maximum graph nodes returned.",
+                "maximum": 120,
+                "minimum": 1,
+                "type": "integer"
+              },
+              "project": {
+                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "query": {
+                "description": "Symbol query.",
+                "minLength": 1,
+                "type": "string"
+              }
+            },
             "required": [
-              "query"
-            ]
+              "project"
+            ],
+            "type": "object"
           },
           {
-            "required": [
-              "id"
+            "oneOf": [
+              {
+                "required": [
+                  "query"
+                ]
+              },
+              {
+                "required": [
+                  "id"
+                ]
+              }
             ]
           }
-        ],
-        "properties": {
-          "choose": {
-            "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-            "maximum": 50,
-            "minimum": 1,
-            "type": "integer"
-          },
-          "depth": {
-            "default": 1,
-            "description": "Graph depth.",
-            "maximum": 3,
-            "minimum": 0,
-            "type": "integer"
-          },
-          "id": {
-            "description": "Stable node id.",
-            "minLength": 1,
-            "type": "string"
-          },
-          "max_nodes": {
-            "default": 50,
-            "description": "Maximum graph nodes returned.",
-            "maximum": 120,
-            "minimum": 1,
-            "type": "integer"
-          },
-          "project": {
-            "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-            "minLength": 1,
-            "type": "string"
-          },
-          "query": {
-            "description": "Symbol query.",
-            "minLength": 1,
-            "type": "string"
-          }
-        },
-        "required": [
-          "project"
         ],
         "type": "object"
       },
@@ -24534,59 +24954,66 @@
       },
       "description": "Return a bounded outgoing callee graph around a symbol.",
       "inputSchema": {
-        "additionalProperties": false,
-        "description": "Return a bounded local graph alias around one node.",
-        "oneOf": [
+        "allOf": [
           {
+            "additionalProperties": false,
+            "description": "Return a bounded local graph alias around one node.",
+            "properties": {
+              "choose": {
+                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                "maximum": 50,
+                "minimum": 1,
+                "type": "integer"
+              },
+              "depth": {
+                "default": 1,
+                "description": "Graph depth.",
+                "maximum": 3,
+                "minimum": 0,
+                "type": "integer"
+              },
+              "id": {
+                "description": "Stable node id.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "max_nodes": {
+                "default": 50,
+                "description": "Maximum graph nodes returned.",
+                "maximum": 120,
+                "minimum": 1,
+                "type": "integer"
+              },
+              "project": {
+                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "query": {
+                "description": "Symbol query.",
+                "minLength": 1,
+                "type": "string"
+              }
+            },
             "required": [
-              "query"
-            ]
+              "project"
+            ],
+            "type": "object"
           },
           {
-            "required": [
-              "id"
+            "oneOf": [
+              {
+                "required": [
+                  "query"
+                ]
+              },
+              {
+                "required": [
+                  "id"
+                ]
+              }
             ]
           }
-        ],
-        "properties": {
-          "choose": {
-            "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-            "maximum": 50,
-            "minimum": 1,
-            "type": "integer"
-          },
-          "depth": {
-            "default": 1,
-            "description": "Graph depth.",
-            "maximum": 3,
-            "minimum": 0,
-            "type": "integer"
-          },
-          "id": {
-            "description": "Stable node id.",
-            "minLength": 1,
-            "type": "string"
-          },
-          "max_nodes": {
-            "default": 50,
-            "description": "Maximum graph nodes returned.",
-            "maximum": 120,
-            "minimum": 1,
-            "type": "integer"
-          },
-          "project": {
-            "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-            "minLength": 1,
-            "type": "string"
-          },
-          "query": {
-            "description": "Symbol query.",
-            "minLength": 1,
-            "type": "string"
-          }
-        },
-        "required": [
-          "project"
         ],
         "type": "object"
       },
@@ -24856,74 +25283,81 @@
       },
       "description": "Return a readable trace around a symbol.",
       "inputSchema": {
-        "additionalProperties": false,
-        "description": "Return a readable trace around a symbol id or query.",
-        "oneOf": [
+        "allOf": [
           {
+            "additionalProperties": false,
+            "description": "Return a readable trace around a symbol id or query.",
+            "properties": {
+              "choose": {
+                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                "maximum": 50,
+                "minimum": 1,
+                "type": "integer"
+              },
+              "depth": {
+                "default": 2,
+                "description": "Trail depth.",
+                "maximum": 10,
+                "minimum": 0,
+                "type": "integer"
+              },
+              "direction": {
+                "default": "both",
+                "description": "Trail direction.",
+                "enum": [
+                  "incoming",
+                  "outgoing",
+                  "both"
+                ],
+                "type": "string"
+              },
+              "id": {
+                "description": "Stable node id.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "max_nodes": {
+                "default": 120,
+                "description": "Maximum graph nodes returned.",
+                "maximum": 120,
+                "minimum": 1,
+                "type": "integer"
+              },
+              "project": {
+                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "query": {
+                "description": "Symbol query.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "story": {
+                "default": true,
+                "description": "Include a readable trail story DTO.",
+                "type": "boolean"
+              }
+            },
             "required": [
-              "query"
-            ]
-          },
-          {
-            "required": [
-              "id"
-            ]
-          }
-        ],
-        "properties": {
-          "choose": {
-            "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-            "maximum": 50,
-            "minimum": 1,
-            "type": "integer"
-          },
-          "depth": {
-            "default": 2,
-            "description": "Trail depth.",
-            "maximum": 10,
-            "minimum": 0,
-            "type": "integer"
-          },
-          "direction": {
-            "default": "both",
-            "description": "Trail direction.",
-            "enum": [
-              "incoming",
-              "outgoing",
-              "both"
+              "project"
             ],
-            "type": "string"
+            "type": "object"
           },
-          "id": {
-            "description": "Stable node id.",
-            "minLength": 1,
-            "type": "string"
-          },
-          "max_nodes": {
-            "default": 120,
-            "description": "Maximum graph nodes returned.",
-            "maximum": 120,
-            "minimum": 1,
-            "type": "integer"
-          },
-          "project": {
-            "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-            "minLength": 1,
-            "type": "string"
-          },
-          "query": {
-            "description": "Symbol query.",
-            "minLength": 1,
-            "type": "string"
-          },
-          "story": {
-            "default": true,
-            "description": "Include a readable trail story DTO.",
-            "type": "boolean"
+          {
+            "oneOf": [
+              {
+                "required": [
+                  "query"
+                ]
+              },
+              {
+                "required": [
+                  "id"
+                ]
+              }
+            ]
           }
-        },
-        "required": [
-          "project"
         ],
         "type": "object"
       },
@@ -25152,45 +25586,52 @@
       },
       "description": "Return one stable graph node with file references for source inspection and relationship navigation.",
       "inputSchema": {
-        "additionalProperties": false,
-        "description": "Resolve a single indexed graph node by stable id or query.",
-        "oneOf": [
+        "allOf": [
           {
+            "additionalProperties": false,
+            "description": "Resolve a single indexed graph node by stable id or query.",
+            "properties": {
+              "choose": {
+                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                "maximum": 50,
+                "minimum": 1,
+                "type": "integer"
+              },
+              "id": {
+                "description": "Stable node id.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "project": {
+                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "query": {
+                "description": "Symbol query.",
+                "minLength": 1,
+                "type": "string"
+              }
+            },
             "required": [
-              "query"
-            ]
+              "project"
+            ],
+            "type": "object"
           },
           {
-            "required": [
-              "id"
+            "oneOf": [
+              {
+                "required": [
+                  "query"
+                ]
+              },
+              {
+                "required": [
+                  "id"
+                ]
+              }
             ]
           }
-        ],
-        "properties": {
-          "choose": {
-            "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-            "maximum": 50,
-            "minimum": 1,
-            "type": "integer"
-          },
-          "id": {
-            "description": "Stable node id.",
-            "minLength": 1,
-            "type": "string"
-          },
-          "project": {
-            "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-            "minLength": 1,
-            "type": "string"
-          },
-          "query": {
-            "description": "Symbol query.",
-            "minLength": 1,
-            "type": "string"
-          }
-        },
-        "required": [
-          "project"
         ],
         "type": "object"
       },
@@ -25460,69 +25901,76 @@
       },
       "description": "Return a bounded graph neighborhood around one node.",
       "inputSchema": {
-        "additionalProperties": false,
-        "description": "Return a bounded graph neighborhood around one node.",
-        "oneOf": [
+        "allOf": [
           {
+            "additionalProperties": false,
+            "description": "Return a bounded graph neighborhood around one node.",
+            "properties": {
+              "choose": {
+                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                "maximum": 50,
+                "minimum": 1,
+                "type": "integer"
+              },
+              "depth": {
+                "default": 1,
+                "description": "Graph depth.",
+                "maximum": 3,
+                "minimum": 0,
+                "type": "integer"
+              },
+              "direction": {
+                "default": "both",
+                "description": "Graph direction.",
+                "enum": [
+                  "incoming",
+                  "outgoing",
+                  "both"
+                ],
+                "type": "string"
+              },
+              "id": {
+                "description": "Stable node id.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "max_nodes": {
+                "default": 50,
+                "description": "Maximum graph nodes returned.",
+                "maximum": 120,
+                "minimum": 1,
+                "type": "integer"
+              },
+              "project": {
+                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "query": {
+                "description": "Symbol query.",
+                "minLength": 1,
+                "type": "string"
+              }
+            },
             "required": [
-              "query"
-            ]
-          },
-          {
-            "required": [
-              "id"
-            ]
-          }
-        ],
-        "properties": {
-          "choose": {
-            "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-            "maximum": 50,
-            "minimum": 1,
-            "type": "integer"
-          },
-          "depth": {
-            "default": 1,
-            "description": "Graph depth.",
-            "maximum": 3,
-            "minimum": 0,
-            "type": "integer"
-          },
-          "direction": {
-            "default": "both",
-            "description": "Graph direction.",
-            "enum": [
-              "incoming",
-              "outgoing",
-              "both"
+              "project"
             ],
-            "type": "string"
+            "type": "object"
           },
-          "id": {
-            "description": "Stable node id.",
-            "minLength": 1,
-            "type": "string"
-          },
-          "max_nodes": {
-            "default": 50,
-            "description": "Maximum graph nodes returned.",
-            "maximum": 120,
-            "minimum": 1,
-            "type": "integer"
-          },
-          "project": {
-            "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-            "minLength": 1,
-            "type": "string"
-          },
-          "query": {
-            "description": "Symbol query.",
-            "minLength": 1,
-            "type": "string"
+          {
+            "oneOf": [
+              {
+                "required": [
+                  "query"
+                ]
+              },
+              {
+                "required": [
+                  "id"
+                ]
+              }
+            ]
           }
-        },
-        "required": [
-          "project"
         ],
         "type": "object"
       },
@@ -26098,69 +26546,76 @@
       },
       "description": "Return a bounded subgraph around one resolved node for relationship navigation.",
       "inputSchema": {
-        "additionalProperties": false,
-        "description": "Return a bounded graph subgraph around one resolved node.",
-        "oneOf": [
+        "allOf": [
           {
+            "additionalProperties": false,
+            "description": "Return a bounded graph subgraph around one resolved node.",
+            "properties": {
+              "choose": {
+                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                "maximum": 50,
+                "minimum": 1,
+                "type": "integer"
+              },
+              "depth": {
+                "default": 2,
+                "description": "Graph depth.",
+                "maximum": 3,
+                "minimum": 0,
+                "type": "integer"
+              },
+              "direction": {
+                "default": "both",
+                "description": "Graph direction.",
+                "enum": [
+                  "incoming",
+                  "outgoing",
+                  "both"
+                ],
+                "type": "string"
+              },
+              "id": {
+                "description": "Stable node id.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "max_nodes": {
+                "default": 80,
+                "description": "Maximum graph nodes returned.",
+                "maximum": 120,
+                "minimum": 1,
+                "type": "integer"
+              },
+              "project": {
+                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "query": {
+                "description": "Symbol query.",
+                "minLength": 1,
+                "type": "string"
+              }
+            },
             "required": [
-              "query"
-            ]
-          },
-          {
-            "required": [
-              "id"
-            ]
-          }
-        ],
-        "properties": {
-          "choose": {
-            "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-            "maximum": 50,
-            "minimum": 1,
-            "type": "integer"
-          },
-          "depth": {
-            "default": 2,
-            "description": "Graph depth.",
-            "maximum": 3,
-            "minimum": 0,
-            "type": "integer"
-          },
-          "direction": {
-            "default": "both",
-            "description": "Graph direction.",
-            "enum": [
-              "incoming",
-              "outgoing",
-              "both"
+              "project"
             ],
-            "type": "string"
+            "type": "object"
           },
-          "id": {
-            "description": "Stable node id.",
-            "minLength": 1,
-            "type": "string"
-          },
-          "max_nodes": {
-            "default": 80,
-            "description": "Maximum graph nodes returned.",
-            "maximum": 120,
-            "minimum": 1,
-            "type": "integer"
-          },
-          "project": {
-            "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-            "minLength": 1,
-            "type": "string"
-          },
-          "query": {
-            "description": "Symbol query.",
-            "minLength": 1,
-            "type": "string"
+          {
+            "oneOf": [
+              {
+                "required": [
+                  "query"
+                ]
+              },
+              {
+                "required": [
+                  "id"
+                ]
+              }
+            ]
           }
-        },
-        "required": [
-          "project"
         ],
         "type": "object"
       },
@@ -26430,45 +26885,52 @@
       },
       "description": "Return definition metadata for a symbol id or query.",
       "inputSchema": {
-        "additionalProperties": false,
-        "description": "Resolve a symbol by query or stable node id.",
-        "oneOf": [
+        "allOf": [
           {
+            "additionalProperties": false,
+            "description": "Resolve a symbol by query or stable node id.",
+            "properties": {
+              "choose": {
+                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                "maximum": 50,
+                "minimum": 1,
+                "type": "integer"
+              },
+              "id": {
+                "description": "Stable node id.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "project": {
+                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "query": {
+                "description": "Symbol query.",
+                "minLength": 1,
+                "type": "string"
+              }
+            },
             "required": [
-              "query"
-            ]
+              "project"
+            ],
+            "type": "object"
           },
           {
-            "required": [
-              "id"
+            "oneOf": [
+              {
+                "required": [
+                  "query"
+                ]
+              },
+              {
+                "required": [
+                  "id"
+                ]
+              }
             ]
           }
-        ],
-        "properties": {
-          "choose": {
-            "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-            "maximum": 50,
-            "minimum": 1,
-            "type": "integer"
-          },
-          "id": {
-            "description": "Stable node id.",
-            "minLength": 1,
-            "type": "string"
-          },
-          "project": {
-            "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-            "minLength": 1,
-            "type": "string"
-          },
-          "query": {
-            "description": "Symbol query.",
-            "minLength": 1,
-            "type": "string"
-          }
-        },
-        "required": [
-          "project"
         ],
         "type": "object"
       },
@@ -26722,45 +27184,52 @@
       },
       "description": "Return incoming references for a symbol id or query.",
       "inputSchema": {
-        "additionalProperties": false,
-        "description": "Resolve a symbol by query or stable node id.",
-        "oneOf": [
+        "allOf": [
           {
+            "additionalProperties": false,
+            "description": "Resolve a symbol by query or stable node id.",
+            "properties": {
+              "choose": {
+                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                "maximum": 50,
+                "minimum": 1,
+                "type": "integer"
+              },
+              "id": {
+                "description": "Stable node id.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "project": {
+                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "query": {
+                "description": "Symbol query.",
+                "minLength": 1,
+                "type": "string"
+              }
+            },
             "required": [
-              "query"
-            ]
+              "project"
+            ],
+            "type": "object"
           },
           {
-            "required": [
-              "id"
+            "oneOf": [
+              {
+                "required": [
+                  "query"
+                ]
+              },
+              {
+                "required": [
+                  "id"
+                ]
+              }
             ]
           }
-        ],
-        "properties": {
-          "choose": {
-            "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-            "maximum": 50,
-            "minimum": 1,
-            "type": "integer"
-          },
-          "id": {
-            "description": "Stable node id.",
-            "minLength": 1,
-            "type": "string"
-          },
-          "project": {
-            "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-            "minLength": 1,
-            "type": "string"
-          },
-          "query": {
-            "description": "Symbol query.",
-            "minLength": 1,
-            "type": "string"
-          }
-        },
-        "required": [
-          "project"
         ],
         "type": "object"
       },
@@ -27280,176 +27749,190 @@
       },
       "description": "Read line-numbered source for a selected symbol or path. Use `paths` to inspect several file ranges in one call; ordinary host source reads are also available.",
       "inputSchema": {
-        "additionalProperties": false,
-        "description": "Return bounded source: either resolve one symbol, or read line ranges from files named by earlier evidence.",
-        "oneOf": [
+        "allOf": [
           {
-            "required": [
-              "query"
-            ]
-          },
-          {
-            "required": [
-              "id"
-            ]
-          },
-          {
-            "required": [
-              "paths"
-            ]
-          },
-          {
-            "required": [
-              "path"
-            ]
-          },
-          {
-            "required": [
-              "file_path"
-            ]
-          },
-          {
-            "required": [
-              "symbol_id"
-            ]
-          }
-        ],
-        "properties": {
-          "choose": {
-            "description": "Resolve by the 1-based alternative number from an ambiguity error.",
-            "maximum": 50,
-            "minimum": 1,
-            "type": "integer"
-          },
-          "context": {
-            "default": 4,
-            "description": "Surrounding context lines above and below the selected source range.",
-            "maximum": 200,
-            "minimum": 0,
-            "type": "integer"
-          },
-          "end_line": {
-            "description": "Last line to return with top-level `path`. Defaults to a bounded window after the start.",
-            "maximum": 1000000,
-            "minimum": 1,
-            "type": "integer"
-          },
-          "file_path": {
-            "description": "Alias for `path`. Hits report this field name.",
-            "minLength": 1,
-            "type": "string"
-          },
-          "function_body": {
-            "description": "CLI-compatible scope selector; true requests `function_body`, false requests `line_context`.",
-            "type": "boolean"
-          },
-          "id": {
-            "description": "Stable node id.",
-            "minLength": 1,
-            "type": "string"
-          },
-          "line": {
-            "description": "1-based line from a search, trail, or packet hit. Used with `path`.",
-            "maximum": 1000000,
-            "minimum": 1,
-            "type": "integer"
-          },
-          "lines": {
-            "description": "Agent-friendly compatibility alias for `context`.",
-            "maximum": 200,
-            "minimum": 0,
-            "type": "integer"
-          },
-          "path": {
-            "description": "Single-file alias for `paths`: repository-relative path as returned in `file_path`. Combine with `line`.",
-            "minLength": 1,
-            "type": "string"
-          },
-          "paths": {
-            "description": "File ranges to read in one call, instead of resolving a symbol. Line-numbered and bounded in total; use the paths and lines that search, trail, or packet already returned.",
-            "items": {
-              "additionalProperties": false,
-              "description": "One file range to read. Paste `file_path` and `line` straight from a search, trail, or packet hit.",
-              "oneOf": [
-                {
-                  "required": [
-                    "path"
-                  ]
-                },
-                {
-                  "required": [
-                    "file_path"
-                  ]
-                }
-              ],
-              "properties": {
-                "end_line": {
-                  "description": "Last line to return, 1-based. Defaults to a bounded window after the start.",
-                  "maximum": 1000000,
-                  "minimum": 1,
-                  "type": "integer"
-                },
-                "file_path": {
-                  "description": "Alias for `path`. Hits report this field name.",
-                  "minLength": 1,
-                  "type": "string"
-                },
-                "line": {
-                  "description": "Line of interest, 1-based, as returned in `line`. A window is returned around it.",
-                  "maximum": 1000000,
-                  "minimum": 1,
-                  "type": "integer"
-                },
-                "path": {
-                  "description": "Repository-relative file path, as returned in `file_path`.",
-                  "minLength": 1,
-                  "type": "string"
-                },
-                "start_line": {
-                  "description": "First line to return, 1-based. Alternative to `line`.",
-                  "maximum": 1000000,
-                  "minimum": 1,
-                  "type": "integer"
-                }
+            "additionalProperties": false,
+            "description": "Return bounded source: either resolve one symbol, or read line ranges from files named by earlier evidence.",
+            "properties": {
+              "choose": {
+                "description": "Resolve by the 1-based alternative number from an ambiguity error.",
+                "maximum": 50,
+                "minimum": 1,
+                "type": "integer"
               },
-              "required": [],
-              "type": "object"
+              "context": {
+                "default": 4,
+                "description": "Surrounding context lines above and below the selected source range.",
+                "maximum": 200,
+                "minimum": 0,
+                "type": "integer"
+              },
+              "end_line": {
+                "description": "Last line to return with top-level `path`. Defaults to a bounded window after the start.",
+                "maximum": 1000000,
+                "minimum": 1,
+                "type": "integer"
+              },
+              "file_path": {
+                "description": "Alias for `path`. Hits report this field name.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "function_body": {
+                "description": "CLI-compatible scope selector; true requests `function_body`, false requests `line_context`.",
+                "type": "boolean"
+              },
+              "id": {
+                "description": "Stable node id.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "line": {
+                "description": "1-based line from a search, trail, or packet hit. Used with `path`.",
+                "maximum": 1000000,
+                "minimum": 1,
+                "type": "integer"
+              },
+              "lines": {
+                "description": "Agent-friendly compatibility alias for `context`.",
+                "maximum": 200,
+                "minimum": 0,
+                "type": "integer"
+              },
+              "path": {
+                "description": "Single-file alias for `paths`: repository-relative path as returned in `file_path`. Combine with `line`.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "paths": {
+                "description": "File ranges to read in one call, instead of resolving a symbol. Line-numbered and bounded in total; use the paths and lines that search, trail, or packet already returned.",
+                "items": {
+                  "allOf": [
+                    {
+                      "additionalProperties": false,
+                      "description": "One file range to read. Paste `file_path` and `line` straight from a search, trail, or packet hit.",
+                      "properties": {
+                        "end_line": {
+                          "description": "Last line to return, 1-based. Defaults to a bounded window after the start.",
+                          "maximum": 1000000,
+                          "minimum": 1,
+                          "type": "integer"
+                        },
+                        "file_path": {
+                          "description": "Alias for `path`. Hits report this field name.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "line": {
+                          "description": "Line of interest, 1-based, as returned in `line`. A window is returned around it.",
+                          "maximum": 1000000,
+                          "minimum": 1,
+                          "type": "integer"
+                        },
+                        "path": {
+                          "description": "Repository-relative file path, as returned in `file_path`.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "start_line": {
+                          "description": "First line to return, 1-based. Alternative to `line`.",
+                          "maximum": 1000000,
+                          "minimum": 1,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [],
+                      "type": "object"
+                    },
+                    {
+                      "oneOf": [
+                        {
+                          "required": [
+                            "path"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "file_path"
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "project": {
+                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "query": {
+                "description": "Symbol query.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "scope": {
+                "default": "line_context",
+                "description": "Snippet scope.",
+                "enum": [
+                  "line_context",
+                  "function_body"
+                ],
+                "type": "string"
+              },
+              "start_line": {
+                "description": "First line to return with top-level `path`. Alternative to `line`.",
+                "maximum": 1000000,
+                "minimum": 1,
+                "type": "integer"
+              },
+              "symbol_id": {
+                "description": "Alias for `id`. Hits report this field name.",
+                "minLength": 1,
+                "type": "string"
+              }
             },
-            "type": "array"
-          },
-          "project": {
-            "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-            "minLength": 1,
-            "type": "string"
-          },
-          "query": {
-            "description": "Symbol query.",
-            "minLength": 1,
-            "type": "string"
-          },
-          "scope": {
-            "default": "line_context",
-            "description": "Snippet scope.",
-            "enum": [
-              "line_context",
-              "function_body"
+            "required": [
+              "project"
             ],
-            "type": "string"
+            "type": "object"
           },
-          "start_line": {
-            "description": "First line to return with top-level `path`. Alternative to `line`.",
-            "maximum": 1000000,
-            "minimum": 1,
-            "type": "integer"
-          },
-          "symbol_id": {
-            "description": "Alias for `id`. Hits report this field name.",
-            "minLength": 1,
-            "type": "string"
+          {
+            "oneOf": [
+              {
+                "required": [
+                  "query"
+                ]
+              },
+              {
+                "required": [
+                  "id"
+                ]
+              },
+              {
+                "required": [
+                  "paths"
+                ]
+              },
+              {
+                "required": [
+                  "path"
+                ]
+              },
+              {
+                "required": [
+                  "file_path"
+                ]
+              },
+              {
+                "required": [
+                  "symbol_id"
+                ]
+              }
+            ]
           }
-        },
-        "required": [
-          "project"
         ],
         "type": "object"
       },
@@ -27767,61 +28250,68 @@
       },
       "description": "Build closed source and graph evidence for one concrete target; not broad question answering.",
       "inputSchema": {
-        "additionalProperties": false,
-        "description": "Build a deep evidence packet for one concrete retrieval target.",
-        "oneOf": [
+        "allOf": [
           {
+            "additionalProperties": false,
+            "description": "Build a deep evidence packet for one concrete retrieval target.",
+            "properties": {
+              "bookmark": {
+                "description": "Saved bookmark id to build context around.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "id": {
+                "description": "Stable node id to build context around.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "include_evidence": {
+                "default": true,
+                "description": "Include citation edge ids and score details.",
+                "type": "boolean"
+              },
+              "max_results": {
+                "default": 8,
+                "description": "Maximum retrieval results.",
+                "maximum": 50,
+                "minimum": 1,
+                "type": "integer"
+              },
+              "project": {
+                "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "query": {
+                "description": "Concrete symbol, file, literal, API path, module, or behavior term.",
+                "minLength": 1,
+                "type": "string"
+              }
+            },
             "required": [
-              "query"
-            ]
+              "project"
+            ],
+            "type": "object"
           },
           {
-            "required": [
-              "id"
-            ]
-          },
-          {
-            "required": [
-              "bookmark"
+            "oneOf": [
+              {
+                "required": [
+                  "query"
+                ]
+              },
+              {
+                "required": [
+                  "id"
+                ]
+              },
+              {
+                "required": [
+                  "bookmark"
+                ]
+              }
             ]
           }
-        ],
-        "properties": {
-          "bookmark": {
-            "description": "Saved bookmark id to build context around.",
-            "minLength": 1,
-            "type": "string"
-          },
-          "id": {
-            "description": "Stable node id to build context around.",
-            "minLength": 1,
-            "type": "string"
-          },
-          "include_evidence": {
-            "default": true,
-            "description": "Include citation edge ids and score details.",
-            "type": "boolean"
-          },
-          "max_results": {
-            "default": 8,
-            "description": "Maximum retrieval results.",
-            "maximum": 50,
-            "minimum": 1,
-            "type": "integer"
-          },
-          "project": {
-            "description": "Absolute repository root for this request. The MCP server is multi-project and does not retain a global workspace binding.",
-            "minLength": 1,
-            "type": "string"
-          },
-          "query": {
-            "description": "Concrete symbol, file, literal, API path, module, or behavior term.",
-            "minLength": 1,
-            "type": "string"
-          }
-        },
-        "required": [
-          "project"
         ],
         "type": "object"
       },

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -4353,14 +4353,12 @@ function validatePublishedSchemaValue(schema, value, pointer = '/arguments') {
     }
   }
   if (Array.isArray(schema.allOf)) {
-    const failed = schema.allOf.find((constraint) => !publishedSchemaAccepts(constraint, value));
-    if (failed) {
-      if (schema.allOf.length === 1) {
-        violations.push(...validatePublishedSchemaValue(failed, value, pointer));
-      } else {
-        const names = Array.isArray(failed?.not?.required)
-          ? failed.not.required.map((name) => `\`${name}\``).join(' and ')
-          : '';
+    const combinedBudget = schema.allOf.length > 1
+      && schema.allOf.every((constraint) => Array.isArray(constraint?.not?.required));
+    if (combinedBudget) {
+      const failed = schema.allOf.find((constraint) => !publishedSchemaAccepts(constraint, value));
+      if (failed) {
+        const names = failed.not.required.map((name) => `\`${name}\``).join(' and ');
         violations.push(publishedSchemaViolation(
           names ? 'combined_item_limit' : 'unsatisfied_all_of',
           pointer,
@@ -4368,6 +4366,10 @@ function validatePublishedSchemaValue(schema, value, pointer = '/arguments') {
             ? `${names} may hold at most ${schema.allOf.length} item(s) together`
             : 'value violates a declared combined constraint',
         ));
+      }
+    } else {
+      for (const constraint of schema.allOf) {
+        violations.push(...validatePublishedSchemaValue(constraint, value, pointer));
       }
     }
   }

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -179,7 +179,7 @@ test("fail-open tool schemas are the generated canonical MCP catalog", async () 
   );
   const snippet = catalog.tools.find(({ name }) => name === "snippet");
   assert.deepEqual(
-    Object.keys(snippet.inputSchema.properties).sort(),
+    Object.keys(snippet.inputSchema.allOf[0].properties).sort(),
     ["choose", "context", "end_line", "file_path", "function_body", "id", "line", "lines", "path", "paths", "project", "query", "scope", "start_line", "symbol_id"],
   );
 });
@@ -661,6 +661,28 @@ test("fail-open schema interpreter covers const anyOf and allOf", () => {
   const violations = validate(schema, { kind: "wrong", value: "forbidden" }, "/arguments");
   assert.ok(violations.some(({ code, pointer }) => code === "invalid_const_value" && pointer === "/arguments/kind"));
   assert.ok(violations.some(({ code, pointer }) => code === "forbidden_combination" && pointer === "/arguments"));
+});
+
+test("composed selectors preserve argument diagnostics and project routing", () => {
+  const common = {
+    type: "object", additionalProperties: false, required: ["project"],
+    properties: {
+      project: { type: "string", minLength: 1 },
+      id: { type: "string", minLength: 1 },
+      query: { type: "string", minLength: 1 },
+    },
+  };
+  const selector = { oneOf: [{ required: ["id"] }, { required: ["query"] }] };
+  const flat = { ...common, ...selector };
+  const composed = { type: "object", allOf: [common, selector] };
+  const validate = launcherTest.validatePublishedSchemaValue;
+  for (const value of [null, [], 1, "x", {}, { id: "a" }, { project: "", id: "" },
+    { project: "/repo", id: "a", query: "b", extra: true }, { project: "/repo", query: "b" }]) {
+    assert.deepEqual(validate(composed, value), validate(flat, value), JSON.stringify(value));
+  }
+  const nestedFlat = { type: "array", items: flat };
+  const nestedComposed = { type: "array", items: composed };
+  assert.deepEqual(validate(nestedComposed, [{ id: "" }, 2]), validate(nestedFlat, [{ id: "" }, 2]));
 });
 
 test("fail-open schema validation covers every generated input keyword", () => {


### PR DESCRIPTION
Thirteen navigation tools publish selector-only `oneOf` branches alongside common arguments. Codex 0.153.4 projects those declarations as unknown-key unions, hiding `project`, named arguments and nested snippet ranges. The canonical emitter now puts common fields and selector constraints in a compact `allOf` composition. Native and launcher validation preserve leaf diagnostics, project routing, aliases and combined item limits while enforcing that published schema.

Review `stdio_catalog.rs` for input-only composition and `stdio_arguments.rs` plus the launcher for validation. The catalog is regenerated from the compiled CLI; all twenty tools, protocol profiles, output schemas and guidance remain unchanged. The outer object type preserves scalar rejection; tagged unions and schema-shaped default values are left intact.

Source head: `2e5c441e19315af2377cbd325f5e6c06d76386f3`; tree: `dadf13545852da9f3a1e6a4fe5dd3ccf60dafec3`; base: `c7134b54016a4ce491b15cb4b59b01024bd2f640`. Worktree: `/Users/albert/.codex/worktrees/0176-schema-projection/CodeStory`. Root owns implementation and native checks; an independent verifier owns the hostile compatibility matrix. This PR stays draft until exact-head review and required CI pass.

Validation completed on these source bytes:

- 32 native argument tests and seven catalog tests passed.
- Complete stdio protocol suite: 66 passed. Its initial run had a schema-inspection helper that assumed root properties (updated for composition), and an intermittent cold-search reply missing `tool`; the latter passed unchanged on isolated and concurrent full-suite reruns. The failure is retained and is not claimed fixed here.
- Plugin and installer suite: 148 passed, one platform skip. Catalog regeneration check and `git diff --check` passed.
- Before the change, the launcher regression collapsed missing-project and selector diagnostics into `unsatisfied_all_of`; the same test now preserves both precise errors.

Actual Codex mock-provider evidence already restores all thirteen named-field sets for this composition without real model calls. The exact pushed head passed independent hostile acceptance: 36,445 actual launcher executions with zero acceptance, diagnostic or error-envelope mismatches; all thirteen candidate schemas exactly equal the actual-host fixture schemas (65 profile/default bindings). Root verified all 28 acceptance-artifact bindings. The matrix also retained 633 dormant combined-limit cases and 400 alias memberships. Native tests were executed by root and bound by the reviewer; they were not independently reexecuted. All five applicable CI checks passed on this exact head; the Windows manifest placeholder was skipped. Selector exclusivity still does not render as a precise TypeScript union. No input-token saving, maintenance-panel pass, breadth quality, installed-candidate or release claim is made. Broad release proof remains deferred until unified source convergence.

Closes #2177
Refs #2135
Refs #2173
