### PR TITLE
[codex] reject ownerless Go calls to receiver methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Go navigation no longer binds an ownerless bare call or conversion such as
+`string(...)` or `run()` to an unrelated receiver method. Package functions and
+genuine receiver calls keep their previous targets.
+
 Code-mode hosts can see named navigation arguments, including project routing
 and snippet ranges, when a tool accepts alternative selectors.
 

--- a/crates/codestory-indexer/src/resolution/candidate_selection.rs
+++ b/crates/codestory-indexer/src/resolution/candidate_selection.rs
@@ -1089,8 +1089,8 @@ mod tests {
     }
 
     #[test]
-    fn go_ownerless_bare_call_does_not_select_semantic_method_when_fallback_is_enabled() -> Result<()>
-    {
+    fn go_ownerless_bare_call_does_not_select_semantic_method_when_fallback_is_enabled()
+    -> Result<()> {
         let conn = Connection::open_in_memory()?;
         create_node_table(&conn)?;
         insert_typed_callable(
@@ -1134,7 +1134,15 @@ mod tests {
             1,
             4,
         )?;
-        insert_typed_callable(&conn, 11, NodeKind::FUNCTION, "string", "probe.string", 1, 6)?;
+        insert_typed_callable(
+            &conn,
+            11,
+            NodeKind::FUNCTION,
+            "string",
+            "probe.string",
+            1,
+            6,
+        )?;
 
         let index =
             CandidateIndex::load(&conn, &[NodeKind::FUNCTION as i32, NodeKind::METHOD as i32])?;
@@ -1148,8 +1156,7 @@ mod tests {
                 confidence: 0.95,
             }],
         )?;
-        let without_semantic =
-            compute_call_resolution(&resolution_pass(false), &index, &row, &[])?;
+        let without_semantic = compute_call_resolution(&resolution_pass(false), &index, &row, &[])?;
 
         assert_eq!(
             with_semantic.strategy,

--- a/crates/codestory-indexer/src/resolution/candidate_selection.rs
+++ b/crates/codestory-indexer/src/resolution/candidate_selection.rs
@@ -216,6 +216,15 @@ pub(super) fn compute_call_resolution(
     let prepared_name = PreparedName::new(lookup_target_name);
     let is_common_unqualified = is_common_unqualified_call_name(&prepared_name.original);
     let is_owner_qualified = is_owner_qualified_call_name(&prepared_name.original);
+    let ownerless_go_bare_call = is_go_ownerless_bare_identifier_call(
+        receiver_owner,
+        callsite_identity.as_deref(),
+        caller_file_path.as_deref(),
+    );
+    let allow_call_candidate = |candidate: i64| {
+        !ownerless_go_bare_call
+            || candidate_index.node_kind(candidate) == Some(NodeKind::FUNCTION as i32)
+    };
 
     // The parser proved that this bare JavaScript-family call shares an exact local name with a
     // runtime import binding. That proves a lexical external boundary, not the implementation
@@ -236,12 +245,13 @@ pub(super) fn compute_call_resolution(
         if pass.flags.store_candidates {
             candidate_ids.push(candidate.target_node_id);
         }
-        if !is_common_unqualified
-            || should_keep_common_call_resolution(
-                &prepared_name.original,
-                candidate.confidence,
-                callsite_identity.as_deref(),
-            )
+        if allow_call_candidate(candidate.target_node_id)
+            && (!is_common_unqualified
+                || should_keep_common_call_resolution(
+                    &prepared_name.original,
+                    candidate.confidence,
+                    callsite_identity.as_deref(),
+                ))
         {
             semantic_fallback.consider(candidate.target_node_id, candidate.confidence);
         }
@@ -324,11 +334,13 @@ pub(super) fn compute_call_resolution(
         if pass.flags.store_candidates {
             candidate_ids.push(*target_node_id);
         }
-        selected = Some((
-            *target_node_id,
-            pass.policy.call_same_file,
-            ResolutionStrategy::CallSameFile,
-        ));
+        if allow_call_candidate(*target_node_id) {
+            selected = Some((
+                *target_node_id,
+                pass.policy.call_same_file,
+                ResolutionStrategy::CallSameFile,
+            ));
+        }
     }
 
     if selected.is_none()
@@ -342,11 +354,13 @@ pub(super) fn compute_call_resolution(
         if pass.flags.store_candidates {
             candidate_ids.push(candidate);
         }
-        selected = Some((
-            candidate,
-            pass.policy.call_same_file,
-            ResolutionStrategy::CallSameFile,
-        ));
+        if allow_call_candidate(candidate) {
+            selected = Some((
+                candidate,
+                pass.policy.call_same_file,
+                ResolutionStrategy::CallSameFile,
+            ));
+        }
     }
 
     if selected.is_none()
@@ -362,7 +376,7 @@ pub(super) fn compute_call_resolution(
         if pass.flags.store_candidates {
             candidate_ids.push(candidate);
         }
-        if !is_common_unqualified {
+        if !is_common_unqualified && allow_call_candidate(candidate) {
             selected = Some((
                 candidate,
                 pass.policy.call_same_module,
@@ -439,12 +453,14 @@ pub(super) fn compute_call_resolution(
         if pass.flags.store_candidates {
             candidate_ids.push(candidate);
         }
-        let confidence = if is_owner_qualified {
-            pass.policy.call_same_file
-        } else {
-            pass.policy.call_global_unique
-        };
-        selected = Some((candidate, confidence, ResolutionStrategy::CallGlobalUnique));
+        if allow_call_candidate(candidate) {
+            let confidence = if is_owner_qualified {
+                pass.policy.call_same_file
+            } else {
+                pass.policy.call_global_unique
+            };
+            selected = Some((candidate, confidence, ResolutionStrategy::CallGlobalUnique));
+        }
     }
 
     if selected.is_none()
@@ -476,12 +492,19 @@ pub(super) fn compute_call_resolution(
     if selected.is_none()
         && !is_owner_qualified
         && let Some((candidate, confidence)) = semantic_fallback.selected()
+        && allow_call_candidate(candidate)
     {
         selected = Some((
             candidate,
             confidence,
             ResolutionStrategy::CallSemanticFallback,
         ));
+    }
+
+    if ownerless_go_bare_call
+        && selected.is_some_and(|(candidate, _, _)| !allow_call_candidate(candidate))
+    {
+        selected = None;
     }
 
     if let Some((_, confidence, _)) = selected
@@ -510,6 +533,16 @@ pub(super) fn compute_call_resolution(
 
 fn is_owner_qualified_call_name(name: &str) -> bool {
     name.contains("::") || name.contains('.')
+}
+
+fn is_go_ownerless_bare_identifier_call(
+    receiver_owner: Option<&str>,
+    callsite_identity: Option<&str>,
+    caller_file_path: Option<&str>,
+) -> bool {
+    semantic_language_bucket(caller_file_path) == Some("go")
+        && receiver_owner.is_none()
+        && !is_go_selector_call_placeholder(EdgeKind::CALL, callsite_identity)
 }
 
 fn is_relative_import_module_name(name: &str) -> bool {
@@ -780,12 +813,32 @@ mod tests {
         file_node_id: i64,
         start_line: i64,
     ) -> Result<()> {
+        insert_typed_callable(
+            conn,
+            id,
+            NodeKind::FUNCTION,
+            serialized_name,
+            qualified_name,
+            file_node_id,
+            start_line,
+        )
+    }
+
+    fn insert_typed_callable(
+        conn: &Connection,
+        id: i64,
+        kind: NodeKind,
+        serialized_name: &str,
+        qualified_name: &str,
+        file_node_id: i64,
+        start_line: i64,
+    ) -> Result<()> {
         conn.execute(
             "INSERT INTO node (id, kind, serialized_name, qualified_name, file_node_id, start_line)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
             params![
                 id,
-                NodeKind::FUNCTION as i32,
+                kind as i32,
                 serialized_name,
                 qualified_name,
                 file_node_id,
@@ -988,6 +1041,126 @@ mod tests {
             Some(ResolutionStrategy::CallGlobalUnique)
         );
         assert_eq!(computed.update.resolved_target_node_id, Some(10));
+        Ok(())
+    }
+
+    fn go_call_row(
+        edge_id: i64,
+        file_id: i64,
+        caller_qualified: &str,
+        target_name: &str,
+        callsite_identity: Option<&str>,
+    ) -> UnresolvedEdgeRow {
+        (
+            edge_id,
+            Some(file_id),
+            Some(caller_qualified.to_string()),
+            "Convert".to_string(),
+            target_name.to_string(),
+            0,
+            Some("convert.go".to_string()),
+            callsite_identity.map(str::to_string),
+            None,
+        )
+    }
+
+    #[test]
+    fn go_ownerless_bare_call_does_not_select_same_file_method_via_suffix() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        create_node_table(&conn)?;
+        insert_typed_callable(
+            &conn,
+            10,
+            NodeKind::METHOD,
+            "Handler.String",
+            "probe.Handler.String",
+            1,
+            4,
+        )?;
+
+        let index =
+            CandidateIndex::load(&conn, &[NodeKind::FUNCTION as i32, NodeKind::METHOD as i32])?;
+        let row = go_call_row(1, 1, "probe.Convert", "string", Some("1:6:1:1"));
+        let computed = compute_call_resolution(&resolution_pass(false), &index, &row, &[])?;
+
+        assert_eq!(computed.strategy, None);
+        assert_eq!(computed.update.resolved_target_node_id, None);
+        Ok(())
+    }
+
+    #[test]
+    fn go_ownerless_bare_call_does_not_select_semantic_method_when_fallback_is_enabled() -> Result<()>
+    {
+        let conn = Connection::open_in_memory()?;
+        create_node_table(&conn)?;
+        insert_typed_callable(
+            &conn,
+            10,
+            NodeKind::METHOD,
+            "Handler.string",
+            "probe.Handler.string",
+            1,
+            4,
+        )?;
+
+        let index =
+            CandidateIndex::load(&conn, &[NodeKind::FUNCTION as i32, NodeKind::METHOD as i32])?;
+        let row = go_call_row(2, 1, "probe.Convert", "string", Some("1:6:1:1"));
+        let computed = compute_call_resolution(
+            &resolution_pass(false),
+            &index,
+            &row,
+            &[SemanticResolutionCandidate {
+                target_node_id: 10,
+                confidence: 0.95,
+            }],
+        )?;
+
+        assert_eq!(computed.strategy, None);
+        assert_eq!(computed.update.resolved_target_node_id, None);
+        Ok(())
+    }
+
+    #[test]
+    fn go_ownerless_bare_call_keeps_package_function_with_competing_method() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        create_node_table(&conn)?;
+        insert_typed_callable(
+            &conn,
+            10,
+            NodeKind::METHOD,
+            "Handler.String",
+            "probe.Handler.String",
+            1,
+            4,
+        )?;
+        insert_typed_callable(&conn, 11, NodeKind::FUNCTION, "string", "probe.string", 1, 6)?;
+
+        let index =
+            CandidateIndex::load(&conn, &[NodeKind::FUNCTION as i32, NodeKind::METHOD as i32])?;
+        let row = go_call_row(3, 1, "probe.Convert", "string", Some("1:8:1:1"));
+        let with_semantic = compute_call_resolution(
+            &resolution_pass(false),
+            &index,
+            &row,
+            &[SemanticResolutionCandidate {
+                target_node_id: 10,
+                confidence: 0.95,
+            }],
+        )?;
+        let without_semantic =
+            compute_call_resolution(&resolution_pass(false), &index, &row, &[])?;
+
+        assert_eq!(
+            with_semantic.strategy,
+            Some(ResolutionStrategy::CallSameFile)
+        );
+        assert_eq!(with_semantic.update.resolved_target_node_id, Some(11));
+        assert_eq!(
+            without_semantic.strategy,
+            Some(ResolutionStrategy::CallSameFile)
+        );
+        assert_eq!(without_semantic.update.resolved_target_node_id, Some(11));
         Ok(())
     }
 }

--- a/crates/codestory-indexer/src/resolution/mod.rs
+++ b/crates/codestory-indexer/src/resolution/mod.rs
@@ -77,7 +77,10 @@ const REFERENCE_SINK_EDGE_KINDS: [EdgeKind; 11] = [
     EdgeKind::ANNOTATION_USAGE,
 ];
 /// Version for cached resolution-support snapshots.
-pub const RESOLUTION_SUPPORT_SNAPSHOT_VERSION: i64 = 6;
+///
+/// Bumped when call-candidate snapshots gained stored node kind so Go
+/// ownerless bare-call eligibility can be reapplied after snapshot load.
+pub const RESOLUTION_SUPPORT_SNAPSHOT_VERSION: i64 = 7;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct SemanticResolutionRequestKey {
@@ -106,6 +109,7 @@ struct ResolutionLookupCache {
 #[derive(Debug, Clone)]
 struct CandidateNode {
     id: i64,
+    kind: i32,
     file_node_id: Option<i64>,
     file_path: Option<String>,
     normalized_file_path: Option<String>,
@@ -118,6 +122,7 @@ struct CandidateNode {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct CandidateNodeSnapshot {
     id: i64,
+    kind: i32,
     file_node_id: Option<i64>,
     file_path: Option<String>,
     serialized_name: String,
@@ -1829,7 +1834,7 @@ impl CandidateIndex {
         let reference_node_ids = Self::load_reference_node_ids(conn)?;
         let kind_clause = kind_clause(kinds);
         let query = format!(
-            "SELECT n.id, n.file_node_id, n.serialized_name, n.qualified_name, file_node.serialized_name
+            "SELECT n.id, n.file_node_id, n.kind, n.serialized_name, n.qualified_name, file_node.serialized_name
              FROM node n
              LEFT JOIN node file_node ON file_node.id = n.file_node_id
              WHERE n.kind IN ({})
@@ -1838,17 +1843,18 @@ impl CandidateIndex {
         );
         let mut stmt = conn.prepare(&query)?;
         let rows = stmt.query_map([], |row| {
-            let serialized_name: String = row.get(2)?;
-            let file_path: Option<String> = row.get(4)?;
+            let serialized_name: String = row.get(3)?;
+            let file_path: Option<String> = row.get(5)?;
             let id = row.get(0)?;
             Ok(CandidateNode {
                 id,
                 file_node_id: row.get(1)?,
+                kind: row.get(2)?,
                 normalized_file_path: file_path.as_deref().and_then(normalize_resolution_path),
                 file_path,
                 serialized_name_ascii_lower: serialized_name.to_ascii_lowercase(),
                 serialized_name,
-                qualified_name: row.get(3)?,
+                qualified_name: row.get(4)?,
                 is_declaration: !reference_node_ids.contains(&id),
             })
         })?;
@@ -1926,6 +1932,7 @@ impl CandidateIndex {
             .iter()
             .map(|node| CandidateNodeSnapshot {
                 id: node.id,
+                kind: node.kind,
                 file_node_id: node.file_node_id,
                 file_path: node.file_path.clone(),
                 serialized_name: node.serialized_name.clone(),
@@ -1940,6 +1947,7 @@ impl CandidateIndex {
             .iter()
             .map(|node| CandidateNodeSnapshot {
                 id: node.id,
+                kind: node.kind,
                 file_node_id: node.file_node_id,
                 file_path: node.file_path.clone(),
                 serialized_name: node.serialized_name.clone(),
@@ -1969,6 +1977,7 @@ impl CandidateIndex {
             .into_iter()
             .map(|node| CandidateNode {
                 id: node.id,
+                kind: node.kind,
                 file_node_id: node.file_node_id,
                 normalized_file_path: node
                     .file_path
@@ -2061,6 +2070,13 @@ impl CandidateIndex {
 
     fn is_import_binding_node(&self, node_id: i64) -> bool {
         self.import_binding_node_ids.contains(&node_id)
+    }
+
+    fn node_kind(&self, node_id: i64) -> Option<i32> {
+        self.node_offset_by_id
+            .get(&node_id)
+            .and_then(|offset| self.nodes.get(*offset))
+            .map(|node| node.kind)
     }
 
     #[cfg(test)]
@@ -3919,6 +3935,7 @@ mod tests {
     fn test_relative_import_lookup_matches_imported_file_symbol() {
         let index = CandidateIndex::from_nodes(vec![CandidateNode {
             id: 42,
+            kind: NodeKind::FUNCTION as i32,
             file_node_id: Some(2),
             file_path: Some(r"\\?\C:\repo\lib\client.js".to_string()),
             normalized_file_path: normalize_resolution_path(r"\\?\C:\repo\lib\client.js"),
@@ -3948,6 +3965,7 @@ mod tests {
         let mut nodes = (0..250)
             .map(|idx| CandidateNode {
                 id: 10_000 + idx,
+                kind: NodeKind::METHOD as i32,
                 file_node_id: Some(1),
                 file_path: None,
                 normalized_file_path: None,
@@ -3959,6 +3977,7 @@ mod tests {
             .collect::<Vec<_>>();
         nodes.push(CandidateNode {
             id: 42,
+            kind: NodeKind::METHOD as i32,
             file_node_id: Some(1),
             file_path: None,
             normalized_file_path: None,

--- a/crates/codestory-indexer/src/semantic/go.rs
+++ b/crates/codestory-indexer/src/semantic/go.rs
@@ -68,7 +68,7 @@ impl GoSemanticResolver {
             return Ok(Vec::new());
         };
 
-        let kinds = [NodeKind::METHOD as i32, NodeKind::FUNCTION as i32];
+        let kinds = [NodeKind::FUNCTION as i32];
         resolve_call_candidates(
             index,
             &kinds,

--- a/crates/codestory-indexer/tests/call_resolution_common_methods.rs
+++ b/crates/codestory-indexer/tests/call_resolution_common_methods.rs
@@ -1,5 +1,6 @@
 use codestory_contracts::events::EventBus;
-use codestory_contracts::graph::{Edge, EdgeKind, Node, NodeId, ResolutionCertainty};
+use codestory_contracts::graph::{Edge, EdgeKind, Node, NodeId, NodeKind, ResolutionCertainty};
+use codestory_indexer::resolution::RESOLUTION_SUPPORT_SNAPSHOT_VERSION;
 use codestory_indexer::WorkspaceIndexer;
 use codestory_store::Store as Storage;
 use std::collections::{HashMap, HashSet};
@@ -603,6 +604,66 @@ fn assert_resolved_call_to_name(
     assert!(
         found,
         "Case `{case_name}`: expected CALL from `{caller_name}` to resolve to `{callee_name}`. Calls: {:?}",
+        describe_call_edges(edges, nodes)
+    );
+}
+
+fn assert_resolved_call_to_kind(
+    case_name: &str,
+    nodes: &[Node],
+    edges: &[Edge],
+    caller_name: &str,
+    callee_name: &str,
+    expected_kind: NodeKind,
+) {
+    let node_by_id: HashMap<_, _> = nodes.iter().map(|n| (n.id, n)).collect();
+    let found = edges
+        .iter()
+        .filter(|edge| edge.kind == EdgeKind::CALL)
+        .filter_map(|edge| {
+            let source = node_by_id.get(&edge.source)?;
+            if !is_matching_name(&source.serialized_name, caller_name) {
+                return None;
+            }
+            let resolved_id = edge.resolved_target?;
+            node_by_id.get(&resolved_id).copied()
+        })
+        .any(|resolved| {
+            is_matching_name(&resolved.serialized_name, callee_name)
+                && resolved.kind == expected_kind
+        });
+
+    assert!(
+        found,
+        "Case `{case_name}`: expected CALL from `{caller_name}` to resolve to `{callee_name}` with kind {expected_kind:?}. Calls: {:?}",
+        describe_call_edges(edges, nodes)
+    );
+}
+
+fn assert_no_resolved_call_of_kind(
+    case_name: &str,
+    nodes: &[Node],
+    edges: &[Edge],
+    caller_name: &str,
+    expected_kind: NodeKind,
+) {
+    let node_by_id: HashMap<_, _> = nodes.iter().map(|n| (n.id, n)).collect();
+    let found = edges
+        .iter()
+        .filter(|edge| edge.kind == EdgeKind::CALL)
+        .filter_map(|edge| {
+            let source = node_by_id.get(&edge.source)?;
+            if !is_matching_name(&source.serialized_name, caller_name) {
+                return None;
+            }
+            let resolved_id = edge.resolved_target?;
+            node_by_id.get(&resolved_id).copied()
+        })
+        .any(|resolved| resolved.kind == expected_kind);
+
+    assert!(
+        !found,
+        "Case `{case_name}`: CALL from `{caller_name}` must not resolve to kind {expected_kind:?}. Calls: {:?}",
         describe_call_edges(edges, nodes)
     );
 }
@@ -16728,5 +16789,319 @@ public ref struct TypeMapPlanBuilder(TypeMap typeMap)
 
     assert_no_call_self_edges("csharp automapper mirror", &edges);
     assert_no_type_usage_self_edges("csharp automapper mirror", &edges);
+    Ok(())
+}
+
+#[test]
+fn test_go_ownerless_bare_call_rejects_receiver_methods() -> anyhow::Result<()> {
+    // G01: builtin conversion vs uppercase method.
+    let (nodes, edges) = index_files(&[(
+        "g01.go",
+        r#"
+package probe
+type Key string
+type Handler struct{}
+func (Handler) String() string { return "handler" }
+func Convert(k Key) string { return string(k) }
+"#,
+    )])?;
+    assert_no_resolved_call_to_method_owner("G01", &nodes, &edges, "Convert", "Handler", "String");
+    assert_no_resolved_call_of_kind("G01", &nodes, &edges, "Convert", NodeKind::METHOD);
+
+    // G02: same conversion vs lowercase method.
+    let (nodes, edges) = index_files(&[(
+        "g02.go",
+        r#"
+package probe
+type Key string
+type Handler struct{}
+func (Handler) string() int { return 1 }
+func Convert(k Key) string { return string(k) }
+"#,
+    )])?;
+    assert_no_resolved_call_to_method_owner("G02", &nodes, &edges, "Convert", "Handler", "string");
+    assert_no_resolved_call_of_kind("G02", &nodes, &edges, "Convert", NodeKind::METHOD);
+
+    // G03: callable parameter vs same-named method.
+    let (nodes, edges) = index_files(&[(
+        "g03.go",
+        r#"
+package probe
+type Handler struct{}
+func (Handler) run() int { return 1 }
+func Variable(run func() int) int { return run() }
+"#,
+    )])?;
+    assert_no_resolved_call_to_method_owner("G03", &nodes, &edges, "Variable", "Handler", "run");
+    assert_no_resolved_call_of_kind("G03", &nodes, &edges, "Variable", NodeKind::METHOD);
+
+    // G04: package function named string wins over Handler.String.
+    let (nodes, edges) = index_files(&[(
+        "g04.go",
+        r#"
+package probe
+type Handler struct{}
+func (Handler) String() int { return 1 }
+func string(n int) int { return n }
+func Convert() int { return string(2) }
+"#,
+    )])?;
+    assert_resolved_call_to_kind("G04", &nodes, &edges, "Convert", "string", NodeKind::FUNCTION);
+    assert_no_resolved_call_to_method_owner("G04", &nodes, &edges, "Convert", "Handler", "String");
+
+    // G05: named conversion must not target Handler.Token.
+    let (nodes, edges) = index_files(&[(
+        "g05.go",
+        r#"
+package probe
+type Token string
+type Handler struct{}
+func (Handler) Token() {}
+func Convert() Token { return Token("x") }
+"#,
+    )])?;
+    assert_no_resolved_call_to_method_owner("G05", &nodes, &edges, "Convert", "Handler", "Token");
+    assert_no_resolved_call_of_kind("G05", &nodes, &edges, "Convert", NodeKind::METHOD);
+
+    // G06: package Run() vs method Run(), declaration order method-first.
+    let (nodes, edges) = index_files(&[(
+        "g06.go",
+        r#"
+package probe
+type Handler struct{}
+func (Handler) Run() {}
+func Run() {}
+func Caller() { Run() }
+"#,
+    )])?;
+    assert_resolved_call_to_kind("G06", &nodes, &edges, "Caller", "Run", NodeKind::FUNCTION);
+    assert_no_resolved_call_to_method_owner("G06", &nodes, &edges, "Caller", "Handler", "Run");
+
+    let (nodes, edges) = index_files(&[(
+        "g06b.go",
+        r#"
+package probe
+type Handler struct{}
+func Run() {}
+func (Handler) Run() {}
+func Caller() { Run() }
+"#,
+    )])?;
+    assert_resolved_call_to_kind(
+        "G06-function-first",
+        &nodes,
+        &edges,
+        "Caller",
+        "Run",
+        NodeKind::FUNCTION,
+    );
+    assert_no_resolved_call_to_method_owner(
+        "G06-function-first",
+        &nodes,
+        &edges,
+        "Caller",
+        "Handler",
+        "Run",
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_go_owner_qualified_receiver_calls_keep_intended_owner() -> anyhow::Result<()> {
+    // G07: genuine lowercase/uppercase receiver calls with other-owner collisions.
+    let source = r#"
+package probe
+type Handler struct{}
+func (Handler) String() string { return "H" }
+func (Handler) string() string { return "h" }
+type Other struct{}
+func (Other) String() string { return "O" }
+func (Other) string() string { return "o" }
+func RealUpper(h Handler) string { return h.String() }
+func RealLower(h Handler) string { return h.string() }
+"#;
+    let (nodes, edges) = index_files(&[("g07.go", source)])?;
+    assert_resolved_call_to_method_owner("G07-upper", &nodes, &edges, "RealUpper", "Handler", "String");
+    assert_resolved_call_to_method_owner("G07-lower", &nodes, &edges, "RealLower", "Handler", "string");
+    assert_no_resolved_call_to_method_owner("G07-upper", &nodes, &edges, "RealUpper", "Other", "String");
+    assert_no_resolved_call_to_method_owner("G07-lower", &nodes, &edges, "RealLower", "Other", "string");
+    Ok(())
+}
+
+#[test]
+fn test_go_ownerless_bare_call_rejects_cross_file_method_and_keeps_package_function()
+-> anyhow::Result<()> {
+    // G08: misleading METHOD lives in a second file of the same package.
+    let methods = r#"
+package probe
+type Handler struct{}
+func (Handler) String() string { return "handler" }
+func (Handler) string() int { return 1 }
+func (Handler) run() int { return 1 }
+"#;
+    let conversions = r#"
+package probe
+type Key string
+func Convert(k Key) string { return string(k) }
+func Variable(run func() int) int { return run() }
+"#;
+    let (nodes, edges) = index_files(&[("methods.go", methods), ("calls.go", conversions)])?;
+    assert_no_resolved_call_to_method_owner("G08-string", &nodes, &edges, "Convert", "Handler", "String");
+    assert_no_resolved_call_to_method_owner("G08-string-lower", &nodes, &edges, "Convert", "Handler", "string");
+    assert_no_resolved_call_to_method_owner("G08-run", &nodes, &edges, "Variable", "Handler", "run");
+    assert_no_resolved_call_of_kind("G08-string", &nodes, &edges, "Convert", NodeKind::METHOD);
+    assert_no_resolved_call_of_kind("G08-run", &nodes, &edges, "Variable", NodeKind::METHOD);
+
+    // G09: package FUNCTION in a second file, competing receiver METHOD.
+    let helpers = r#"
+package probe
+func Run() {}
+"#;
+    let methods = r#"
+package probe
+type Handler struct{}
+func (Handler) Run() {}
+"#;
+    let caller = r#"
+package probe
+func Caller() { Run() }
+"#;
+    let (nodes, edges) = index_files(&[
+        ("helpers.go", helpers),
+        ("methods.go", methods),
+        ("caller.go", caller),
+    ])?;
+    assert_resolved_call_to_kind("G09", &nodes, &edges, "Caller", "Run", NodeKind::FUNCTION);
+    assert_no_resolved_call_to_method_owner("G09", &nodes, &edges, "Caller", "Handler", "Run");
+    Ok(())
+}
+
+#[test]
+fn test_go_imported_and_unowned_selector_controls_stay_in_place() -> anyhow::Result<()> {
+    // G10: imported typed receiver with same-named methods elsewhere.
+    let notifier_source = r#"
+package notifier
+type Notifier interface {
+    Notify()
+}
+"#;
+    let workflow_source = r#"
+package workflow
+import mail "example.com/project/notifier"
+type Notifier interface {
+    Notify()
+}
+func Run(n mail.Notifier) {
+    n.Notify()
+}
+"#;
+    let other_notifier_source = r#"
+package other
+type Notifier interface {
+    Notify()
+}
+"#;
+    let (nodes, edges) = index_files(&[
+        ("project/notifier/notifier.go", notifier_source),
+        ("other/notifier/notifier.go", other_notifier_source),
+        ("workflow.go", workflow_source),
+    ])?;
+    assert_resolved_call_to_method_owner_in_file(
+        "G10",
+        &nodes,
+        &edges,
+        "Run",
+        "Notifier",
+        "Notify",
+        "project/notifier/notifier.go",
+    );
+    assert_no_resolved_call_to_method_owner_in_file(
+        "G10",
+        &nodes,
+        &edges,
+        "Run",
+        "Notifier",
+        "Notify",
+        "other/notifier/notifier.go",
+    );
+
+    // G11: unowned selector must not gain a concrete METHOD target.
+    let (nodes, edges) = index_files(&[(
+        "g11.go",
+        r#"
+package probe
+type Handler struct{}
+func (Handler) String() string { return "handler" }
+func Guess(x any) { x.String() }
+"#,
+    )])?;
+    assert_no_resolved_call_to_method_owner("G11", &nodes, &edges, "Guess", "Handler", "String");
+    assert_no_resolved_call_of_kind("G11", &nodes, &edges, "Guess", NodeKind::METHOD);
+    Ok(())
+}
+
+#[test]
+fn test_go_ownerless_bare_call_eligibility_survives_resolution_support_refresh() -> anyhow::Result<()>
+{
+    // G13: snapshot reuse, then refresh changing the misleading method's case.
+    let dir = tempdir()?;
+    let root = dir.path();
+    let file_path = root.join("g13.go");
+    fs::write(
+        &file_path,
+        r#"
+package probe
+type Key string
+type Handler struct{}
+func (Handler) String() string { return "handler" }
+func Convert(k Key) string { return string(k) }
+"#,
+    )?;
+
+    let mut storage = Storage::new_in_memory()?;
+    let indexer = WorkspaceIndexer::new(root.to_path_buf());
+    let event_bus = EventBus::new();
+    let refresh = |storage: &mut Storage, files: Vec<std::path::PathBuf>| {
+        indexer.run_incremental(
+            storage,
+            &codestory_workspace::RefreshInfo {
+                mode: codestory_workspace::BuildMode::Incremental,
+                files_to_index: files,
+                files_to_remove: vec![],
+                existing_file_ids: std::collections::HashMap::new(),
+            },
+            &event_bus,
+            None,
+        )
+    };
+
+    let first = refresh(&mut storage, vec![file_path.clone()])?;
+    assert!(!first.resolution_support_snapshot_hit);
+    assert!(first.resolution_support_snapshot_stored);
+    assert!(storage.has_ready_resolution_support_snapshot(RESOLUTION_SUPPORT_SNAPSHOT_VERSION)?);
+
+    let nodes = storage.get_nodes()?;
+    let edges = storage.get_edges()?;
+    assert_no_resolved_call_to_method_owner("G13-initial", &nodes, &edges, "Convert", "Handler", "String");
+    assert_no_resolved_call_of_kind("G13-initial", &nodes, &edges, "Convert", NodeKind::METHOD);
+
+    fs::write(
+        &file_path,
+        r#"
+package probe
+type Key string
+type Handler struct{}
+func (Handler) string() string { return "handler" }
+func Convert(k Key) string { return string(k) }
+"#,
+    )?;
+    refresh(&mut storage, vec![file_path])?;
+
+    let nodes = storage.get_nodes()?;
+    let edges = storage.get_edges()?;
+    assert_no_resolved_call_to_method_owner("G13-refresh", &nodes, &edges, "Convert", "Handler", "string");
+    assert_no_resolved_call_to_method_owner("G13-refresh", &nodes, &edges, "Convert", "Handler", "String");
+    assert_no_resolved_call_of_kind("G13-refresh", &nodes, &edges, "Convert", NodeKind::METHOD);
     Ok(())
 }

--- a/crates/codestory-indexer/tests/call_resolution_common_methods.rs
+++ b/crates/codestory-indexer/tests/call_resolution_common_methods.rs
@@ -1,7 +1,7 @@
 use codestory_contracts::events::EventBus;
 use codestory_contracts::graph::{Edge, EdgeKind, Node, NodeId, NodeKind, ResolutionCertainty};
-use codestory_indexer::resolution::RESOLUTION_SUPPORT_SNAPSHOT_VERSION;
 use codestory_indexer::WorkspaceIndexer;
+use codestory_indexer::resolution::{RESOLUTION_SUPPORT_SNAPSHOT_VERSION, ResolutionPass};
 use codestory_store::Store as Storage;
 use std::collections::{HashMap, HashSet};
 use std::fs;
@@ -16846,7 +16846,14 @@ func string(n int) int { return n }
 func Convert() int { return string(2) }
 "#,
     )])?;
-    assert_resolved_call_to_kind("G04", &nodes, &edges, "Convert", "string", NodeKind::FUNCTION);
+    assert_resolved_call_to_kind(
+        "G04",
+        &nodes,
+        &edges,
+        "Convert",
+        "string",
+        NodeKind::FUNCTION,
+    );
     assert_no_resolved_call_to_method_owner("G04", &nodes, &edges, "Convert", "Handler", "String");
 
     // G05: named conversion must not target Handler.Token.
@@ -16922,10 +16929,38 @@ func RealUpper(h Handler) string { return h.String() }
 func RealLower(h Handler) string { return h.string() }
 "#;
     let (nodes, edges) = index_files(&[("g07.go", source)])?;
-    assert_resolved_call_to_method_owner("G07-upper", &nodes, &edges, "RealUpper", "Handler", "String");
-    assert_resolved_call_to_method_owner("G07-lower", &nodes, &edges, "RealLower", "Handler", "string");
-    assert_no_resolved_call_to_method_owner("G07-upper", &nodes, &edges, "RealUpper", "Other", "String");
-    assert_no_resolved_call_to_method_owner("G07-lower", &nodes, &edges, "RealLower", "Other", "string");
+    assert_resolved_call_to_method_owner(
+        "G07-upper",
+        &nodes,
+        &edges,
+        "RealUpper",
+        "Handler",
+        "String",
+    );
+    assert_resolved_call_to_method_owner(
+        "G07-lower",
+        &nodes,
+        &edges,
+        "RealLower",
+        "Handler",
+        "string",
+    );
+    assert_no_resolved_call_to_method_owner(
+        "G07-upper",
+        &nodes,
+        &edges,
+        "RealUpper",
+        "Other",
+        "String",
+    );
+    assert_no_resolved_call_to_method_owner(
+        "G07-lower",
+        &nodes,
+        &edges,
+        "RealLower",
+        "Other",
+        "string",
+    );
     Ok(())
 }
 
@@ -16947,9 +16982,25 @@ func Convert(k Key) string { return string(k) }
 func Variable(run func() int) int { return run() }
 "#;
     let (nodes, edges) = index_files(&[("methods.go", methods), ("calls.go", conversions)])?;
-    assert_no_resolved_call_to_method_owner("G08-string", &nodes, &edges, "Convert", "Handler", "String");
-    assert_no_resolved_call_to_method_owner("G08-string-lower", &nodes, &edges, "Convert", "Handler", "string");
-    assert_no_resolved_call_to_method_owner("G08-run", &nodes, &edges, "Variable", "Handler", "run");
+    assert_no_resolved_call_to_method_owner(
+        "G08-string",
+        &nodes,
+        &edges,
+        "Convert",
+        "Handler",
+        "String",
+    );
+    assert_no_resolved_call_to_method_owner(
+        "G08-string-lower",
+        &nodes,
+        &edges,
+        "Convert",
+        "Handler",
+        "string",
+    );
+    assert_no_resolved_call_to_method_owner(
+        "G08-run", &nodes, &edges, "Variable", "Handler", "run",
+    );
     assert_no_resolved_call_of_kind("G08-string", &nodes, &edges, "Convert", NodeKind::METHOD);
     assert_no_resolved_call_of_kind("G08-run", &nodes, &edges, "Variable", NodeKind::METHOD);
 
@@ -17042,9 +17093,13 @@ func Guess(x any) { x.String() }
 }
 
 #[test]
-fn test_go_ownerless_bare_call_eligibility_survives_resolution_support_refresh() -> anyhow::Result<()>
-{
-    // G13: snapshot reuse, then refresh changing the misleading method's case.
+fn test_go_ownerless_bare_call_eligibility_survives_resolution_support_refresh()
+-> anyhow::Result<()> {
+    // G13: eligibility after snapshot-loaded resolution, then after a method-case
+    // refresh. Unchanged incremental indexing skips ResolutionPass when
+    // graph_projection_changed is false; the authentic reuse path is the same
+    // standalone ResolutionPass::run used by the existing snapshot integration
+    // test.
     let dir = tempdir()?;
     let root = dir.path();
     let file_path = root.join("g13.go");
@@ -17083,8 +17138,39 @@ func Convert(k Key) string { return string(k) }
 
     let nodes = storage.get_nodes()?;
     let edges = storage.get_edges()?;
-    assert_no_resolved_call_to_method_owner("G13-initial", &nodes, &edges, "Convert", "Handler", "String");
+    assert_no_resolved_call_to_method_owner(
+        "G13-initial",
+        &nodes,
+        &edges,
+        "Convert",
+        "Handler",
+        "String",
+    );
     assert_no_resolved_call_of_kind("G13-initial", &nodes, &edges, "Convert", NodeKind::METHOD);
+
+    let snapshot_loaded = ResolutionPass::new().run(&mut storage)?;
+    assert!(
+        snapshot_loaded.telemetry.support_snapshot_hit,
+        "G13 must load v7 call-candidate kind from the stored snapshot"
+    );
+    assert!(!snapshot_loaded.telemetry.support_snapshot_stored);
+    let nodes = storage.get_nodes()?;
+    let edges = storage.get_edges()?;
+    assert_no_resolved_call_to_method_owner(
+        "G13-snapshot-hit",
+        &nodes,
+        &edges,
+        "Convert",
+        "Handler",
+        "String",
+    );
+    assert_no_resolved_call_of_kind(
+        "G13-snapshot-hit",
+        &nodes,
+        &edges,
+        "Convert",
+        NodeKind::METHOD,
+    );
 
     fs::write(
         &file_path,
@@ -17100,8 +17186,22 @@ func Convert(k Key) string { return string(k) }
 
     let nodes = storage.get_nodes()?;
     let edges = storage.get_edges()?;
-    assert_no_resolved_call_to_method_owner("G13-refresh", &nodes, &edges, "Convert", "Handler", "string");
-    assert_no_resolved_call_to_method_owner("G13-refresh", &nodes, &edges, "Convert", "Handler", "String");
+    assert_no_resolved_call_to_method_owner(
+        "G13-refresh",
+        &nodes,
+        &edges,
+        "Convert",
+        "Handler",
+        "string",
+    );
+    assert_no_resolved_call_to_method_owner(
+        "G13-refresh",
+        &nodes,
+        &edges,
+        "Convert",
+        "Handler",
+        "String",
+    );
     assert_no_resolved_call_of_kind("G13-refresh", &nodes, &edges, "Convert", NodeKind::METHOD);
     Ok(())
 }


### PR DESCRIPTION
Ownerless Go calls no longer bind to unrelated receiver methods with matching names. The indexer excludes METHOD targets from bare-identifier resolution across file, module, global and semantic fallback, while preserving package FUNCTION targets and owner-qualified receiver paths. Resolution-support snapshots retain node kind; version 7 rebuilds older support snapshots on refresh.

Review candidate eligibility, Go semantic lookup and persisted support together. Regression fixtures cover case collisions, conversions, callable parameters, package functions, qualified/imported receivers, semantic candidates and actual snapshot reuse before a case-changing refresh. The change does not add general points-to analysis or alter other languages.

Current head: `da868920a12ffce34f5c11d51832e7a7f0697f52`, tree `e02e98ba8e97da792cdfe9a8cbc91fa3531b7416`, integration base `3e106d6edfe1747e3c772d75488f9443d0278d5f`. The caller-scope integration is included; the only conflict was the changelog, where both entries were retained. Indexer bytes match the accepted Go head `aca7460d545aa268a88ca6f1f8e9310c6ed9ff27`; CLI/plugin bytes match the accepted integration base.

Locked tests passed: 3 focused unit regressions, the full 126-test call-resolution binary, 8 fidelity regressions and 13 language-coverage tests. Independent native checks on the unchanged Go delta removed three false METHOD targets while retaining receiver and package-function positives. All four fresh database hashes, source fixtures and binary identity were verified. On the combined head, the CLI build and full 67-test MCP protocol binary passed. Independent combined native verification passed all 86 caller-scope cases and four fresh Go fixture publications on CLI SHA-256 `9ce50856f5ae8919dc9a9c195b2be8b71dd06c1a95477cbeb5488841d961c626`. Root rechecked every behavioral row, nested CLI response, four database hashes and process cleanup. Current-head CI remains pending; this PR stays draft. Prior failed attempts are preserved.

Proof covers graph/index behavior, including symbolic operation without CPU embedding fallback. Installed-host breadth behavior, full retrieval and release qualification remain later gates. Root coordinates one Cursor/Grok implementer and one independent verifier in `/Users/albert/.codex/worktrees/0176-go-call-targets/CodeStory`. Next: finish combined-head review and CI, then serialize integration.

Closes #2180
Refs #2173, #2135
