### PR TITLE
[codex] expose test caller scope in MCP graph tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+MCP graph navigation (`trail`, `trace`, `callers`, `callees`, `neighbors`,
+`query_subgraph`, `shortest_path`) accepts `caller_scope` so agents can include
+test and bench callers. The default stays production-only, and empty results
+describe that filtered view instead of claiming no graph edges were indexed.
+
 Code-mode hosts can see named navigation arguments, including project routing
 and snippet ranges, when a tool accepts alternative selectors.
 

--- a/crates/codestory-cli/src/app/source_commands/trail.rs
+++ b/crates/codestory-cli/src/app/source_commands/trail.rs
@@ -2,13 +2,17 @@ use super::super::artifacts::preflight_output_file;
 use super::super::rendering::build_query_resolution_output_with_runtime;
 use super::super::resolution::resolve_target_or_emit_ambiguity;
 use crate::args;
-use crate::args::{CliDirection, CliTrailMode, TrailCommand, TrailJsonOutput, build_trail_request};
+use crate::args::{
+    CliDirection, CliTrailMode, TrailCommand, TrailJsonOutput, build_trail_request,
+    trail_caller_scope_wire_label,
+};
 use crate::output::{
     RenderedPublicOutput, emit_public_operation, render_trail_dot, render_trail_markdown,
     render_trail_mermaid, render_trail_story_markdown,
 };
 use crate::runtime::{RuntimeContext, ensure_index_ready, map_api_error};
 use anyhow::{Result, bail};
+use codestory_contracts::api::TrailCallerScope;
 use std::fmt::Write as _;
 
 pub(in crate::app) fn run_trail(cmd: TrailCommand) -> Result<()> {
@@ -38,6 +42,7 @@ pub(in crate::app) fn run_trail(cmd: TrailCommand) -> Result<()> {
             cmd.output_file.as_deref(),
         )?;
         let request = build_trail_request(&target.selected.node_id, &cmd);
+        let caller_scope = request.caller_scope;
         let context = runtime
             .browser
             .trail_context(request)
@@ -52,7 +57,7 @@ pub(in crate::app) fn run_trail(cmd: TrailCommand) -> Result<()> {
                 &context,
             )));
         }
-        let notes = trail_guidance_notes(&context);
+        let notes = trail_guidance_notes(&context, caller_scope);
         let mut markdown = if let Some(story) = context.story.as_ref() {
             render_trail_story_markdown(&runtime.project_root, &target, &context, &cmd, story)
         } else {
@@ -67,6 +72,7 @@ pub(in crate::app) fn run_trail(cmd: TrailCommand) -> Result<()> {
         let output = TrailJsonOutput {
             resolution,
             trail: &context,
+            caller_scope: trail_caller_scope_wire_label(caller_scope),
             notes,
         };
         RenderedPublicOutput::structured(&output, markdown)
@@ -95,6 +101,7 @@ pub(in crate::app) fn run_trace(mut cmd: TrailCommand) -> Result<()> {
 
 pub(super) fn trail_guidance_notes(
     context: &codestory_contracts::api::TrailContextDto,
+    caller_scope: TrailCallerScope,
 ) -> Vec<String> {
     if !context.trail.edges.is_empty() || context.trail.nodes.len() > 1 {
         return Vec::new();
@@ -102,8 +109,114 @@ pub(super) fn trail_guidance_notes(
     if context.focus.file_path.is_none() {
         return Vec::new();
     }
+    let (scope_label, control) = match caller_scope {
+        TrailCallerScope::ProductionOnly => (
+            "production-only caller scope (tests and benches excluded)",
+            "Pass --include-tests to include test and benchmark callers",
+        ),
+        TrailCallerScope::IncludeTestsAndBenches => (
+            "include-tests-and-benches caller scope",
+            "This view already includes test and benchmark callers",
+        ),
+    };
     vec![format!(
-        "No graph edges were indexed for `{}`. For object/config exports, use `snippet --id {}` or `explore --id {}` to inspect fields, hooks, access rules, and imports.",
-        context.focus.display_name, context.focus.id.0, context.focus.id.0
+        "Returned {scope_label} for `{}`. {control}. This filtered view is not a claim that no graph edges were indexed. truncated={} omitted_edge_count={}.",
+        context.focus.display_name, context.trail.truncated, context.trail.omitted_edge_count
     )]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codestory_contracts::api::{
+        GraphNodeDto, GraphResponse, NodeDetailsDto, NodeId, NodeKind, TrailCallerScope,
+        TrailContextDto,
+    };
+
+    fn empty_focus_trail(truncated: bool, omitted_edge_count: u32) -> TrailContextDto {
+        let id = NodeId("9196608968427629473".to_string());
+        TrailContextDto {
+            focus: NodeDetailsDto {
+                id: id.clone(),
+                kind: NodeKind::FUNCTION,
+                display_name: "test_entry".to_string(),
+                serialized_name: "test_entry".to_string(),
+                qualified_name: Some("test_entry".to_string()),
+                canonical_id: None,
+                file_path: Some("tests/test_flow.py".to_string()),
+                start_line: Some(4),
+                start_col: Some(1),
+                end_line: Some(5),
+                end_col: Some(18),
+                evidence_tier: None,
+                evidence_producer: None,
+                resolution_status: None,
+                member_access: None,
+                route_endpoint: None,
+            },
+            trail: GraphResponse {
+                center_id: id.clone(),
+                nodes: vec![GraphNodeDto {
+                    id,
+                    label: "test_entry".to_string(),
+                    kind: NodeKind::FUNCTION,
+                    depth: 0,
+                    label_policy: None,
+                    badge_visible_members: None,
+                    badge_total_members: None,
+                    merged_symbol_examples: Vec::new(),
+                    file_path: Some("tests/test_flow.py".to_string()),
+                    qualified_name: Some("test_entry".to_string()),
+                    member_access: None,
+                }],
+                edges: Vec::new(),
+                truncated,
+                omitted_edge_count,
+                canonical_layout: None,
+            },
+            story: None,
+        }
+    }
+
+    #[test]
+    fn production_only_empty_view_does_not_claim_edges_were_unindexed() {
+        let notes = trail_guidance_notes(
+            &empty_focus_trail(false, 0),
+            TrailCallerScope::ProductionOnly,
+        );
+        assert_eq!(notes.len(), 1, "{notes:?}");
+        assert!(
+            notes[0].contains("production-only") && notes[0].contains("--include-tests"),
+            "{notes:?}"
+        );
+        assert!(
+            !notes[0].contains("No graph edges were indexed"),
+            "{notes:?}"
+        );
+        assert!(
+            notes[0].contains("truncated=false") && notes[0].contains("omitted_edge_count=0"),
+            "filtering must stay distinct from truncation: {notes:?}"
+        );
+    }
+
+    #[test]
+    fn include_tests_empty_view_does_not_invent_omitted_counts() {
+        let notes = trail_guidance_notes(
+            &empty_focus_trail(true, 4),
+            TrailCallerScope::IncludeTestsAndBenches,
+        );
+        assert_eq!(notes.len(), 1, "{notes:?}");
+        assert!(
+            notes[0].contains("include-tests") || notes[0].contains("tests and benches"),
+            "{notes:?}"
+        );
+        assert!(
+            notes[0].contains("truncated=true") && notes[0].contains("omitted_edge_count=4"),
+            "{notes:?}"
+        );
+        assert!(
+            !notes[0].contains("No graph edges were indexed"),
+            "{notes:?}"
+        );
+    }
 }

--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -1894,6 +1894,7 @@ pub(crate) struct SymbolJsonOutput<'a> {
 pub(crate) struct TrailJsonOutput<'a> {
     pub(crate) resolution: QueryResolutionOutput,
     pub(crate) trail: &'a TrailContextDto,
+    pub(crate) caller_scope: &'static str,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub(crate) notes: Vec<String>,
 }
@@ -2604,6 +2605,13 @@ pub(crate) fn build_trail_request(
     cmd: &TrailCommand,
 ) -> codestory_contracts::api::TrailConfigDto {
     build_trail_request_impl(root_id, cmd)
+}
+
+pub(crate) fn trail_caller_scope_wire_label(scope: TrailCallerScope) -> &'static str {
+    match scope {
+        TrailCallerScope::ProductionOnly => "production_only",
+        TrailCallerScope::IncludeTestsAndBenches => "include_tests_and_benches",
+    }
 }
 
 fn build_trail_request_impl(

--- a/crates/codestory-cli/src/http_transport.rs
+++ b/crates/codestory-cli/src/http_transport.rs
@@ -279,6 +279,7 @@ pub(crate) fn handle_http_request(
                         depth,
                         direction,
                         story,
+                        TrailCallerScope::ProductionOnly,
                     ))
                     .map_err(map_api_error)
             }) {
@@ -435,6 +436,7 @@ pub(crate) fn browser_trail_config(
     depth: u32,
     direction: TrailDirection,
     story: bool,
+    caller_scope: TrailCallerScope,
 ) -> TrailConfigDto {
     TrailConfigDto {
         root_id,
@@ -442,7 +444,7 @@ pub(crate) fn browser_trail_config(
         target_id: None,
         depth,
         direction,
-        caller_scope: TrailCallerScope::ProductionOnly,
+        caller_scope,
         edge_filter: Vec::new(),
         show_utility_calls: false,
         hide_speculative: false,

--- a/crates/codestory-cli/src/stdio_catalog.rs
+++ b/crates/codestory-cli/src/stdio_catalog.rs
@@ -813,6 +813,13 @@ const PACKET_EVIDENCE_RESOLUTIONS: &[&str] = &[
     "diagnostic_only",
 ];
 const SEARCH_REPO_TEXT_MODES: &[&str] = &["auto", "on", "off"];
+const GRAPH_CALLER_SCOPES: &[&str] = &["production_only", "include_tests_and_benches"];
+const GRAPH_CALLER_SCOPE_PROPERTY: SchemaProperty = SchemaProperty::string(
+    "caller_scope",
+    "CALL-edge caller file scope. Omitted or production_only hides test and bench callers; include_tests_and_benches includes them. Filtering is not truncation and does not invent omitted-edge counts.",
+)
+.with_enum(GRAPH_CALLER_SCOPES)
+.with_default(ValueLiteral::String("production_only"));
 const INDEXED_FILE_ROLES: &[&str] = &["source", "test", "generated", "vendor", "unknown"];
 const SNIPPET_SCOPES: &[&str] = &["line_context", "function_body"];
 const GROUNDING_BUDGETS: &[&str] = &["strict", "balanced", "max"];
@@ -1566,6 +1573,11 @@ static TRAIL_CONTEXT_SCHEMA: SchemaObject = SchemaObject::object(
         SchemaProperty::object("focus", "Focused node details DTO."),
         SchemaProperty::object("trail", "Graph response DTO."),
         SchemaProperty::object("story", "Optional readable trail story DTO.").nullable(),
+        SchemaProperty::string(
+            "caller_scope",
+            "Applied CALL-edge caller file scope for this filtered view.",
+        )
+        .with_enum(GRAPH_CALLER_SCOPES),
     ],
     &["focus", "trail"],
 );
@@ -1586,6 +1598,15 @@ static GRAPH_TOOL_OUTPUT_SCHEMA: SchemaObject = SchemaObject::object(
         SchemaProperty::integer("node_count", "Returned node count."),
         SchemaProperty::integer("edge_count", "Returned edge count."),
         SchemaProperty::boolean("truncated", "Whether the graph result was truncated."),
+        SchemaProperty::string(
+            "caller_scope",
+            "Applied CALL-edge caller file scope for this filtered view.",
+        )
+        .with_enum(GRAPH_CALLER_SCOPES),
+        SchemaProperty::string("from_id", "Shortest-path source node id, when applicable.")
+            .nullable(),
+        SchemaProperty::string("to_id", "Shortest-path target node id, when applicable.")
+            .nullable(),
     ],
     &[
         "certainty",
@@ -1877,6 +1898,7 @@ static TRAIL_INPUT_SCHEMA: SchemaObject = SchemaObject::object(
             .with_bounds(1, 120),
         SchemaProperty::boolean("story", "Include a readable trail story DTO.")
             .with_default(ValueLiteral::Boolean(false)),
+        GRAPH_CALLER_SCOPE_PROPERTY,
     ],
     &[],
 )
@@ -1898,6 +1920,7 @@ static LOCAL_GRAPH_ALIAS_INPUT_SCHEMA: SchemaObject = SchemaObject::object(
         SchemaProperty::integer("max_nodes", "Maximum graph nodes returned.")
             .with_default(ValueLiteral::Integer(50))
             .with_bounds(1, 120),
+        GRAPH_CALLER_SCOPE_PROPERTY,
     ],
     &[],
 )
@@ -1924,6 +1947,7 @@ static TRACE_INPUT_SCHEMA: SchemaObject = SchemaObject::object(
             .with_bounds(1, 120),
         SchemaProperty::boolean("story", "Include a readable trail story DTO.")
             .with_default(ValueLiteral::Boolean(true)),
+        GRAPH_CALLER_SCOPE_PROPERTY,
     ],
     &[],
 )
@@ -2079,6 +2103,7 @@ static GRAPH_NEIGHBORS_INPUT_SCHEMA: SchemaObject = SchemaObject::object(
         SchemaProperty::integer("max_nodes", "Maximum graph nodes returned.")
             .with_default(ValueLiteral::Integer(50))
             .with_bounds(1, 120),
+        GRAPH_CALLER_SCOPE_PROPERTY,
     ],
     &[],
 )
@@ -2095,6 +2120,7 @@ static SHORTEST_PATH_INPUT_SCHEMA: SchemaObject = SchemaObject::object(
         SchemaProperty::integer("max_nodes", "Maximum graph nodes returned.")
             .with_default(ValueLiteral::Integer(80))
             .with_bounds(2, 120),
+        GRAPH_CALLER_SCOPE_PROPERTY,
     ],
     &["from_id", "to_id"],
 );
@@ -2118,6 +2144,7 @@ static QUERY_SUBGRAPH_INPUT_SCHEMA: SchemaObject = SchemaObject::object(
         SchemaProperty::integer("max_nodes", "Maximum graph nodes returned.")
             .with_default(ValueLiteral::Integer(80))
             .with_bounds(1, 120),
+        GRAPH_CALLER_SCOPE_PROPERTY,
     ],
     &[],
 )
@@ -3152,6 +3179,68 @@ mod tests {
         assert!(
             satisfies_required_any_of(&schema, &payload),
             "files success payload must satisfy an anyOf required branch: {schema}"
+        );
+    }
+
+    fn graph_schema_property<'a>(schema: &'a Value, name: &str) -> &'a Value {
+        schema
+            .pointer(&format!("/properties/{name}"))
+            .or_else(|| {
+                schema
+                    .get("allOf")
+                    .and_then(Value::as_array)
+                    .and_then(|branches| {
+                        branches
+                            .iter()
+                            .find_map(|branch| branch.pointer(&format!("/properties/{name}")))
+                    })
+            })
+            .unwrap_or_else(|| panic!("missing property {name}: {schema}"))
+    }
+
+    #[test]
+    fn graph_tools_advertise_caller_scope_with_production_only_default() {
+        let catalog = tools_list_json();
+        let tools = catalog["result"]["tools"].as_array().expect("tools");
+        let expected = json!(["production_only", "include_tests_and_benches"]);
+        for name in [
+            "trail",
+            "trace",
+            "callers",
+            "callees",
+            "neighbors",
+            "query_subgraph",
+            "shortest_path",
+        ] {
+            let tool = tools
+                .iter()
+                .find(|tool| tool["name"] == name)
+                .unwrap_or_else(|| panic!("{name}"));
+            let scope = graph_schema_property(&tool["inputSchema"], "caller_scope");
+            assert_eq!(
+                scope["enum"], expected,
+                "{name} must publish the runtime caller-scope choice: {scope}"
+            );
+            assert_eq!(
+                scope.get("default"),
+                Some(&json!("production_only")),
+                "{name} must keep production-only as the documented default: {scope}"
+            );
+            let output = graph_schema_property(&tool["outputSchema"], "caller_scope");
+            assert_eq!(
+                output["enum"], expected,
+                "{name} output must make the applied caller scope visible: {output}"
+            );
+        }
+        let get_node = tools
+            .iter()
+            .find(|tool| tool["name"] == "get_node")
+            .expect("get_node");
+        assert!(
+            get_node["inputSchema"]["properties"]
+                .get("caller_scope")
+                .is_none(),
+            "get_node is not a caller-scoped graph walk: {get_node}"
         );
     }
 }

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -4961,13 +4961,29 @@ fn handle_stdio_trail(
         .pointer("/params/arguments/story")
         .and_then(|value| value.as_bool())
         .unwrap_or(default_story);
+    let caller_scope = stdio_graph_caller_scope(request);
     resolve_target(runtime, stdio_target_selection(request), None)
         .and_then(|target| {
-            let mut config = browser_trail_config(target.selected.node_id, depth, direction, story);
+            let mut config = browser_trail_config(
+                target.selected.node_id,
+                depth,
+                direction,
+                story,
+                caller_scope,
+            );
             config.max_nodes = max_nodes;
             runtime.browser.trail_context(config).map_err(map_api_error)
         })
-        .map(|result| serde_json::json!({"result": result}))
+        .map(|result| {
+            let mut value = serde_json::to_value(result).unwrap_or(serde_json::Value::Null);
+            if let Some(object) = value.as_object_mut() {
+                object.insert(
+                    "caller_scope".to_string(),
+                    serde_json::json!(args::trail_caller_scope_wire_label(caller_scope)),
+                );
+            }
+            serde_json::json!({"result": value})
+        })
         .unwrap_or_else(
             |error| serde_json::json!({"error": stdio_typed_error_value(runtime, &error)}),
         )
@@ -5066,10 +5082,16 @@ fn handle_stdio_neighbors(
     let direction = fixed_direction.unwrap_or_else(|| stdio_graph_direction(request));
     let depth = stdio_graph_u32_arg(request, "depth", default_depth, 0, 3);
     let max_nodes = stdio_graph_u32_arg(request, "max_nodes", default_max_nodes, 1, 120);
+    let caller_scope = stdio_graph_caller_scope(request);
     resolve_target(runtime, stdio_target_selection(request), None)
         .and_then(|target| {
-            let mut config =
-                browser_trail_config(target.selected.node_id.clone(), depth, direction, false);
+            let mut config = browser_trail_config(
+                target.selected.node_id.clone(),
+                depth,
+                direction,
+                false,
+                caller_scope,
+            );
             config.max_nodes = max_nodes;
             runtime
                 .browser
@@ -5089,8 +5111,10 @@ fn handle_stdio_neighbors(
                             "direction": stdio_graph_direction_label(direction),
                             "depth": depth,
                             "max_nodes": max_nodes,
-                            "max_edges": max_nodes.saturating_mul(3).max(128)
+                            "max_edges": max_nodes.saturating_mul(3).max(128),
+                            "caller_scope": args::trail_caller_scope_wire_label(caller_scope)
                         }),
+                        caller_scope,
                     )
                 })
         })
@@ -5114,6 +5138,7 @@ fn handle_stdio_shortest_path(
     };
     let max_depth = stdio_graph_u32_arg(request, "max_depth", 6, 1, 10);
     let max_nodes = stdio_graph_u32_arg(request, "max_nodes", 80, 2, 120);
+    let caller_scope = stdio_graph_caller_scope(request);
     let from = NodeId(from_id.to_string());
     let to = NodeId(to_id.to_string());
     if let Err(error) = runtime
@@ -5136,7 +5161,7 @@ fn handle_stdio_shortest_path(
             target_id: Some(to.clone()),
             depth: max_depth,
             direction: TrailDirection::Outgoing,
-            caller_scope: TrailCallerScope::ProductionOnly,
+            caller_scope,
             edge_filter: Vec::new(),
             show_utility_calls: false,
             hide_speculative: false,
@@ -5154,8 +5179,10 @@ fn handle_stdio_shortest_path(
                     "direction": "outgoing",
                     "max_depth": max_depth,
                     "max_nodes": max_nodes,
-                    "max_edges": max_nodes.saturating_mul(3).max(128)
+                    "max_edges": max_nodes.saturating_mul(3).max(128),
+                    "caller_scope": args::trail_caller_scope_wire_label(caller_scope)
                 }),
+                caller_scope,
             );
             if let Some(object) = output.as_object_mut() {
                 object.insert("from_id".to_string(), serde_json::json!(from.0.as_str()));
@@ -5384,6 +5411,16 @@ fn stdio_graph_direction_label(direction: TrailDirection) -> &'static str {
     }
 }
 
+fn stdio_graph_caller_scope(request: &serde_json::Value) -> TrailCallerScope {
+    match request
+        .pointer("/params/arguments/caller_scope")
+        .and_then(|value| value.as_str())
+    {
+        Some("include_tests_and_benches") => TrailCallerScope::IncludeTestsAndBenches,
+        _ => TrailCallerScope::ProductionOnly,
+    }
+}
+
 fn stdio_graph_u32_arg(
     request: &serde_json::Value,
     name: &str,
@@ -5410,6 +5447,7 @@ fn stdio_graph_tool_output(
     resolution: serde_json::Value,
     graph: GraphResponse,
     limits: serde_json::Value,
+    caller_scope: TrailCallerScope,
 ) -> serde_json::Value {
     let file_refs = stdio_graph_file_refs(&graph);
     let node_count = graph.nodes.len();
@@ -5424,6 +5462,7 @@ fn stdio_graph_tool_output(
         "node_count": node_count,
         "edge_count": edge_count,
         "truncated": truncated,
+        "caller_scope": args::trail_caller_scope_wire_label(caller_scope),
     })
 }
 
@@ -7642,6 +7681,7 @@ fn read_stdio_template_resource(
                 BROWSER_TRAIL_DEFAULT_DEPTH,
                 TrailDirection::Both,
                 false,
+                TrailCallerScope::ProductionOnly,
             ))
             .map(|value| serde_json::json!(value))
             .map_err(map_api_error),

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -3079,6 +3079,27 @@ fn tool_catalog_input_schemas_capture_stable_arguments() {
         Some(&json!(false)),
         "trail.story should document the stdio default: {trail}"
     );
+    for name in [
+        "trail",
+        "trace",
+        "callers",
+        "callees",
+        "neighbors",
+        "query_subgraph",
+        "shortest_path",
+    ] {
+        let schema = tool_input_schema(&tools, name);
+        assert_eq!(
+            schema_property(schema, "caller_scope")["enum"],
+            json!(["production_only", "include_tests_and_benches"]),
+            "{name}.caller_scope must publish the runtime caller-scope choice: {schema}"
+        );
+        assert_eq!(
+            schema_property(schema, "caller_scope").get("default"),
+            Some(&json!("production_only")),
+            "{name}.caller_scope must keep production-only as the default: {schema}"
+        );
+    }
     for name in ["callers", "callees"] {
         let alias = tool_input_schema(&tools, name);
         assert_eq!(
@@ -7181,5 +7202,308 @@ fn unknown_prompt_returns_jsonrpc_error() {
             .expect("error message")
             .contains("Unknown prompt"),
         "unknown prompt message should identify the missing prompt: {response}"
+    );
+}
+
+fn write_python_test_scope_workspace(root: &Path) {
+    fs::write(
+        root.join("pyproject.toml"),
+        "[project]\nname = \"test-scope-probe\"\nversion = \"0.0.0\"\n",
+    )
+    .expect("write pyproject.toml");
+    let tests = root.join("tests");
+    fs::create_dir_all(&tests).expect("create tests dir");
+    fs::write(
+        tests.join("test_flow.py"),
+        "def leaf():\n    return 1\n\ndef test_entry():\n    return leaf()\n",
+    )
+    .expect("write test_flow.py");
+}
+
+fn indexed_python_test_scope_fixture() -> StdioFixture {
+    let workspace = tempfile::tempdir().expect("workspace dir");
+    let cache_dir = tempfile::tempdir().expect("cache dir");
+    write_python_test_scope_workspace(workspace.path());
+
+    let mut command = test_support::cli_command();
+    command
+        .arg("index")
+        .arg("--refresh")
+        .arg("full")
+        .arg("--format")
+        .arg("json")
+        .arg("--project")
+        .arg(workspace.path())
+        .arg("--cache-dir")
+        .arg(cache_dir.path());
+    let output = command.output().expect("run index");
+    assert!(
+        output.status.success(),
+        "index failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    StdioFixture {
+        workspace,
+        cache_dir,
+        latest_release_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+        disable_release_probe: false,
+        disable_installed_cli_probe: false,
+        plugin_data_dir: None,
+        plugin_cli_source: None,
+        dirty_marker_path: None,
+        dirty_marker_project_root: None,
+        local_refresh_timeout_ms: None,
+    }
+}
+
+fn graph_edge_count(payload: &Value) -> usize {
+    payload
+        .pointer("/graph/edges")
+        .or_else(|| payload.pointer("/trail/edges"))
+        .and_then(Value::as_array)
+        .map(Vec::len)
+        .unwrap_or(0)
+}
+
+fn graph_truncated(payload: &Value) -> bool {
+    payload
+        .get("truncated")
+        .or_else(|| payload.pointer("/trail/truncated"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+fn graph_omitted_edge_count(payload: &Value) -> u64 {
+    payload
+        .pointer("/graph/omitted_edge_count")
+        .or_else(|| payload.pointer("/trail/omitted_edge_count"))
+        .and_then(Value::as_u64)
+        .unwrap_or(0)
+}
+
+fn call_graph_tool(server: &mut StdioServer, id: &str, name: &str, arguments: Value) -> Value {
+    let response = send_json(
+        server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": "tools/call",
+            "params": {"name": name, "arguments": arguments}
+        }),
+    );
+    assert_tool_success(&response, json!(id)).clone()
+}
+
+#[test]
+fn mcp_graph_caller_scope_hides_stored_test_call_until_explicitly_included() {
+    let fixture = indexed_python_test_scope_fixture();
+    let mut server = spawn_stdio_server(&fixture);
+    initialize_stdio_server(&mut server, "init-scope");
+
+    let test_entry = call_graph_tool(
+        &mut server,
+        "symbol-test-entry",
+        "symbol",
+        json!({
+            "project": fixture.workspace.path(),
+            "query": "test_entry"
+        }),
+    );
+    let test_id = test_entry["node"]["id"]
+        .as_str()
+        .expect("test_entry id")
+        .to_string();
+    let leaf = call_graph_tool(
+        &mut server,
+        "symbol-leaf",
+        "symbol",
+        json!({
+            "project": fixture.workspace.path(),
+            "query": "leaf"
+        }),
+    );
+    let leaf_id = leaf["node"]["id"].as_str().expect("leaf id").to_string();
+
+    for (name, extra) in [
+        (
+            "callees",
+            json!({"id": test_id, "depth": 1, "max_nodes": 12}),
+        ),
+        (
+            "trail",
+            json!({"id": test_id, "direction": "outgoing", "depth": 1, "max_nodes": 12}),
+        ),
+        (
+            "trace",
+            json!({"id": test_id, "direction": "outgoing", "depth": 1, "max_nodes": 12}),
+        ),
+        (
+            "neighbors",
+            json!({"id": test_id, "direction": "outgoing", "depth": 1, "max_nodes": 12}),
+        ),
+        (
+            "query_subgraph",
+            json!({"id": test_id, "direction": "outgoing", "depth": 1, "max_nodes": 12}),
+        ),
+    ] {
+        let mut default_args = extra.clone();
+        default_args
+            .as_object_mut()
+            .expect("args")
+            .insert("project".to_string(), json!(fixture.workspace.path()));
+        let default_payload = call_graph_tool(
+            &mut server,
+            &format!("{name}-default"),
+            name,
+            default_args.clone(),
+        );
+        assert_eq!(
+            default_payload["caller_scope"],
+            json!("production_only"),
+            "{name} default must name production-only scope: {default_payload}"
+        );
+        assert_eq!(
+            graph_edge_count(&default_payload),
+            0,
+            "{name} default must hide the stored test CALL: {default_payload}"
+        );
+        assert!(
+            !graph_truncated(&default_payload),
+            "{name} empty production-only view is filtered, not truncated: {default_payload}"
+        );
+        assert_eq!(
+            graph_omitted_edge_count(&default_payload),
+            0,
+            "{name} must not invent omitted-edge counts for caller-scope filtering: {default_payload}"
+        );
+
+        let mut include_args = default_args;
+        include_args.as_object_mut().expect("args").insert(
+            "caller_scope".to_string(),
+            json!("include_tests_and_benches"),
+        );
+        let include_payload =
+            call_graph_tool(&mut server, &format!("{name}-include"), name, include_args);
+        assert_eq!(
+            include_payload["caller_scope"],
+            json!("include_tests_and_benches"),
+            "{name} include-tests must name the selected scope: {include_payload}"
+        );
+        assert_eq!(
+            graph_edge_count(&include_payload),
+            1,
+            "{name} include-tests must expose the stored CALL: {include_payload}"
+        );
+        assert!(
+            !graph_truncated(&include_payload),
+            "{name} single stored CALL must not be reported as truncated: {include_payload}"
+        );
+    }
+
+    let callers_default = call_graph_tool(
+        &mut server,
+        "callers-default",
+        "callers",
+        json!({
+            "project": fixture.workspace.path(),
+            "id": leaf_id,
+            "depth": 1,
+            "max_nodes": 12
+        }),
+    );
+    assert_eq!(callers_default["caller_scope"], json!("production_only"));
+    assert_eq!(graph_edge_count(&callers_default), 0, "{callers_default}");
+
+    let callers_include = call_graph_tool(
+        &mut server,
+        "callers-include",
+        "callers",
+        json!({
+            "project": fixture.workspace.path(),
+            "id": leaf_id,
+            "depth": 1,
+            "max_nodes": 12,
+            "caller_scope": "include_tests_and_benches"
+        }),
+    );
+    assert_eq!(
+        callers_include["caller_scope"],
+        json!("include_tests_and_benches")
+    );
+    assert_eq!(graph_edge_count(&callers_include), 1, "{callers_include}");
+
+    let both_include = call_graph_tool(
+        &mut server,
+        "neighbors-both",
+        "neighbors",
+        json!({
+            "project": fixture.workspace.path(),
+            "id": test_id,
+            "direction": "both",
+            "depth": 1,
+            "max_nodes": 12,
+            "caller_scope": "include_tests_and_benches"
+        }),
+    );
+    assert_eq!(graph_edge_count(&both_include), 1, "{both_include}");
+
+    let path_default = call_graph_tool(
+        &mut server,
+        "path-default",
+        "shortest_path",
+        json!({
+            "project": fixture.workspace.path(),
+            "from_id": test_id,
+            "to_id": leaf_id,
+            "max_depth": 4,
+            "max_nodes": 12
+        }),
+    );
+    assert_eq!(path_default["caller_scope"], json!("production_only"));
+    assert_eq!(graph_edge_count(&path_default), 0, "{path_default}");
+
+    let path_include = call_graph_tool(
+        &mut server,
+        "path-include",
+        "shortest_path",
+        json!({
+            "project": fixture.workspace.path(),
+            "from_id": test_id,
+            "to_id": leaf_id,
+            "max_depth": 4,
+            "max_nodes": 12,
+            "caller_scope": "include_tests_and_benches"
+        }),
+    );
+    assert_eq!(
+        path_include["caller_scope"],
+        json!("include_tests_and_benches")
+    );
+    assert_eq!(graph_edge_count(&path_include), 1, "{path_include}");
+
+    let malformed = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "bad-scope",
+            "method": "tools/call",
+            "params": {
+                "name": "callees",
+                "arguments": {
+                    "project": fixture.workspace.path(),
+                    "id": test_id,
+                    "caller_scope": "all"
+                }
+            }
+        }),
+    );
+    assert_invalid_params(
+        &malformed,
+        json!("bad-scope"),
+        "callees",
+        "/arguments/caller_scope",
+        "invalid_enum_value",
     );
 }

--- a/plugins/codestory/generated-mcp-catalog.json
+++ b/plugins/codestory/generated-mcp-catalog.json
@@ -10,15 +10,15 @@
     ],
     "preferredMcpProtocolVersion": "2025-11-25",
     "discoveryContracts": {
-      "2024-11-05": "d24bec8284385c2e54657d3a070892e0f80dff6e0f7643a5815c3c785c99b93b",
-      "2025-03-26": "bb9c8f4a92824a1a7fc957fdce7afb396923bdcae432485d832e46d8a0918b68",
-      "2025-06-18": "bb1d1bed64295ed30b4cc3b34dd93ff30f897668a8470689351ef13c3c653333",
-      "2025-11-25": "bc504546354df593b0fced962f29299c2a700553e5d3d3310065b87b239b24f1"
+      "2024-11-05": "8fdea8a20e1d99582494f2ab720eccf6861580b09b5d3c6af060450e69d224ef",
+      "2025-03-26": "7ad01810d1f9d073c427f57479ee5650add94f4cf5e2005f217501686cafa75e",
+      "2025-06-18": "40f8d58d3588bab257d0e12db648e2bf84d588196f42da37680cf8eca6b4e4d5",
+      "2025-11-25": "f6f7225044ad16a896ba83b3822e9aee2c9d00ae702451b1536f293dd606e6a5"
     }
   },
   "revisionProfiles": {
     "2024-11-05": {
-      "discoveryContractSha256": "d24bec8284385c2e54657d3a070892e0f80dff6e0f7643a5815c3c785c99b93b",
+      "discoveryContractSha256": "8fdea8a20e1d99582494f2ab720eccf6861580b09b5d3c6af060450e69d224ef",
       "tools": [
         {
           "description": "Inspect CodeStory readiness for the requested repository when diagnostics are needed. CodeStory effect: observational and does not activate managed state.",
@@ -634,6 +634,15 @@
                 "additionalProperties": false,
                 "description": "Return a graph trail around a symbol id or query.",
                 "properties": {
+                  "caller_scope": {
+                    "default": "production_only",
+                    "description": "CALL-edge caller file scope. Omitted or production_only hides test and bench callers; include_tests_and_benches includes them. Filtering is not truncation and does not invent omitted-edge counts.",
+                    "enum": [
+                      "production_only",
+                      "include_tests_and_benches"
+                    ],
+                    "type": "string"
+                  },
                   "choose": {
                     "description": "Resolve by the 1-based alternative number from an ambiguity error.",
                     "maximum": 50,
@@ -717,6 +726,15 @@
                 "additionalProperties": false,
                 "description": "Return a bounded local graph alias around one node.",
                 "properties": {
+                  "caller_scope": {
+                    "default": "production_only",
+                    "description": "CALL-edge caller file scope. Omitted or production_only hides test and bench callers; include_tests_and_benches includes them. Filtering is not truncation and does not invent omitted-edge counts.",
+                    "enum": [
+                      "production_only",
+                      "include_tests_and_benches"
+                    ],
+                    "type": "string"
+                  },
                   "choose": {
                     "description": "Resolve by the 1-based alternative number from an ambiguity error.",
                     "maximum": 50,
@@ -785,6 +803,15 @@
                 "additionalProperties": false,
                 "description": "Return a bounded local graph alias around one node.",
                 "properties": {
+                  "caller_scope": {
+                    "default": "production_only",
+                    "description": "CALL-edge caller file scope. Omitted or production_only hides test and bench callers; include_tests_and_benches includes them. Filtering is not truncation and does not invent omitted-edge counts.",
+                    "enum": [
+                      "production_only",
+                      "include_tests_and_benches"
+                    ],
+                    "type": "string"
+                  },
                   "choose": {
                     "description": "Resolve by the 1-based alternative number from an ambiguity error.",
                     "maximum": 50,
@@ -853,6 +880,15 @@
                 "additionalProperties": false,
                 "description": "Return a readable trace around a symbol id or query.",
                 "properties": {
+                  "caller_scope": {
+                    "default": "production_only",
+                    "description": "CALL-edge caller file scope. Omitted or production_only hides test and bench callers; include_tests_and_benches includes them. Filtering is not truncation and does not invent omitted-edge counts.",
+                    "enum": [
+                      "production_only",
+                      "include_tests_and_benches"
+                    ],
+                    "type": "string"
+                  },
                   "choose": {
                     "description": "Resolve by the 1-based alternative number from an ambiguity error.",
                     "maximum": 50,
@@ -990,6 +1026,15 @@
                 "additionalProperties": false,
                 "description": "Return a bounded graph neighborhood around one node.",
                 "properties": {
+                  "caller_scope": {
+                    "default": "production_only",
+                    "description": "CALL-edge caller file scope. Omitted or production_only hides test and bench callers; include_tests_and_benches includes them. Filtering is not truncation and does not invent omitted-edge counts.",
+                    "enum": [
+                      "production_only",
+                      "include_tests_and_benches"
+                    ],
+                    "type": "string"
+                  },
                   "choose": {
                     "description": "Resolve by the 1-based alternative number from an ambiguity error.",
                     "maximum": 50,
@@ -1066,6 +1111,15 @@
             "additionalProperties": false,
             "description": "Return a bounded forward path graph between two stable node ids.",
             "properties": {
+              "caller_scope": {
+                "default": "production_only",
+                "description": "CALL-edge caller file scope. Omitted or production_only hides test and bench callers; include_tests_and_benches includes them. Filtering is not truncation and does not invent omitted-edge counts.",
+                "enum": [
+                  "production_only",
+                  "include_tests_and_benches"
+                ],
+                "type": "string"
+              },
               "from_id": {
                 "description": "Stable source node id.",
                 "minLength": 1,
@@ -1113,6 +1167,15 @@
                 "additionalProperties": false,
                 "description": "Return a bounded graph subgraph around one resolved node.",
                 "properties": {
+                  "caller_scope": {
+                    "default": "production_only",
+                    "description": "CALL-edge caller file scope. Omitted or production_only hides test and bench callers; include_tests_and_benches includes them. Filtering is not truncation and does not invent omitted-edge counts.",
+                    "enum": [
+                      "production_only",
+                      "include_tests_and_benches"
+                    ],
+                    "type": "string"
+                  },
                   "choose": {
                     "description": "Resolve by the 1-based alternative number from an ambiguity error.",
                     "maximum": 50,
@@ -1650,7 +1713,7 @@
       ]
     },
     "2025-03-26": {
-      "discoveryContractSha256": "bb9c8f4a92824a1a7fc957fdce7afb396923bdcae432485d832e46d8a0918b68",
+      "discoveryContractSha256": "7ad01810d1f9d073c427f57479ee5650add94f4cf5e2005f217501686cafa75e",
       "tools": [
         {
           "annotations": {
@@ -2314,6 +2377,15 @@
                 "additionalProperties": false,
                 "description": "Return a graph trail around a symbol id or query.",
                 "properties": {
+                  "caller_scope": {
+                    "default": "production_only",
+                    "description": "CALL-edge caller file scope. Omitted or production_only hides test and bench callers; include_tests_and_benches includes them. Filtering is not truncation and does not invent omitted-edge counts.",
+                    "enum": [
+                      "production_only",
+                      "include_tests_and_benches"
+                    ],
+                    "type": "string"
+                  },
                   "choose": {
                     "description": "Resolve by the 1-based alternative number from an ambiguity error.",
                     "maximum": 50,
@@ -2403,6 +2475,15 @@
                 "additionalProperties": false,
                 "description": "Return a bounded local graph alias around one node.",
                 "properties": {
+                  "caller_scope": {
+                    "default": "production_only",
+                    "description": "CALL-edge caller file scope. Omitted or production_only hides test and bench callers; include_tests_and_benches includes them. Filtering is not truncation and does not invent omitted-edge counts.",
+                    "enum": [
+                      "production_only",
+                      "include_tests_and_benches"
+                    ],
+                    "type": "string"
+                  },
                   "choose": {
                     "description": "Resolve by the 1-based alternative number from an ambiguity error.",
                     "maximum": 50,
@@ -2477,6 +2558,15 @@
                 "additionalProperties": false,
                 "description": "Return a bounded local graph alias around one node.",
                 "properties": {
+                  "caller_scope": {
+                    "default": "production_only",
+                    "description": "CALL-edge caller file scope. Omitted or production_only hides test and bench callers; include_tests_and_benches includes them. Filtering is not truncation and does not invent omitted-edge counts.",
+                    "enum": [
+                      "production_only",
+                      "include_tests_and_benches"
+                    ],
+                    "type": "string"
+                  },
                   "choose": {
                     "description": "Resolve by the 1-based alternative number from an ambiguity error.",
                     "maximum": 50,
@@ -2551,6 +2641,15 @@
                 "additionalProperties": false,
                 "description": "Return a readable trace around a symbol id or query.",
                 "properties": {
+                  "caller_scope": {
+                    "default": "production_only",
+                    "description": "CALL-edge caller file scope. Omitted or production_only hides test and bench callers; include_tests_and_benches includes them. Filtering is not truncation and does not invent omitted-edge counts.",
+                    "enum": [
+                      "production_only",
+                      "include_tests_and_benches"
+                    ],
+                    "type": "string"
+                  },
                   "choose": {
                     "description": "Resolve by the 1-based alternative number from an ambiguity error.",
                     "maximum": 50,
@@ -2700,6 +2799,15 @@
                 "additionalProperties": false,
                 "description": "Return a bounded graph neighborhood around one node.",
                 "properties": {
+                  "caller_scope": {
+                    "default": "production_only",
+                    "description": "CALL-edge caller file scope. Omitted or production_only hides test and bench callers; include_tests_and_benches includes them. Filtering is not truncation and does not invent omitted-edge counts.",
+                    "enum": [
+                      "production_only",
+                      "include_tests_and_benches"
+                    ],
+                    "type": "string"
+                  },
                   "choose": {
                     "description": "Resolve by the 1-based alternative number from an ambiguity error.",
                     "maximum": 50,
@@ -2782,6 +2890,15 @@
             "additionalProperties": false,
             "description": "Return a bounded forward path graph between two stable node ids.",
             "properties": {
+              "caller_scope": {
+                "default": "production_only",
+                "description": "CALL-edge caller file scope. Omitted or production_only hides test and bench callers; include_tests_and_benches includes them. Filtering is not truncation and does not invent omitted-edge counts.",
+                "enum": [
+                  "production_only",
+                  "include_tests_and_benches"
+                ],
+                "type": "string"
+              },
               "from_id": {
                 "description": "Stable source node id.",
                 "minLength": 1,
@@ -2835,6 +2952,15 @@
                 "additionalProperties": false,
                 "description": "Return a bounded graph subgraph around one resolved node.",
                 "properties": {
+                  "caller_scope": {
+                    "default": "production_only",
+                    "description": "CALL-edge caller file scope. Omitted or production_only hides test and bench callers; include_tests_and_benches includes them. Filtering is not truncation and does not invent omitted-edge counts.",
+                    "enum": [
+                      "production_only",
+                      "include_tests_and_benches"
+                    ],
+                    "type": "string"
+                  },
                   "choose": {
                     "description": "Resolve by the 1-based alternative number from an ambiguity error.",
                     "maximum": 50,
@@ -3402,7 +3528,7 @@
       ]
     },
     "2025-06-18": {
-      "discoveryContractSha256": "bb1d1bed64295ed30b4cc3b34dd93ff30f897668a8470689351ef13c3c653333",
+      "discoveryContractSha256": "40f8d58d3588bab257d0e12db648e2bf84d588196f42da37680cf8eca6b4e4d5",
       "tools": [
         {
           "_meta": {
@@ -7362,6 +7488,15 @@
                 "additionalProperties": false,
                 "description": "Return a graph trail around a symbol id or query.",
                 "properties": {
+                  "caller_scope": {
+                    "default": "production_only",
+                    "description": "CALL-edge caller file scope. Omitted or production_only hides test and bench callers; include_tests_and_benches includes them. Filtering is not truncation and does not invent omitted-edge counts.",
+                    "enum": [
+                      "production_only",
+                      "include_tests_and_benches"
+                    ],
+                    "type": "string"
+                  },
                   "choose": {
                     "description": "Resolve by the 1-based alternative number from an ambiguity error.",
                     "maximum": 50,
@@ -7458,6 +7593,14 @@
                     ],
                     "description": "CodeStory trail context DTO.",
                     "properties": {
+                      "caller_scope": {
+                        "description": "Applied CALL-edge caller file scope for this filtered view.",
+                        "enum": [
+                          "production_only",
+                          "include_tests_and_benches"
+                        ],
+                        "type": "string"
+                      },
                       "cause_code": {
                         "description": "Underlying activation or cache cause code.",
                         "type": "string"
@@ -7665,6 +7808,15 @@
                 "additionalProperties": false,
                 "description": "Return a bounded local graph alias around one node.",
                 "properties": {
+                  "caller_scope": {
+                    "default": "production_only",
+                    "description": "CALL-edge caller file scope. Omitted or production_only hides test and bench callers; include_tests_and_benches includes them. Filtering is not truncation and does not invent omitted-edge counts.",
+                    "enum": [
+                      "production_only",
+                      "include_tests_and_benches"
+                    ],
+                    "type": "string"
+                  },
                   "choose": {
                     "description": "Resolve by the 1-based alternative number from an ambiguity error.",
                     "maximum": 50,
@@ -7750,6 +7902,14 @@
                     ],
                     "description": "Bounded CodeStory graph primitive output.",
                     "properties": {
+                      "caller_scope": {
+                        "description": "Applied CALL-edge caller file scope for this filtered view.",
+                        "enum": [
+                          "production_only",
+                          "include_tests_and_benches"
+                        ],
+                        "type": "string"
+                      },
                       "cause_code": {
                         "description": "Underlying activation or cache cause code.",
                         "type": "string"
@@ -7787,6 +7947,13 @@
                           "type": "object"
                         },
                         "type": "array"
+                      },
+                      "from_id": {
+                        "description": "Shortest-path source node id, when applicable.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
                       },
                       "graph": {
                         "description": "Graph response DTO.",
@@ -7880,6 +8047,13 @@
                       "state": {
                         "description": "preparing, unavailable, or cancelled.",
                         "type": "string"
+                      },
+                      "to_id": {
+                        "description": "Shortest-path target node id, when applicable.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
                       },
                       "tool": {
                         "description": "Tool that produced this envelope.",
@@ -7994,6 +8168,15 @@
                 "additionalProperties": false,
                 "description": "Return a bounded local graph alias around one node.",
                 "properties": {
+                  "caller_scope": {
+                    "default": "production_only",
+                    "description": "CALL-edge caller file scope. Omitted or production_only hides test and bench callers; include_tests_and_benches includes them. Filtering is not truncation and does not invent omitted-edge counts.",
+                    "enum": [
+                      "production_only",
+                      "include_tests_and_benches"
+                    ],
+                    "type": "string"
+                  },
                   "choose": {
                     "description": "Resolve by the 1-based alternative number from an ambiguity error.",
                     "maximum": 50,
@@ -8079,6 +8262,14 @@
                     ],
                     "description": "Bounded CodeStory graph primitive output.",
                     "properties": {
+                      "caller_scope": {
+                        "description": "Applied CALL-edge caller file scope for this filtered view.",
+                        "enum": [
+                          "production_only",
+                          "include_tests_and_benches"
+                        ],
+                        "type": "string"
+                      },
                       "cause_code": {
                         "description": "Underlying activation or cache cause code.",
                         "type": "string"
@@ -8116,6 +8307,13 @@
                           "type": "object"
                         },
                         "type": "array"
+                      },
+                      "from_id": {
+                        "description": "Shortest-path source node id, when applicable.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
                       },
                       "graph": {
                         "description": "Graph response DTO.",
@@ -8209,6 +8407,13 @@
                       "state": {
                         "description": "preparing, unavailable, or cancelled.",
                         "type": "string"
+                      },
+                      "to_id": {
+                        "description": "Shortest-path target node id, when applicable.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
                       },
                       "tool": {
                         "description": "Tool that produced this envelope.",
@@ -8323,6 +8528,15 @@
                 "additionalProperties": false,
                 "description": "Return a readable trace around a symbol id or query.",
                 "properties": {
+                  "caller_scope": {
+                    "default": "production_only",
+                    "description": "CALL-edge caller file scope. Omitted or production_only hides test and bench callers; include_tests_and_benches includes them. Filtering is not truncation and does not invent omitted-edge counts.",
+                    "enum": [
+                      "production_only",
+                      "include_tests_and_benches"
+                    ],
+                    "type": "string"
+                  },
                   "choose": {
                     "description": "Resolve by the 1-based alternative number from an ambiguity error.",
                     "maximum": 50,
@@ -8419,6 +8633,14 @@
                     ],
                     "description": "CodeStory trail context DTO.",
                     "properties": {
+                      "caller_scope": {
+                        "description": "Applied CALL-edge caller file scope for this filtered view.",
+                        "enum": [
+                          "production_only",
+                          "include_tests_and_benches"
+                        ],
+                        "type": "string"
+                      },
                       "cause_code": {
                         "description": "Underlying activation or cache cause code.",
                         "type": "string"
@@ -8697,6 +8919,14 @@
                     ],
                     "description": "Bounded CodeStory graph primitive output.",
                     "properties": {
+                      "caller_scope": {
+                        "description": "Applied CALL-edge caller file scope for this filtered view.",
+                        "enum": [
+                          "production_only",
+                          "include_tests_and_benches"
+                        ],
+                        "type": "string"
+                      },
                       "cause_code": {
                         "description": "Underlying activation or cache cause code.",
                         "type": "string"
@@ -8734,6 +8964,13 @@
                           "type": "object"
                         },
                         "type": "array"
+                      },
+                      "from_id": {
+                        "description": "Shortest-path source node id, when applicable.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
                       },
                       "graph": {
                         "description": "Graph response DTO.",
@@ -8827,6 +9064,13 @@
                       "state": {
                         "description": "preparing, unavailable, or cancelled.",
                         "type": "string"
+                      },
+                      "to_id": {
+                        "description": "Shortest-path target node id, when applicable.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
                       },
                       "tool": {
                         "description": "Tool that produced this envelope.",
@@ -8941,6 +9185,15 @@
                 "additionalProperties": false,
                 "description": "Return a bounded graph neighborhood around one node.",
                 "properties": {
+                  "caller_scope": {
+                    "default": "production_only",
+                    "description": "CALL-edge caller file scope. Omitted or production_only hides test and bench callers; include_tests_and_benches includes them. Filtering is not truncation and does not invent omitted-edge counts.",
+                    "enum": [
+                      "production_only",
+                      "include_tests_and_benches"
+                    ],
+                    "type": "string"
+                  },
                   "choose": {
                     "description": "Resolve by the 1-based alternative number from an ambiguity error.",
                     "maximum": 50,
@@ -9036,6 +9289,14 @@
                     ],
                     "description": "Bounded CodeStory graph primitive output.",
                     "properties": {
+                      "caller_scope": {
+                        "description": "Applied CALL-edge caller file scope for this filtered view.",
+                        "enum": [
+                          "production_only",
+                          "include_tests_and_benches"
+                        ],
+                        "type": "string"
+                      },
                       "cause_code": {
                         "description": "Underlying activation or cache cause code.",
                         "type": "string"
@@ -9073,6 +9334,13 @@
                           "type": "object"
                         },
                         "type": "array"
+                      },
+                      "from_id": {
+                        "description": "Shortest-path source node id, when applicable.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
                       },
                       "graph": {
                         "description": "Graph response DTO.",
@@ -9166,6 +9434,13 @@
                       "state": {
                         "description": "preparing, unavailable, or cancelled.",
                         "type": "string"
+                      },
+                      "to_id": {
+                        "description": "Shortest-path target node id, when applicable.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
                       },
                       "tool": {
                         "description": "Tool that produced this envelope.",
@@ -9278,6 +9553,15 @@
             "additionalProperties": false,
             "description": "Return a bounded forward path graph between two stable node ids.",
             "properties": {
+              "caller_scope": {
+                "default": "production_only",
+                "description": "CALL-edge caller file scope. Omitted or production_only hides test and bench callers; include_tests_and_benches includes them. Filtering is not truncation and does not invent omitted-edge counts.",
+                "enum": [
+                  "production_only",
+                  "include_tests_and_benches"
+                ],
+                "type": "string"
+              },
               "from_id": {
                 "description": "Stable source node id.",
                 "minLength": 1,
@@ -9342,6 +9626,14 @@
                     ],
                     "description": "Bounded CodeStory graph primitive output.",
                     "properties": {
+                      "caller_scope": {
+                        "description": "Applied CALL-edge caller file scope for this filtered view.",
+                        "enum": [
+                          "production_only",
+                          "include_tests_and_benches"
+                        ],
+                        "type": "string"
+                      },
                       "cause_code": {
                         "description": "Underlying activation or cache cause code.",
                         "type": "string"
@@ -9379,6 +9671,13 @@
                           "type": "object"
                         },
                         "type": "array"
+                      },
+                      "from_id": {
+                        "description": "Shortest-path source node id, when applicable.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
                       },
                       "graph": {
                         "description": "Graph response DTO.",
@@ -9472,6 +9771,13 @@
                       "state": {
                         "description": "preparing, unavailable, or cancelled.",
                         "type": "string"
+                      },
+                      "to_id": {
+                        "description": "Shortest-path target node id, when applicable.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
                       },
                       "tool": {
                         "description": "Tool that produced this envelope.",
@@ -9586,6 +9892,15 @@
                 "additionalProperties": false,
                 "description": "Return a bounded graph subgraph around one resolved node.",
                 "properties": {
+                  "caller_scope": {
+                    "default": "production_only",
+                    "description": "CALL-edge caller file scope. Omitted or production_only hides test and bench callers; include_tests_and_benches includes them. Filtering is not truncation and does not invent omitted-edge counts.",
+                    "enum": [
+                      "production_only",
+                      "include_tests_and_benches"
+                    ],
+                    "type": "string"
+                  },
                   "choose": {
                     "description": "Resolve by the 1-based alternative number from an ambiguity error.",
                     "maximum": 50,
@@ -9681,6 +9996,14 @@
                     ],
                     "description": "Bounded CodeStory graph primitive output.",
                     "properties": {
+                      "caller_scope": {
+                        "description": "Applied CALL-edge caller file scope for this filtered view.",
+                        "enum": [
+                          "production_only",
+                          "include_tests_and_benches"
+                        ],
+                        "type": "string"
+                      },
                       "cause_code": {
                         "description": "Underlying activation or cache cause code.",
                         "type": "string"
@@ -9718,6 +10041,13 @@
                           "type": "object"
                         },
                         "type": "array"
+                      },
+                      "from_id": {
+                        "description": "Shortest-path source node id, when applicable.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
                       },
                       "graph": {
                         "description": "Graph response DTO.",
@@ -9811,6 +10141,13 @@
                       "state": {
                         "description": "preparing, unavailable, or cancelled.",
                         "type": "string"
+                      },
+                      "to_id": {
+                        "description": "Shortest-path target node id, when applicable.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
                       },
                       "tool": {
                         "description": "Tool that produced this envelope.",
@@ -10291,6 +10628,14 @@
                     ],
                     "description": "CodeStory trail context DTO.",
                     "properties": {
+                      "caller_scope": {
+                        "description": "Applied CALL-edge caller file scope for this filtered view.",
+                        "enum": [
+                          "production_only",
+                          "include_tests_and_benches"
+                        ],
+                        "type": "string"
+                      },
                       "cause_code": {
                         "description": "Underlying activation or cache cause code.",
                         "type": "string"
@@ -11885,7 +12230,7 @@
       ]
     },
     "2025-11-25": {
-      "discoveryContractSha256": "bc504546354df593b0fced962f29299c2a700553e5d3d3310065b87b239b24f1",
+      "discoveryContractSha256": "f6f7225044ad16a896ba83b3822e9aee2c9d00ae702451b1536f293dd606e6a5",
       "tools": [
         {
           "_meta": {
@@ -15845,6 +16190,15 @@
                 "additionalProperties": false,
                 "description": "Return a graph trail around a symbol id or query.",
                 "properties": {
+                  "caller_scope": {
+                    "default": "production_only",
+                    "description": "CALL-edge caller file scope. Omitted or production_only hides test and bench callers; include_tests_and_benches includes them. Filtering is not truncation and does not invent omitted-edge counts.",
+                    "enum": [
+                      "production_only",
+                      "include_tests_and_benches"
+                    ],
+                    "type": "string"
+                  },
                   "choose": {
                     "description": "Resolve by the 1-based alternative number from an ambiguity error.",
                     "maximum": 50,
@@ -15941,6 +16295,14 @@
                     ],
                     "description": "CodeStory trail context DTO.",
                     "properties": {
+                      "caller_scope": {
+                        "description": "Applied CALL-edge caller file scope for this filtered view.",
+                        "enum": [
+                          "production_only",
+                          "include_tests_and_benches"
+                        ],
+                        "type": "string"
+                      },
                       "cause_code": {
                         "description": "Underlying activation or cache cause code.",
                         "type": "string"
@@ -16148,6 +16510,15 @@
                 "additionalProperties": false,
                 "description": "Return a bounded local graph alias around one node.",
                 "properties": {
+                  "caller_scope": {
+                    "default": "production_only",
+                    "description": "CALL-edge caller file scope. Omitted or production_only hides test and bench callers; include_tests_and_benches includes them. Filtering is not truncation and does not invent omitted-edge counts.",
+                    "enum": [
+                      "production_only",
+                      "include_tests_and_benches"
+                    ],
+                    "type": "string"
+                  },
                   "choose": {
                     "description": "Resolve by the 1-based alternative number from an ambiguity error.",
                     "maximum": 50,
@@ -16233,6 +16604,14 @@
                     ],
                     "description": "Bounded CodeStory graph primitive output.",
                     "properties": {
+                      "caller_scope": {
+                        "description": "Applied CALL-edge caller file scope for this filtered view.",
+                        "enum": [
+                          "production_only",
+                          "include_tests_and_benches"
+                        ],
+                        "type": "string"
+                      },
                       "cause_code": {
                         "description": "Underlying activation or cache cause code.",
                         "type": "string"
@@ -16270,6 +16649,13 @@
                           "type": "object"
                         },
                         "type": "array"
+                      },
+                      "from_id": {
+                        "description": "Shortest-path source node id, when applicable.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
                       },
                       "graph": {
                         "description": "Graph response DTO.",
@@ -16363,6 +16749,13 @@
                       "state": {
                         "description": "preparing, unavailable, or cancelled.",
                         "type": "string"
+                      },
+                      "to_id": {
+                        "description": "Shortest-path target node id, when applicable.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
                       },
                       "tool": {
                         "description": "Tool that produced this envelope.",
@@ -16477,6 +16870,15 @@
                 "additionalProperties": false,
                 "description": "Return a bounded local graph alias around one node.",
                 "properties": {
+                  "caller_scope": {
+                    "default": "production_only",
+                    "description": "CALL-edge caller file scope. Omitted or production_only hides test and bench callers; include_tests_and_benches includes them. Filtering is not truncation and does not invent omitted-edge counts.",
+                    "enum": [
+                      "production_only",
+                      "include_tests_and_benches"
+                    ],
+                    "type": "string"
+                  },
                   "choose": {
                     "description": "Resolve by the 1-based alternative number from an ambiguity error.",
                     "maximum": 50,
@@ -16562,6 +16964,14 @@
                     ],
                     "description": "Bounded CodeStory graph primitive output.",
                     "properties": {
+                      "caller_scope": {
+                        "description": "Applied CALL-edge caller file scope for this filtered view.",
+                        "enum": [
+                          "production_only",
+                          "include_tests_and_benches"
+                        ],
+                        "type": "string"
+                      },
                       "cause_code": {
                         "description": "Underlying activation or cache cause code.",
                         "type": "string"
@@ -16599,6 +17009,13 @@
                           "type": "object"
                         },
                         "type": "array"
+                      },
+                      "from_id": {
+                        "description": "Shortest-path source node id, when applicable.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
                       },
                       "graph": {
                         "description": "Graph response DTO.",
@@ -16692,6 +17109,13 @@
                       "state": {
                         "description": "preparing, unavailable, or cancelled.",
                         "type": "string"
+                      },
+                      "to_id": {
+                        "description": "Shortest-path target node id, when applicable.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
                       },
                       "tool": {
                         "description": "Tool that produced this envelope.",
@@ -16806,6 +17230,15 @@
                 "additionalProperties": false,
                 "description": "Return a readable trace around a symbol id or query.",
                 "properties": {
+                  "caller_scope": {
+                    "default": "production_only",
+                    "description": "CALL-edge caller file scope. Omitted or production_only hides test and bench callers; include_tests_and_benches includes them. Filtering is not truncation and does not invent omitted-edge counts.",
+                    "enum": [
+                      "production_only",
+                      "include_tests_and_benches"
+                    ],
+                    "type": "string"
+                  },
                   "choose": {
                     "description": "Resolve by the 1-based alternative number from an ambiguity error.",
                     "maximum": 50,
@@ -16902,6 +17335,14 @@
                     ],
                     "description": "CodeStory trail context DTO.",
                     "properties": {
+                      "caller_scope": {
+                        "description": "Applied CALL-edge caller file scope for this filtered view.",
+                        "enum": [
+                          "production_only",
+                          "include_tests_and_benches"
+                        ],
+                        "type": "string"
+                      },
                       "cause_code": {
                         "description": "Underlying activation or cache cause code.",
                         "type": "string"
@@ -17180,6 +17621,14 @@
                     ],
                     "description": "Bounded CodeStory graph primitive output.",
                     "properties": {
+                      "caller_scope": {
+                        "description": "Applied CALL-edge caller file scope for this filtered view.",
+                        "enum": [
+                          "production_only",
+                          "include_tests_and_benches"
+                        ],
+                        "type": "string"
+                      },
                       "cause_code": {
                         "description": "Underlying activation or cache cause code.",
                         "type": "string"
@@ -17217,6 +17666,13 @@
                           "type": "object"
                         },
                         "type": "array"
+                      },
+                      "from_id": {
+                        "description": "Shortest-path source node id, when applicable.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
                       },
                       "graph": {
                         "description": "Graph response DTO.",
@@ -17310,6 +17766,13 @@
                       "state": {
                         "description": "preparing, unavailable, or cancelled.",
                         "type": "string"
+                      },
+                      "to_id": {
+                        "description": "Shortest-path target node id, when applicable.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
                       },
                       "tool": {
                         "description": "Tool that produced this envelope.",
@@ -17424,6 +17887,15 @@
                 "additionalProperties": false,
                 "description": "Return a bounded graph neighborhood around one node.",
                 "properties": {
+                  "caller_scope": {
+                    "default": "production_only",
+                    "description": "CALL-edge caller file scope. Omitted or production_only hides test and bench callers; include_tests_and_benches includes them. Filtering is not truncation and does not invent omitted-edge counts.",
+                    "enum": [
+                      "production_only",
+                      "include_tests_and_benches"
+                    ],
+                    "type": "string"
+                  },
                   "choose": {
                     "description": "Resolve by the 1-based alternative number from an ambiguity error.",
                     "maximum": 50,
@@ -17519,6 +17991,14 @@
                     ],
                     "description": "Bounded CodeStory graph primitive output.",
                     "properties": {
+                      "caller_scope": {
+                        "description": "Applied CALL-edge caller file scope for this filtered view.",
+                        "enum": [
+                          "production_only",
+                          "include_tests_and_benches"
+                        ],
+                        "type": "string"
+                      },
                       "cause_code": {
                         "description": "Underlying activation or cache cause code.",
                         "type": "string"
@@ -17556,6 +18036,13 @@
                           "type": "object"
                         },
                         "type": "array"
+                      },
+                      "from_id": {
+                        "description": "Shortest-path source node id, when applicable.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
                       },
                       "graph": {
                         "description": "Graph response DTO.",
@@ -17649,6 +18136,13 @@
                       "state": {
                         "description": "preparing, unavailable, or cancelled.",
                         "type": "string"
+                      },
+                      "to_id": {
+                        "description": "Shortest-path target node id, when applicable.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
                       },
                       "tool": {
                         "description": "Tool that produced this envelope.",
@@ -17761,6 +18255,15 @@
             "additionalProperties": false,
             "description": "Return a bounded forward path graph between two stable node ids.",
             "properties": {
+              "caller_scope": {
+                "default": "production_only",
+                "description": "CALL-edge caller file scope. Omitted or production_only hides test and bench callers; include_tests_and_benches includes them. Filtering is not truncation and does not invent omitted-edge counts.",
+                "enum": [
+                  "production_only",
+                  "include_tests_and_benches"
+                ],
+                "type": "string"
+              },
               "from_id": {
                 "description": "Stable source node id.",
                 "minLength": 1,
@@ -17825,6 +18328,14 @@
                     ],
                     "description": "Bounded CodeStory graph primitive output.",
                     "properties": {
+                      "caller_scope": {
+                        "description": "Applied CALL-edge caller file scope for this filtered view.",
+                        "enum": [
+                          "production_only",
+                          "include_tests_and_benches"
+                        ],
+                        "type": "string"
+                      },
                       "cause_code": {
                         "description": "Underlying activation or cache cause code.",
                         "type": "string"
@@ -17862,6 +18373,13 @@
                           "type": "object"
                         },
                         "type": "array"
+                      },
+                      "from_id": {
+                        "description": "Shortest-path source node id, when applicable.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
                       },
                       "graph": {
                         "description": "Graph response DTO.",
@@ -17955,6 +18473,13 @@
                       "state": {
                         "description": "preparing, unavailable, or cancelled.",
                         "type": "string"
+                      },
+                      "to_id": {
+                        "description": "Shortest-path target node id, when applicable.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
                       },
                       "tool": {
                         "description": "Tool that produced this envelope.",
@@ -18069,6 +18594,15 @@
                 "additionalProperties": false,
                 "description": "Return a bounded graph subgraph around one resolved node.",
                 "properties": {
+                  "caller_scope": {
+                    "default": "production_only",
+                    "description": "CALL-edge caller file scope. Omitted or production_only hides test and bench callers; include_tests_and_benches includes them. Filtering is not truncation and does not invent omitted-edge counts.",
+                    "enum": [
+                      "production_only",
+                      "include_tests_and_benches"
+                    ],
+                    "type": "string"
+                  },
                   "choose": {
                     "description": "Resolve by the 1-based alternative number from an ambiguity error.",
                     "maximum": 50,
@@ -18164,6 +18698,14 @@
                     ],
                     "description": "Bounded CodeStory graph primitive output.",
                     "properties": {
+                      "caller_scope": {
+                        "description": "Applied CALL-edge caller file scope for this filtered view.",
+                        "enum": [
+                          "production_only",
+                          "include_tests_and_benches"
+                        ],
+                        "type": "string"
+                      },
                       "cause_code": {
                         "description": "Underlying activation or cache cause code.",
                         "type": "string"
@@ -18201,6 +18743,13 @@
                           "type": "object"
                         },
                         "type": "array"
+                      },
+                      "from_id": {
+                        "description": "Shortest-path source node id, when applicable.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
                       },
                       "graph": {
                         "description": "Graph response DTO.",
@@ -18294,6 +18843,13 @@
                       "state": {
                         "description": "preparing, unavailable, or cancelled.",
                         "type": "string"
+                      },
+                      "to_id": {
+                        "description": "Shortest-path target node id, when applicable.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
                       },
                       "tool": {
                         "description": "Tool that produced this envelope.",
@@ -18774,6 +19330,14 @@
                     ],
                     "description": "CodeStory trail context DTO.",
                     "properties": {
+                      "caller_scope": {
+                        "description": "Applied CALL-edge caller file scope for this filtered view.",
+                        "enum": [
+                          "production_only",
+                          "include_tests_and_benches"
+                        ],
+                        "type": "string"
+                      },
                       "cause_code": {
                         "description": "Underlying activation or cache cause code.",
                         "type": "string"
@@ -24327,6 +24891,15 @@
             "additionalProperties": false,
             "description": "Return a graph trail around a symbol id or query.",
             "properties": {
+              "caller_scope": {
+                "default": "production_only",
+                "description": "CALL-edge caller file scope. Omitted or production_only hides test and bench callers; include_tests_and_benches includes them. Filtering is not truncation and does not invent omitted-edge counts.",
+                "enum": [
+                  "production_only",
+                  "include_tests_and_benches"
+                ],
+                "type": "string"
+              },
               "choose": {
                 "description": "Resolve by the 1-based alternative number from an ambiguity error.",
                 "maximum": 50,
@@ -24423,6 +24996,14 @@
                 ],
                 "description": "CodeStory trail context DTO.",
                 "properties": {
+                  "caller_scope": {
+                    "description": "Applied CALL-edge caller file scope for this filtered view.",
+                    "enum": [
+                      "production_only",
+                      "include_tests_and_benches"
+                    ],
+                    "type": "string"
+                  },
                   "cause_code": {
                     "description": "Underlying activation or cache cause code.",
                     "type": "string"
@@ -24630,6 +25211,15 @@
             "additionalProperties": false,
             "description": "Return a bounded local graph alias around one node.",
             "properties": {
+              "caller_scope": {
+                "default": "production_only",
+                "description": "CALL-edge caller file scope. Omitted or production_only hides test and bench callers; include_tests_and_benches includes them. Filtering is not truncation and does not invent omitted-edge counts.",
+                "enum": [
+                  "production_only",
+                  "include_tests_and_benches"
+                ],
+                "type": "string"
+              },
               "choose": {
                 "description": "Resolve by the 1-based alternative number from an ambiguity error.",
                 "maximum": 50,
@@ -24715,6 +25305,14 @@
                 ],
                 "description": "Bounded CodeStory graph primitive output.",
                 "properties": {
+                  "caller_scope": {
+                    "description": "Applied CALL-edge caller file scope for this filtered view.",
+                    "enum": [
+                      "production_only",
+                      "include_tests_and_benches"
+                    ],
+                    "type": "string"
+                  },
                   "cause_code": {
                     "description": "Underlying activation or cache cause code.",
                     "type": "string"
@@ -24752,6 +25350,13 @@
                       "type": "object"
                     },
                     "type": "array"
+                  },
+                  "from_id": {
+                    "description": "Shortest-path source node id, when applicable.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "graph": {
                     "description": "Graph response DTO.",
@@ -24845,6 +25450,13 @@
                   "state": {
                     "description": "preparing, unavailable, or cancelled.",
                     "type": "string"
+                  },
+                  "to_id": {
+                    "description": "Shortest-path target node id, when applicable.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "tool": {
                     "description": "Tool that produced this envelope.",
@@ -24959,6 +25571,15 @@
             "additionalProperties": false,
             "description": "Return a bounded local graph alias around one node.",
             "properties": {
+              "caller_scope": {
+                "default": "production_only",
+                "description": "CALL-edge caller file scope. Omitted or production_only hides test and bench callers; include_tests_and_benches includes them. Filtering is not truncation and does not invent omitted-edge counts.",
+                "enum": [
+                  "production_only",
+                  "include_tests_and_benches"
+                ],
+                "type": "string"
+              },
               "choose": {
                 "description": "Resolve by the 1-based alternative number from an ambiguity error.",
                 "maximum": 50,
@@ -25044,6 +25665,14 @@
                 ],
                 "description": "Bounded CodeStory graph primitive output.",
                 "properties": {
+                  "caller_scope": {
+                    "description": "Applied CALL-edge caller file scope for this filtered view.",
+                    "enum": [
+                      "production_only",
+                      "include_tests_and_benches"
+                    ],
+                    "type": "string"
+                  },
                   "cause_code": {
                     "description": "Underlying activation or cache cause code.",
                     "type": "string"
@@ -25081,6 +25710,13 @@
                       "type": "object"
                     },
                     "type": "array"
+                  },
+                  "from_id": {
+                    "description": "Shortest-path source node id, when applicable.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "graph": {
                     "description": "Graph response DTO.",
@@ -25174,6 +25810,13 @@
                   "state": {
                     "description": "preparing, unavailable, or cancelled.",
                     "type": "string"
+                  },
+                  "to_id": {
+                    "description": "Shortest-path target node id, when applicable.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "tool": {
                     "description": "Tool that produced this envelope.",
@@ -25288,6 +25931,15 @@
             "additionalProperties": false,
             "description": "Return a readable trace around a symbol id or query.",
             "properties": {
+              "caller_scope": {
+                "default": "production_only",
+                "description": "CALL-edge caller file scope. Omitted or production_only hides test and bench callers; include_tests_and_benches includes them. Filtering is not truncation and does not invent omitted-edge counts.",
+                "enum": [
+                  "production_only",
+                  "include_tests_and_benches"
+                ],
+                "type": "string"
+              },
               "choose": {
                 "description": "Resolve by the 1-based alternative number from an ambiguity error.",
                 "maximum": 50,
@@ -25384,6 +26036,14 @@
                 ],
                 "description": "CodeStory trail context DTO.",
                 "properties": {
+                  "caller_scope": {
+                    "description": "Applied CALL-edge caller file scope for this filtered view.",
+                    "enum": [
+                      "production_only",
+                      "include_tests_and_benches"
+                    ],
+                    "type": "string"
+                  },
                   "cause_code": {
                     "description": "Underlying activation or cache cause code.",
                     "type": "string"
@@ -25662,6 +26322,14 @@
                 ],
                 "description": "Bounded CodeStory graph primitive output.",
                 "properties": {
+                  "caller_scope": {
+                    "description": "Applied CALL-edge caller file scope for this filtered view.",
+                    "enum": [
+                      "production_only",
+                      "include_tests_and_benches"
+                    ],
+                    "type": "string"
+                  },
                   "cause_code": {
                     "description": "Underlying activation or cache cause code.",
                     "type": "string"
@@ -25699,6 +26367,13 @@
                       "type": "object"
                     },
                     "type": "array"
+                  },
+                  "from_id": {
+                    "description": "Shortest-path source node id, when applicable.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "graph": {
                     "description": "Graph response DTO.",
@@ -25792,6 +26467,13 @@
                   "state": {
                     "description": "preparing, unavailable, or cancelled.",
                     "type": "string"
+                  },
+                  "to_id": {
+                    "description": "Shortest-path target node id, when applicable.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "tool": {
                     "description": "Tool that produced this envelope.",
@@ -25906,6 +26588,15 @@
             "additionalProperties": false,
             "description": "Return a bounded graph neighborhood around one node.",
             "properties": {
+              "caller_scope": {
+                "default": "production_only",
+                "description": "CALL-edge caller file scope. Omitted or production_only hides test and bench callers; include_tests_and_benches includes them. Filtering is not truncation and does not invent omitted-edge counts.",
+                "enum": [
+                  "production_only",
+                  "include_tests_and_benches"
+                ],
+                "type": "string"
+              },
               "choose": {
                 "description": "Resolve by the 1-based alternative number from an ambiguity error.",
                 "maximum": 50,
@@ -26001,6 +26692,14 @@
                 ],
                 "description": "Bounded CodeStory graph primitive output.",
                 "properties": {
+                  "caller_scope": {
+                    "description": "Applied CALL-edge caller file scope for this filtered view.",
+                    "enum": [
+                      "production_only",
+                      "include_tests_and_benches"
+                    ],
+                    "type": "string"
+                  },
                   "cause_code": {
                     "description": "Underlying activation or cache cause code.",
                     "type": "string"
@@ -26038,6 +26737,13 @@
                       "type": "object"
                     },
                     "type": "array"
+                  },
+                  "from_id": {
+                    "description": "Shortest-path source node id, when applicable.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "graph": {
                     "description": "Graph response DTO.",
@@ -26131,6 +26837,13 @@
                   "state": {
                     "description": "preparing, unavailable, or cancelled.",
                     "type": "string"
+                  },
+                  "to_id": {
+                    "description": "Shortest-path target node id, when applicable.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "tool": {
                     "description": "Tool that produced this envelope.",
@@ -26243,6 +26956,15 @@
         "additionalProperties": false,
         "description": "Return a bounded forward path graph between two stable node ids.",
         "properties": {
+          "caller_scope": {
+            "default": "production_only",
+            "description": "CALL-edge caller file scope. Omitted or production_only hides test and bench callers; include_tests_and_benches includes them. Filtering is not truncation and does not invent omitted-edge counts.",
+            "enum": [
+              "production_only",
+              "include_tests_and_benches"
+            ],
+            "type": "string"
+          },
           "from_id": {
             "description": "Stable source node id.",
             "minLength": 1,
@@ -26307,6 +27029,14 @@
                 ],
                 "description": "Bounded CodeStory graph primitive output.",
                 "properties": {
+                  "caller_scope": {
+                    "description": "Applied CALL-edge caller file scope for this filtered view.",
+                    "enum": [
+                      "production_only",
+                      "include_tests_and_benches"
+                    ],
+                    "type": "string"
+                  },
                   "cause_code": {
                     "description": "Underlying activation or cache cause code.",
                     "type": "string"
@@ -26344,6 +27074,13 @@
                       "type": "object"
                     },
                     "type": "array"
+                  },
+                  "from_id": {
+                    "description": "Shortest-path source node id, when applicable.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "graph": {
                     "description": "Graph response DTO.",
@@ -26437,6 +27174,13 @@
                   "state": {
                     "description": "preparing, unavailable, or cancelled.",
                     "type": "string"
+                  },
+                  "to_id": {
+                    "description": "Shortest-path target node id, when applicable.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "tool": {
                     "description": "Tool that produced this envelope.",
@@ -26551,6 +27295,15 @@
             "additionalProperties": false,
             "description": "Return a bounded graph subgraph around one resolved node.",
             "properties": {
+              "caller_scope": {
+                "default": "production_only",
+                "description": "CALL-edge caller file scope. Omitted or production_only hides test and bench callers; include_tests_and_benches includes them. Filtering is not truncation and does not invent omitted-edge counts.",
+                "enum": [
+                  "production_only",
+                  "include_tests_and_benches"
+                ],
+                "type": "string"
+              },
               "choose": {
                 "description": "Resolve by the 1-based alternative number from an ambiguity error.",
                 "maximum": 50,
@@ -26646,6 +27399,14 @@
                 ],
                 "description": "Bounded CodeStory graph primitive output.",
                 "properties": {
+                  "caller_scope": {
+                    "description": "Applied CALL-edge caller file scope for this filtered view.",
+                    "enum": [
+                      "production_only",
+                      "include_tests_and_benches"
+                    ],
+                    "type": "string"
+                  },
                   "cause_code": {
                     "description": "Underlying activation or cache cause code.",
                     "type": "string"
@@ -26683,6 +27444,13 @@
                       "type": "object"
                     },
                     "type": "array"
+                  },
+                  "from_id": {
+                    "description": "Shortest-path source node id, when applicable.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "graph": {
                     "description": "Graph response DTO.",
@@ -26776,6 +27544,13 @@
                   "state": {
                     "description": "preparing, unavailable, or cancelled.",
                     "type": "string"
+                  },
+                  "to_id": {
+                    "description": "Shortest-path target node id, when applicable.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "tool": {
                     "description": "Tool that produced this envelope.",
@@ -27256,6 +28031,14 @@
                 ],
                 "description": "CodeStory trail context DTO.",
                 "properties": {
+                  "caller_scope": {
+                    "description": "Applied CALL-edge caller file scope for this filtered view.",
+                    "enum": [
+                      "production_only",
+                      "include_tests_and_benches"
+                    ],
+                    "type": "string"
+                  },
                   "cause_code": {
                     "description": "Underlying activation or cache cause code.",
                     "type": "string"

--- a/plugins/codestory/skills/codestory-grounding/references/generated-mcp-syntax.md
+++ b/plugins/codestory/skills/codestory-grounding/references/generated-mcp-syntax.md
@@ -27,14 +27,14 @@ There is no MCP `index`, `doctor`, `ready`, `explore`, `drill`, `query`,
 | `files` | | `language`, `path`, `role`, `limit`, `include_framework_coverage` | Refreshes the local map before dispatch. No `refresh` field. |
 | `affected` | exactly one of `paths`, `changed_paths`, `change_records` | `depth`, `filter` | Never discovers git changes. |
 | `symbol` | `query` or `id` | `choose` | |
-| `trail` | `query` or `id` | `direction` (`incoming`/`outgoing`/`both`), `depth`, `max_nodes`, `story`, `choose` | There is no `mode` field. |
-| `callers` | `query` or `id` | `depth`, `max_nodes`, `choose` | |
-| `callees` | `query` or `id` | `depth`, `max_nodes`, `choose` | |
-| `trace` | `query` or `id` | `direction`, `depth`, `max_nodes`, `story`, `choose` | |
+| `trail` | `query` or `id` | `direction` (`incoming`/`outgoing`/`both`), `depth`, `max_nodes`, `story`, `choose`, `caller_scope` (`production_only`/`include_tests_and_benches`) | There is no `mode` field. Default caller scope hides test/bench callers. |
+| `callers` | `query` or `id` | `depth`, `max_nodes`, `choose`, `caller_scope` | |
+| `callees` | `query` or `id` | `depth`, `max_nodes`, `choose`, `caller_scope` | |
+| `trace` | `query` or `id` | `direction`, `depth`, `max_nodes`, `story`, `choose`, `caller_scope` | |
 | `get_node` | `query` or `id` | `choose` | |
-| `neighbors` | `query` or `id` | `direction`, `depth`, `max_nodes`, `choose` | |
-| `shortest_path` | `from_id`, `to_id` | `max_depth`, `max_nodes` | |
-| `query_subgraph` | `query` or `id` | `direction`, `depth`, `max_nodes`, `choose` | Bounded node-centered relationship navigation. |
+| `neighbors` | `query` or `id` | `direction`, `depth`, `max_nodes`, `choose`, `caller_scope` | |
+| `shortest_path` | `from_id`, `to_id` | `max_depth`, `max_nodes`, `caller_scope` | |
+| `query_subgraph` | `query` or `id` | `direction`, `depth`, `max_nodes`, `choose`, `caller_scope` | Bounded node-centered relationship navigation. |
 | `definition` | `query` or `id` | `choose` | |
 | `references` | `query` or `id` | `choose` | Incoming references. |
 | `symbols` | | `parent_id`, `limit` | Root symbols, or children of `parent_id`. |

--- a/plugins/codestory/skills/codestory-grounding/references/trail.md
+++ b/plugins/codestory/skills/codestory-grounding/references/trail.md
@@ -40,7 +40,10 @@ Markdown trail output renders edge certainty directly in the arrow shape:
 | missing certainty | `-call-> [unresolved]` | Legacy or unresolved certainty metadata |
 
 MCP `trail` optional `story: true` includes a readable trail story DTO. There
-is no `mode`, `include_tests`, `mermaid`, or `output_file` field.
+is no `mode`, `mermaid`, or `output_file` field. Optional `caller_scope`
+(`production_only` default, or `include_tests_and_benches`) maps to the existing
+runtime caller-scope contract. A production-only empty graph is a filtered view,
+not proof that no CALL edges were indexed and not truncation.
 
 ## Interpreting Trail Noise
 


### PR DESCRIPTION
Graph navigation can now include test and benchmark callers explicitly. Previously the MCP tools exposed only the production-filtered view, and empty CLI output could incorrectly imply that no calls were indexed. The seven graph tools accept `caller_scope`, retain `production_only` as the default, and return the applied scope. Filtering does not change truncation counts.

Review the catalog argument and response schemas, transport parsing, and the existing `TrailCallerScope` mapping. HTTP keeps its existing production-only behavior. The generated catalog and skill syntax reflect the new argument. The indexer is unchanged.

Validation on source candidate `c057719397d6edd6fce45fcbe623ee287d8fb6f9` (tree `859eff4eec26f6d0965a418c5d5559f00740a657`): complete stdio protocol binary 67 passed; plugin static checks 142 passed and one platform skip; focused CLI tests, generated syntax check, formatting and diff checks passed. A native MCP fixture returned zero edges by default and its stored CALL with explicit test scope, with no truncation or omitted edges. Failed attempts remain recorded. Independent review accepted this exact clean head after 86 native hostile cases with zero failures (55.742 seconds), spanning all seven tools on protocols 2024-11-05 and 2025-11-25, defaults, explicit scope, directions, shortest paths and malformed arguments. Root verified the probe, transcript, case-summary and runtime hashes. Graph-local proof ran with embedding runtime unavailable; it does not establish full retrieval. Required draft CI remains pending, so the PR remains draft.

Base: `e98993be97bcd81cc08ca0ac7ec711013191c926`. Worktree: `/Users/albert/.codex/worktrees/0176-mcp-caller-scope/CodeStory`. Root coordinates one Cursor/Grok implementer and one independent verifier. Next gate is the remaining exact-head draft CI check. Installed-host breadth behavior and release qualification remain later unified-track gates.

Closes #2179
Refs #2173, #2135
